### PR TITLE
Added Config Window Position/Size Reset

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -481,6 +481,49 @@ end
 
 gConfig.appliedPositions = {};
 
+-- Forward-declare GetDefaultWindowPositions so it can be used at load time
+local function GetDefaultWindowPositions()
+    local defPos = require('libs.defaultpositions');
+    local px, py = defPos.GetPlayerBarPosition();
+    local tx, ty = defPos.GetTargetBarPosition();
+    local pl1x, pl1y = defPos.GetPartyListPosition();
+    local pl2x, pl2y = defPos.GetPartyList2Position();
+    local pl3x, pl3y = defPos.GetPartyList3Position();
+    local cx, cy = defPos.GetCastBarPosition();
+    local nx, ny = defPos.GetNotificationsPosition();
+    local tpx, tpy = defPos.GetTreasurePoolPosition();
+    local petx, pety = defPos.GetPetBarPosition();
+    local ex, ey = defPos.GetExpBarPosition();
+    local gx, gy = defPos.GetGilTrackerPosition();
+    local ix, iy = defPos.GetInventoryPosition();
+    local elx, ely = defPos.GetEnemyListPosition();
+    local ccx, ccy = defPos.GetCastCostPosition();
+
+    local staggerY = 35;
+    return {
+        PlayerBar = { x = px, y = py },
+        TargetBar = { x = tx, y = ty },
+        PartyList = { x = pl1x, y = pl1y },
+        PartyList2 = { x = pl2x, y = pl2y },
+        PartyList3 = { x = pl3x, y = pl3y },
+        CastBar = { x = cx, y = cy },
+        Notifications_Group1 = { x = nx, y = ny },
+        Notifications_Group2 = { x = nx, y = ny + 180 },
+        TreasurePool = { x = tpx, y = tpy },
+        PetBar = { x = petx, y = pety },
+        ExpBar = { x = ex, y = ey },
+        GilTracker = { x = gx, y = gy },
+        EnemyList = { x = elx, y = ely },
+        CastCost = { x = ccx, y = ccy },
+        InventoryTracker = { x = ix, y = iy },
+        SatchelTracker = { x = ix, y = iy + staggerY },
+        SafeTracker = { x = ix, y = iy + staggerY * 2 },
+        StorageTracker = { x = ix, y = iy + staggerY * 3 },
+        LockerTracker = { x = ix, y = iy + staggerY * 4 },
+        WardrobeTracker = { x = ix, y = iy + staggerY * 5 },
+    };
+end
+
 -- Inject default positions if profile has none (brand new profile)
 if (not gConfig.windowPositions or next(gConfig.windowPositions) == nil) then
     gConfig.windowPositions = GetDefaultWindowPositions();
@@ -526,48 +569,6 @@ end
 function GetLayoutTemplate(partyIndex)
     local party = GetPartySettings(partyIndex);
     return party.layout == 1 and gConfig.layoutCompact or gConfig.layoutHorizontal;
-end
-
-local function GetDefaultWindowPositions()
-    local defPos = require('libs.defaultpositions');
-    local px, py = defPos.GetPlayerBarPosition();
-    local tx, ty = defPos.GetTargetBarPosition();
-    local pl1x, pl1y = defPos.GetPartyListPosition();
-    local pl2x, pl2y = defPos.GetPartyList2Position();
-    local pl3x, pl3y = defPos.GetPartyList3Position();
-    local cx, cy = defPos.GetCastBarPosition();
-    local nx, ny = defPos.GetNotificationsPosition();
-    local tpx, tpy = defPos.GetTreasurePoolPosition();
-    local petx, pety = defPos.GetPetBarPosition();
-    local ex, ey = defPos.GetExpBarPosition();
-    local gx, gy = defPos.GetGilTrackerPosition();
-    local ix, iy = defPos.GetInventoryPosition();
-    local elx, ely = defPos.GetEnemyListPosition();
-    local ccx, ccy = defPos.GetCastCostPosition();
-
-    local staggerY = 35;
-    return {
-        PlayerBar = { x = px, y = py },
-        TargetBar = { x = tx, y = ty },
-        PartyList = { x = pl1x, y = pl1y },
-        PartyList2 = { x = pl2x, y = pl2y },
-        PartyList3 = { x = pl3x, y = pl3y },
-        CastBar = { x = cx, y = cy },
-        Notifications_Group1 = { x = nx, y = ny },
-        Notifications_Group2 = { x = nx, y = ny + 180 },
-        TreasurePool = { x = tpx, y = tpy },
-        PetBar = { x = petx, y = pety },
-        ExpBar = { x = ex, y = ey },
-        GilTracker = { x = gx, y = gy },
-        EnemyList = { x = elx, y = ely },
-        CastCost = { x = ccx, y = ccy },
-        InventoryTracker = { x = ix, y = iy },
-        SatchelTracker = { x = ix, y = iy + staggerY },
-        SafeTracker = { x = ix, y = iy + staggerY * 2 },
-        StorageTracker = { x = ix, y = iy + staggerY * 3 },
-        LockerTracker = { x = ix, y = iy + staggerY * 4 },
-        WardrobeTracker = { x = ix, y = iy + staggerY * 5 },
-    };
 end
 
 function CreateProfile(name)

--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -686,6 +686,9 @@ function RecoverAllPositions()
     -- Force re-apply on next frame
     gConfig.appliedPositions = {};
 
+    -- Clear persisted alignment state so alignBottom doesn't override the restored positions
+    gConfig.partyListState = {};
+
     -- Save
     profileManager.SaveProfileSettings(config.currentProfile, gConfig);
     bInternalSave = true;

--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -480,6 +480,12 @@ else
 end
 
 gConfig.appliedPositions = {};
+
+-- Inject default positions if profile has none (brand new profile)
+if (not gConfig.windowPositions or next(gConfig.windowPositions) == nil) then
+    gConfig.windowPositions = GetDefaultWindowPositions();
+end
+
 gConfigVersion = 0;
 settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
 
@@ -536,7 +542,10 @@ local function GetDefaultWindowPositions()
     local ex, ey = defPos.GetExpBarPosition();
     local gx, gy = defPos.GetGilTrackerPosition();
     local ix, iy = defPos.GetInventoryPosition();
+    local elx, ely = defPos.GetEnemyListPosition();
+    local ccx, ccy = defPos.GetCastCostPosition();
 
+    local staggerY = 35;
     return {
         PlayerBar = { x = px, y = py },
         TargetBar = { x = tx, y = ty },
@@ -550,7 +559,14 @@ local function GetDefaultWindowPositions()
         PetBar = { x = petx, y = pety },
         ExpBar = { x = ex, y = ey },
         GilTracker = { x = gx, y = gy },
+        EnemyList = { x = elx, y = ely },
+        CastCost = { x = ccx, y = ccy },
         InventoryTracker = { x = ix, y = iy },
+        SatchelTracker = { x = ix, y = iy + staggerY },
+        SafeTracker = { x = ix, y = iy + staggerY * 2 },
+        StorageTracker = { x = ix, y = iy + staggerY * 3 },
+        LockerTracker = { x = ix, y = iy + staggerY * 4 },
+        WardrobeTracker = { x = ix, y = iy + staggerY * 5 },
     };
 end
 

--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -675,24 +675,16 @@ function ResetSettings()
     hotbar.ResetPositions();
 end
 
-function CenterAllPositions()
-    local defPos = require('libs.defaultpositions');
-    local sw, sh = defPos.GetScreenSize();
-    local cx = sw / 2;
-    local cy = sh / 2;
-
+function RecoverAllPositions()
     if not gConfig.windowPositions then gConfig.windowPositions = {}; end
 
-    -- Center every known window position
+    -- Move every known window position to top-left corner
     for windowName, _ in pairs(gConfig.windowPositions) do
-        gConfig.windowPositions[windowName] = { x = cx, y = cy };
+        gConfig.windowPositions[windowName] = { x = 20, y = 20 };
     end
 
     -- Force re-apply on next frame
     gConfig.appliedPositions = {};
-
-    -- Reset the config window position too
-    configMenu.ResetConfigWindowPosition();
 
     -- Save
     profileManager.SaveProfileSettings(config.currentProfile, gConfig);
