### PR TITLE
Add per-entity-type HP bar color customization for target bar and ToT

### DIFF
--- a/XIUI/config/targetbar.lua
+++ b/XIUI/config/targetbar.lua
@@ -64,6 +64,8 @@ local function DrawTargetBarSettingsContent()
             imgui.ShowHelp('Also show HP% for NPCs, players, and other non-monster targets.');
             imgui.Unindent(20);
         end
+        components.DrawCheckbox('Color HP Bar by Target Type', 'targetBarHpColorByType');
+        imgui.ShowHelp('Use different HP bar colors for party members, other players, NPCs, and mobs.\nConfigure colors in the Color Settings tab.');
         components.DrawCheckbox('Show Bookends', 'showTargetBarBookends');
         components.DrawCheckbox('Show Lock On', 'showTargetBarLockOnBorder');
         imgui.ShowHelp('Display the lock icon and colored border when locked on to a target.');
@@ -383,7 +385,14 @@ end
 -- Helper: Draw Target Bar specific color settings (used in tab)
 local function DrawTargetBarColorSettingsContent()
     if components.CollapsingSection('Bar Colors##targetBarColor') then
-        components.DrawGradientPicker("Target HP Bar", gConfig.colorCustomization.targetBar.hpGradient, "Target HP bar color");
+        if gConfig.targetBarHpColorByType then
+            components.DrawGradientPicker("HP Bar: Party Member", gConfig.colorCustomization.targetBar.hpGradientPartyPlayer, "HP bar color when targeting a party/alliance member");
+            components.DrawGradientPicker("HP Bar: Other Player", gConfig.colorCustomization.targetBar.hpGradientOtherPlayer, "HP bar color when targeting a non-party player");
+            components.DrawGradientPicker("HP Bar: NPC", gConfig.colorCustomization.targetBar.hpGradientNpc, "HP bar color when targeting an NPC");
+            components.DrawGradientPicker("HP Bar: Monster", gConfig.colorCustomization.targetBar.hpGradientMob, "HP bar color when targeting a monster");
+        else
+            components.DrawGradientPicker("Target HP Bar", gConfig.colorCustomization.targetBar.hpGradient, "Target HP bar color");
+        end
         if (not HzLimitedMode) then
             components.DrawGradientPicker("Cast Bar", gConfig.colorCustomization.targetBar.castBarGradient, "Enemy cast bar color");
         end
@@ -398,7 +407,14 @@ local function DrawTargetBarColorSettingsContent()
     end
 
     if components.CollapsingSection('Target of Target##targetBarColor') then
-        components.DrawGradientPicker("ToT HP Bar", gConfig.colorCustomization.totBar.hpGradient, "Target of Target HP bar color");
+        if gConfig.targetBarHpColorByType then
+            components.DrawGradientPicker("ToT HP: Party Member", gConfig.colorCustomization.totBar.hpGradientPartyPlayer, "ToT HP bar color for party/alliance members");
+            components.DrawGradientPicker("ToT HP: Other Player", gConfig.colorCustomization.totBar.hpGradientOtherPlayer, "ToT HP bar color for non-party players");
+            components.DrawGradientPicker("ToT HP: NPC", gConfig.colorCustomization.totBar.hpGradientNpc, "ToT HP bar color for NPCs");
+            components.DrawGradientPicker("ToT HP: Monster", gConfig.colorCustomization.totBar.hpGradientMob, "ToT HP bar color for monsters");
+        else
+            components.DrawGradientPicker("ToT HP Bar", gConfig.colorCustomization.totBar.hpGradient, "Target of Target HP bar color");
+        end
         imgui.ShowHelp("ToT name text color is set dynamically based on target type");
     end
 end

--- a/XIUI/core/settings/colors.lua
+++ b/XIUI/core/settings/colors.lua
@@ -36,6 +36,11 @@ function M.createColorCustomizationDefaults()
             castBarGradient = T{ enabled = true, start = '#ffaa00', stop = '#ffcc44' },
             distanceTextColor = 0xFFFFFFFF,
             castTextColor = 0xFFFFAA00,  -- Orange color for enemy casting
+            -- Per-entity-type HP bar gradients (used when targetBarHpColorByType is enabled)
+            hpGradientPartyPlayer = T{ enabled = true, start = '#3898ce', stop = '#78c4ee' },    -- Blue/teal
+            hpGradientOtherPlayer = T{ enabled = true, start = '#8888cc', stop = '#aaaaee' },    -- Lavender
+            hpGradientNpc = T{ enabled = true, start = '#5aab5a', stop = '#7dcf7d' },            -- Green
+            hpGradientMob = T{ enabled = true, start = '#e26c6c', stop = '#fb9494' },            -- Red-pink (same as default)
             -- Note: HP percent text color is set dynamically based on HP amount
             -- Note: Entity name colors are in shared section
         },
@@ -43,6 +48,11 @@ function M.createColorCustomizationDefaults()
         -- Target of Target Bar
         totBar = T{
             hpGradient = T{ enabled = true, start = '#e16c6c', stop = '#fb9494' },
+            -- Per-entity-type HP bar gradients (used when targetBarHpColorByType is enabled)
+            hpGradientPartyPlayer = T{ enabled = true, start = '#3898ce', stop = '#78c4ee' },
+            hpGradientOtherPlayer = T{ enabled = true, start = '#8888cc', stop = '#aaaaee' },
+            hpGradientNpc = T{ enabled = true, start = '#5aab5a', stop = '#7dcf7d' },
+            hpGradientMob = T{ enabled = true, start = '#e16c6c', stop = '#fb9494' },
         },
 
         -- Subtarget Bar

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -289,6 +289,7 @@ function M.createUserSettingsDefaults()
         showEnemyId = false,
         showEnemyIdHex = true,
         targetBarHideDuringEvents = true,
