### PR TITLE
Fix pet target in preview mode and anchor settings

### DIFF
--- a/XIUI/config/petbar.lua
+++ b/XIUI/config/petbar.lua
@@ -1091,6 +1091,13 @@ local function DrawPetTargetSettingsContent()
         local currentAnchor = (gConfig.petTargetSnapAnchor == 'top') and 'Top' or 'Bottom';
         components.DrawComboBox('Anchor Point##petTargetSnap', currentAnchor, anchorOptions, function(newValue)
             gConfig.petTargetSnapAnchor = (newValue == 'Top') and 'top' or 'bottom';
+            if newValue == 'Top' then
+                gConfig.petTargetSnapOffsetX = 180;
+                gConfig.petTargetSnapOffsetY = 0;
+            else
+                gConfig.petTargetSnapOffsetX = 0;
+                gConfig.petTargetSnapOffsetY = 16;
+            end
             SaveSettingsOnly();
         end);
         imgui.ShowHelp('Bottom: offset from bottom of pet bar (shifts when buffs change height). Top: offset from top (stays fixed when buffs change height).');

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -823,7 +823,7 @@ function M.createUserSettingsDefaults()
         petTargetSnapToPetBar = true,        -- When enabled, pet target snaps below petbar
         petTargetSnapAnchor = 'bottom',      -- 'bottom' = offset from bottom of pet bar, 'top' = offset from top (static when buffs change height)
         petTargetSnapOffsetX = 0,            -- Horizontal offset from petbar position
-        petTargetSnapOffsetY = 0,           -- Vertical offset below petbar (accounts for background border)
+        petTargetSnapOffsetY = 16,           -- Vertical offset below petbar (accounts for background border)
 
         -- Per-pet-type settings (Avatar, Charm, Jug, Automaton, Wyvern each have independent visual settings)
         petBarAvatar = factories.createPetBarTypeDefaults(),


### PR DESCRIPTION
The new pet buffs will sometimes shift the pet window. This change allows for pet target to be anchored to top or bottom depending on where you want your display. This should also resolves the issue where the pet target is off screen and causing rendering issues.

Forgot to add to video, but non-anchor mode works as expected and you can move it around/play with it.

## Pet Target Window Not Visible in Preview Mode

### Problem

The pet target window did not appear when preview mode was enabled for the pet bar. This made it impossible to configure or reposition the pet target window without having an active pet in-game.

### Cause

`pettarget.DrawWindow()` checked `data.petTargetServerId` early and returned if it was `nil`. In preview mode there is no real pet or target, so this value is always `nil`, causing the window to never render.

### Fix

Changes in `XIUI/modules/petbar/pettarget.lua`:

- **Preview mode detection** — Added `isPreview` check using the same `showConfig[1] and gConfig.petBarPreview` pattern used throughout the pet bar module.
- **Mock target data** — When in preview mode, provides fake target values ("Goblin Mugger", 72% HP, 6.3 distance) instead of requiring real entity data. All real-data checks (petTargetServerId, entity lookup, self-targeting) are skipped.
- **Movable in preview** — Lock condition updated from `gConfig.lockPositions` to `gConfig.lockPositions and not isPreview` so the pet target window can be repositioned during preview, matching the main pet bar behavior.
- **Target data extraction refactored** — `targetName`, `targetHp`, `targetDistance`, `targetIndex` are now set in a preview/else branch before the rendering code, rather than extracted from `targetEnt` inside the `imgui.Begin` block. The non-preview path is functionally identical to the original.

### Additional Changes

**Default snap offsets** (`pettarget.lua`, `core/settings/user.lua`):
- `petTargetSnapOffsetY` default changed from `4`/`0` to `16` (better default for bottom anchor)

**Anchor toggle updates offsets** (`config/petbar.lua`):
- Switching to **Top** anchor sets snapOffsetX=180, snapOffsetY=0
- Switching to **Bottom** anchor sets snapOffsetX=0, snapOffsetY=16

Example:

https://github.com/user-attachments/assets/ce0c238a-9bb5-4303-876c-b2e034fcc622

