### PR TITLE
Fixed max HP/MP math and Added 'None' display option

### DIFF
--- a/XIUI/config/components.lua
+++ b/XIUI/config/components.lua
@@ -751,7 +751,8 @@ function components.DrawDisplayModeDropdown(label, parentTable, configKey, helpT
         percent = 'Percent Only',
         both = 'Number (Percent)',
         both_percent_first = 'Percent (Number)',
-        current_max = 'Current/Max'
+        current_max = 'Current/Max',
+        none = 'None'
     };
 
     local labelToMode = {
@@ -759,7 +760,8 @@ function components.DrawDisplayModeDropdown(label, parentTable, configKey, helpT
         ['Percent Only'] = 'percent',
         ['Number (Percent)'] = 'both',
         ['Percent (Number)'] = 'both_percent_first',
-        ['Current/Max'] = 'current_max'
+        ['Current/Max'] = 'current_max',
+        ['None'] = 'none'
     };
 
     local currentMode = parentTable[configKey] or 'number';
@@ -770,7 +772,8 @@ function components.DrawDisplayModeDropdown(label, parentTable, configKey, helpT
         'Percent Only',
         'Number (Percent)',
         'Percent (Number)',
-        'Current/Max'
+        'Current/Max',
+        'None'
     }, function(newLabel)
         parentTable[configKey] = labelToMode[newLabel];
         SaveSettingsOnly();

--- a/XIUI/config/partylist.lua
+++ b/XIUI/config/partylist.lua
@@ -102,11 +102,11 @@ local function DrawPartyTabContent(party, partyName)
 
         -- HP Display Mode dropdown
         components.DrawDisplayModeDropdown('HP Display##party' .. partyName, party, 'hpDisplayMode',
-            'How HP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), or current/max (1234/1500).');
+            'How HP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), current/max (1234/1500), or none.');
 
         -- MP Display Mode dropdown
         components.DrawDisplayModeDropdown('MP Display##party' .. partyName, party, 'mpDisplayMode',
-            'How MP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), or current/max (750/1000).');
+            'How MP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), current/max (750/1000), or none.');
 
         components.DrawPartyCheckbox(party, 'Always Show MP Bar', 'alwaysShowMpBar');
         imgui.ShowHelp('When disabled, hides the MP bar for jobs without MP (WAR, MNK, THF, etc.). Cast bars will still appear when casting.');

--- a/XIUI/config/playerbar.lua
+++ b/XIUI/config/playerbar.lua
@@ -39,11 +39,11 @@ function M.DrawSettings()
 
         -- HP Display Mode dropdown
         components.DrawDisplayModeDropdown('HP Display##playerBar', gConfig, 'playerBarHpDisplayMode',
-            'How HP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), or current/max (1234/1500).');
+            'How HP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), current/max (1234/1500), or none.');
 
         -- MP Display Mode dropdown
         components.DrawDisplayModeDropdown('MP Display##playerBar', gConfig, 'playerBarMpDisplayMode',
-            'How MP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), or current/max (750/1000).');
+            'How MP is displayed: number (1234), percent (100%), number first (1234 (100%)), percent first (100% (1234)), current/max (750/1000), or none.');
     end
 
     -- Text offsets section (collapsed by default)

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -135,6 +135,8 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         hpDisplayText = tostring(hpPercent) .. '% (' .. tostring(memInfo.hp) .. ')';
     elseif hpDisplayMode == 'current_max' then
         hpDisplayText = tostring(memInfo.hp) .. '/' .. tostring(memInfo.maxhp);
+    elseif hpDisplayMode == 'none' then
+        hpDisplayText = '';
     else
         hpDisplayText = tostring(memInfo.hp);
     end
@@ -153,6 +155,8 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         mpDisplayText = tostring(mpPercent) .. '% (' .. tostring(memInfo.mp) .. ')';
     elseif mpDisplayMode == 'current_max' then
         mpDisplayText = tostring(memInfo.mp) .. '/' .. tostring(memInfo.maxmp);
+    elseif mpDisplayMode == 'none' then
+        mpDisplayText = '';
     else
         mpDisplayText = tostring(memInfo.mp);
     end

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -507,6 +507,8 @@ playerbar.DrawWindow = function(settings)
 			hpDisplayText = string.format("%.0f", SelfHPPercent) .. '% (' .. tostring(SelfHP) .. ')';
 		elseif hpDisplayMode == 'current_max' then
 			hpDisplayText = tostring(SelfHP) .. '/' .. tostring(SelfHPMax);
+		elseif hpDisplayMode == 'none' then
+			hpDisplayText = '';
 		else
 			hpDisplayText = tostring(SelfHP);
 		end
@@ -553,6 +555,8 @@ playerbar.DrawWindow = function(settings)
 				mpDisplayText = string.format("%.0f", SelfMPPercent) .. '% (' .. tostring(SelfMP) .. ')';
 			elseif mpDisplayMode == 'current_max' then
 				mpDisplayText = tostring(SelfMP) .. '/' .. tostring(SelfMPMax);
+			elseif mpDisplayMode == 'none' then
+				mpDisplayText = '';
 			else
 				mpDisplayText = tostring(SelfMP);
 			end


### PR DESCRIPTION
- Resolves #136 
- Resolves #186 

---

- Add a new display mode "none" to hide HP/MP text in playerbar and partylist.
- Update configuration components and dropdowns to include the new option.
- Fix HP/MP max calculation for Player List Module to handle sync/weakness states more accurately