### PR TITLE
Add enemy list background opacity and widen offset ranges

### DIFF
--- a/XIUI/config/enemylist.lua
+++ b/XIUI/config/enemylist.lua
@@ -68,19 +68,26 @@ function M.DrawSettings()
         if (gConfig.showEnemyListDebuffs) then
             components.DrawLeftRightAnchorDropdown('Debuff Anchor', gConfig, 'enemyListDebuffsAnchor',
                 'Which side of the enemy entry to anchor debuff icons.');
-            components.DrawSlider('Debuff Offset X', 'enemyListDebuffOffsetX', -100, 200);
+            components.DrawSlider('Debuff Offset X', 'enemyListDebuffOffsetX', -500, 500);
             imgui.ShowHelp('Horizontal offset for debuff icons from the anchor edge.');
-            components.DrawSlider('Debuff Offset Y', 'enemyListDebuffOffsetY', -100, 200);
+            components.DrawSlider('Debuff Offset Y', 'enemyListDebuffOffsetY', -500, 500);
             imgui.ShowHelp('Vertical offset for debuff icons from top of entry.');
             components.DrawSlider('Status Effect Icon Size', 'enemyListIconScale', 0.1, 3.0, '%.1f');
         end
     end
 
+    if components.CollapsingSection('Background##enemyList') then
+        components.DrawSlider('Entry Background Opacity', 'enemyListBackgroundOpacity', 0.0, 1.0, '%.2f');
+        imgui.ShowHelp('Opacity of the background behind each enemy entry. Set to 0 to hide.');
+        components.DrawSlider('Target Background Opacity', 'enemyListTargetBackgroundOpacity', 0.0, 1.0, '%.2f');
+        imgui.ShowHelp('Opacity of the background behind enemy target containers. Set to 0 to hide.');
+    end
+
     if components.CollapsingSection('Enemy Targets##enemyList', false) then
         if (gConfig.showEnemyListTargets) then
-            components.DrawSlider('Target Offset X', 'enemyListTargetOffsetX', -100, 200);
+            components.DrawSlider('Target Offset X', 'enemyListTargetOffsetX', -500, 500);
             imgui.ShowHelp('Horizontal offset for enemy target container from the enemy entry.');
-            components.DrawSlider('Target Offset Y', 'enemyListTargetOffsetY', -100, 100);
+            components.DrawSlider('Target Offset Y', 'enemyListTargetOffsetY', -500, 500);
             imgui.ShowHelp('Vertical offset for enemy target container.');
             components.DrawSlider('Target Width', 'enemyListTargetWidth', 50, 200);
             imgui.ShowHelp('Width of the enemy target container.');
@@ -104,7 +111,8 @@ function M.DrawColorSettings()
     end
 
     if components.CollapsingSection('Background Colors##enemyListColor') then
-        components.DrawTextColorPicker("Background", gConfig.colorCustomization.enemyList, 'backgroundColor', "Background color for list entries");
+        components.DrawTextColorPicker("Entry Background", gConfig.colorCustomization.enemyList, 'backgroundColor', "Background color for enemy list entries");
+        components.DrawTextColorPicker("Target Background", gConfig.colorCustomization.enemyList, 'targetBackgroundColor', "Background color for enemy target containers");
         components.DrawTextColorPicker("Default Border", gConfig.colorCustomization.enemyList, 'borderColor', "Default border color for enemies");
         components.DrawTextColorPicker("Target Border", gConfig.colorCustomization.enemyList, 'targetBorderColor', "Border color for currently targeted enemy");
         components.DrawTextColorPicker("Subtarget Border", gConfig.colorCustomization.enemyList, 'subtargetBorderColor', "Border color for subtargeted enemy");

--- a/XIUI/core/settings/colors.lua
+++ b/XIUI/core/settings/colors.lua
@@ -67,6 +67,7 @@ function M.createColorCustomizationDefaults()
             distanceTextColor = 0xFFFFFFFF,
             percentTextColor = 0xFFFFFFFF,
             backgroundColor = 0x66000000,        -- Semi-transparent black - Alpha is the first byte: 0.4 * 255 = 102 = 0x66
