### PR TITLE
Add defensive error handling for Linux/Wine crash prevention

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -927,67 +927,81 @@ end);
 * Event Handlers
 ]]--
 
+-- Rate-limited error logging for render errors (avoids chat spam)
+local lastPresentErrorTime = 0;
+local PRESENT_ERROR_INTERVAL = 60; -- seconds between error messages
+
 ashita.events.register('d3d_present', 'present_cb', function ()
     if not bInitialized then return; end
 
-    -- Clear internal save flag (deferred for Ashita 4.3+ async callbacks)
-    if bPendingInternalSaveClear then
-        bInternalSave = false;
-        bPendingInternalSaveClear = false;
-    end
+    local ok, err = pcall(function()
+        -- Clear internal save flag (deferred for Ashita 4.3+ async callbacks)
+        if bPendingInternalSaveClear then
+            bInternalSave = false;
+            bPendingInternalSaveClear = false;
+        end
 
-    -- Process pending profile change outside the render loop
-    if pendingProfileChange then
-        local name = pendingProfileChange;
-        pendingProfileChange = nil;
-        if ChangeProfile(name) then
-            if pendingProfileDeletion then
-                profileManager.DeleteProfile(pendingProfileDeletion);
-                pendingProfileDeletion = nil;
+        -- Process pending profile change outside the render loop
+        if pendingProfileChange then
+            local name = pendingProfileChange;
+            pendingProfileChange = nil;
+            if ChangeProfile(name) then
+                if pendingProfileDeletion then
+                    profileManager.DeleteProfile(pendingProfileDeletion);
+                    pendingProfileDeletion = nil;
+                end
             end
         end
-    end
 
-    -- Process pending visual updates outside the render loop
-    if pendingVisualUpdate then
-        pendingVisualUpdate = false;
-        statusHandler.clear_cache();
-        UpdateUserSettings();
-        uiModules.UpdateVisualsAll(gAdjustedSettings);
-    end
-
-    local eventSystemActive = gameState.GetEventSystemActive();
-    local menuOpen = gameState.IsMenuOpen();
-
-    if not gameState.ShouldHideUI(gConfig.hideDuringEvents, bLoggedIn) then
-        -- Sync treasure pool from memory (authoritative source of truth)
-        -- This ensures we never miss items, even if packets were dropped
-        if gConfig.showNotifications then
-            notifications.SyncTreasurePoolFromMemory();
-            -- Check pending pool items - creates "Treasure Pool" notification if item
-            -- hasn't been awarded (0x00D3) within 200ms of dropping (0x00D2)
-            notifications.CheckPendingPoolNotifications();
+        -- Process pending visual updates outside the render loop
+        if pendingVisualUpdate then
+            pendingVisualUpdate = false;
+            statusHandler.clear_cache();
+            UpdateUserSettings();
+            uiModules.UpdateVisualsAll(gAdjustedSettings);
         end
 
-        -- Render all registered modules
-        for name, _ in pairs(uiModules.GetAll()) do
-            uiModules.RenderModule(name, gConfig, gAdjustedSettings, eventSystemActive, menuOpen);
+        local eventSystemActive = gameState.GetEventSystemActive();
+        local menuOpen = gameState.IsMenuOpen();
+
+        if not gameState.ShouldHideUI(gConfig.hideDuringEvents, bLoggedIn) then
+            -- Sync treasure pool from memory (authoritative source of truth)
+            -- This ensures we never miss items, even if packets were dropped
+            if gConfig.showNotifications then
+                notifications.SyncTreasurePoolFromMemory();
+                -- Check pending pool items - creates "Treasure Pool" notification if item
+                -- hasn't been awarded (0x00D3) within 200ms of dropping (0x00D2)
+                notifications.CheckPendingPoolNotifications();
+            end
+
+            -- Render all registered modules
+            for name, _ in pairs(uiModules.GetAll()) do
+                uiModules.RenderModule(name, gConfig, gAdjustedSettings, eventSystemActive, menuOpen);
+            end
+
+            configMenu.DrawWindow();
+        else
+            uiModules.HideAll();
         end
 
-        configMenu.DrawWindow();
-    else
-        uiModules.HideAll();
-    end
-
-    -- XIUI DEV ONLY
-    if _XIUI_DEV_HOT_RELOADING_ENABLED then
-        local currentTime = os.time();
-        if not _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME then
-            _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME = currentTime;
+        -- XIUI DEV ONLY
+        if _XIUI_DEV_HOT_RELOADING_ENABLED then
+            local currentTime = os.time();
+            if not _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME then
+                _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME = currentTime;
+            end
+            if currentTime - _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME > _XIUI_DEV_HOT_RELOAD_POLL_TIME_SECONDS then
+                _check_hot_reload();
+                _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME = currentTime;
+            end
         end
-        if currentTime - _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME > _XIUI_DEV_HOT_RELOAD_POLL_TIME_SECONDS then
-            _check_hot_reload();
-            _XIUI_DEV_HOT_RELOAD_LAST_RELOAD_TIME = currentTime;
+    end);
+
+    if not ok then
+        local now = os.time();
+        if now - lastPresentErrorTime >= PRESENT_ERROR_INTERVAL then
+            lastPresentErrorTime = now;
+            print(chat.header(addon.name):append(chat.error('Render error: ' .. tostring(err))));
         end
     end
 end);