+        targetBarHpColorByType = false,  -- Use different HP bar colors per entity type
         splitTargetOfTarget = false,
         totBarScaleX = 1,
         totBarScaleY = 1,

--- a/XIUI/modules/targetbar.lua
+++ b/XIUI/modules/targetbar.lua
@@ -67,6 +67,21 @@ local function IsPet(idx, pEnt)
 	return pEnt and pEnt.PetTargetIndex and pEnt.PetTargetIndex ~= 0 and idx == pEnt.PetTargetIndex;
 end
 
+-- Get HP gradient key based on entity type (for per-type HP bar coloring)
+local function GetEntityHpGradientKey(entity, index)
+	if entity == nil then return 'hpGradientMob'; end
+	local flag = entity.SpawnFlags;
+	if bit.band(flag, SPAWN_FLAG_PLAYER) == SPAWN_FLAG_PLAYER then
+		if IsMemberOfParty(index) then
+			return 'hpGradientPartyPlayer';
+		end
+		return 'hpGradientOtherPlayer';
+	elseif bit.band(flag, SPAWN_FLAG_NPC) == SPAWN_FLAG_NPC then
+		return 'hpGradientNpc';
+	end
+	return 'hpGradientMob';
+end
+
 local _XIUI_DEV_DEBUG_INTERPOLATION = false;
 local _XIUI_DEV_DEBUG_INTERPOLATION_DELAY = 1;
 local _XIUI_DEV_DEBUG_HP_PERCENT_PERSISTENT = 100;
@@ -322,7 +337,12 @@ targetbar.DrawWindow = function(settings)
 			end
 		end
 
-		local targetGradient = GetCustomGradient(gConfig.colorCustomization.targetBar, 'hpGradient') or {'#e26c6c', '#fb9494'};
+		-- Select HP gradient: per-type if enabled, otherwise single gradient
+		local gradientKey = 'hpGradient';
+		if gConfig.targetBarHpColorByType then
+			gradientKey = GetEntityHpGradientKey(targetEntity, targetIndex);
+		end
+		local targetGradient = GetCustomGradient(gConfig.colorCustomization.targetBar, gradientKey) or {'#e26c6c', '#fb9494'};
 		local hpGradientStart = targetGradient[1];
 		local hpGradientEnd = targetGradient[2];
 
@@ -722,7 +742,11 @@ targetbar.DrawWindow = function(settings)
 				local totTextPadding = 8;
 
 				-- Get interpolated HP data for ToT bar using shared helper
-				local totGradient = GetCustomGradient(gConfig.colorCustomization.totBar, 'hpGradient') or {'#e16c6c', '#fb9494'};
+				local totGradientKey = 'hpGradient';
+				if gConfig.targetBarHpColorByType then
+					totGradientKey = GetEntityHpGradientKey(totEntity, totIndex);
+				end
+				local totGradient = GetCustomGradient(gConfig.colorCustomization.totBar, totGradientKey) or {'#e16c6c', '#fb9494'};
 				local totHpPercentData = HpInterpolation.update('tot', totEntity.HPPercent, totIndex, settings, currentTime, totGradient);
 				progressbar.ProgressBar(totHpPercentData, {settings.barWidth / 3, settings.totBarHeight}, {decorate = gConfig.showTargetBarBookends});
 				-- Submit a dummy item to properly extend window bounds after SetCursorScreenPos
@@ -950,7 +974,11 @@ targetbar.DrawWindow = function(settings)
 				local totTextPaddingSplit = 8;
 
 				-- Get interpolated HP data for split ToT bar using shared helper
-				local totGradientSplit = GetCustomGradient(gConfig.colorCustomization.totBar, 'hpGradient') or {'#e16c6c', '#fb9494'};
+				local totGradientKeySplit = 'hpGradient';
+				if gConfig.targetBarHpColorByType then
+					totGradientKeySplit = GetEntityHpGradientKey(totEntity, totIndex);
+				end
+				local totGradientSplit = GetCustomGradient(gConfig.colorCustomization.totBar, totGradientKeySplit) or {'#e16c6c', '#fb9494'};
 				local totHpPercentDataSplit = HpInterpolation.update('tot', totEntity.HPPercent, totIndex, settings, currentTime, totGradientSplit);
 				progressbar.ProgressBar(totHpPercentDataSplit, {settings.totBarWidth, settings.totBarHeightSplit}, {decorate = gConfig.showTargetBarBookends});
 


### PR DESCRIPTION
## Summary
- Adds a new **"Color HP Bar by Target Type"** option under Target Bar > Display Options
- When enabled, the target bar and target-of-target bar use different HP bar gradient colors based on entity type: party member (blue), other player (lavender), NPC (green), monster (red-pink)
- All per-type colors are fully customizable via gradient pickers in the Color Settings tab
- Off by default for backwards compatibility; existing single-gradient behavior is unchanged

Closes #260