### PR TITLE
Move Center UI button to Global > General settings

### DIFF
--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -85,7 +85,6 @@ end
 
 -- State for confirmation dialogs
 local showRestoreDefaultsConfirm = false;
-local showResetPositionsConfirm = false;
 local pendingResetConfigWindow = false;
 
 -- Social icon textures
@@ -719,13 +718,6 @@ config.DrawWindow = function(us)
         imgui.ShowHelp('Reset current profile settings.');
 
         imgui.SameLine();
-        if imgui.Button('Center UI', { 0, boxSize }) then
-            showResetPositionsConfirm = true;
-        end
-        imgui.SameLine();
-        imgui.ShowHelp('Move all UI elements to the center of the screen.');
-
-        imgui.SameLine();
         imgui.SetCursorPosX(windowWidth - (boxSize * 3) - (boxSpacing * 2));
 
         -- Discord button
@@ -796,30 +788,6 @@ config.DrawWindow = function(us)
             if (imgui.Button("Confirm", { 120, 0 })) then
                 ResetSettings();
                 UpdateSettings();
-                imgui.CloseCurrentPopup();
-            end
-            imgui.SameLine();
-            if (imgui.Button("Cancel", { 120, 0 })) then
-                imgui.CloseCurrentPopup();
-            end
-
-            imgui.EndPopup();
-        end
-
-        -- Reset Positions confirmation popup
-        if (showResetPositionsConfirm) then
-            imgui.OpenPopup("Confirm Center UI");
-            showResetPositionsConfirm = false;
-        end
-
-        if (imgui.BeginPopupModal("Confirm Center UI", true, ImGuiWindowFlags_AlwaysAutoResize)) then
-            anyModalOpen = true;
-            imgui.Text("Move all UI elements to the center of the screen?");
-            imgui.Text("This only affects positions, not your other settings.");
-            imgui.NewLine();
-
-            if (imgui.Button("Confirm", { 120, 0 })) then
-                CenterAllPositions();
                 imgui.CloseCurrentPopup();
             end
             imgui.SameLine();

--- a/XIUI/config/global.lua
+++ b/XIUI/config/global.lua
@@ -14,6 +14,9 @@ local M = {};
 -- Local state for profile creation/management
 -- (Moved to config.lua)
 
+-- Center UI confirmation state
+local showCenterUIConfirm = false;
+
 -- Section: Global Settings (combines General, Font, and Bar settings)
 function M.DrawSettings()
     if components.CollapsingSection('General##global') then
@@ -41,6 +44,36 @@ function M.DrawSettings()
         imgui.ShowHelp('Scales the size of the tooltip. Note that text may appear blured if scaled too large.');
 
         components.DrawCheckbox('Hide During Events', 'hideDuringEvents');
+
+        imgui.Spacing();
+        if imgui.Button('Center UI') then
+            showCenterUIConfirm = true;
+        end
+        imgui.SameLine();
+        imgui.ShowHelp('Move all UI elements to the center of the screen.');
+
+        -- Center UI confirmation popup
+        if showCenterUIConfirm then
+            imgui.OpenPopup("Confirm Center UI");
+            showCenterUIConfirm = false;
+        end
+
+        if (imgui.BeginPopupModal("Confirm Center UI", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+            imgui.Text("Move all UI elements to the center of the screen?");
+            imgui.Text("This only affects positions, not your other settings.");
+            imgui.NewLine();
+
+            if (imgui.Button("Confirm", { 120, 0 })) then
+                CenterAllPositions();
+                imgui.CloseCurrentPopup();
+            end
+            imgui.SameLine();
+            if (imgui.Button("Cancel", { 120, 0 })) then
+                imgui.CloseCurrentPopup();
+            end
+
+            imgui.EndPopup();
+        end
     end
 
     if components.CollapsingSection('Text Settings##global') then


### PR DESCRIPTION
## Summary
- Moves the "Center UI" button from the config top bar into the Global > General settings section
- Keeps the same confirmation popup behavior