@@ -1522,6 +1536,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         TextureManager.clearOnZone();
         MarkPartyCacheDirty();
         ClearEntityCache();
+        ResetD3D8Device();
         bLoggedIn = true;
         -- Initialize hotbar job on zone-in (handles initial login and job change during zone)
         if gConfig.hotbarEnabled then
@@ -1569,6 +1584,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         treasurePool.HandleZonePacket();
         gilTracker.HandleZoneOutPacket(e);  -- Track zone-out/logout for login detection (issue #111)
         TextureManager.clearOnZone();
+        ResetD3D8Device();
         bLoggedIn = false;
         -- Also notify hotbar of zone (clears state)
         if gConfig.hotbarEnabled then

--- a/XIUI/core/moduleregistry.lua
+++ b/XIUI/core/moduleregistry.lua
@@ -3,6 +3,8 @@
 * Data-driven module management for initialization, rendering, cleanup, and visibility
 ]]--
 
+local chat = require('chat');
+
 local M = {};
 
 -- Module registry - defines all UI modules and their configuration
@@ -14,6 +16,10 @@ local M = {};
 --   hideOnMenuFocusKey: config key for hiding when game menu is open (optional)
 --   hasSetHidden: whether module has SetHidden function
 local registry = {};
+
+-- Rate-limited per-module error tracking
+local moduleErrorTimes = {};
+local MODULE_ERROR_INTERVAL = 60;
 
 function M.Register(name, config)
     registry[name] = config;
@@ -107,7 +113,14 @@ function M.RenderModule(name, gConfig, gAdjustedSettings, eventSystemActive, men
             entry.module.SetHidden(false);
         end
         if entry.module.DrawWindow then
-            entry.module.DrawWindow(gAdjustedSettings[entry.settingsKey]);
+            local ok, err = pcall(entry.module.DrawWindow, gAdjustedSettings[entry.settingsKey]);
+            if not ok then
+                local now = os.time();
+                if not moduleErrorTimes[name] or (now - moduleErrorTimes[name] >= MODULE_ERROR_INTERVAL) then
+                    moduleErrorTimes[name] = now;
+                    print(chat.header('XIUI'):append(chat.error('Module \'' .. name .. '\' error: ' .. tostring(err))));
+                end
+            end
         end
         return true;
     else

--- a/XIUI/handlers/helpers.lua
+++ b/XIUI/handlers/helpers.lua
@@ -88,6 +88,7 @@ CURE_SPELLS = fastcastLib.CURE_SPELLS;
 
 -- Memory Accessors (from memory.lua)
 GetD3D8Device = memoryLib.GetD3D8Device;
+ResetD3D8Device = memoryLib.ResetD3D8Device;
 GetPlayerSafe = memoryLib.GetPlayerSafe;
 GetPartySafe = memoryLib.GetPartySafe;
 GetEntitySafe = memoryLib.GetEntitySafe;

--- a/XIUI/libs/fonts.lua
+++ b/XIUI/libs/fonts.lua
@@ -3,9 +3,25 @@
 * FontManager, ColorCachedFont, and font helper functions
 ]]--
 
