### PR TITLE
Added background + border color options for enemy list

### DIFF
--- a/XIUI/config/enemylist.lua
+++ b/XIUI/config/enemylist.lua
@@ -21,6 +21,14 @@ function M.DrawSettings()
         components.DrawCheckbox('Show Enemy Targets', 'showEnemyListTargets');
         imgui.ShowHelp('Shows who each enemy is targeting based on their last action.');
         components.DrawCheckbox('Show Bookends', 'showEnemyListBookends');
+        components.DrawCheckbox('Show Borders', 'showEnemyListBorders');
+        imgui.ShowHelp('Draws a border around each enemy in the list');
+        if gConfig.showEnemyListBorders then
+            imgui.SameLine();
+            components.DrawCheckbox('Use Name Color', 'showEnemyListBordersUseNameColor');
+            imgui.ShowHelp('Use enemy name color as the default border color');
+        end
+
         if (not HzLimitedMode) then
             components.DrawCheckbox('Click to Target', 'enableEnemyListClickTarget');
             imgui.ShowHelp('Click on an enemy entry to target it. Requires /shorthand to be enabled.');
@@ -93,7 +101,9 @@ function M.DrawColorSettings()
         imgui.ShowHelp("Enemy name colors are in the Global section");
     end
 
-    if components.CollapsingSection('Border Colors##enemyListColor') then
+    if components.CollapsingSection('Background Colors##enemyListColor') then
+        components.DrawTextColorPicker("Background", gConfig.colorCustomization.enemyList, 'backgroundColor', "Background color for list entries");
+        components.DrawTextColorPicker("Default Border", gConfig.colorCustomization.enemyList, 'borderColor', "Default border color for enemies");
         components.DrawTextColorPicker("Target Border", gConfig.colorCustomization.enemyList, 'targetBorderColor', "Border color for currently targeted enemy");
         components.DrawTextColorPicker("Subtarget Border", gConfig.colorCustomization.enemyList, 'subtargetBorderColor', "Border color for subtargeted enemy");
     end

--- a/XIUI/core/settings/colors.lua
+++ b/XIUI/core/settings/colors.lua
@@ -49,6 +49,8 @@ function M.createColorCustomizationDefaults()
             hpGradient = T{ enabled = true, start = '#e16c6c', stop = '#fb9494' },
             distanceTextColor = 0xFFFFFFFF,
             percentTextColor = 0xFFFFFFFF,
+            backgroundColor = 0x66000000,        -- Semi-transparent black - Alpha is the first byte: 0.4 * 255 = 102 = 0x66
+            borderColor = 0x00000000,            -- transparent black - default border
             targetBorderColor = 0xFFFFFFFF,      -- white - border for main target
             subtargetBorderColor = 0xFF8080FF,   -- blue - border for subtarget
             targetNameTextColor = 0xFFFFAA00,    -- orange - enemy's target name

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -195,6 +195,8 @@ function M.createUserSettingsDefaults()
         showEnemyDistance = true,
         showEnemyHPPText = true,
         showEnemyListBookends = false,
+        showEnemyListBorders = true,
+        showEnemyListBordersUseNameColor = false,
         -- Enemy target container settings
         enemyListTargetOffsetX = 0,
         enemyListTargetOffsetY = 43,

--- a/XIUI/modules/enemylist.lua
+++ b/XIUI/modules/enemylist.lua
@@ -305,19 +305,20 @@ enemylist.DrawWindow = function(settings)
 					nameColor = GetEntityNameColor(ent, k, gConfig.colorCustomization.shared);
 				end
 
-				-- Draw border first if this is the selected target
-				local borderColor;
-				if (subTargetIndex ~= nil and k == subTargetIndex) then
-					-- Subtarget border - use configured color
-					local rgba = ARGBToRGBA(gConfig.colorCustomization.enemyList.subtargetBorderColor);
-					borderColor = imgui.GetColorU32(rgba);
-				elseif (targetIndex ~= nil and k == targetIndex) then
-					-- Main target border - use configured color
-					local rgba = ARGBToRGBA(gConfig.colorCustomization.enemyList.targetBorderColor);
-					borderColor = imgui.GetColorU32(rgba);
-				end
+				if (gConfig.showEnemyListBorders) then
+					local borderColor;
+					if (subTargetIndex ~= nil and k == subTargetIndex) then
+						-- Subtarget border - use configured color
+						borderColor = imgui.GetColorU32(ARGBToRGBA(gConfig.colorCustomization.enemyList.subtargetBorderColor));
+					elseif (targetIndex ~= nil and k == targetIndex) then
+						-- Main target border - use configured color
+						borderColor = imgui.GetColorU32(ARGBToRGBA(gConfig.colorCustomization.enemyList.targetBorderColor));
+					elseif (gConfig.showEnemyListBordersUseNameColor) then
+						borderColor = imgui.GetColorU32(ARGBToRGBA(nameColor));
+					else
+						borderColor = imgui.GetColorU32(ARGBToRGBA(gConfig.colorCustomization.enemyList.borderColor));
+					end
 
-				if (borderColor) then
 					-- Draw border rectangle around the entire entry
 					-- Window margins ensure this won't be clipped
 					imgui.GetWindowDrawList():AddRect(
@@ -347,9 +348,7 @@ enemylist.DrawWindow = function(settings)
 					bg.position_y = entryStartY;
 					bg.width = entryWidth;
 					bg.height = entryHeight;
-					-- Set semi-transparent black color (ARGB format)
-					-- Alpha is the first byte: 0.4 * 255 = 102 = 0x66
-					bg.color = 0x66000000;  -- Semi-transparent black
+					bg.color = gConfig.colorCustomization.enemyList.backgroundColor;
 					bg.visible = true;
 				end
 


### PR DESCRIPTION
- Added option to show/hide borders for enemy list.
  - Defaults to true.
- Added sub option to use enemy name color as the default border color.
  - Defaults to false.
- Added default border color picker which is used if enemy name option is not.
  - Defaults to transparent.
- Added color picker for enemy list background color.
  - Defaults to semi-transparent black.
  
Default values are set to maintain user experience with previous versions.