### PR TITLE
Add charm pet level indicator

### DIFF
--- a/XIUI/config/petbar.lua
+++ b/XIUI/config/petbar.lua
@@ -146,12 +146,9 @@ local function DrawPetTypeVisualSettings(configKey, petTypeLabel)
         imgui.ShowHelp('Always show the pet bar (recast timers) even when no pet is present.');
         imgui.Spacing();
 
-        -- Charmed pets don't have levels, so hide this option for Charm
-        if configKey ~= 'petBarCharm' then
-            components.DrawPartyCheckbox(typeSettings, 'Show Pet Level##' .. configKey, 'showLevel');
-            imgui.ShowHelp('Show pet level before the name (e.g., "Lv.35 FunguarFamiliar").');
-            imgui.Spacing();
-        end
+        components.DrawPartyCheckbox(typeSettings, 'Show Pet Level##' .. configKey, 'showLevel');
+        imgui.ShowHelp('Show pet level before the name (e.g., "Lv.35 FunguarFamiliar").');
+        imgui.Spacing();
 
         components.DrawPartyCheckbox(typeSettings, 'Align Bottom##' .. configKey, 'alignBottom');
         imgui.ShowHelp('Anchor the pet bar to its bottom edge. When the window height changes, it expands upward.');

--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -651,13 +651,13 @@ function data.GetPetData()
     local party = GetPartySafe();
     local playerEnt = GetPlayerEntity();
 
-    if player == nil or party == nil or playerEnt == nil then
-        -- No pet - clear tracking
-        data.TrackPetSummon(nil, nil);
+    if player.isZoning or player:GetMainJob() == 0 then
         return nil;
     end
 
-    if player.isZoning or player:GetMainJob() == 0 then
+    if player == nil or party == nil or playerEnt == nil then
+        -- No pet - clear tracking
+        data.TrackPetSummon(nil, nil);
         return nil;
     end
 

--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -279,8 +279,14 @@ function data.GetPetLevel(petName, playerLevel)
         return playerLevel;
     end
 
-    -- For charmed pets, we can't know the level without tracking the charm action
+    -- For charmed pets, get level from charm check packet
+    if gConfig.petBarCharmLevel then
+       return gConfig.petBarCharmLevel;
+    end
+
+    -- Fallback
     return nil;
+    
 end
 
 -- ============================================
@@ -1416,7 +1422,7 @@ function data.GetPreviewPetData(previewType)
         mockData.job = data.JOB_BST;
         mockData.showMp = false;
         mockData.isCharmed = true;
-        mockData.level = nil;  -- Unknown for charmed pets
+        mockData.level = 35;
         mockData.charmElapsed = 183;  -- ~3 minutes elapsed
         mockData.petType = 'charm';
     end

--- a/XIUI/modules/petbar/init.lua
+++ b/XIUI/modules/petbar/init.lua
@@ -387,6 +387,7 @@ petbar.HandlePacket = function(e)
 
                 -- Persist to config
                 if gConfig then
+                    gConfig.petBarCharmLevel = param1;
                     gConfig.petBarCharmExpireTime = data.charmExpireTime;
                 end
             end


### PR DESCRIPTION
This small change enables XIUI to show charmed pet level indicators in the UI (if enabled in the configuration).  This is important data for BST and /BST players to determine a charmed pet's general strength and fitness vs another mob.

- **modules/petbar/init.lua** was already capturing the charmed pet level to calculate the charm duration, so this change now stores the pet's level value in gConfig.petBarCharmLevel when charmed
- The data.GetPetLevel function in **modules/petbar/data.lua** has been updated to look for gConfig.petBarCharmLevel and return it if present.  If not, it will still fallback to returning nil as before.
- **config/petbar.lua** has been updated so it no longer excludes charmed pets from displaying the option to show pet levels, giving users the ability to toggle this feature on and off like other pet types.
- mockData.level has been given an arbitrary value for previewType == data.PREVIEW_CHARMED in **modules/petbar/data.lua** so that toggling the option on or off in the settings shows a proper preview of how this feature will look in the UI

<img width="312" height="326" alt="Screenshot 2026-04-30 111703" src="https://github.com/user-attachments/assets/d4cbbc35-f8f9-43d7-80d4-3b92aa06ba8a" />
