### PR TITLE
Extend timer when Familiar is cast

### DIFF
--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -239,6 +239,7 @@ data.PacketID = {
 data.ActionID = {
     CHARM = 0x34,
 };
+
 data.CharmState = {
     NONE = 0,
     SENDING_PACKET = 1,

--- a/XIUI/modules/petbar/init.lua
+++ b/XIUI/modules/petbar/init.lua
@@ -166,7 +166,6 @@ petbar.Initialize = function(settings)
             local category = struct.unpack('H', e.data, 0x0A + 0x01);
             local actionId = struct.unpack('H', e.data, 0x0C + 0x01);
 
-
             if (category == 0x09 and actionId == data.ActionID.CHARM) then
                 -- Validate: Player must not have a pet
                 if (data.petType ~= nil) then return; end


### PR DESCRIPTION
When casting Familiar we will add 25m to the timer. The time is random (25-30m) so using 25m to be safe. I have also updated the code to show how far overtime you are. Instead of stopping at 0 you will go negative and will stay red. This hopefully gets your blood boilin to get a new pet. 

<img width="278" height="182" alt="nagative" src="https://github.com/user-attachments/assets/1386a8c0-684a-4ee9-80fc-2ba8a7d2b1e6" />
