### PR TITLE
Fix multiple running macro issue

### DIFF
--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -1434,8 +1434,7 @@ function M.DrawSlot(resources, params)
                 if params.onClick then
                     params.onClick();
                 elseif command then
-                    -- Default: execute the command (handles multi-line macros)
-                    actions.ExecuteCommandString(command);
+                    actions.ExecuteCommandString(command, bind and bind.actionType == 'macro');
                 end
             end
         end


### PR DESCRIPTION
Currently if you execute a macro it is not possible to cancel. This shows up a lot with crafting macros which are usually long with waits. You can also hit the action multiple times and it will result in multiple simultaneous execution. 

This change only allows a single macro flow to be executing at a time. Clicking a new/same macro will replace the current one if its still going. Other actions/spells will not interrupt a macro.