### PR TITLE
Notification Progress Bar Directions

### DIFF
--- a/XIUI/config/notifications.lua
+++ b/XIUI/config/notifications.lua
@@ -72,14 +72,14 @@ function M.DrawSettings()
     components.DrawCheckbox('Hide During Events', 'notificationsHideDuringEvents');
 
     if components.CollapsingSection('Display Options##notifications') then
-        -- Direction dropdown
-        local directions = {'Down', 'Up'};
-        local directionValues = {'down', 'up'};
+        -- Stack Direction dropdown
+        local stackDirections = {'Down', 'Up'};
+        local stackDirectionValues = {'down', 'up'};
         local currentDirIndex = gConfig.notificationsDirection == 'up' and 2 or 1;
-        if imgui.BeginCombo('Stack Direction', directions[currentDirIndex]) then
-            for i, label in ipairs(directions) do
+        if imgui.BeginCombo('Stack Direction', stackDirections[currentDirIndex]) then
+            for i, label in ipairs(stackDirections) do
                 if imgui.Selectable(label, i == currentDirIndex) then
-                    gConfig.notificationsDirection = directionValues[i];
+                    gConfig.notificationsDirection = stackDirectionValues[i];
                     -- Clear window anchors when direction changes
                     notificationData.ClearWindowAnchors();
                     SaveSettingsOnly();
@@ -88,6 +88,21 @@ function M.DrawSettings()
             imgui.EndCombo();
         end
         imgui.ShowHelp('Direction notifications stack. Up: window anchors at bottom, grows upward. Down: window anchors at top, grows downward.');
+
+        -- Progress Bar Direction dropdown
+        local progressBarDirections = {'Left', 'Right'};
+        local progressBarDirectionValues = {'left', 'right'};
+        local currentBarDirIndex = gConfig.notificationsProgressBarDirection == 'right' and 2 or 1;
+        if imgui.BeginCombo('Progress Bar Direction', progressBarDirections[currentBarDirIndex]) then
+            for i, label in ipairs(progressBarDirections) do
+                if imgui.Selectable(label, i == currentBarDirIndex) then
+                    gConfig.notificationsProgressBarDirection = progressBarDirectionValues[i];
+                    SaveSettingsOnly();
+                end
+            end
+            imgui.EndCombo();
+        end
+        imgui.ShowHelp('Direction the progress bar drains as time elapses.');
 
         components.DrawSlider('Max Visible', 'notificationsMaxVisible', 1, 10, '%.0f');
         imgui.ShowHelp('Maximum notifications shown at once');

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -65,6 +65,7 @@ function M.createUserSettingsDefaults()
         notificationsSubtitleFontSize = 12,
         notificationsProgressBarScaleY = 1.0,
         notificationsHideDuringEvents = false,
+        notificationsProgressBarDirection = 'left',
 
         -- Background/Border settings
         notificationsBackgroundTheme = 'Plain',

--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -591,6 +591,11 @@ local function drawNotification(slot, notification, x, y, width, height, setting
         local barColor2 = notificationData.GetCachedBarColor(colorKey2, barHex2);
         local filledWidth = barWidth * progress;
 
+        -- Inverse direction if configured
+        if (gConfig.notificationsProgressBarDirection == "right") then
+            barX = x + (barWidth - filledWidth);
+        end
+
         -- Draw filled portion with gradient
         if filledWidth > 0 then
             drawList:AddRectFilledMultiColor(


### PR DESCRIPTION
- Added ability to swap notification progress bar to empty to the right
- Added configuration drop down button to swap between empty left and empty right
  - Defaults to left to maintain behavior of previous version
  

https://github.com/user-attachments/assets/25d17a32-36ed-4c2c-8a92-0f14d58fdc3c

