### PR TITLE
Bug Fixes Jan 10-14, 2026

### DIFF
--- a/XIUI/config/expbar.lua
+++ b/XIUI/config/expbar.lua
@@ -25,7 +25,7 @@ function M.DrawSettings()
 
     if components.CollapsingSection('Scale & Position##expBar') then
         components.DrawSlider('Scale X', 'expBarScaleX', 0.1, 8.0, '%.2f');
-        components.DrawSlider('Scale Y', 'expBarScaleY', 0.1, 3.0, '%.2f');
+        components.DrawSlider('Scale Y', 'expBarScaleY', 0.2, 3.0, '%.2f');
     end
 
     if components.CollapsingSection('Text Settings##expBar') then

--- a/XIUI/modules/expbar.lua
+++ b/XIUI/modules/expbar.lua
@@ -170,15 +170,19 @@ expbar.DrawWindow = function(settings)
         end
     end
 
-    -- Let ImGui auto-size the window based on content (Dummy call in progressbar)
-    -- Use {0, 0} to allow unlimited auto-sizing (not {-1, -1} which can cause clipping)
-    imgui.SetNextWindowSize({ 0, 0 }, ImGuiCond_Always);
+    -- Compute window width to fully contain the bar (and inline text if enabled)
+    local progressBarWidth = settings.barWidth;
+    local windowWidth = progressBarWidth;
+    if inlineMode then
+        windowWidth = windowWidth + actualTextWidth;
+    end
+
+    -- Explicitly size the window wide enough so dragging works across the full bar
+    imgui.SetNextWindowSize({ windowWidth, 0 }, ImGuiCond_Always);
 	local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
     if (imgui.Begin('ExpBar', true, windowFlags)) then
 
-		-- Draw the progress bar
-        local progressBarWidth = settings.barWidth;
-
+		-- Draw the progress bar        
 		-- Get window origin for text positioning
 		local startX, startY = imgui.GetCursorScreenPos();
 
@@ -198,8 +202,8 @@ expbar.DrawWindow = function(settings)
 			expGradient = GetCustomGradient(gConfig.colorCustomization.expBar, 'expBarGradient') or {'#c39040', '#e9c466'};
 		end
 		-- Let progressbar handle its own Dummy for sizing (includes border extent)
-		-- Use GetUIDrawList: foreground when config closed (no clipping), window when config open (respects layering)
-		progressbar.ProgressBar({{progressBarProgress, expGradient}}, {progressBarWidth, settings.barHeight}, {decorate = gConfig.showExpBarBookends, drawList = drawing.GetUIDrawList()});
+		-- Use GetBackgroundDrawList to avoid clipping issues with large scales (window clipping)
+		progressbar.ProgressBar({{progressBarProgress, expGradient}}, {progressBarWidth, settings.barHeight}, {decorate = gConfig.showExpBarBookends, drawList = imgui.GetBackgroundDrawList()});
 
         -- Calculate text padding
         local bookendWidth = gConfig.showExpBarBookends and (settings.barHeight / 2) or 0;

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -74,12 +74,33 @@ playerbar.DrawWindow = function(settings)
 	end
 
 	local SelfHP = party:GetMemberHP(0);
-	local SelfHPMax = player:GetHPMax();
-	-- Calculate percentage from actual values to avoid stale party API data (issue #92)
-	local SelfHPPercent = (SelfHPMax > 0) and math.clamp((SelfHP / SelfHPMax) * 100, 0, 100) or 0;
+	local SelfHPPercentParty = party:GetMemberHPPercent(0);
+	local SelfHPMaxPlayer = player:GetHPMax();
+	local SelfHPMaxFromParty = 0;
+	if SelfHPPercentParty and SelfHPPercentParty > 0 then
+		SelfHPMaxFromParty = math.floor((SelfHP * 100) / SelfHPPercentParty + 0.5);
+	end
+	local SelfHPMax = SelfHPMaxPlayer;
+	if SelfHPMaxFromParty > 0 then
+		if SelfHPMaxPlayer == 0 or math.abs(SelfHPMaxFromParty - SelfHPMaxPlayer) > 50 then
+			SelfHPMax = SelfHPMaxFromParty;
+		end
+	end
+	local SelfHPPercent = (SelfHPMax > 0) and math.clamp((SelfHP / SelfHPMax) * 100, 0, 100) or (SelfHPPercentParty or 0);
 	local SelfMP = party:GetMemberMP(0);
-	local SelfMPMax = player:GetMPMax();
-	local SelfMPPercent = (SelfMPMax > 0) and math.clamp((SelfMP / SelfMPMax) * 100, 0, 100) or 0;
+	local SelfMPPercentParty = party:GetMemberMPPercent(0);
+	local SelfMPMaxPlayer = player:GetMPMax();
+	local SelfMPMaxFromParty = 0;
+	if SelfMPPercentParty and SelfMPPercentParty > 0 then
+		SelfMPMaxFromParty = math.floor((SelfMP * 100) / SelfMPPercentParty + 0.5);
+	end
+	local SelfMPMax = SelfMPMaxPlayer;
+	if SelfMPMaxFromParty > 0 then
+		if SelfMPMaxPlayer == 0 or math.abs(SelfMPMaxFromParty - SelfMPMaxPlayer) > 20 then
+			SelfMPMax = SelfMPMaxFromParty;
+		end
+	end
+	local SelfMPPercent = (SelfMPMax > 0) and math.clamp((SelfMP / SelfMPMax) * 100, 0, 100) or (SelfMPPercentParty or 0);
 	local SelfTP = party:GetMemberTP(0);
 
 	local currentTime = os.clock();


### PR DESCRIPTION
- Resolves #147 
- Resolves #154 
- Resolves #155 
- Resolves #156 

---

Fixes bugs in posted in Jan 10-14, 2026
- Fixed Gil Tracker showing gil difference as gain or loss when switching characters.
- Fixed first load showing character gil as gained gil. Should now properly track characters as separate and start sessions at +0
- Fixed exp bar getting cut off if x scale width is too long, should now properly draw the bar.
- Fixed exp bar not being able to be dragged if x scale goes past screen width.
- Fixed bars not updating properly when level synced or weakened.