### PR TITLE
Implements WHM and BRD Cure Speed / Sing Speed on Cast Bar

### DIFF
--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -24,7 +24,7 @@
 
 addon.name      = 'HXUI';
 addon.author    = 'Team HXUI';
-addon.version   = '1.3.5';
+addon.version   = '1.3.6';
 addon.desc      = 'Multiple UI elements with manager';
 addon.link      = 'https://github.com/tirem/HXUI'
 
@@ -219,29 +219,31 @@ T{
 	castBarFontOffset = 0,
 	castBarFastCastEnabled = false,
 	castBarFastCastRDMSJ = 0.17,
+	castBarFastCastWHMCureSpeed = 0.15,
+	castBarFastCastBRDSingSpeed = 0.37,
 	castBarFastCast = {
-		[1] = 0.02,
-		[2] = 0.02,
-		[3] = 0.04,
-		[4] = 0.04,
-		[5] = 0.42,
-		[6] = 0.07,
-		[7] = 0.07,
-		[8] = 0.07,
-		[9] = 0.02,
-		[10] = 0.04,
-		[11] = 0.02,
-		[12] = 0.02,
-		[13] = 0.02,
-		[14] = 0.07,
-		[15] = 0.04,
-		[16] = 0.07,
-		[17] = 0.02,
-		[18] = 0.04,
-		[19] = 0.02,
-		[20] = 0.02,
-		[21] = 0.02,
-		[22] = 0.02,
+		[1] = 0.02, -- WAR
+		[2] = 0.02, -- MNK
+		[3] = 0.04, -- WHM
+		[4] = 0.04, -- BLM
+		[5] = 0.42, -- RDM
+		[6] = 0.07, -- THF
+		[7] = 0.07, -- PLD
+		[8] = 0.07, -- DRK
+		[9] = 0.02, -- BST
+		[10] = 0.04, -- BRD
+		[11] = 0.02, -- RNG
+		[12] = 0.02, -- SAM
+		[13] = 0.02, -- NIN
+		[14] = 0.07, -- DRG
+		[15] = 0.04, -- SMN
+		[16] = 0.07, -- BLU
+		[17] = 0.02, -- COR
+		[18] = 0.04, -- PUP
+		[19] = 0.02, -- DNC
+		[20] = 0.02, -- SCH
+		[21] = 0.02, -- GEO
+		[22] = 0.02, -- RUN
 	},
 
 	healthBarFlashEnabled = true,

--- a/HXUI/castbar.lua
+++ b/HXUI/castbar.lua
@@ -19,8 +19,14 @@ local castbar = {
 	currentItemId = nil,
 };
 
+local CureSpells = T{ 'Cure','Cure II','Cure III','Cure IV','Cure V','Cure VI','Full Cure','Curaga','Curaga II','Curaga III','Curaga IV','Curaga V' }
+
 castbar.GetSpellName = function(spellId)
 	return AshitaCore:GetResourceManager():GetSpellById(spellId).Name[1];
+end
+
+castbar.GetSpellType = function(spellId)
+	return AshitaCore:GetResourceManager():GetSpellById(spellId).Skill;
 end
 
 castbar.GetItemName = function(itemId)
@@ -51,6 +57,17 @@ castbar.DrawWindow = function(settings)
 		if (gConfig.castBarFastCast[MID]) then
 			fastCast = fastCast + tonumber(string.format("%.2f", gConfig.castBarFastCast[MID]))
 		end
+
+		if (castbar.currentSpellId) then
+			if (MID == 3 and castbar.GetSpellType(castbar.currentSpellId) == 33) then -- if WHM MJ and Healing Magic
+				if (CureSpells:contains(castbar.GetSpellName(castbar.currentSpellId))) then
+					fastCast = fastCast + tonumber(string.format("%.2f", gConfig.castBarFastCastWHMCureSpeed))
+				end
+			elseif (MID == 10 and castbar.GetSpellType(castbar.currentSpellId) == 40) then -- if BRD MJ and Singing
+				fastCast = fastCast + tonumber(string.format("%.2f", gConfig.castBarFastCastBRDSingSpeed))
+			end
+		end
+
 		if (SID == 5 and gConfig.castBarFastCastRDMSJ) then -- if RDM SJ
 			fastCast = fastCast + tonumber(string.format("%.2f", gConfig.castBarFastCastRDMSJ))
 		end

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -653,6 +653,16 @@ config.DrawWindow = function(us)
                 gConfig.castBarFastCastRDMSJ = castBarFCRDMSJ[1];
                 UpdateSettings();
             end
+            local castBarFCWHMCureSpeed = { gConfig.castBarFastCastWHMCureSpeed };
+            if (imgui.SliderFloat('WHM Cure Speed', castBarFCWHMCureSpeed, 0.00, 1.00, '%.2f')) then
+                gConfig.castBarFastCastWHMCureSpeed = castBarFCWHMCureSpeed[1];
+                UpdateSettings();
+            end
+            local castBarFCBRDSingSpeed = { gConfig.castBarFastCastBRDSingSpeed };
+            if (imgui.SliderFloat('BRD Sing Speed', castBarFCBRDSingSpeed, 0.00, 1.00, '%.2f')) then
+                gConfig.castBarFastCastBRDSingSpeed = castBarFCBRDSingSpeed[1];
+                UpdateSettings();
+            end
             local castBarFC1 = { gConfig.castBarFastCast[1] };
             if (imgui.SliderFloat('Fast Cast - WAR', castBarFC1, 0.00, 1.00, '%.2f')) then
                 gConfig.castBarFastCast[1] = castBarFC1[1];


### PR DESCRIPTION
This allows differentiation from Fast Cast for Cure Clogs / Minstrel's Ring etc.

There are magic numbers used for Job ID / Spell Type but I've left these as is or added comments in lieu of any constants files / tables anywhere in pre-existing code.