### PR TITLE
hotbar: SMN blood pact registry (HorizonXI data)

### DIFF
--- a/XIUI/modules/hotbar/petregistry.lua
+++ b/XIUI/modules/hotbar/petregistry.lua
@@ -323,142 +323,191 @@ M.genericPetCommands = {
 };
 
 -- SMN Blood Pacts - Rage (offensive)
+-- Level/MP aligned with HorizonXI Summoner wiki where listed
 M.bloodPactsRage = {
-    -- Shared
-    { name = 'Punch', avatars = {'Ifrit'} },
-    { name = 'Fire II', avatars = {'Ifrit'} },
-    { name = 'Burning Strike', avatars = {'Ifrit'} },
-    { name = 'Double Punch', avatars = {'Ifrit'} },
-    { name = 'Flaming Crush', avatars = {'Ifrit'} },
-    { name = 'Meteor Strike', avatars = {'Ifrit'} },
-    { name = 'Conflag Strike', avatars = {'Ifrit'} },
-    { name = 'Fire IV', avatars = {'Ifrit'} },
+    -- Ifrit
+    { name = 'Punch', level = 1, mp = 9, avatars = {'Ifrit'} },
+    { name = 'Fire II', level = 10, mp = 24, avatars = {'Ifrit'} },
+    { name = 'Burning Strike', level = 23, mp = 48, avatars = {'Ifrit'} },
+    { name = 'Double Punch', level = 30, mp = 56, avatars = {'Ifrit'} },
+    { name = 'Fire IV', level = 60, mp = 118, avatars = {'Ifrit'} },
+    { name = 'Flaming Crush', level = 70, mp = 164, avatars = {'Ifrit'} },
+    { name = 'Meteor Strike', level = 75, mp = 182, avatars = {'Ifrit'} },
+    { name = 'Conflag Strike', level = 0, mp = 0, avatars = {'Ifrit'} }, -- Not on Wiki
+    { name = 'Inferno', level = 1, mp = -1, avatars = {'Ifrit'}, requiresFlow = true },
     -- Shiva
-    { name = 'Axe Kick', avatars = {'Shiva'} },
-    { name = 'Blizzard II', avatars = {'Shiva'} },
-    { name = 'Double Slap', avatars = {'Shiva'} },
-    { name = 'Blizzard IV', avatars = {'Shiva'} },
-    { name = 'Rush', avatars = {'Shiva'} },
-    { name = 'Heavenly Strike', avatars = {'Shiva'} },
+    { name = 'Axe Kick', level = 1, mp = 10, avatars = {'Shiva'} },
+    { name = 'Blizzard II', level = 10, mp = 24, avatars = {'Shiva'} },
+    { name = 'Double Slap', level = 50, mp = 96, avatars = {'Shiva'} },
+    { name = 'Blizzard IV', level = 60, mp = 118, avatars = {'Shiva'} },
+    { name = 'Rush', level = 70, mp = 164, avatars = {'Shiva'} },
+    { name = 'Heavenly Strike', level = 75, mp = 182, avatars = {'Shiva'} },
+    { name = 'Diamond Dust', level = 1, mp = -1, avatars = {'Shiva'}, requiresFlow = true },
     -- Garuda
-    { name = 'Claw', avatars = {'Garuda'} },
-    { name = 'Aero II', avatars = {'Garuda'} },
-    { name = 'Aero IV', avatars = {'Garuda'} },
-    { name = 'Predator Claws', avatars = {'Garuda'} },
-    { name = 'Wind Blade', avatars = {'Garuda'} },
+    { name = 'Claw', level = 1, mp = 7, avatars = {'Garuda'} },
+    { name = 'Aero II', level = 10, mp = 24, avatars = {'Garuda'} },
+    { name = 'Aero IV', level = 60, mp = 118, avatars = {'Garuda'} },
+    { name = 'Predator Claws', level = 70, mp = 164, avatars = {'Garuda'} },
+    { name = 'Wind Blade', level = 75, mp = 182, avatars = {'Garuda'} },
+    { name = 'Aerial Blast', level = 1, mp = -1, avatars = {'Garuda'}, requiresFlow = true },
     -- Titan
-    { name = 'Rock Throw', avatars = {'Titan'} },
-    { name = 'Stone II', avatars = {'Titan'} },
-    { name = 'Stone IV', avatars = {'Titan'} },
-    { name = 'Rock Buster', avatars = {'Titan'} },
-    { name = 'Megalith Throw', avatars = {'Titan'} },
-    { name = 'Mountain Buster', avatars = {'Titan'} },
-    { name = 'Geocrush', avatars = {'Titan'} },
-    { name = 'Crag Throw', avatars = {'Titan'} },
+    { name = 'Rock Throw', level = 1, mp = 10, avatars = {'Titan'}, status = 'Slow' },
+    { name = 'Stone II', level = 10, mp = 24, avatars = {'Titan'} },
+    { name = 'Rock Buster', level = 21, mp = 39, avatars = {'Titan'}, status = 'Bind' },
+    { name = 'Megalith Throw', level = 35, mp = 62, avatars = {'Titan'}, status = 'Slow' },
+    { name = 'Stone IV', level = 60, mp = 118, avatars = {'Titan'} },
+    { name = 'Mountain Buster', level = 70, mp = 164, avatars = {'Titan'}, status = 'Bind' },
+    { name = 'Geocrush', level = 75, mp = 182, avatars = {'Titan'}, status = 'Stun' },
+    { name = 'Crag Throw', level = 0, mp = 0, avatars = {'Titan'} }, -- Not on Wiki
+    { name = 'Earthen Fury', level = 1, mp = -1, avatars = {'Titan'}, requiresFlow = true },
     -- Ramuh
-    { name = 'Shock Strike', avatars = {'Ramuh'} },
-    { name = 'Thunder II', avatars = {'Ramuh'} },
-    { name = 'Thunder IV', avatars = {'Ramuh'} },
-    { name = 'Chaotic Strike', avatars = {'Ramuh'} },
-    { name = 'Thunderstorm', avatars = {'Ramuh'} },
-    { name = 'Thunderspark', avatars = {'Ramuh'} },
-    { name = 'Volt Strike', avatars = {'Ramuh'} },
+    { name = 'Shock Strike', level = 1, mp = 6, avatars = {'Ramuh'}, status = 'Stun' },
+    { name = 'Thunder II', level = 10, mp = 24, avatars = {'Ramuh'} },
+    { name = 'Thunderspark', level = 19, mp = 38, avatars = {'Ramuh'}, status = 'Paralyze' },
+    { name = 'Thunder IV', level = 60, mp = 118, avatars = {'Ramuh'} },
+    { name = 'Chaotic Strike', level = 70, mp = 164, avatars = {'Ramuh'}, status = 'Stun' },
+    { name = 'Thunderstorm', level = 75, mp = 182, avatars = {'Ramuh'} },
+    { name = 'Volt Strike', level = 0, mp = 0, avatars = {'Ramuh'} }, -- Not on Wiki
+    { name = 'Judgement Bolt', level = 1, mp = -1, avatars = {'Ramuh'}, requiresFlow = true },
     -- Leviathan
-    { name = 'Barracuda Dive', avatars = {'Leviathan'} },
-    { name = 'Water II', avatars = {'Leviathan'} },
-    { name = 'Water IV', avatars = {'Leviathan'} },
-    { name = 'Tail Whip', avatars = {'Leviathan'} },
-    { name = 'Spinning Dive', avatars = {'Leviathan'} },
-    { name = 'Grand Fall', avatars = {'Leviathan'} },
+    { name = 'Barracuda Dive', level = 1, mp = 8, avatars = {'Leviathan'} },
+    { name = 'Water II', level = 10, mp = 24, avatars = {'Leviathan'} },
+    { name = 'Tail Whip', level = 26, mp = 49, avatars = {'Leviathan'}, status = 'Weight' },
+    { name = 'Water IV', level = 60, mp = 118, avatars = {'Leviathan'} },
+    { name = 'Spinning Dive', level = 70, mp = 164, avatars = {'Leviathan'} },
+    { name = 'Grand Fall', level = 75, mp = 182, avatars = {'Leviathan'} },
+    { name = 'Tidal Wave', level = 1, mp = -1, avatars = {'Leviathan'}, requiresFlow = true },
     -- Fenrir
-    { name = 'Moonlit Charge', avatars = {'Fenrir'} },
-    { name = 'Crescent Fang', avatars = {'Fenrir'} },
-    { name = 'Eclipse Bite', avatars = {'Fenrir'} },
-    { name = 'Howling Moon', avatars = {'Fenrir'} },
-    { name = 'Impact', avatars = {'Fenrir'} },
+    { name = 'Moonlit Charge', level = 5, mp = 17, avatars = {'Fenrir'}, status = 'Blind' },
+    { name = 'Crescent Fang', level = 10, mp = 19, avatars = {'Fenrir'}, status = 'Paralyze' },
+    { name = 'Eclipse Bite', level = 65, mp = 109, avatars = {'Fenrir'} },
+    { name = 'Impact', level = 75, mp = 182, avatars = {'Fenrir'} },
+    { name = 'Howling Moon', level = 1, mp = -1, avatars = {'Fenrir'}, requiresFlow = true },
     -- Diabolos
-    { name = 'Camisado', avatars = {'Diabolos'} },
-    { name = 'Nether Blast', avatars = {'Diabolos'} },
-    { name = 'Night Terror', avatars = {'Diabolos'} },
+    { name = 'Camisado', level = 1, mp = 20, avatars = {'Diabolos'}, status = 'Knockback' },
+    { name = 'Nether Blast', level = 65, mp = 109, avatars = {'Diabolos'} },
+    { name = 'Night Terror', level = 70, mp = 158, avatars = {'Diabolos'} },
+    { name = 'Ruinous Omen', level = 1, mp = -1, avatars = {'Diabolos'}, requiresFlow = true },
     -- Carbuncle
-    { name = 'Poison Nails', avatars = {'Carbuncle'} },
-    { name = 'Holy Mist', avatars = {'Carbuncle'} },
-    { name = 'Meteorite', avatars = {'Carbuncle'} },
+    { name = 'Poison Nails', level = 5, mp = 11, avatars = {'Carbuncle'}, status = 'Poison' },
+    { name = 'Holy Mist', level = 65, mp = 130, avatars = {'Carbuncle'} },
+    { name = 'Meteorite', level = 55, mp = 108, avatars = {'Carbuncle'} },
+    { name = 'Searing Light', level = 1, mp = -1, avatars = {'Carbuncle'}, requiresFlow = true },
     -- Odin
-    { name = 'Zantetsuken', avatars = {'Odin'} },
-    -- Cait Sith
-    { name = 'Regal Scratch', avatars = {'Cait Sith'} },
-    { name = 'Level ? Holy', avatars = {'Cait Sith'} },
-    { name = 'Regal Gash', avatars = {'Cait Sith'} },
-    -- Siren
-    { name = 'Clarsach Call', avatars = {'Siren'} },
-    { name = 'Sonic Buffet', avatars = {'Siren'} },
-    { name = 'Tornado II', avatars = {'Siren'} },
-    { name = 'Hysteric Assault', avatars = {'Siren'} },
-    { name = 'Welt', avatars = {'Siren'} },
-    { name = 'Katabatic Blades', avatars = {'Siren'} },
+    { name = 'Zantetsuken', level = 1, mp = -1, avatars = {'Odin'}, requiresFlow = true },
+    -- Cait Sith (Basic entries)
+    { name = 'Regal Scratch', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    { name = 'Level ? Holy', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    { name = 'Regal Gash', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    -- Siren (Basic entries)
+    { name = 'Clarsach Call', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Sonic Buffet', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Tornado II', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Hysteric Assault', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Welt', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Katabatic Blades', level = 1, mp = 10, avatars = {'Siren'} },
 };
 
 -- SMN Blood Pacts - Ward (support)
+-- Level/MP aligned with HorizonXI Summoner wiki where listed
 M.bloodPactsWard = {
     -- Carbuncle
-    { name = 'Soothing Ruby', avatars = {'Carbuncle'} },
-    { name = 'Healing Ruby', avatars = {'Carbuncle'} },
-    { name = 'Shining Ruby', avatars = {'Carbuncle'} },
-    { name = 'Glittering Ruby', avatars = {'Carbuncle'} },
-    { name = 'Healing Ruby II', avatars = {'Carbuncle'} },
-    { name = 'Pacifying Ruby', avatars = {'Carbuncle'} },
+    { name = 'Soothing Ruby', level = 1, mp = 0, avatars = {'Carbuncle'} },
+    { name = 'Healing Ruby', level = 1, mp = 6, avatars = {'Carbuncle'} },
+    { name = 'Poison Ruby', level = 6, mp = 12, avatars = {'Carbuncle'}, status = 'Poison' },
+    { name = 'Shining Ruby', level = 24, mp = 44, avatars = {'Carbuncle'} },
+    { name = 'Glittering Ruby', level = 44, mp = 62, avatars = {'Carbuncle'} },
+    { name = 'Healing Ruby II', level = 65, mp = 124, avatars = {'Carbuncle'} },
+    { name = 'Pacifying Ruby', level = 0, mp = 0, avatars = {'Carbuncle'} },
     -- Ifrit
-    { name = 'Crimson Howl', avatars = {'Ifrit'} },
-    { name = 'Inferno Howl', avatars = {'Ifrit'} },
+    { name = 'Crimson Howl', level = 39, mp = 84, avatars = {'Ifrit'} },
+    { name = 'Inferno Howl', level = 1, mp = 10, avatars = {'Ifrit'} },
     -- Shiva
-    { name = 'Frost Armor', avatars = {'Shiva'} },
-    { name = 'Sleepga', avatars = {'Shiva'} },
-    { name = 'Diamond Storm', avatars = {'Shiva'} },
-    { name = 'Crystal Blessing', avatars = {'Shiva'} },
+    { name = 'Frost Armor', level = 28, mp = 63, avatars = {'Shiva'} },
+    { name = 'Sleepga', level = 39, mp = 54, avatars = {'Shiva'}, status = 'Sleep' },
+    { name = 'Diamond Storm', level = 50, mp = 92, avatars = {'Shiva'}, status = 'Evasion Down' },
+    { name = 'Crystal Blessing', level = 0, mp = 0, avatars = {'Shiva'} },
     -- Garuda
-    { name = 'Aerial Armor', avatars = {'Garuda'} },
-    { name = 'Whispering Wind', avatars = {'Garuda'} },
-    { name = 'Hastega', avatars = {'Garuda'} },
-    { name = 'Fleet Wind', avatars = {'Garuda'} },
+    { name = 'Whispering Wind', level = 38, mp = 119, avatars = {'Garuda'} },
+    { name = 'Hastega', level = 48, mp = 129, avatars = {'Garuda'} },
+    { name = 'Aerial Armor', level = 25, mp = 92, avatars = {'Garuda'} },
+    { name = 'Fleet Wind', level = 0, mp = 0, avatars = {'Garuda'} },
     -- Titan
-    { name = 'Earthen Ward', avatars = {'Titan'} },
-    { name = 'Earthen Armor', avatars = {'Titan'} },
+    { name = 'Earthen Ward', level = 46, mp = 92, avatars = {'Titan'} },
+    { name = 'Earthen Armor', level = 0, mp = 0, avatars = {'Titan'} },
     -- Ramuh
-    { name = 'Rolling Thunder', avatars = {'Ramuh'} },
-    { name = 'Lightning Armor', avatars = {'Ramuh'} },
-    { name = 'Shock Squall', avatars = {'Ramuh'} },
+    { name = 'Rolling Thunder', level = 31, mp = 52, avatars = {'Ramuh'} },
+    { name = 'Lightning Armor', level = 42, mp = 91, avatars = {'Ramuh'} },
+    { name = 'Shock Squall', level = 0, mp = 0, avatars = {'Ramuh'} },
     -- Leviathan
-    { name = 'Slowga', avatars = {'Leviathan'} },
-    { name = 'Spring Water', avatars = {'Leviathan'} },
-    { name = 'Tidal Roar', avatars = {'Leviathan'} },
+    { name = 'Slowga', level = 33, mp = 48, avatars = {'Leviathan'}, status = 'Slow' },
+    { name = 'Spring Water', level = 47, mp = 99, avatars = {'Leviathan'} },
+    { name = 'Tidal Roar', level = 0, mp = 0, avatars = {'Leviathan'} },
     -- Fenrir
-    { name = 'Ecliptic Growl', avatars = {'Fenrir'} },
-    { name = 'Ecliptic Howl', avatars = {'Fenrir'} },
-    { name = 'Lunar Cry', avatars = {'Fenrir'} },
-    { name = 'Lunar Roar', avatars = {'Fenrir'} },
+    { name = 'Ecliptic Growl', level = 54, mp = 46, avatars = {'Fenrir'} },
+    { name = 'Ecliptic Howl', level = 43, mp = 57, avatars = {'Fenrir'} },
+    { name = 'Lunar Cry', level = 21, mp = 41, avatars = {'Fenrir'}, status = 'Accuracy Down' },
+    { name = 'Lunar Roar', level = 32, mp = 27, avatars = {'Fenrir'} },
     -- Diabolos
-    { name = 'Pavor Nocturnus', avatars = {'Diabolos'} },
-    { name = 'Somnolence', avatars = {'Diabolos'} },
-    { name = 'Nightmare', avatars = {'Diabolos'} },
-    { name = 'Ultimate Terror', avatars = {'Diabolos'} },
-    { name = 'Noctoshield', avatars = {'Diabolos'} },
-    { name = 'Dream Shroud', avatars = {'Diabolos'} },
+    { name = 'Pavor Nocturnus', level = 1, mp = 10, avatars = {'Diabolos'} },
+    { name = 'Somnolence', level = 20, mp = 30, avatars = {'Diabolos'}, status = 'Weight' },
+    { name = 'Nightmare', level = 29, mp = 42, avatars = {'Diabolos'}, status = 'Sleep' },
+    { name = 'Ultimate Terror', level = 37, mp = 27, avatars = {'Diabolos'} },
+    { name = 'Noctoshield', level = 49, mp = 92, avatars = {'Diabolos'} },
+    { name = 'Dream Shroud', level = 56, mp = 121, avatars = {'Diabolos'} },
     -- Cait Sith
-    { name = 'Mewing Lullaby', avatars = {'Cait Sith'} },
-    { name = 'Eerie Eye', avatars = {'Cait Sith'} },
-    { name = 'Altana\'s Favor', avatars = {'Cait Sith'} },
-    { name = 'Raise II', avatars = {'Cait Sith'} },
-    { name = 'Reraise II', avatars = {'Cait Sith'} },
+    { name = 'Mewing Lullaby', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    { name = 'Eerie Eye', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    { name = 'Altana\'s Favor', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    { name = 'Raise II', level = 1, mp = 10, avatars = {'Cait Sith'} },
+    { name = 'Reraise II', level = 1, mp = 10, avatars = {'Cait Sith'} },
     -- Alexander
-    { name = 'Perfect Defense', avatars = {'Alexander'} },
+    { name = 'Perfect Defense', level = 1, mp = -1, avatars = {'Alexander'}, requiresFlow = true },
     -- Atomos
-    { name = 'Chronoshift', avatars = {'Atomos'} },
+    { name = 'Chronoshift', level = 1, mp = 10, avatars = {'Atomos'} },
     -- Siren
-    { name = 'Lunatic Voice', avatars = {'Siren'} },
-    { name = 'Chinook', avatars = {'Siren'} },
-    { name = 'Bitter Elegy', avatars = {'Siren'} },
+    { name = 'Lunatic Voice', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Chinook', level = 1, mp = 10, avatars = {'Siren'} },
+    { name = 'Bitter Elegy', level = 1, mp = 10, avatars = {'Siren'} },
 };
+
+-- ============================================
+-- SMN Blood Pact Lookup Index (name -> pact data)
+-- ============================================
+
+-- Build a fast lookup table for Blood Pact data by name.
+-- This avoids scanning the pact lists every frame when rendering MP costs.
+local function BuildBloodPactIndex()
+    local idx = {};
+
+    for _, pact in ipairs(M.bloodPactsRage or {}) do
+        if pact and pact.name then
+            idx[pact.name] = pact;
+        end
+    end
+    for _, pact in ipairs(M.bloodPactsWard or {}) do
+        if pact and pact.name then
+            idx[pact.name] = pact;
+        end
+    end
+
+    return idx;
+end
+
+-- NOTE: This is built once at load time. If you mutate blood pact tables at runtime,
+-- call `M.RebuildBloodPactIndex()` after changes.
+M.bloodPactIndexByName = BuildBloodPactIndex();
+
+function M.RebuildBloodPactIndex()
+    M.bloodPactIndexByName = BuildBloodPactIndex();
+end
+
+-- Get Blood Pact data by name (Rage or Ward).
+-- Returns the underlying pact table (contains name, level, mp, requiresFlow, avatars, etc.) or nil.
+function M.GetBloodPactByName(name)
+    if not name then return nil; end
+    return M.bloodPactIndexByName and M.bloodPactIndexByName[name] or nil;
+end
 
 -- DRG Wyvern abilities
 M.wyvernCommands = {

--- a/XIUI/modules/hotbar/petregistry.lua
+++ b/XIUI/modules/hotbar/petregistry.lua
@@ -368,7 +368,7 @@ M.bloodPactsRage = {
     { name = 'Chaotic Strike', level = 70, mp = 164, avatars = {'Ramuh'}, status = 'Stun' },
     { name = 'Thunderstorm', level = 75, mp = 182, avatars = {'Ramuh'} },
     { name = 'Volt Strike', level = 0, mp = 0, avatars = {'Ramuh'} }, -- Not on Wiki
-    { name = 'Judgement Bolt', level = 1, mp = -1, avatars = {'Ramuh'}, requiresFlow = true },
+    { name = 'Judgment Bolt', level = 1, mp = -1, avatars = {'Ramuh'}, requiresFlow = true },
     -- Leviathan
     { name = 'Barracuda Dive', level = 1, mp = 8, avatars = {'Leviathan'} },
     { name = 'Water II', level = 10, mp = 24, avatars = {'Leviathan'} },


### PR DESCRIPTION
- Expand Rage/Ward tables with learn levels, MP costs, optional status labels, and requiresFlow for Astral Flow pacts.

- Add bloodPactIndexByName lookup and RebuildBloodPactIndex for fast name resolution.