### PR TITLE
Add pet target anchor

### DIFF
--- a/XIUI/config/petbar.lua
+++ b/XIUI/config/petbar.lua
@@ -1084,12 +1084,20 @@ local function DrawPetTargetSettingsContent()
     imgui.ShowHelp('Show information about what the pet is targeting in a separate window.');
 
     components.DrawCheckbox('Snap to Pet Bar', 'petTargetSnapToPetBar');
-    imgui.ShowHelp('Position the pet target window directly below the pet bar.');
+    imgui.ShowHelp('Position the pet target window relative to the pet bar.');
 
     if gConfig.petTargetSnapToPetBar then
+        local anchorOptions = { 'Bottom', 'Top' };
+        local currentAnchor = (gConfig.petTargetSnapAnchor == 'top') and 'Top' or 'Bottom';
+        components.DrawComboBox('Anchor Point##petTargetSnap', currentAnchor, anchorOptions, function(newValue)
+            gConfig.petTargetSnapAnchor = (newValue == 'Top') and 'top' or 'bottom';
+            SaveSettingsOnly();
+        end);
+        imgui.ShowHelp('Bottom: offset from bottom of pet bar (shifts when buffs change height). Top: offset from top (stays fixed when buffs change height).');
+
         components.DrawSlider('Snap Offset X##petTargetSnap', 'petTargetSnapOffsetX', -200, 200);
         components.DrawSlider('Snap Offset Y##petTargetSnap', 'petTargetSnapOffsetY', -200, 200);
-        imgui.ShowHelp('Offset from top of pet bar. Stays fixed when buffs change the bar height.');
+        imgui.ShowHelp(string.format('Offset from %s of pet bar.', (gConfig.petTargetSnapAnchor == 'top') and 'top' or 'bottom'));
     end
 
     if components.CollapsingSection('Display Options##petTarget', false) then

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -821,8 +821,9 @@ function M.createUserSettingsDefaults()
 
         -- Pet Target snap to petbar (positions pet target directly below petbar)
         petTargetSnapToPetBar = true,        -- When enabled, pet target snaps below petbar
+        petTargetSnapAnchor = 'bottom',      -- 'bottom' = offset from bottom of pet bar, 'top' = offset from top (static when buffs change height)
         petTargetSnapOffsetX = 0,            -- Horizontal offset from petbar position
-        petTargetSnapOffsetY = 16,           -- Vertical offset below petbar (accounts for background border)
+        petTargetSnapOffsetY = 0,           -- Vertical offset below petbar (accounts for background border)
 
         -- Per-pet-type settings (Avatar, Charm, Jug, Automaton, Wyvern each have independent visual settings)
         petBarAvatar = factories.createPetBarTypeDefaults(),

--- a/XIUI/modules/petbar/pettarget.lua
+++ b/XIUI/modules/petbar/pettarget.lua
@@ -144,13 +144,15 @@ function pettarget.DrawWindow(settings)
     -- Get pet target specific color config
     local colorConfig = gConfig.colorCustomization and gConfig.colorCustomization.petTarget or {};
 
-    -- Handle snap to petbar positioning (Y offset is from top of pet bar so it stays static when buffs change height)
+    -- Handle snap to petbar positioning (anchor: bottom = offset from bottom, top = offset from top so it stays static when buffs change height)
     local snapEnabled = gConfig.petTargetSnapToPetBar;
-    if snapEnabled and data.lastMainWindowPosX ~= nil and data.lastMainWindowTop ~= nil then
+    local anchor = gConfig.petTargetSnapAnchor or 'bottom';
+    local anchorY = (anchor == 'top' and data.lastMainWindowTop) or data.lastMainWindowBottom;
+    if snapEnabled and data.lastMainWindowPosX ~= nil and anchorY ~= nil then
         local snapOffsetX = gConfig.petTargetSnapOffsetX or 0;
         local snapOffsetY = gConfig.petTargetSnapOffsetY or 4;
         local snapX = data.lastMainWindowPosX + snapOffsetX;
-        local snapY = data.lastMainWindowTop + snapOffsetY;
+        local snapY = anchorY + snapOffsetY;
         imgui.SetNextWindowPos({snapX, snapY}, ImGuiCond_Always);
     end
 


### PR DESCRIPTION
With the new pet buffs the main pet window will grow when buffs are applied. This will cause issues if people have the target bar anchored to the side. 

This change adds a anchor toggle to fix the anchor point to bottom (by default) or top. 

This should allow for customized target bars but having a single frame to drag.
<img width="406" height="224" alt="Screenshot 2026-02-11 054447" src="https://github.com/user-attachments/assets/7cc5417c-deb9-4374-ba4e-76714fa69f53" />
