### PR TITLE
Fix Cast Cost not tracking mount cooldown

### DIFF
--- a/XIUI/modules/castcost/data.lua
+++ b/XIUI/modules/castcost/data.lua
@@ -271,14 +271,33 @@ function M.GetAbilityInfo(abilityId)
     };
 end
 
+-- Mount recast cooldown is always 60 seconds in FFXI
+local MOUNT_MAX_RECAST = 60;
+
+-- Get mount recast timer via IPlayer (returns remaining seconds, or 0 if ready)
+function M.GetMountRecast()
+    local player = GetPlayerSafe();
+    if player == nil then return 0; end
+
+    local timer = player:GetMountRecast();
+    if timer == nil or timer <= 0 then return 0; end
+
+    -- Convert from 1/60th seconds to seconds (same format as other recasts)
+    return timer / 60;
+end
+
 function M.GetMountInfo(mountId)
     if mountId == nil or mountId < 0 then return nil; end
     local mountName = AshitaCore:GetResourceManager():GetString('mounts.names', mountId);
     if mountName == nil then return nil; end
 
+    local currentRecast = M.GetMountRecast();
+
     return {
         id = mountId,
         name = encoding:ShiftJIS_To_UTF8(mountName, true),
+        currentRecast = currentRecast,
+        maxRecast = MOUNT_MAX_RECAST,
     };
 end
 

--- a/XIUI/modules/castcost/display.lua
+++ b/XIUI/modules/castcost/display.lua
@@ -268,8 +268,12 @@ function M.Render(itemInfo, itemType, settings, colors)
         end
 
     elseif itemType == 'mount' then
-        -- Mount: Just show name
-        -- No additional info needed
+        -- Mount: Show name + cooldown
+        if isOnCooldown and itemInfo.maxRecast and itemInfo.maxRecast > 0 then
+            cooldownPercent = 1 - (itemInfo.currentRecast / itemInfo.maxRecast);
+            cooldownPercent = math.clamp(cooldownPercent, 0, 1);
+            cooldownText = formatCooldown(itemInfo.currentRecast);
+        end
     end
 
     -- Set up ImGui window


### PR DESCRIPTION
## Summary

Fixes #249

- Read mount recast timer from `IPlayer:GetMountRecast()` and populate `currentRecast`/`maxRecast` fields in `GetMountInfo()`
- Display the cooldown progress bar and timer text in the Cast Cost overlay when a mount is on cooldown
- Mount name is greyed out while on cooldown, matching spell/ability behavior

## Details

The Cast Cost module already had full cooldown rendering infrastructure (progress bar, timer text, greyed-out name). The only missing piece was the data layer — `GetMountInfo()` wasn't reading mount recast from the Ashita SDK's `IPlayer` interface, so the display layer had nothing to render.

Mount recast is always 60 seconds in FFXI and is stored separately from spell/ability recasts on the `IPlayer` object (via `mountrecast_t`).