+            targetBackgroundColor = 0x66000000,  -- Target container background (defaults to same as entry background)
             borderColor = 0x00000000,            -- transparent black - default border
             targetBorderColor = 0xFFFFFFFF,      -- white - border for main target
             subtargetBorderColor = 0xFF8080FF,   -- blue - border for subtarget

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -317,6 +317,9 @@ function M.createUserSettingsDefaults()
         showEnemyListBookends = false,
         showEnemyListBorders = true,
         showEnemyListBordersUseNameColor = false,
+        -- Enemy list background opacity
+        enemyListBackgroundOpacity = 1.0,
+        enemyListTargetBackgroundOpacity = 1.0,
         -- Enemy target container settings
         enemyListTargetOffsetX = 0,
         enemyListTargetOffsetY = 43,

--- a/XIUI/modules/enemylist.lua
+++ b/XIUI/modules/enemylist.lua
@@ -17,8 +17,14 @@ local lastSavedPosX, lastSavedPosY = nil, nil;
 -- Note: RENDER_FLAG_VISIBLE and RENDER_FLAG_HIDDEN are now imported from helpers.lua
 
 -- Background rendering constants
-local bgAlpha = 0.4;
 local bgRadius = 3;
+
+-- Apply opacity to an ARGB color by replacing its alpha byte
+local function ApplyOpacityToColor(color, opacity)
+	local alphaByte = math.floor((opacity or 1.0) * 255);
+	local rgb = bit.band(color or 0xFFFFFFFF, 0x00FFFFFF);
+	return bit.bor(bit.lshift(alphaByte, 24), rgb);
+end
 
 -- Layout constants
 local windowMargin = 6;  -- Extra margin around window content to prevent clipping
@@ -371,7 +377,12 @@ enemylist.DrawWindow = function(settings)
 					bg.position_y = entryStartY;
 					bg.width = entryWidth;
 					bg.height = entryHeight;
-					bg.color = gConfig.colorCustomization.enemyList.backgroundColor;
+					local bgColor = gConfig.colorCustomization.enemyList.backgroundColor;
+					local bgOpacity = gConfig.enemyListBackgroundOpacity;
+					if (bgOpacity ~= nil and bgOpacity < 1.0) then
+						bgColor = ApplyOpacityToColor(bgColor, bgOpacity);
+					end
+					bg.color = bgColor;
 					bg.visible = true;
 				end
 
@@ -567,8 +578,12 @@ enemylist.DrawWindow = function(settings)
 							targetBg.position_y = targetContainerY;
 							targetBg.width = targetWidth;
 							targetBg.height = targetTotalHeight;
-							-- Semi-transparent black (0.4 alpha * 255 = 102 = 0x66)
-							targetBg.color = 0x66000000;
+							local targetBgColor = gConfig.colorCustomization.enemyList.targetBackgroundColor or gConfig.colorCustomization.enemyList.backgroundColor;
+							local targetBgOpacity = gConfig.enemyListTargetBackgroundOpacity;
+							if (targetBgOpacity ~= nil and targetBgOpacity < 1.0) then
+								targetBgColor = ApplyOpacityToColor(targetBgColor, targetBgOpacity);
+							end
+							targetBg.color = targetBgColor;
 							targetBg.visible = true;
 						end
 


### PR DESCRIPTION
## Summary
Addresses #229 — adds background transparency controls and more positioning freedom for the enemy list module.

## Changes
- **Background opacity sliders** — Separate `Entry Background Opacity` and `Target Background Opacity` sliders (0.0–1.0) in a new "Background" config section. Set to 0 to fully hide backgrounds.
- **Target container background color** — Was hardcoded to `0x66000000`; now reads from a new `targetBackgroundColor` color setting (with its own color picker in the Colors tab).
- **Wider offset ranges** — Target Offset X/Y and Debuff Offset X/Y sliders expanded from `[-100, 200]` to `[-500, 500]` for much more positioning freedom.
- **Cleanup** — Removed unused `bgAlpha` constant that was declared but never referenced.

## Files Changed
| File | What changed |
|------|-------------|
| `modules/enemylist.lua` | Added `ApplyOpacityToColor()` helper, use opacity settings for both backgrounds, removed `bgAlpha` |
| `config/enemylist.lua` | New "Background" section with opacity sliders, widened offset ranges, added target bg color picker |
| `core/settings/user.lua` | Added `enemyListBackgroundOpacity` and `enemyListTargetBackgroundOpacity` defaults |
| `core/settings/colors.lua` | Added `targetBackgroundColor` default |

Closes #229