### PR TITLE
Fix window location issue

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -691,6 +691,9 @@ function CenterAllPositions()
     -- Force re-apply on next frame
     gConfig.appliedPositions = {};
 
+    -- Reset the config window position too
+    configMenu.ResetConfigWindowPosition();
+
     -- Save
     profileManager.SaveProfileSettings(config.currentProfile, gConfig);
     bInternalSave = true;
@@ -1318,6 +1321,13 @@ ashita.events.register('command', 'command_cb', function (e)
         -- ============================================
 
         if (command_args[2] == 'profile') then
+            -- /xiui profile reset positions
+            if (command_args[3] == 'reset' and command_args[4] == 'positions') then
+                CenterAllPositions();
+                print(chat.header(addon.name):append(chat.message('All UI positions reset to center.')));
+                return;
+            end
+
             -- /xiui profile reset
             if (command_args[3] == 'reset') then
                  configMenu.OpenResetSettingsPopup();

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -86,6 +86,7 @@ end
 -- State for confirmation dialogs
 local showRestoreDefaultsConfirm = false;
 local showResetPositionsConfirm = false;
+local pendingResetConfigWindow = false;
 
 -- Social icon textures
 local discordTexture = nil;
@@ -643,6 +644,11 @@ config.DrawWindow = function(us)
     PushThemeStyles();
 
     imgui.SetNextWindowSize({ 900, 650 }, ImGuiCond_FirstUseEver);
+    imgui.SetNextWindowPos({ 50, 50 }, ImGuiCond_FirstUseEver);
+    if pendingResetConfigWindow then
+        imgui.SetNextWindowPos({ 50, 50 }, ImGuiCond_Always);
+        pendingResetConfigWindow = false;
+    end
     if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
         local windowWidth = imgui.GetContentRegionAvail();
         local sidebarWidth = 180;
@@ -999,6 +1005,10 @@ end
 function config.OpenResetSettingsPopup()
     showConfig[1] = true;
     showRestoreDefaultsConfirm = true;
+end
+
+function config.ResetConfigWindowPosition()
+    pendingResetConfigWindow = true;
 end
 
 return config;


### PR DESCRIPTION
## Add "Center UI" Button to Reset All Element Positions

### Problem

When switching profiles or using unusual screen resolutions, UI elements can end up in off-screen or unexpected positions with no easy way to recover without resetting the entire profile (losing all customizations).

### Fix

Added a "Center UI" button in the config header bar (next to the existing reset button) that moves all UI elements to the center of the screen without touching any other settings.

- **Button** appears next to the reset (refresh) icon with matching height, with a help tooltip explaining what it does.
- **Confirmation popup** prevents accidental repositioning.
- **`CenterAllPositions()`** iterates every key in `gConfig.windowPositions` and sets them to screen center (`sw/2, sh/2`), then clears `appliedPositions` to force re-apply and saves the profile.
- Works for all modules including dynamically named windows (Hotbar1-6, Crossbar, notification groups, party lists, etc.) since it loops over whatever exists in the positions table.

### Config Window Default Position

The config window now defaults to `(50, 50)` on first open, ensuring it's always visible regardless of screen resolution. Previously it had no explicit default position and imgui would place it arbitrarily, which could put it off-screen on unusual resolutions.

### CLI

`/xiui profile reset positions` command can also be used to reset the elements positions.

### Files Changed

- `XIUI/config.lua` — Added `showResetPositionsConfirm` state, "Center UI" button, and confirmation popup
- `XIUI/XIUI.lua` — Added `CenterAllPositions()` function

## Example

https://github.com/user-attachments/assets/de2f6443-2b27-41d2-b0ae-5df5270c15b4

