### PR TITLE
Add xiui-icons as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 CLAUDE.md
 ai-docs/
 ai-docs/*
+ai/
+ai/*
 XIUI/docs/*
 
 # Custom item icons (user-provided)

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "XIUI/submodules/mobdb"]
 	path = XIUI/submodules/mobdb
 	url = https://github.com/ThornyFFXI/mobdb.git
+[submodule "XIUI/submodules/xiui-icons"]
+	path = XIUI/submodules/xiui-icons
+	url = https://github.com/Vincerno/xiui-icons.git


### PR DESCRIPTION
## Summary
- Register `XIUI/submodules/xiui-icons` as a proper Git submodule (was previously an embedded repo)
- Add `ai/` directory to `.gitignore`