@@ -1337,8 +1329,8 @@ ashita.events.register('command', 'command_cb', function (e)
         if (command_args[2] == 'profile') then
             -- /xiui profile reset positions
             if (command_args[3] == 'reset' and command_args[4] == 'positions') then
-                CenterAllPositions();
-                print(chat.header(addon.name):append(chat.message('All UI positions reset to center.')));
+                RecoverAllPositions();
+                print(chat.header(addon.name):append(chat.message('All UI positions recovered to top-left.')));
                 return;
             end
 

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -34,6 +34,10 @@ local config = {};
 -- Track previous config state to detect when config closes
 local wasConfigOpen = false;
 
+-- Track last known config window geometry for smart reposition on open
+local lastConfigPosX, lastConfigPosY = 20, 20;
+local lastConfigSizeW, lastConfigSizeH = 900, 650;
+
 -- Global modal state (accessible by other modules to know when to dim foreground elements)
 _XIUI_MODAL_OPEN = false;
 
@@ -85,7 +89,6 @@ end
 
 -- State for confirmation dialogs
 local showRestoreDefaultsConfirm = false;
-local pendingResetConfigWindow = false;
 
 -- Social icon textures
 local discordTexture = nil;
@@ -633,6 +636,7 @@ config.DrawWindow = function(us)
         gConfig.treasurePoolMiniPreview = false;
         gConfig.treasurePoolFullPreview = false;
     end
+    local configJustOpened = isConfigOpen and not wasConfigOpen;
     wasConfigOpen = isConfigOpen;
 
     -- Early exit if config window isn't shown (atom0s recommendation)
@@ -642,11 +646,29 @@ config.DrawWindow = function(us)
     -- XIUI Theme Colors (dark + gold accent)
     PushThemeStyles();
 
-    imgui.SetNextWindowSize({ 900, 650 }, ImGuiCond_FirstUseEver);
-    imgui.SetNextWindowPos({ 50, 50 }, ImGuiCond_FirstUseEver);
-    if pendingResetConfigWindow then
-        imgui.SetNextWindowPos({ 50, 50 }, ImGuiCond_Always);
-        pendingResetConfigWindow = false;
+    -- Constrain config window to never exceed the game's render resolution.
+    -- Prevents the window from being larger than the screen or lost off-screen on small resolutions.
+    local io = imgui.GetIO();
+    local sw = io.DisplaySize.x;
+    local sh = io.DisplaySize.y;
+    if not sw or sw < 1 then return; end
+    if not sh or sh < 1 then return; end
+    local maxW = math.min(900, sw - 40);
+    local maxH = math.min(650, sh - 40);
+    imgui.SetNextWindowSizeConstraints({ 400, 300 }, { sw, sh });
+    -- On open: only reset size if it exceeds screen, only reset position if any part is off-screen
+    if configJustOpened then
+        local sizeExceeds = lastConfigSizeW > (sw - 40) or lastConfigSizeH > (sh - 40);
+        if sizeExceeds then
+            imgui.SetNextWindowSize({ maxW, maxH }, ImGuiCond_Always);
+        end
+        local offScreen = lastConfigPosX < 0
+            or lastConfigPosY < 0
+            or (lastConfigPosX + lastConfigSizeW) > sw
+            or (lastConfigPosY + lastConfigSizeH) > sh;
+        if offScreen then
+            imgui.SetNextWindowPos({ 20, 20 }, ImGuiCond_Always);
+        end
     end
     if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
         local windowWidth = imgui.GetContentRegionAvail();
@@ -942,6 +964,12 @@ config.DrawWindow = function(us)
         imgui.EndChild();
     end
 
+    -- Capture config window geometry while open for smart reposition on next open.
+    -- Two local assignments per frame — negligible cost, but ensures we always have
+    -- current values even on addon unload or profile change without an extra frame.
+    lastConfigPosX, lastConfigPosY = imgui.GetWindowPos();
+    lastConfigSizeW, lastConfigSizeH = imgui.GetWindowSize();
+
     imgui.End();
 
     -- Draw migration wizard if open (after main window so it overlays)
@@ -973,10 +1001,6 @@ end
 function config.OpenResetSettingsPopup()
     showConfig[1] = true;
     showRestoreDefaultsConfirm = true;
-end
-
-function config.ResetConfigWindowPosition()
-    pendingResetConfigWindow = true;
 end
 
 return config;

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -646,9 +646,9 @@ config.DrawWindow = function(us)
 
     -- Constrain config window to never exceed the game's render resolution.
     -- Prevents the window from being larger than the screen or lost off-screen on small resolutions.
-    local io = imgui.GetIO();
-    local sw = io.DisplaySize.x;
-    local sh = io.DisplaySize.y;
+    local ioData = imgui.GetIO();
+    local sw = ioData.DisplaySize.x;
+    local sh = ioData.DisplaySize.y;
     if not sw or sw < 1 then return; end
     if not sh or sh < 1 then return; end
 

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -643,9 +643,6 @@ config.DrawWindow = function(us)
     -- This prevents unnecessary style pushes and imgui.End() calls when window is hidden
     if (not showConfig[1]) then return; end
 
-    -- XIUI Theme Colors (dark + gold accent)
-    PushThemeStyles();
-
     -- Constrain config window to never exceed the game's render resolution.
     -- Prevents the window from being larger than the screen or lost off-screen on small resolutions.
     local io = imgui.GetIO();
@@ -653,6 +650,11 @@ config.DrawWindow = function(us)
     local sh = io.DisplaySize.y;
     if not sw or sw < 1 then return; end
     if not sh or sh < 1 then return; end
+
+    -- XIUI Theme Colors (dark + gold accent)
+    -- Push theme styles AFTER validating DisplaySize to avoid leaking
+    -- style/var pushes on early returns (which corrupt ImGui state).
+    PushThemeStyles();
     local maxW = math.min(900, sw - 40);
     local maxH = math.min(650, sh - 40);
     imgui.SetNextWindowSizeConstraints({ 400, 300 }, { sw, sh });

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -37,6 +37,7 @@ local wasConfigOpen = false;
 -- Track last known config window geometry for smart reposition on open
 local lastConfigPosX, lastConfigPosY = 20, 20;
 local lastConfigSizeW, lastConfigSizeH = 900, 650;
+local configHasBeenOpened = false;
 
 -- Global modal state (accessible by other modules to know when to dim foreground elements)
 _XIUI_MODAL_OPEN = false;
@@ -658,10 +659,12 @@ config.DrawWindow = function(us)
     local maxW = math.min(900, sw - 40);
     local maxH = math.min(650, sh - 40);
     imgui.SetNextWindowSizeConstraints({ 400, 300 }, { sw, sh });
-    -- On open: only reset size if it exceeds screen, only reset position if any part is off-screen
+    -- On open: set ideal size for the current resolution and reset position if off-screen.
     if configJustOpened then
-        local sizeExceeds = lastConfigSizeW > (sw - 40) or lastConfigSizeH > (sh - 40);
-        if sizeExceeds then
+        if not configHasBeenOpened then
+            imgui.SetNextWindowSize({ maxW, maxH }, ImGuiCond_Always);
+            configHasBeenOpened = true;
+        elseif lastConfigSizeW > (sw - 40) or lastConfigSizeH > (sh - 40) then
             imgui.SetNextWindowSize({ maxW, maxH }, ImGuiCond_Always);
         end
         local offScreen = lastConfigPosX < 0

--- a/XIUI/config/global.lua
+++ b/XIUI/config/global.lua
@@ -46,11 +46,11 @@ function M.DrawSettings()
         components.DrawCheckbox('Hide During Events', 'hideDuringEvents');
 
         imgui.Spacing();
-        if imgui.Button('Center UI') then
+        if imgui.Button('Recover UI Positions') then
             showCenterUIConfirm = true;
         end
         imgui.SameLine();
-        imgui.ShowHelp('Move all UI elements to the center of the screen.');
+        imgui.ShowHelp('Move all UI elements to the top-left corner so they are visible at any resolution.');
 
         -- Center UI confirmation popup
         if showCenterUIConfirm then
@@ -59,12 +59,12 @@ function M.DrawSettings()
         end
 
         if (imgui.BeginPopupModal("Confirm Center UI", true, ImGuiWindowFlags_AlwaysAutoResize)) then
-            imgui.Text("Move all UI elements to the center of the screen?");
+            imgui.Text("Move all UI elements to the top-left corner?");
             imgui.Text("This only affects positions, not your other settings.");
             imgui.NewLine();
 
             if (imgui.Button("Confirm", { 120, 0 })) then
-                CenterAllPositions();
+                RecoverAllPositions();
                 imgui.CloseCurrentPopup();
             end
             imgui.SameLine();

--- a/XIUI/config/global.lua
+++ b/XIUI/config/global.lua
@@ -52,13 +52,13 @@ function M.DrawSettings()
         imgui.SameLine();
         imgui.ShowHelp('Move all UI elements to the top-left corner so they are visible at any resolution.');
 
-        -- Center UI confirmation popup
+        -- Recover UI confirmation popup
         if showCenterUIConfirm then
-            imgui.OpenPopup("Confirm Center UI");
+            imgui.OpenPopup("Confirm Recover UI");
             showCenterUIConfirm = false;
         end
 
-        if (imgui.BeginPopupModal("Confirm Center UI", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+        if (imgui.BeginPopupModal("Confirm Recover UI", true, ImGuiWindowFlags_AlwaysAutoResize)) then
             imgui.Text("Move all UI elements to the top-left corner?");
             imgui.Text("This only affects positions, not your other settings.");
             imgui.NewLine();

--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -850,6 +850,98 @@ function M.MigrateCrossbarComboModeSettings(gConfig, defaults)
     end
 end
 
+-- Migrate legacy per-module *WindowPosX/Y fields into the unified windowPositions table
+-- This ensures old profiles don't retain stale position data that could conflict
+function M.MigrateLegacyPositionFields(gConfig)
+    if not gConfig then return; end
+
+    -- Map of legacy field name pairs to windowPositions key
+    local legacyFields = {
+        { xKey = 'playerBarWindowPosX',   yKey = 'playerBarWindowPosY',   windowName = 'PlayerBar' },
+        { xKey = 'targetBarWindowPosX',   yKey = 'targetBarWindowPosY',   windowName = 'TargetBar' },
+        { xKey = 'castBarWindowPosX',     yKey = 'castBarWindowPosY',     windowName = 'CastBar' },
+        { xKey = 'enemyListWindowPosX',   yKey = 'enemyListWindowPosY',   windowName = 'EnemyList' },
+        { xKey = 'partyListWindowPosX',   yKey = 'partyListWindowPosY',   windowName = 'PartyList' },
+        { xKey = 'partyList2WindowPosX',  yKey = 'partyList2WindowPosY',  windowName = 'PartyList2' },
+        { xKey = 'partyList3WindowPosX',  yKey = 'partyList3WindowPosY',  windowName = 'PartyList3' },
+        { xKey = 'expBarWindowPosX',      yKey = 'expBarWindowPosY',      windowName = 'ExpBar' },
+        { xKey = 'gilTrackerWindowPosX',  yKey = 'gilTrackerWindowPosY',  windowName = 'GilTracker' },
+        { xKey = 'treasurePoolWindowPosX', yKey = 'treasurePoolWindowPosY', windowName = 'TreasurePool' },
+        { xKey = 'petBarWindowPosX',      yKey = 'petBarWindowPosY',      windowName = 'PetBar' },
+        { xKey = 'notificationsWindowPosX', yKey = 'notificationsWindowPosY', windowName = 'Notifications_Group1' },
+        { xKey = 'crossbarWindowPosX',    yKey = 'crossbarWindowPosY',    windowName = 'Crossbar' },
+    };
+
+    local migrated = false;
+
+    for _, entry in ipairs(legacyFields) do
+        local x = gConfig[entry.xKey];
+        local y = gConfig[entry.yKey];
+
+        if x ~= nil and y ~= nil then
+            -- Migrate to windowPositions if no entry exists yet
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            if not gConfig.windowPositions[entry.windowName] then
+                gConfig.windowPositions[entry.windowName] = { x = x, y = y };
+            end
+            migrated = true;
+        end
+
+        -- Always clear the legacy fields
+        gConfig[entry.xKey] = nil;
+        gConfig[entry.yKey] = nil;
+    end
+
+    -- Handle nested castCost.windowPosX/Y
+    if gConfig.castCost then
+        local ccX = gConfig.castCost.windowPosX;
+        local ccY = gConfig.castCost.windowPosY;
+        if ccX ~= nil and ccY ~= nil then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            if not gConfig.windowPositions['CastCost'] then
+                gConfig.windowPositions['CastCost'] = { x = ccX, y = ccY };
+            end
+            migrated = true;
+        end
+        gConfig.castCost.windowPosX = nil;
+        gConfig.castCost.windowPosY = nil;
+    end
+
+    -- Handle legacy hotbarCrossbarPosition table
+    if gConfig.hotbarCrossbarPosition then
+        local pos = gConfig.hotbarCrossbarPosition;
+        if pos.x and pos.y then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            if not gConfig.windowPositions['Crossbar'] then
+                gConfig.windowPositions['Crossbar'] = { x = pos.x, y = pos.y };
+            end
+            migrated = true;
+        end
+        gConfig.hotbarCrossbarPosition = nil;
+    end
+
+    -- Handle legacy inventoryWindowPosX/Y (doesn't directly map, just clean up)
+    gConfig.inventoryWindowPosX = nil;
+    gConfig.inventoryWindowPosY = nil;
+
+    -- Handle legacy hotbarBarPositions (per-bar position table)
+    if gConfig.hotbarBarPositions then
+        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+        for barIndex, pos in pairs(gConfig.hotbarBarPositions) do
+            if pos.x and pos.y then
+                local windowName = string.format('Hotbar%d', barIndex);
+                if not gConfig.windowPositions[windowName] then
+                    gConfig.windowPositions[windowName] = { x = pos.x, y = pos.y };
+                end
+                migrated = true;
+            end
+        end
+        gConfig.hotbarBarPositions = nil;
+    end
+
+    return migrated;
+end
+
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
 function M.RunStructureMigrations(gConfig, defaults)
@@ -864,6 +956,7 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateBlockedGameKeys(gConfig, defaults);
     M.MigrateNotificationGroups(gConfig, defaults);
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
+    M.MigrateLegacyPositionFields(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -17,32 +17,6 @@ function M.createUserSettingsDefaults()
         tooltipScale = 1.0,
         hideDuringEvents = true,
 
-        -- Window positions (saved when user moves windows, nil = use defaults)
-        playerBarWindowPosX = nil,
-        playerBarWindowPosY = nil,
-        targetBarWindowPosX = nil,
-        targetBarWindowPosY = nil,
-        castBarWindowPosX = nil,
-        castBarWindowPosY = nil,
-        enemyListWindowPosX = nil,
-        enemyListWindowPosY = nil,
-        partyListWindowPosX = nil,
-        partyListWindowPosY = nil,
-        partyList2WindowPosX = nil,
-        partyList2WindowPosY = nil,
-        partyList3WindowPosX = nil,
-        partyList3WindowPosY = nil,
-        expBarWindowPosX = nil,
-        expBarWindowPosY = nil,
-        gilTrackerWindowPosX = nil,
-        gilTrackerWindowPosY = nil,
-        inventoryWindowPosX = nil,  -- Shared by all inventory container types
-        inventoryWindowPosY = nil,
-        treasurePoolWindowPosX = nil,
-        treasurePoolWindowPosY = nil,
-        notificationsWindowPosX = nil,
-        notificationsWindowPosY = nil,
-
         showPlayerBar = true,
         showTargetBar = true,
         showEnemyList = true,
@@ -92,9 +66,6 @@ function M.createUserSettingsDefaults()
         -- Lock movement: when true, disables drag/drop and slot swapping for hotbar bars
         hotbarLockMovement = false,
         hotbarPreview = false,                -- Show preview with test data
-        hotbarBarPositions = nil,             -- Per-bar positions (nil = defaults)
-        crossbarWindowPosX = nil,             -- Crossbar X position
-        crossbarWindowPosY = nil,             -- Crossbar Y position
 
         -- Global hotbar visual settings (used when bar's useGlobalSettings = true)
         hotbarGlobal = factories.createHotbarGlobalDefaults(),
@@ -696,9 +667,6 @@ function M.createUserSettingsDefaults()
         petBarScaleY = 1.0,
         petBarHideDuringEvents = true,
         petBarPreview = true,
-        -- Window positions (saved when user moves window)
-        petBarWindowPosX = nil,
-        petBarWindowPosY = nil,
         petBarPreviewType = 2, -- Avatar (SMN)
         petBarShowDistance = true,
         petBarShowTarget = true,

--- a/XIUI/handlers/helpers.lua
+++ b/XIUI/handlers/helpers.lua
@@ -49,8 +49,10 @@ function ApplyWindowPosition(windowName)
             -- print('[XIUI] Applying position for ' .. windowName .. ': ' .. pos.x .. ',' .. pos.y);
             imgui.SetNextWindowPos({ pos.x, pos.y }, ImGuiCond_Always);
             gConfig.appliedPositions[windowName] = true;
+            return true;
         end
     end
+    return false;
 end
 
 -- Save Window Position Helper

--- a/XIUI/modules/castbar.lua
+++ b/XIUI/modules/castbar.lua
@@ -15,11 +15,6 @@ local allFonts; -- Table for batch visibility operations
 local lastSpellTextColor;
 local lastPercentTextColor;
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 local castbar = {
 	previousPercent = 0,
 	currentSpellId = nil,
@@ -84,20 +79,6 @@ castbar.DrawWindow = function(settings)
 	if ((percent < 1 and percent ~= castbar.previousPercent) or showConfig[1]) then
 		imgui.SetNextWindowSize({settings.barWidth, -1});
 
-		-- Handle position reset or restore
-		if forcePositionReset then
-			local defX, defY = defaultPositions.GetCastBarPosition();
-			imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-			forcePositionReset = false;
-			hasAppliedSavedPosition = true;
-			lastSavedPosX, lastSavedPosY = defX, defY;
-		elseif not hasAppliedSavedPosition and gConfig.castBarWindowPosX ~= nil then
-			imgui.SetNextWindowPos({gConfig.castBarWindowPosX, gConfig.castBarWindowPosY}, ImGuiCond_Once);
-			hasAppliedSavedPosition = true;
-			lastSavedPosX = gConfig.castBarWindowPosX;
-			lastSavedPosY = gConfig.castBarWindowPosY;
-		end
-
 		local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
         ApplyWindowPosition('CastBar');
 		if (imgui.Begin('CastBar', true, windowFlags)) then
@@ -151,19 +132,6 @@ castbar.DrawWindow = function(settings)
 			end
 
 			SetFontsVisible(allFonts,true);
-
-			-- Save position if moved (with change detection to avoid spam)
-			local winPosX, winPosY = imgui.GetWindowPos();
-			if not gConfig.lockPositions then
-				if lastSavedPosX == nil or
-				   math.abs(winPosX - lastSavedPosX) > 1 or
-				   math.abs(winPosY - lastSavedPosY) > 1 then
-					gConfig.castBarWindowPosX = winPosX;
-					gConfig.castBarWindowPosY = winPosY;
-					lastSavedPosX = winPosX;
-					lastSavedPosY = winPosY;
-				end
-			end
 		end
 
 		imgui.End();
@@ -234,8 +202,13 @@ castbar.Cleanup = function()
 end
 
 castbar.ResetPositions = function()
-	forcePositionReset = true;
-	hasAppliedSavedPosition = false;
+	local defX, defY = defaultPositions.GetCastBarPosition();
+	if gConfig.windowPositions then
+		gConfig.windowPositions['CastBar'] = { x = defX, y = defY };
+	end
+	if gConfig.appliedPositions then
+		gConfig.appliedPositions['CastBar'] = nil;
+	end
 end
 
 return castbar;

--- a/XIUI/modules/castcost/display.lua
+++ b/XIUI/modules/castcost/display.lua
@@ -52,12 +52,6 @@ local windowState = {
     height = nil,
 };
 
--- Position saving state
-local hasAppliedSavedPosition = false;
-local lastSavedPosX = nil;
-local lastSavedPosY = nil;
-local forcePositionReset = false;
-
 -- ============================================
 -- Initialization
 -- ============================================
@@ -280,7 +274,7 @@ function M.Render(itemInfo, itemType, settings, colors)
     imgui.SetNextWindowSize({ -1, -1 }, ImGuiCond_Always);
 
     -- Apply saved position from profile
-    ApplyWindowPosition('CastCost');
+    local positionJustApplied = ApplyWindowPosition('CastCost');
 
     local windowFlags = bit.bor(
         ImGuiWindowFlags_NoDecoration,
@@ -569,43 +563,42 @@ function M.Render(itemInfo, itemType, settings, colors)
             local winPosX, winPosY = imgui.GetWindowPos();
             local totalHeight = contentHeight + (paddingY * 2);
 
-            if windowState.height ~= nil and windowState.height ~= totalHeight then
+            -- Detect external position change (forced reset, user drag, etc.)
+            local positionChanged = windowState.y ~= nil and windowState.y ~= winPosY;
+
+            if positionJustApplied or positionChanged then
+                -- Position was externally moved; clear tracking so height adjustment
+                -- doesn't fire until state is re-established on the next frame
+                windowState.x = nil;
+                windowState.y = nil;
+                windowState.height = nil;
+            elseif windowState.height ~= nil and windowState.height ~= totalHeight then
                 -- Height changed, adjust Y to keep bottom edge fixed
                 local newPosY = windowState.y + windowState.height - totalHeight;
                 imgui.SetWindowPos('CastCost', { winPosX, newPosY });
                 winPosY = newPosY;
-            end
-
-            -- Save current state
-            windowState.x = winPosX;
-            windowState.y = winPosY;
-            windowState.height = totalHeight;
-        end
-
-        -- Save position when user moves window (check on mouse release)
-        if not gConfig.lockPositions then
-            local winPosX, winPosY = imgui.GetWindowPos();
-            -- Only save if position changed significantly (avoid floating point noise)
-            local posChanged = (lastSavedPosX == nil or lastSavedPosY == nil) or
-                               (math.abs(winPosX - lastSavedPosX) > 1) or
-                               (math.abs(winPosY - lastSavedPosY) > 1);
-            if posChanged and not imgui.IsMouseDown(0) then
-                -- Mouse released and position changed - save to settings
-                local cc = gConfig.castCost or {};
-                cc.windowPosX = winPosX;
-                cc.windowPosY = winPosY;
-                gConfig.castCost = cc;
-                lastSavedPosX = winPosX;
-                lastSavedPosY = winPosY;
+                windowState.x = winPosX;
+                windowState.y = winPosY;
+                windowState.height = totalHeight;
+            else
+                windowState.x = winPosX;
+                windowState.y = winPosY;
+                windowState.height = totalHeight;
             end
         end
+
     end
     imgui.End();
 end
 
 M.ResetPositions = function()
-    forcePositionReset = true;
-    hasAppliedSavedPosition = false;
+    local defX, defY = defaultPositions.GetCastCostPosition();
+    if gConfig.windowPositions then
+        gConfig.windowPositions['CastCost'] = { x = defX, y = defY };
+    end
+    if gConfig.appliedPositions then
+        gConfig.appliedPositions['CastCost'] = nil;
+    end
 end
 
 return M;

--- a/XIUI/modules/enemylist.lua
+++ b/XIUI/modules/enemylist.lua
@@ -9,11 +9,6 @@ local actionTracker = require('handlers.actiontracker');
 local progressbar = require('libs.progressbar');
 local defaultPositions = require('libs.defaultpositions');
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 -- Note: RENDER_FLAG_VISIBLE and RENDER_FLAG_HIDDEN are now imported from helpers.lua
 
 -- Background rendering constants
@@ -165,20 +160,6 @@ enemylist.DrawWindow = function(settings)
 	local singleColumnWidth = settings.barWidth;
 	local windowWidth = (windowMargin * 2) + (singleColumnWidth * maxColumns) + (columnSpacing * (maxColumns - 1));
 	imgui.SetNextWindowSize({ windowWidth, -1, }, ImGuiCond_Always);
-
-	-- Handle position reset or restore
-	if forcePositionReset then
-		local defX, defY = defaultPositions.GetEnemyListPosition();
-		imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-		forcePositionReset = false;
-		hasAppliedSavedPosition = true;
-		lastSavedPosX, lastSavedPosY = defX, defY;
-	elseif not hasAppliedSavedPosition and gConfig.enemyListWindowPosX ~= nil then
-		imgui.SetNextWindowPos({gConfig.enemyListWindowPosX, gConfig.enemyListWindowPosY}, ImGuiCond_Once);
-		hasAppliedSavedPosition = true;
-		lastSavedPosX = gConfig.enemyListWindowPosX;
-		lastSavedPosY = gConfig.enemyListWindowPosY;
-	end
 
 	-- Draw the main target window
 	local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
@@ -716,18 +697,6 @@ enemylist.DrawWindow = function(settings)
 			imgui.Dummy({windowWidth, 0});
 		end
 
-		-- Save position if moved (with change detection to avoid spam)
-		local winPosX, winPosY = imgui.GetWindowPos();
-		if not gConfig.lockPositions then
-			if lastSavedPosX == nil or
-			   math.abs(winPosX - lastSavedPosX) > 1 or
-			   math.abs(winPosY - lastSavedPosY) > 1 then
-				gConfig.enemyListWindowPosX = winPosX;
-				gConfig.enemyListWindowPosY = winPosY;
-				lastSavedPosX = winPosX;
-				lastSavedPosY = winPosY;
-			end
-		end
 	end
 
 	-- Restore ImGui style variables (must be before End() to avoid affecting other windows)
@@ -907,8 +876,13 @@ enemylist.Cleanup = function()
 end
 
 enemylist.ResetPositions = function()
-	forcePositionReset = true;
-	hasAppliedSavedPosition = false;
+	local defX, defY = defaultPositions.GetEnemyListPosition();
+	if gConfig.windowPositions then
+		gConfig.windowPositions['EnemyList'] = { x = defX, y = defY };
+	end
+	if gConfig.appliedPositions then
+		gConfig.appliedPositions['EnemyList'] = nil;
+	end
 end
 
 return enemylist;

--- a/XIUI/modules/expbar.lua
+++ b/XIUI/modules/expbar.lua
@@ -17,11 +17,6 @@ local lastJobTextColor;
 local lastExpTextColor;
 local lastPercentTextColor;
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 local expbar = {
     limitPoints = {},
     meritPoints = {},
@@ -186,19 +181,6 @@ expbar.DrawWindow = function(settings)
     -- Explicitly size the window wide enough so dragging works across the full bar
     imgui.SetNextWindowSize({ windowWidth, 0 }, ImGuiCond_Always);
 
-    -- Handle position reset or restore
-    if forcePositionReset then
-        local defX, defY = defaultPositions.GetExpBarPosition();
-        imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-        forcePositionReset = false;
-        hasAppliedSavedPosition = true;
-        lastSavedPosX, lastSavedPosY = defX, defY;
-    elseif not hasAppliedSavedPosition and gConfig.expBarWindowPosX ~= nil then
-        imgui.SetNextWindowPos({gConfig.expBarWindowPosX, gConfig.expBarWindowPosY}, ImGuiCond_Once);
-        hasAppliedSavedPosition = true;
-        lastSavedPosX = gConfig.expBarWindowPosX;
-        lastSavedPosY = gConfig.expBarWindowPosY;
-    end
 	local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
     ApplyWindowPosition('ExpBar');
     if (imgui.Begin('ExpBar', true, windowFlags)) then
@@ -369,19 +351,6 @@ expbar.DrawWindow = function(settings)
         else
             percentText:set_visible(false);
         end
-
-        -- Save position if moved (with change detection to avoid spam)
-        local winPosX, winPosY = imgui.GetWindowPos();
-        if not gConfig.lockPositions then
-            if lastSavedPosX == nil or
-               math.abs(winPosX - lastSavedPosX) > 1 or
-               math.abs(winPosY - lastSavedPosY) > 1 then
-                gConfig.expBarWindowPosX = winPosX;
-                gConfig.expBarWindowPosY = winPosY;
-                lastSavedPosX = winPosX;
-                lastSavedPosY = winPosY;
-            end
-        end
     end
 	imgui.End();
 end
@@ -483,8 +452,13 @@ expbar.Cleanup = function()
 end
 
 expbar.ResetPositions = function()
-	forcePositionReset = true;
-	hasAppliedSavedPosition = false;
+	local defX, defY = defaultPositions.GetExpBarPosition();
+	if gConfig.windowPositions then
+		gConfig.windowPositions['ExpBar'] = { x = defX, y = defY };
+	end
+	if gConfig.appliedPositions then
+		gConfig.appliedPositions['ExpBar'] = nil;
+	end
 end
 
 return expbar;

--- a/XIUI/modules/giltracker.lua
+++ b/XIUI/modules/giltracker.lua
@@ -6,11 +6,6 @@ local ffi = require("ffi");
 local defaultPositions = require('libs.defaultpositions');
 local TextureManager = require('libs.texturemanager');
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 -- Gil texture (loaded via TextureManager)
 local gilTexture;
 local gilText;
@@ -219,20 +214,6 @@ giltracker.DrawWindow = function(settings)
     imgui.SetNextWindowSize({ -1, -1, }, ImGuiCond_Always);
 	local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
 
-	-- Handle position reset or restore
-	if forcePositionReset then
-		local defX, defY = defaultPositions.GetGilTrackerPosition();
-		imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-		forcePositionReset = false;
-		hasAppliedSavedPosition = true;
-		lastSavedPosX, lastSavedPosY = defX, defY;
-	elseif not hasAppliedSavedPosition and gConfig.gilTrackerWindowPosX ~= nil then
-		imgui.SetNextWindowPos({gConfig.gilTrackerWindowPosX, gConfig.gilTrackerWindowPosY}, ImGuiCond_Once);
-		hasAppliedSavedPosition = true;
-		lastSavedPosX = gConfig.gilTrackerWindowPosX;
-		lastSavedPosY = gConfig.gilTrackerWindowPosY;
-	end
-
 	local showIcon = settings.showIcon;
 
 	-- For text-only mode, remove window padding so draggable area matches text exactly
@@ -438,19 +419,6 @@ giltracker.DrawWindow = function(settings)
 		end
 
 		gilText:set_visible(true);
-
-		-- Save position if moved (with change detection to avoid spam)
-		local winPosX, winPosY = imgui.GetWindowPos();
-		if not gConfig.lockPositions then
-			if lastSavedPosX == nil or
-			   math.abs(winPosX - lastSavedPosX) > 1 or
-			   math.abs(winPosY - lastSavedPosY) > 1 then
-				gConfig.gilTrackerWindowPosX = winPosX;
-				gConfig.gilTrackerWindowPosY = winPosY;
-				lastSavedPosX = winPosX;
-				lastSavedPosY = winPosY;
-			end
-		end
     end
 	imgui.End();
 
@@ -554,8 +522,13 @@ giltracker.ResetTracking = function()
 end
 
 giltracker.ResetPositions = function()
-	forcePositionReset = true;
-	hasAppliedSavedPosition = false;
+	local defX, defY = defaultPositions.GetGilTrackerPosition();
+	if gConfig.windowPositions then
+		gConfig.windowPositions['GilTracker'] = { x = defX, y = defY };
+	end
+	if gConfig.appliedPositions then
+		gConfig.appliedPositions['GilTracker'] = nil;
+	end
 end
 
 -- Zone packet handlers are no-ops. Login detection is performed via

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -652,11 +652,8 @@ end
 function M.Initialize(settings, moduleSettings)
     if state.initialized then return; end
 
-    -- Initial position - use saved position or default
-    local savedPos = gConfig and gConfig.hotbarCrossbarPosition;
-    if not savedPos and gConfig.crossbarWindowPosX and gConfig.crossbarWindowPosY then
-        savedPos = { x = gConfig.crossbarWindowPosX, y = gConfig.crossbarWindowPosY };
-    end
+    -- Initial position - use saved position from profile or default
+    local savedPos = gConfig and gConfig.windowPositions and gConfig.windowPositions['Crossbar'];
 
     local defaultX, defaultY = GetDefaultPosition(settings);
     state.windowX = savedPos and savedPos.x or defaultX;
@@ -1255,20 +1252,6 @@ function M.DrawWindow(settings, moduleSettings)
     else
         -- Apply saved position (once) or default
         local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-        
-        -- Migration: Check for legacy position if not found in standard system
-        if not hasSaved then
-            local legPos = gConfig.hotbarCrossbarPosition;
-            if not legPos and gConfig.crossbarWindowPosX and gConfig.crossbarWindowPosY then
-                legPos = { x = gConfig.crossbarWindowPosX, y = gConfig.crossbarWindowPosY };
-            end
-            
-            if legPos then
-                if not gConfig.windowPositions then gConfig.windowPositions = {}; end
-                gConfig.windowPositions[windowName] = { x = legPos.x, y = legPos.y };
-                hasSaved = true;
-            end
-        end
 
         if hasSaved then
             ApplyWindowPosition(windowName);
@@ -1907,6 +1890,12 @@ function M.ResetPositions()
     local defaultX, defaultY = GetDefaultPosition(settings);
     state.windowX = defaultX;
     state.windowY = defaultY;
+    if gConfig.windowPositions then
+        gConfig.windowPositions['Crossbar'] = { x = defaultX, y = defaultY };
+    end
+    if gConfig.appliedPositions then
+        gConfig.appliedPositions['Crossbar'] = nil;
+    end
 end
 
 return M;

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -366,16 +366,6 @@ local function DrawBarWindow(barIndex, settings)
 
     -- Apply saved position if exists (using helper for profile support), otherwise set default
     local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-    
-    -- Migration: Check for legacy position if not found in standard system
-    if not hasSaved and gConfig.hotbarBarPositions and gConfig.hotbarBarPositions[barIndex] then
-        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
-        gConfig.windowPositions[windowName] = { 
-            x = gConfig.hotbarBarPositions[barIndex].x, 
-            y = gConfig.hotbarBarPositions[barIndex].y 
-        };
-        hasSaved = true;
-    end
 
     if hasSaved then
         ApplyWindowPosition(windowName);
@@ -802,6 +792,13 @@ end
 -- Reset all bar positions to defaults (called when settings are reset)
 function M.ResetPositions()
     forcePositionReset = true;
+    if gConfig.windowPositions and gConfig.appliedPositions then
+        for barIndex = 1, data.NUM_BARS do
+            local windowName = string.format('Hotbar%d', barIndex);
+            gConfig.windowPositions[windowName] = nil;
+            gConfig.appliedPositions[windowName] = nil;
+        end
+    end
 end
 
 return M;

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -790,6 +790,8 @@ function M.ClearIconCacheForSlot(barIndex, slotIndex)
 end
 
 -- Reset all bar positions to defaults (called when settings are reset)
+-- Note: Hotbar uses forcePositionReset + nil positions instead of explicit defaults
+-- because it has its own position pipeline with per-bar default calculation at render time.
 function M.ResetPositions()
     forcePositionReset = true;
     if gConfig.windowPositions and gConfig.appliedPositions then

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -89,11 +89,6 @@ function M.Initialize(settings)
     if gConfig then
         gConfig.hotbarPreview = false;
         if gConfig.hotbarEnabled == nil then gConfig.hotbarEnabled = true; end
-
-        -- Per-bar position defaults
-        if gConfig.hotbarBarPositions == nil then
-            gConfig.hotbarBarPositions = {};
-        end
     end
 
     -- Initialize data module (sets player job)

--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -16,11 +16,6 @@ local defaultPositions = require('libs.defaultpositions');
 
 local M = {};
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 -- Global slot counter for notification rendering
 -- Reset at start of DrawWindow, incremented for each notification drawn
 local currentSlot = 0;
@@ -626,7 +621,7 @@ local function drawNotificationWindow(windowName, notifications, settings, split
     -- Apply saved window position (if any) from profile
     -- This runs once per profile load/reset to restore position
     -- For "Stack Up" mode, this sets the initial position which anchors are derived from
-    ApplyWindowPosition(windowName);
+    local positionJustApplied = ApplyWindowPosition(windowName);
 
     -- Helper to calculate notification height
     local function getNotificationHeight(notification)
@@ -682,54 +677,34 @@ local function drawNotificationWindow(windowName, notifications, settings, split
     end
 
     -- Handle bottom-anchoring for "stack up" mode
-    ApplyWindowPosition(windowName);
     if stackUp then
-        -- Get or initialize bottom anchor for this window
-        local anchorKey = 'bottomAnchor_' .. windowName;
-        local bottomAnchor = notificationData.windowAnchors[anchorKey];
-        local isDragging = notificationData.windowAnchors[anchorKey .. '_dragging'];
+        if positionJustApplied then
+            -- Position was just force-applied; clear stale anchor
+            local anchorKey = 'bottomAnchor_' .. windowName;
+            notificationData.windowAnchors[anchorKey] = nil;
+            notificationData.windowAnchors[anchorKey .. '_x'] = nil;
+            notificationData.windowAnchors[anchorKey .. '_dragging'] = nil;
+        else
+            -- Get or initialize bottom anchor for this window
+            local anchorKey = 'bottomAnchor_' .. windowName;
+            local bottomAnchor = notificationData.windowAnchors[anchorKey];
+            local isDragging = notificationData.windowAnchors[anchorKey .. '_dragging'];
 
-        if bottomAnchor and not isDragging then
-            -- Position window so bottom edge stays at anchor (only when not dragging)
-            local newY = bottomAnchor - totalHeight;
-            imgui.SetNextWindowPos({notificationData.windowAnchors[anchorKey .. '_x'] or 0, newY});
-        end
-    end
-
-    -- Handle position reset or restore (main notifications window only)
-    if splitKey == nil then
-        if forcePositionReset then
-            local defX, defY = defaultPositions.GetNotificationsPosition();
-            imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-            forcePositionReset = false;
-            hasAppliedSavedPosition = true;
-            lastSavedPosX, lastSavedPosY = defX, defY;
-        elseif not hasAppliedSavedPosition and gConfig.notificationsWindowPosX ~= nil then
-            imgui.SetNextWindowPos({gConfig.notificationsWindowPosX, gConfig.notificationsWindowPosY}, ImGuiCond_Once);
-            hasAppliedSavedPosition = true;
-            lastSavedPosX = gConfig.notificationsWindowPosX;
-            lastSavedPosY = gConfig.notificationsWindowPosY;
+            if bottomAnchor and not isDragging then
+                -- Position window so bottom edge stays at anchor (only when not dragging)
+                local newY = bottomAnchor - totalHeight;
+                imgui.SetNextWindowPos({notificationData.windowAnchors[anchorKey .. '_x'] or 0, newY});
+            end
         end
     end
 
     -- Create ImGui window
     if imgui.Begin(windowName, true, windowFlags) then
+        SaveWindowPosition(windowName);
         -- Wrap rendering in pcall to ensure End() is always called even if an error occurs
         local renderSuccess, renderErr = pcall(function()
             local windowPosX, windowPosY = imgui.GetWindowPos();
             local drawList = imgui.GetWindowDrawList();
-
-            -- Save position if moved (main notifications window only, with change detection to avoid spam)
-            if splitKey == nil and not gConfig.lockPositions then
-                if lastSavedPosX == nil or
-                   math.abs(windowPosX - lastSavedPosX) > 1 or
-                   math.abs(windowPosY - lastSavedPosY) > 1 then
-                    gConfig.notificationsWindowPosX = windowPosX;
-                    gConfig.notificationsWindowPosY = windowPosY;
-                    lastSavedPosX = windowPosX;
-                    lastSavedPosY = windowPosY;
-                end
-            end
 
             -- Set window size
             imgui.Dummy({notificationWidth, totalHeight});
@@ -1338,14 +1313,19 @@ local function drawGroupWindow(groupNum, settings)
     end
 
     -- Handle bottom-anchoring for "stack up" mode
-    ApplyWindowPosition(windowName);
+    local positionJustApplied = ApplyWindowPosition(windowName);
     if stackUp then
-        local anchor = notificationData.groupWindowAnchors[groupNum];
-        local isDragging = anchor and anchor.dragging;
+        if positionJustApplied then
+            -- Position was just force-applied (e.g., Restore UI Positions); clear stale anchor
+            notificationData.groupWindowAnchors[groupNum] = nil;
+        else
+            local anchor = notificationData.groupWindowAnchors[groupNum];
+            local isDragging = anchor and anchor.dragging;
 
-        if anchor and anchor.y and not isDragging then
-            local newY = anchor.y - totalHeight;
-            imgui.SetNextWindowPos({anchor.x or 0, newY});
+            if anchor and anchor.y and not isDragging then
+                local newY = anchor.y - totalHeight;
+                imgui.SetNextWindowPos({anchor.x or 0, newY});
+            end
         end
     end
 
@@ -1537,10 +1517,6 @@ M.ResetPositions = function()
         -- Clear bottom anchor for stack-up mode
         notificationData.groupWindowAnchors[groupNum] = nil;
     end
-
-    -- Legacy: also reset old main window flags
-    forcePositionReset = true;
-    hasAppliedSavedPosition = false;
 end
 
 return M;

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -21,12 +21,6 @@ local data = require('modules.partylist.data');
 
 local display = {};
 
--- Position save/restore state (per-party)
-local hasAppliedSavedPosition = { false, false, false };
-local forcePositionReset = { false, false, false };
-local lastSavedPosX = { nil, nil, nil };
-local lastSavedPosY = { nil, nil, nil };
-
 -- Helper: Set font text only if changed (avoids texture regeneration)
 local function setCachedText(memIdx, fontKey, font, text)
     if not data.memberTextCache[memIdx] then
@@ -1238,7 +1232,7 @@ function display.DrawPartyWindow(settings, party, partyIndex)
     imgui.PushStyleVar(ImGuiStyleVar_FramePadding, {0,0});
     imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, { settings.barSpacing * scale.x, 0 });
     
-    ApplyWindowPosition(windowName);
+    local positionJustApplied = ApplyWindowPosition(windowName);
     
     if (imgui.Begin(windowName, true, windowFlags)) then
         SaveWindowPosition(windowName);
@@ -1337,28 +1331,6 @@ function display.DrawPartyWindow(settings, party, partyIndex)
         );
     end
 
-    -- Save position if moved (with change detection to avoid spam) - all party windows
-    local winPosX, winPosY = imgui.GetWindowPos();
-    if not gConfig.lockPositions then
-        if lastSavedPosX[partyIndex] == nil or
-           math.abs(winPosX - lastSavedPosX[partyIndex]) > 1 or
-           math.abs(winPosY - lastSavedPosY[partyIndex]) > 1 then
-            if partyIndex == 1 then
-                gConfig.partyListWindowPosX = winPosX;
-                gConfig.partyListWindowPosY = winPosY;
-            elseif partyIndex == 2 then
-                gConfig.partyList2WindowPosX = winPosX;
-                gConfig.partyList2WindowPosY = winPosY;
-            else
-                gConfig.partyList3WindowPosX = winPosX;
-                gConfig.partyList3WindowPosY = winPosY;
-            end
-            lastSavedPosX[partyIndex] = winPosX;
-            lastSavedPosY[partyIndex] = winPosY;
-            -- Position will be persisted on addon unload
-        end
-    end
-
     imgui.End();
     imgui.PopStyleVar(2);
 
@@ -1377,25 +1349,34 @@ function display.DrawPartyWindow(settings, party, partyIndex)
 
         local partyListState = gConfig.partyListState[partyIndex];
 
-        if (partyListState ~= nil) then
-            if (menuHeight ~= partyListState.height) then
-                local newPosY = partyListState.y + partyListState.height - menuHeight;
-                imguiPosY = newPosY;
-                imgui.SetWindowPos(windowName, { imguiPosX, imguiPosY });
-            end
-        end
+        -- Detect external position change (forced reset, user drag, etc.)
+        local positionChanged = partyListState ~= nil and partyListState.y ~= nil and partyListState.y ~= imguiPosY;
 
-        if (partyListState == nil or
-                imguiPosX ~= partyListState.x or imguiPosY ~= partyListState.y or
-                menuWidth ~= partyListState.width or menuHeight ~= partyListState.height) then
-            gConfig.partyListState[partyIndex] = {
-                x = imguiPosX,
-                y = imguiPosY,
-                width = menuWidth,
-                height = menuHeight,
-            };
-            data.lastSettingsSaveTime = os.clock();
-            data.pendingSettingsSave = true;
+        if positionJustApplied or positionChanged then
+            -- Position was externally moved; clear tracking so height adjustment
+            -- doesn't fire until state is re-established on the next frame
+            gConfig.partyListState[partyIndex] = nil;
+        else
+            if (partyListState ~= nil) then
+                if (menuHeight ~= partyListState.height) then
+                    local newPosY = partyListState.y + partyListState.height - menuHeight;
+                    imguiPosY = newPosY;
+                    imgui.SetWindowPos(windowName, { imguiPosX, imguiPosY });
+                end
+            end
+
+            if (partyListState == nil or
+                    imguiPosX ~= partyListState.x or imguiPosY ~= partyListState.y or
+                    menuWidth ~= partyListState.width or menuHeight ~= partyListState.height) then
+                gConfig.partyListState[partyIndex] = {
+                    x = imguiPosX,
+                    y = imguiPosY,
+                    width = menuWidth,
+                    height = menuHeight,
+                };
+                data.lastSettingsSaveTime = os.clock();
+                data.pendingSettingsSave = true;
+            end
         end
     end
 end
@@ -1485,9 +1466,20 @@ function display.DrawWindow(settings)
 end
 
 display.ResetPositions = function()
+    local positionGetters = {
+        defaultPositions.GetPartyListPosition,
+        defaultPositions.GetPartyList2Position,
+        defaultPositions.GetPartyList3Position,
+    };
+    local windowNames = { 'PartyList', 'PartyList2', 'PartyList3' };
     for i = 1, 3 do
-        forcePositionReset[i] = true;
-        hasAppliedSavedPosition[i] = false;
+        local defX, defY = positionGetters[i]();
+        if gConfig.windowPositions then
+            gConfig.windowPositions[windowNames[i]] = { x = defX, y = defY };
+        end
+        if gConfig.appliedPositions then
+            gConfig.appliedPositions[windowNames[i]] = nil;
+        end
     end
 end
 

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -1350,9 +1350,12 @@ function display.DrawPartyWindow(settings, party, partyIndex)
         local partyListState = gConfig.partyListState[partyIndex];
 
         -- Detect external position change (forced reset, user drag, etc.)
+        -- Note: We don't use positionJustApplied here because partyListState is persisted
+        -- in the profile and should be preserved on normal login (when positions are applied
+        -- from saved data). RecoverAllPositions explicitly clears partyListState for resets.
         local positionChanged = partyListState ~= nil and partyListState.y ~= nil and partyListState.y ~= imguiPosY;
 
-        if positionJustApplied or positionChanged then
+        if positionChanged then
             -- Position was externally moved; clear tracking so height adjustment
             -- doesn't fire until state is re-established on the next frame
             gConfig.partyListState[partyIndex] = nil;

--- a/XIUI/modules/petbar/display.lua
+++ b/XIUI/modules/petbar/display.lua
@@ -26,14 +26,6 @@ local windowState = {
     height = nil,
 };
 
--- Position saving state
-local hasAppliedSavedPosition = false;
-local lastSavedPosX = nil;
-local lastSavedPosY = nil;
-
--- Force reset flag for default position restore
-local forcePositionReset = false;
-
 -- ============================================
 -- Per-Pet-Type Settings Helpers
 -- ============================================
@@ -723,21 +715,6 @@ function display.DrawWindow(settings)
         windowFlags = bit.bor(windowFlags, ImGuiWindowFlags_NoMove);
     end
 
-    -- Apply saved position on first render, or force reset to default
-    if forcePositionReset then
-        local defX, defY = defaultPositions.GetPetBarPosition();
-        imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-        forcePositionReset = false;
-        hasAppliedSavedPosition = true;
-        lastSavedPosX = defX;
-        lastSavedPosY = defY;
-    elseif not hasAppliedSavedPosition and gConfig.petBarWindowPosX ~= nil and gConfig.petBarWindowPosY ~= nil then
-        imgui.SetNextWindowPos({gConfig.petBarWindowPosX, gConfig.petBarWindowPosY}, ImGuiCond_Once);
-        hasAppliedSavedPosition = true;
-        lastSavedPosX = gConfig.petBarWindowPosX;
-        lastSavedPosY = gConfig.petBarWindowPosY;
-    end
-
     -- Get per-pet-type settings and colors
     -- typeSettings already retrieved at start of function
     local colorConfig = GetPetTypeColors();
@@ -782,7 +759,7 @@ function display.DrawWindow(settings)
 
     local windowPosX, windowPosY = 0, 0;
 
-    ApplyWindowPosition('PetBar');
+    local positionJustApplied = ApplyWindowPosition('PetBar');
     if imgui.Begin('PetBar', true, windowFlags) then
         SaveWindowPosition('PetBar');
         windowPosX, windowPosY = imgui.GetWindowPos();
@@ -1324,17 +1301,28 @@ function display.DrawWindow(settings)
 
         -- Handle bottom alignment
         if typeSettings.alignBottom then
-            if windowState.height ~= nil and windowState.height ~= windowHeight then
+            -- Detect external position change (forced reset, user drag, etc.)
+            local positionChanged = windowState.y ~= nil and windowState.y ~= windowPosY;
+
+            if positionJustApplied or positionChanged then
+                -- Position was externally moved; clear tracking so height adjustment
+                -- doesn't fire until state is re-established on the next frame
+                windowState.x = nil;
+                windowState.y = nil;
+                windowState.height = nil;
+            elseif windowState.height ~= nil and windowState.height ~= windowHeight then
                 -- Height changed, adjust Y to keep bottom edge fixed
                 local newPosY = windowState.y + windowState.height - windowHeight;
                 imgui.SetWindowPos('PetBar', { windowPosX, newPosY });
                 windowPosY = newPosY;
+                windowState.x = windowPosX;
+                windowState.y = windowPosY;
+                windowState.height = windowHeight;
+            else
+                windowState.x = windowPosX;
+                windowState.y = windowPosY;
+                windowState.height = windowHeight;
             end
-
-            -- Save current state
-            windowState.x = windowPosX;
-            windowState.y = windowPosY;
-            windowState.height = windowHeight;
         end
 
         -- Store main window position for pet target window (top = stable anchor for snap Y offset)
@@ -1344,22 +1332,6 @@ function display.DrawWindow(settings)
 
         -- Update background primitives
         data.UpdateBackground(windowPosX, windowPosY, windowWidth, windowHeight, settings);
-
-        -- Save position when user moves window (check on mouse release)
-        local canMove = not gConfig.lockPositions or (showConfig[1] and gConfig.petBarPreview);
-        if canMove then
-            -- Only save if position changed significantly (avoid floating point noise)
-            local posChanged = (lastSavedPosX == nil or lastSavedPosY == nil) or
-                               (math.abs(windowPosX - lastSavedPosX) > 1) or
-                               (math.abs(windowPosY - lastSavedPosY) > 1);
-            if posChanged and not imgui.IsMouseDown(0) then
-                -- Mouse released and position changed - save to settings
-                gConfig.petBarWindowPosX = windowPosX;
-                gConfig.petBarWindowPosY = windowPosY;
-                lastSavedPosX = windowPosX;
-                lastSavedPosY = windowPosY;
-            end
-        end
     end
     imgui.End();
 
@@ -1370,8 +1342,13 @@ end
 -- ResetPositions - Reset window to default position
 -- ============================================
 display.ResetPositions = function()
-    forcePositionReset = true;
-    hasAppliedSavedPosition = false;
+    local defX, defY = defaultPositions.GetPetBarPosition();
+    if gConfig.windowPositions then
+        gConfig.windowPositions['PetBar'] = { x = defX, y = defY };
+    end
+    if gConfig.appliedPositions then
+        gConfig.appliedPositions['PetBar'] = nil;
+    end
 end
 
 return display;

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -11,12 +11,6 @@ local hpText;
 local mpText;
 local tpText;
 local allFonts; -- Table for batch visibility operations
-local resetPosNextFrame = false;
-
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
 
 -- Cache last set colors to avoid expensive SetColor() calls every frame
 local lastHpTextColor;
@@ -263,20 +257,6 @@ playerbar.DrawWindow = function(settings)
 	playerbar.interpolation.lastFrameTime = currentTime;
 
 	-- Draw the player window
-	-- Handle position reset or restore
-	if forcePositionReset then
-		local defX, defY = defaultPositions.GetPlayerBarPosition();
-		imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-		forcePositionReset = false;
-		hasAppliedSavedPosition = true;
-		lastSavedPosX, lastSavedPosY = defX, defY;
-	elseif not hasAppliedSavedPosition and gConfig.playerBarWindowPosX ~= nil then
-		imgui.SetNextWindowPos({gConfig.playerBarWindowPosX, gConfig.playerBarWindowPosY}, ImGuiCond_Once);
-		hasAppliedSavedPosition = true;
-		lastSavedPosX = gConfig.playerBarWindowPosX;
-		lastSavedPosY = gConfig.playerBarWindowPosY;
-	end
-
 	-- Get base window flags with NoMove dynamically added if positions are locked
 	local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
     ApplyWindowPosition('PlayerBar');
@@ -666,19 +646,6 @@ playerbar.DrawWindow = function(settings)
 		end
 
 		tpText:set_visible(true);
-
-		-- Save position if moved (with change detection to avoid spam)
-		local winX, winY = imgui.GetWindowPos();
-		if not gConfig.lockPositions then
-			if lastSavedPosX == nil or
-			   math.abs(winX - lastSavedPosX) > 1 or
-			   math.abs(winY - lastSavedPosY) > 1 then
-				gConfig.playerBarWindowPosX = winX;
-				gConfig.playerBarWindowPosY = winY;
-				lastSavedPosX = winX;
-				lastSavedPosY = winY;
-			end
-		end
     end
 	imgui.End();
 end
@@ -727,8 +694,13 @@ playerbar.Cleanup = function()
 end
 
 playerbar.ResetPositions = function()
-	forcePositionReset = true;
-	hasAppliedSavedPosition = false;
+	local defX, defY = defaultPositions.GetPlayerBarPosition();
+	if gConfig.windowPositions then
+		gConfig.windowPositions['PlayerBar'] = { x = defX, y = defY };
+	end
+	if gConfig.appliedPositions then
+		gConfig.appliedPositions['PlayerBar'] = nil;
+	end
 end
 
 return playerbar;

--- a/XIUI/modules/targetbar.lua
+++ b/XIUI/modules/targetbar.lua
@@ -14,11 +14,6 @@ local defaultPositions = require('libs.defaultpositions');
 local TextureManager = require('libs.texturemanager');
 local mobdata = require('modules.mobinfo.data');
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 -- TODO: Calculate these instead of manually setting them
 
 local bgAlpha = 0.4;
@@ -302,20 +297,6 @@ targetbar.DrawWindow = function(settings)
 	local isMonster = GetIsMob(targetEntity);
 
 	-- Draw the main target window
-	-- Handle position reset or restore
-	if forcePositionReset then
-		local defX, defY = defaultPositions.GetTargetBarPosition();
-		imgui.SetNextWindowPos({defX, defY}, ImGuiCond_Always);
-		forcePositionReset = false;
-		hasAppliedSavedPosition = true;
-		lastSavedPosX, lastSavedPosY = defX, defY;
-	elseif not hasAppliedSavedPosition and gConfig.targetBarWindowPosX ~= nil then
-		imgui.SetNextWindowPos({gConfig.targetBarWindowPosX, gConfig.targetBarWindowPosY}, ImGuiCond_Once);
-		hasAppliedSavedPosition = true;
-		lastSavedPosX = gConfig.targetBarWindowPosX;
-		lastSavedPosY = gConfig.targetBarWindowPosY;
-	end
-
 	local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
     ApplyWindowPosition('TargetBar');
     if (imgui.Begin('TargetBar', true, windowFlags)) then
@@ -782,18 +763,6 @@ targetbar.DrawWindow = function(settings)
 			local totalCastBarSpace = settings.castBarOffsetY + settings.castBarHeight + 2 + castTextHeight;
 			imgui.Dummy({0, totalCastBarSpace});
 		end
-		-- Save position if moved (with change detection to avoid spam)
-		local winPosX, winPosY = imgui.GetWindowPos();
-		if not gConfig.lockPositions then
-			if lastSavedPosX == nil or
-			   math.abs(winPosX - lastSavedPosX) > 1 or
-			   math.abs(winPosY - lastSavedPosY) > 1 then
-				gConfig.targetBarWindowPosX = winPosX;
-				gConfig.targetBarWindowPosY = winPosY;
-				lastSavedPosX = winPosX;
-				lastSavedPosY = winPosY;
-			end
-		end
     end
     imgui.End();
 
@@ -1077,8 +1046,13 @@ targetbar.Cleanup = function()
 end
 
 targetbar.ResetPositions = function()
-	forcePositionReset = true;
-	hasAppliedSavedPosition = false;
+	local defX, defY = defaultPositions.GetTargetBarPosition();
+	if gConfig.windowPositions then
+		gConfig.windowPositions['TargetBar'] = { x = defX, y = defY };
+	end
+	if gConfig.appliedPositions then
+		gConfig.appliedPositions['TargetBar'] = nil;
+	end
 end
 
 targetbar.HandleActionPacket = function(actionPacket)

--- a/XIUI/modules/treasurepool/display.lua
+++ b/XIUI/modules/treasurepool/display.lua
@@ -32,11 +32,6 @@ local defaultPositions = require('libs.defaultpositions');
 
 local M = {};
 
--- Position save/restore state
-local hasAppliedSavedPosition = false;
-local forcePositionReset = false;
-local lastSavedPosX, lastSavedPosY = nil, nil;
-
 -- Debug logging (set to true to enable)
 local DEBUG_ENABLED = false;
 local function debugLog(msg, ...)
@@ -364,19 +359,6 @@ function M.DrawWindow(settings)
         end
 
         imgui.Dummy({windowWidth, totalHeight});
-
-        -- Save position if moved (with change detection to avoid spam)
-        local winPosX, winPosY = imgui.GetWindowPos();
-        if not gConfig.lockPositions then
-            if lastSavedPosX == nil or
-               math.abs(winPosX - lastSavedPosX) > 1 or
-               math.abs(winPosY - lastSavedPosY) > 1 then
-                gConfig.treasurePoolWindowPosX = winPosX;
-                gConfig.treasurePoolWindowPosY = winPosY;
-                lastSavedPosX = winPosX;
-                lastSavedPosY = winPosY;
-            end
-        end
 
         -- Handle scroll input when hovering over window
         if needsScroll and imgui.IsWindowHovered() then
@@ -1615,8 +1597,13 @@ function M.Cleanup()
 end
 
 M.ResetPositions = function()
-    forcePositionReset = true;
-    hasAppliedSavedPosition = false;
+    local defX, defY = defaultPositions.GetTreasurePoolPosition();
+    if gConfig.windowPositions then
+        gConfig.windowPositions['TreasurePool'] = { x = defX, y = defY };
+    end
+    if gConfig.appliedPositions then
+        gConfig.appliedPositions['TreasurePool'] = nil;
+    end
 end
 
 return M;


### PR DESCRIPTION
Added Config Window Position/Size Reset
- Fixes issues with screen size hiding the config window
- Resizes the config window to screen size if the last known size was bigger than the current resolution on open (This fixes going from a larger resolution to a smaller resolution and config window not being visible)
- Repositions the config window if the last known position is off screen on open
- Also changed the Center UI Positions to Top Left to assure windows are all on screen and visible on smaller resolutions.

Moved PushThemStyles() After DisplaySize Validation
- Fixes windows disappearing in certain resolutions by avoiding leaking style/var pushes on early returns

Fixed Config Initial Load Window Size
- On first load the config window should now open at size 900 x 650 as long as it fits the screen resolution, otherwise it shrink down to fit the screen.

Refactored Window Position Handling
- Fixes window positioning conflicts that were happening due to legacy settings
- Removed legacy position saving and restoring logic from individual modules.
- Centralized position application logic using `ApplyWindowPosition` function.
- Updated position reset functionality to clear applied positions in the configuration.
- Ensured that window positions are saved only when significant changes occur.
- Improved handling of external position changes to maintain UI stability.
- Cleaned up unnecessary variables and code related to position management.

Final Analysis On Window Positioning
- This commit is a final analysis of all the changes in this branch, fixing any remaining bugs I may have missed.
  - Fixed GetDefaultWindowPositions() missing EnemyList, CastCost, and 5 inventory trackers
  - Fixed initial addon load not having default position injection for empty profiles