+local chat = require('chat');
 local gdi = require('submodules.gdifonts.include');
 
 local M = {};
+
+-- Wrap gdi:create_object in pcall to prevent crashes from font failures (e.g., missing fonts on Linux/Wine)
+local fontCreateErrorLogged = false;
+local function safeCreateObject(settings)
+    local ok, result = pcall(gdi.create_object, gdi, settings);
+    if ok then
+        return result;
+    end
+    if not fontCreateErrorLogged then
+        fontCreateErrorLogged = true;
+        print(chat.header('XIUI'):append(chat.error('Font creation failed: ' .. tostring(result))));
+        print(chat.header('XIUI'):append(chat.error('If on Linux/Wine, install corefonts and gdiplus via winetricks.')));
+    end
+    return nil;
+end
 
 -- ========================================
 -- Font Registry (for lightweight property updates)
@@ -59,7 +75,7 @@ end
 M.FontManager = {
     -- Create a single font object (registered for batch updates)
     create = function(settings)
-        local fontObj = gdi:create_object(settings);
+        local fontObj = safeCreateObject(settings);
         if fontObj then
             fontObj._registryId = registerFont(fontObj);
         end
@@ -81,7 +97,7 @@ M.FontManager = {
             unregisterFont(fontObj._registryId);
             gdi:destroy_object(fontObj);
         end
-        local newFont = gdi:create_object(settings);
+        local newFont = safeCreateObject(settings);
         if newFont then
             newFont._registryId = registerFont(newFont);
         end
@@ -92,7 +108,7 @@ M.FontManager = {
     createBatch = function(fontSettingsTable)
         local fonts = {};
         for key, settings in pairs(fontSettingsTable) do
-            local fontObj = gdi:create_object(settings);
+            local fontObj = safeCreateObject(settings);
             if fontObj then
                 fontObj._registryId = registerFont(fontObj);
             end

--- a/XIUI/libs/memory.lua
+++ b/XIUI/libs/memory.lua
@@ -23,6 +23,12 @@ function M.GetD3D8Device()
     return d3d8dev;
 end
 
+-- Force re-fetch of D3D device on next access.
+-- Call on zone changes to handle potential device resets under Wine/Proton.
+function M.ResetD3D8Device()
+    d3d8dev = nil;
+end
+
 -- ========================================
 -- Safe Memory Access Functions
 -- ========================================


### PR DESCRIPTION
## Summary

Addresses #216 — Linux users experiencing EXCEPTION_ACCESS_VIOLATION (C0000005) crashes in the `d3d_present` event handler.

This adds defense-in-depth error handling so that crashes under Wine/Proton become recoverable log messages instead of client-killing ACCESS_VIOLATIONs.

## Changes

- **pcall around d3d_present** (`XIUI.lua`) — wraps the entire render frame body; any error is caught and logged (rate-limited to once per 60s)
- **pcall around module DrawWindow** (`core/moduleregistry.lua`) — isolates per-module crashes so one broken module doesn't take down the rest of the UI
- **pcall around font creation** (`libs/fonts.lua`) — catches `error()` thrown by gdifonts when the GDI interface is missing (e.g., fonts not installed on Linux). Logs a one-time message with the fix (install corefonts/gdiplus via winetricks)
- **D3D device cache invalidation** (`libs/memory.lua`, `handlers/helpers.lua`, `XIUI.lua`) — resets the cached D3D8 device pointer on zone-in (0x00A) and zone-out (0x00B) to prevent stale device pointers after Wine/Proton device resets

## Impact

- **No behavioral change on Windows** — pcall paths only activate when something actually errors
- **On Linux with missing fonts** — text won't render but bars/icons/backgrounds continue working; log message tells user to install fonts
- **On Linux with zone transition crashes** — stale D3D device pointer is cleared and re-fetched next frame

~30 lines of new code across 5 files. No submodule modifications.