### PR TITLE
Migrate window backgrounds to ImGui draw lists

### DIFF
--- a/XIUI/handlers/helpers.lua
+++ b/XIUI/handlers/helpers.lua
@@ -27,7 +27,6 @@ local fastcastLib = require('libs.fastcast');
 local formatLib = require('libs.format');
 local colorLib = require('libs.color');
 local statusIconsLib = require('libs.statusicons');
-local windowBackgroundLib = require('libs.windowbackground');
 
 -- Handler imports (still in handlers/)
 local statusHandler = require('handlers.statushandler');
@@ -216,9 +215,6 @@ function DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOffs
     return statusIconsLib.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOffset, buffTimes, settings, statusHandler, buffTable);
 end
 
-
--- Window Background Utilities (from windowbackground.lua)
-WindowBackground = windowBackgroundLib;
 
 -- ========================================
 -- Window Utilities

--- a/XIUI/libs/button.lua
+++ b/XIUI/libs/button.lua
@@ -33,237 +33,33 @@
 require('common');
 local imgui = require('imgui');
 local ffi = require('ffi');
-local primitives = require('primitives');
 
 local M = {};
 
+-- Forward decls (used by *Prim aliases before non-Prim definitions appear below).
+local DrawImpl, DrawArrowImpl, ARGBToU32Local;
+
 -- ============================================
--- Primitive-based Button Management
+-- API aliases (formerly primitive-based; now route through ImGui draw list)
 -- ============================================
 
--- Store created primitive buttons for reuse
-M.primButtons = {};
-
---[[
-    Get or create a primitive button by ID
-    @param id string: Unique button identifier
-    @return table: Primitive object
-]]--
-function M.GetOrCreatePrim(id)
-    if not M.primButtons[id] then
-        M.primButtons[id] = primitives:new({
-            visible = false,
-            can_focus = false,
-            locked = true,
-        });
-    end
-    return M.primButtons[id];
-end
-
---[[
-    Destroy a primitive button by ID
-    @param id string: Button identifier
-]]--
-function M.DestroyPrim(id)
-    if M.primButtons[id] then
-        M.primButtons[id]:destroy();
-        M.primButtons[id] = nil;
-    end
-end
-
---[[
-    Destroy all primitive buttons
-]]--
-function M.DestroyAllPrims()
-    for id, prim in pairs(M.primButtons) do
-        if prim then
-            prim:destroy();
-        end
-    end
-    M.primButtons = {};
-end
-
---[[
-    Draw a primitive-based button with ImGui text overlay
-
-    @param id string: Unique button identifier
-    @param x number: X position
-    @param y number: Y position
-    @param width number: Button width
-    @param height number: Button height
-    @param options table: Button options (colors, disabled, tooltip)
-    @return boolean: True if clicked
-    @return boolean: True if hovered
-]]--
 function M.DrawPrim(id, x, y, width, height, options)
-    options = options or {};
-
-    local colors = options.colors or M.DEFAULT_COLORS;
-    local disabled = options.disabled or false;
-
-    -- Get or create the primitive
-    local prim = M.GetOrCreatePrim(id);
-
-    -- Set cursor position for invisible button (hover/click detection)
-    imgui.SetCursorScreenPos({x, y});
-
-    -- Create invisible button for interaction
-    local clicked = false;
-    local hovered = false;
-    local held = false;
-
-    if not disabled then
-        imgui.InvisibleButton(id, {width, height});
-        clicked = imgui.IsItemClicked();
-        hovered = imgui.IsItemHovered();
-        held = imgui.IsItemActive();
-    else
-        imgui.Dummy({width, height});
-    end
-
-    -- Determine current color based on state
-    local bgColor;
-    if disabled then
-        bgColor = colors.disabled or M.DEFAULT_COLORS.disabled;
-    elseif held then
-        bgColor = colors.pressed or colors.hovered or M.DEFAULT_COLORS.pressed;
-    elseif hovered then
-        bgColor = colors.hovered or M.DEFAULT_COLORS.hovered;
-    else
-        bgColor = colors.normal or M.DEFAULT_COLORS.normal;
-    end
-
-    -- Update primitive
-    prim.visible = true;
-    prim.position_x = x;
-    prim.position_y = y;
-    prim.width = width;
-    prim.height = height;
-    prim.color = bgColor;
-
-    -- Show tooltip if provided
-    if hovered and options.tooltip then
-        imgui.SetTooltip(options.tooltip);
-    end
-
-    return clicked, hovered;
+    return DrawImpl(id, x, y, width, height, options);
 end
 
---[[
-    Hide a primitive button
-    @param id string: Button identifier
-]]--
-function M.HidePrim(id)
-    if M.primButtons[id] then
-        M.primButtons[id].visible = false;
-    end
-end
-
---[[
-    Draw a primitive-based arrow button
-
-    @param id string: Unique button identifier
-    @param x number: X position
-    @param y number: Y position
-    @param size number: Button size (square)
-    @param direction string: 'up', 'down', 'left', 'right'
-    @param options table: Button options
-    @param drawList: ImGui draw list for arrow rendering
-    @return boolean: True if clicked
-    @return boolean: True if hovered
-]]--
 function M.DrawArrowPrim(id, x, y, size, direction, options, drawList)
     options = options or {};
-
-    local colors = options.colors or M.DEFAULT_COLORS;
-    local disabled = options.disabled or false;
-
-    -- Arrow colors
-    local arrowColors = options.arrowColors or M.ARROW_COLORS;
-    local arrowColor = options.arrowColor or arrowColors.normal or 0xFFCCCCCC;
-    local arrowHoverColor = options.arrowHoverColor or arrowColors.hovered or 0xFFFFFFFF;
-
-    -- Get or create the primitive for background
-    local prim = M.GetOrCreatePrim(id);
-
-    -- Set cursor position for invisible button
-    imgui.SetCursorScreenPos({x, y});
-
-    -- Create invisible button for interaction
-    local clicked = false;
-    local hovered = false;
-    local held = false;
-
-    if not disabled then
-        imgui.InvisibleButton(id, {size, size});
-        clicked = imgui.IsItemClicked();
-        hovered = imgui.IsItemHovered();
-        held = imgui.IsItemActive();
-    else
-        imgui.Dummy({size, size});
+    if drawList ~= nil then
+        -- old-style 7th-arg drawList: pipe through options for DrawArrow
+        options.drawList = drawList;
     end
-
-    -- Determine background color based on state
-    local bgColor;
-    if disabled then
-        bgColor = colors.disabled or M.DEFAULT_COLORS.disabled;
-    elseif held then
-        bgColor = colors.pressed or colors.hovered or M.DEFAULT_COLORS.pressed;
-    elseif hovered then
-        bgColor = colors.hovered or M.DEFAULT_COLORS.hovered;
-    else
-        bgColor = colors.normal or M.DEFAULT_COLORS.normal;
-    end
-
-    -- Update primitive background
-    prim.visible = true;
-    prim.position_x = x;
-    prim.position_y = y;
-    prim.width = size;
-    prim.height = size;
-    prim.color = bgColor;
-
-    -- Draw arrow using ImGui draw list (renders on top of primitive)
-    drawList = drawList or imgui.GetForegroundDrawList();
-    local currentArrowColor = (hovered or held) and arrowHoverColor or arrowColor;
-    local arrowColorU32 = ARGBToU32(currentArrowColor);
-
-    -- Calculate arrow points
-    local centerX = x + size / 2;
-    local centerY = y + size / 2;
-    local arrowSize = size * 0.35;
-
-    local p1, p2, p3;
-
-    if direction == 'up' then
-        p1 = {centerX, centerY - arrowSize};
-        p2 = {centerX - arrowSize, centerY + arrowSize * 0.6};
-        p3 = {centerX + arrowSize, centerY + arrowSize * 0.6};
-    elseif direction == 'down' then
-        p1 = {centerX, centerY + arrowSize};
-        p2 = {centerX - arrowSize, centerY - arrowSize * 0.6};
-        p3 = {centerX + arrowSize, centerY - arrowSize * 0.6};
-    elseif direction == 'left' then
-        p1 = {centerX - arrowSize, centerY};
-        p2 = {centerX + arrowSize * 0.6, centerY - arrowSize};
-        p3 = {centerX + arrowSize * 0.6, centerY + arrowSize};
-    elseif direction == 'right' then
-        p1 = {centerX + arrowSize, centerY};
-        p2 = {centerX - arrowSize * 0.6, centerY - arrowSize};
-        p3 = {centerX - arrowSize * 0.6, centerY + arrowSize};
-    end
-
-    if p1 and p2 and p3 then
-        drawList:AddTriangleFilled(p1, p2, p3, arrowColorU32);
-    end
-
-    -- Show tooltip
-    if hovered and options.tooltip then
-        imgui.SetTooltip(options.tooltip);
-    end
-
-    return clicked, hovered;
+    return DrawArrowImpl(id, x, y, size, direction, options);
 end
+
+-- No-ops kept for callsites that haven't been cleaned up yet (no persistent primitives to manage).
+function M.HidePrim(id) end
+function M.DestroyPrim(id) end
+function M.DestroyAllPrims() end
 
 -- ============================================
 -- Default Colors
@@ -391,7 +187,7 @@ end
     @return boolean: True if button was clicked
     @return boolean: True if button is hovered
 ]]--
-function M.Draw(id, x, y, width, height, options)
+function DrawImpl(id, x, y, width, height, options)
     options = options or {};
 
     local colors = options.colors or M.DEFAULT_COLORS;
@@ -490,7 +286,7 @@ end
     @return boolean: True if clicked
     @return boolean: True if hovered
 ]]--
-function M.DrawArrow(id, x, y, size, direction, options)
+function DrawArrowImpl(id, x, y, size, direction, options)
     options = options or {};
 
     local colors = options.colors or M.DEFAULT_COLORS;
@@ -593,7 +389,7 @@ end
 
 
 --[[
-    Draw a primitive-based minimize/maximize button
+    Draw a minimize/maximize button (renders bg + icon via drawList)
 
     @param id string: Unique button identifier
     @param x number: X position
@@ -601,28 +397,22 @@ end
     @param size number: Button size (square)
     @param isMinimized boolean: True shows maximize icon (□), false shows minimize icon (_)
     @param options table: Button options
-    @param drawList: ImGui draw list for icon rendering
+    @param drawList: ImGui draw list for icon rendering (default: foreground)
     @return boolean: True if clicked
     @return boolean: True if hovered
 ]]--
-function M.DrawMinimizePrim(id, x, y, size, isMinimized, options, drawList)
+function M.DrawMinimize(id, x, y, size, isMinimized, options, drawList)
     options = options or {};
 
     local colors = options.colors or M.DEFAULT_COLORS;
     local disabled = options.disabled or false;
 
-    -- Icon colors
     local iconColors = options.iconColors or M.ARROW_COLORS;
     local iconColor = options.iconColor or iconColors.normal or 0xFFCCCCCC;
     local iconHoverColor = options.iconHoverColor or iconColors.hovered or 0xFFFFFFFF;
 
-    -- Get or create the primitive for background
-    local prim = M.GetOrCreatePrim(id);
-
-    -- Set cursor position for invisible button
     imgui.SetCursorScreenPos({x, y});
 
-    -- Create invisible button for interaction
     local clicked = false;
     local hovered = false;
     local held = false;
@@ -636,7 +426,6 @@ function M.DrawMinimizePrim(id, x, y, size, isMinimized, options, drawList)
         imgui.Dummy({size, size});
     end
 
-    -- Determine background color based on state
     local bgColor;
     if disabled then
         bgColor = colors.disabled or M.DEFAULT_COLORS.disabled;
@@ -648,20 +437,15 @@ function M.DrawMinimizePrim(id, x, y, size, isMinimized, options, drawList)
         bgColor = colors.normal or M.DEFAULT_COLORS.normal;
     end
 
-    -- Update primitive background
-    prim.visible = true;
-    prim.position_x = x;
-    prim.position_y = y;
-    prim.width = size;
-    prim.height = size;
-    prim.color = bgColor;
-
-    -- Draw icon using ImGui draw list (renders on top of primitive)
     drawList = drawList or imgui.GetForegroundDrawList();
+
+    -- Background
+    drawList:AddRectFilled({x, y}, {x + size, y + size}, ARGBToU32(bgColor));
+
+    -- Icon on top
     local currentIconColor = (hovered or held) and iconHoverColor or iconColor;
     local iconColorU32 = ARGBToU32(currentIconColor);
 
-    -- Calculate icon dimensions
     local centerX = x + size / 2;
     local centerY = y + size / 2;
     local iconSize = size * 0.4;
@@ -686,12 +470,15 @@ function M.DrawMinimizePrim(id, x, y, size, isMinimized, options, drawList)
         );
     end
 
-    -- Show tooltip
     if hovered and options.tooltip then
         imgui.SetTooltip(options.tooltip);
     end
 
     return clicked, hovered;
 end
+
+M.Draw = DrawImpl;
+M.DrawArrow = DrawArrowImpl;
+M.DrawMinimizePrim = M.DrawMinimize;
 
 return M;

--- a/XIUI/libs/progressbar.lua
+++ b/XIUI/libs/progressbar.lua
@@ -361,7 +361,11 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 		options.decorate = false;
 	end
 
-	-- Get custom draw list if provided, otherwise use window draw list
+	-- Get custom draw list if provided, otherwise use window draw list.
+	-- Note: if your module draws text via imtext.Draw on GetUIDrawList() and the
+	-- text needs to sit on top of bars, pass `drawList = GetUIDrawList()` here too
+	-- so both render to the same list (otherwise bars render above text when the
+	-- config menu is open and imtext switches to the background drawlist).
 	local drawList = options.drawList or imgui.GetWindowDrawList();
 
 	-- Get position from options or cursor

--- a/XIUI/libs/texturemanager.lua
+++ b/XIUI/libs/texturemanager.lua
@@ -1,7 +1,6 @@
 --[[
 * XIUI TextureManager
 * Centralized texture loading and caching with LRU eviction
-* Follows FontManager pattern for consistent API design
 *
 * Categories:
 *   - item_icons: Item icons from game resources (treasure pool, notifications)

--- a/XIUI/libs/windowbackground.lua
+++ b/XIUI/libs/windowbackground.lua
@@ -1,583 +1,197 @@
 --[[
 * XIUI Window Background Library
-* Unified API for managing window backgrounds with the 5-piece border system
+* Immediate-mode background + border renderer using ImGui draw lists.
 *
-* The 5-piece system consists of:
-*   - bg: Main background texture (scaled)
-*   - tl, tr, bl, br: L-shaped corner/edge border pieces (not scaled)
-*
-* Render order (Ashita primitives render in creation order):
-*   1. Background (bg) - created first, renders at bottom
-*   2. [Consumer creates their own middle-layer content here]
-*   3. Borders (tl, tr, bl, br) - created last, render on top
+* The 5 textures (bg + tl/tr/bl/br) are tinted/positioned per-frame and submitted
+* to the supplied draw list. No persistent handles — callers re-issue Draw every
+* frame as part of their DrawWindow.
 *
 * Theme types:
-*   - '-None-': No background or borders (everything hidden)
-*   - 'Plain': Background only (borders hidden)
-*   - 'Window1-8': Background AND borders visible
+*   - '-None-':   nothing rendered
+*   - 'Plain':    background only (no borders)
+*   - 'Window1-8': background + L-shaped borders
+*
+* Render order within Draw:
+*   1. bg
+*   2. tl, tr, bl, br (borders sit on top so corners are crisp)
+* Callers needing middle-layer content (e.g. petbar's pet image) should call
+* DrawBackground / DrawBorders separately and emit their content between.
 ]]--
 
 require('common');
-local primitives = require('primitives');
-local diagnostics = require('libs.diagnostics');
+local imgui = require('imgui');
+local TextureManager = require('libs.texturemanager');
 
 local M = {};
 
 -- ============================================
 -- Constants
 -- ============================================
-M.BG_IMAGE_KEYS = { 'bg', 'tl', 'tr', 'br', 'bl' };
-M.BORDER_KEYS = { 'tl', 'tr', 'br', 'bl' };
 
--- Default values
 local DEFAULT_PADDING = 8;
 local DEFAULT_BORDER_SIZE = 21;
 local DEFAULT_BG_OFFSET = 1;
-local DEFAULT_BG_SCALE = 1.0;
-local DEFAULT_BORDER_SCALE = 1.0;
 
 -- ============================================
 -- Internal Helpers
 -- ============================================
 
--- Cache-guarded primitive property set: only writes to prim when value changes
-local function set(c, prim, ckey, prop, val)
-    if c[ckey] ~= val then prim[prop] = val; c[ckey] = val; end
-end
-
--- Check if theme is a Window theme (has borders)
 local function IsWindowTheme(themeName)
     if themeName == nil then return false; end
     return themeName:match('^Window%d+$') ~= nil;
 end
 
--- Apply opacity to a color (extract RGB, combine with opacity alpha)
+-- Replace the alpha byte of an ARGB color with opacity*255
 local function ApplyOpacityToColor(color, opacity)
     local alphaByte = math.floor((opacity or 1.0) * 255);
     local rgb = bit.band(color or 0xFFFFFFFF, 0x00FFFFFF);
     return bit.bor(bit.lshift(alphaByte, 24), rgb);
 end
 
--- ============================================
--- Creation Functions
--- ============================================
-
---[[
-    Create background primitive (call first for correct render order)
-
-    @param primData table: Base primitive data (visible, can_focus, locked, etc.)
-    @param themeName string: Theme name ('-None-', 'Plain', 'Window1', etc.)
-    @param bgScale number: Background texture scale (default 1.0)
-    @return table: Background primitive handle with 'bg' key
-]]--
-function M.createBackground(primData, themeName, bgScale)
-    bgScale = bgScale or DEFAULT_BG_SCALE;
-
-    local bgPrim = primitives:new(primData);
-    diagnostics.TrackPrimitiveCreate();  -- Track primitive creation
-    bgPrim.visible = false;
-    bgPrim.can_focus = false;
-    bgPrim.exists = false;
-    bgPrim.scale_x = bgScale;
-    bgPrim.scale_y = bgScale;
-
-    -- Load texture if not '-None-'
-    if themeName ~= '-None-' then
-        local filepath = string.format('%s/assets/backgrounds/%s-bg.png', addon.path, themeName);
-        bgPrim.texture = filepath;
-        bgPrim.exists = ashita.fs.exists(filepath);
+local function ResolveTint(color, opacity)
+    if opacity ~= nil then
+        return ApplyOpacityToColor(color or 0xFFFFFFFF, opacity);
     end
-
-    return {
-        bg = bgPrim,
-        themeName = themeName,
-        bgScale = bgScale,
-    };
+    return color or 0xFFFFFFFF;
 end
 
---[[
-    Create border primitives (call after creating middle-layer content)
-
-    @param primData table: Base primitive data
-    @param themeName string: Theme name
-    @param borderScale number: Border texture scale (default 1.0)
-    @return table: Border primitives handle with 'tl', 'tr', 'bl', 'br' keys
-]]--
-function M.createBorders(primData, themeName, borderScale)
-    borderScale = borderScale or DEFAULT_BORDER_SCALE;
-
-    local borders = {
-        themeName = themeName,
-        borderScale = borderScale,
-    };
-
-    for _, k in ipairs(M.BORDER_KEYS) do
-        local prim = primitives:new(primData);
-        diagnostics.TrackPrimitiveCreate();  -- Track primitive creation
-        prim.visible = false;
-        prim.can_focus = false;
-        prim.exists = false;
-        prim.scale_x = borderScale;
-        prim.scale_y = borderScale;
-
-        -- Load texture if Window theme
-        if IsWindowTheme(themeName) then
-            local filepath = string.format('%s/assets/backgrounds/%s-%s.png', addon.path, themeName, k);
-            prim.texture = filepath;
-            prim.exists = ashita.fs.exists(filepath);
-        end
-
-        borders[k] = prim;
-    end
-
-    return borders;
+-- Cached ARGB -> ImU32 conversion (drawList:AddImage takes ImU32 tints)
+local tintCache = {};
+local function TintU32(argb)
+    local v = tintCache[argb];
+    if v ~= nil then return v; end
+    v = imgui.GetColorU32(ARGBToImGui(argb));
+    tintCache[argb] = v;
+    return v;
 end
 
---[[
-    Create complete window background (background + borders)
-    Convenience function that creates both in correct order.
-    Note: If you need middle-layer content, use createBackground() and createBorders() separately.
+local function LoadPiecePtr(theme, piece)
+    local tex = TextureManager.getFileTexture(string.format('backgrounds/%s-%s', theme, piece));
+    if tex == nil then return nil; end
+    return TextureManager.getTexturePtr(tex);
+end
 
-    @param primData table: Base primitive data
-    @param themeName string: Theme name
-    @param bgScale number: Background texture scale (default 1.0)
-    @param borderScale number: Border texture scale (default 1.0, or bgScale if not specified)
-    @return table: Combined handle with 'bg', 'tl', 'tr', 'bl', 'br' keys
-]]--
-function M.create(primData, themeName, bgScale, borderScale)
-    bgScale = bgScale or DEFAULT_BG_SCALE;
-    borderScale = borderScale or DEFAULT_BORDER_SCALE;
-
-    local bgHandle = M.createBackground(primData, themeName, bgScale);
-    local borderHandle = M.createBorders(primData, themeName, borderScale);
-
-    return {
-        bg = bgHandle.bg,
-        tl = borderHandle.tl,
-        tr = borderHandle.tr,
-        bl = borderHandle.bl,
-        br = borderHandle.br,
-        themeName = themeName,
-        bgScale = bgScale,
-        borderScale = borderScale,
-    };
+-- Compute padded background rect from content rect.
+-- Returns: bgX, bgY, bgW, bgH
+local function ComputeBgRect(x, y, w, h, padding, paddingY)
+    return x - padding, y - paddingY, w + (padding * 2), h + (paddingY * 2);
 end
 
 -- ============================================
--- Update Functions
+-- Public API
 -- ============================================
 
---[[
-    Update background primitive position and visibility
+M.isWindowTheme = IsWindowTheme;
+M.IsWindowTheme = IsWindowTheme;
 
-    @param bgHandle table: Background handle from createBackground()
-    @param x number: Window X position
-    @param y number: Window Y position
-    @param width number: Window width (content area, not including padding)
-    @param height number: Window height (content area, not including padding)
-    @param options table: {
-        theme = string,         -- Theme name (required for visibility logic)
-        padding = number,       -- Horizontal padding (default 8)
-        paddingY = number,      -- Vertical padding (defaults to padding)
-        bgScale = number,       -- Background scale (default 1.0)
-        bgOpacity = number,     -- Background opacity 0-1 (optional, for separate opacity mode)
-        bgColor = number,       -- Background color ARGB (default 0xFFFFFFFF)
-    }
+--[[
+    Render the background piece only.
+
+    @param drawList    ImGui draw list
+    @param x, y, w, h  Content rect (not including padding)
+    @param options     Theme + padding/color options (see Draw())
 ]]--
-function M.updateBackground(bgHandle, x, y, width, height, options)
+function M.DrawBackground(drawList, x, y, w, h, options)
+    if drawList == nil then return; end
     options = options or {};
-    local theme = options.theme or bgHandle.themeName or 'Window1';
-    local padding = options.padding or DEFAULT_PADDING;
+    local theme = options.theme or 'Window1';
+    if theme == '-None-' then return; end
+
+    local padding  = options.padding  or DEFAULT_PADDING;
     local paddingY = options.paddingY or padding;
-    local bgScale = options.bgScale or bgHandle.bgScale or DEFAULT_BG_SCALE;
-    local bgColor = options.bgColor or 0xFFFFFFFF;
+    local bgColor  = options.bgColor  or 0xFFFFFFFF;
 
-    local bgPrim = bgHandle.bg;
+    local bgX, bgY, bgW, bgH = ComputeBgRect(x, y, w, h, padding, paddingY);
 
-    -- Handle '-None-' theme
-    if theme == '-None-' then
-        if bgHandle._cache and bgHandle._cache.bg_vis ~= false then
-            bgPrim.visible = false;
-        end
-        if bgHandle._cache then bgHandle._cache.bg_vis = false; end
-        return;
-    end
+    local ptr = LoadPiecePtr(theme, 'bg');
+    if ptr == nil then return; end
 
-    -- Calculate background dimensions
-    local bgWidth = width + (padding * 2);
-    local bgHeight = height + (paddingY * 2);
-
-    local posX = x - padding;
-    local posY = y - paddingY;
-    local w = math.ceil(bgWidth / bgScale);
-    local h = math.ceil(bgHeight / bgScale);
-
-    local finalColor;
-    if options.bgOpacity ~= nil then
-        finalColor = ApplyOpacityToColor(bgColor, options.bgOpacity);
-    else
-        finalColor = bgColor;
-    end
-
-    -- Cache-guarded property sets
-    local c = bgHandle._cache;
-    if not c then c = {}; bgHandle._cache = c; end
-
-    set(c, bgPrim, 'bg_px', 'position_x', posX);
-    set(c, bgPrim, 'bg_py', 'position_y', posY);
-    set(c, bgPrim, 'bg_w', 'width', w);
-    set(c, bgPrim, 'bg_h', 'height', h);
-    set(c, bgPrim, 'bg_sx', 'scale_x', bgScale);
-    set(c, bgPrim, 'bg_sy', 'scale_y', bgScale);
-    set(c, bgPrim, 'bg_color', 'color', finalColor);
-    set(c, bgPrim, 'bg_vis', 'visible', bgPrim.exists);
+    local tint = TintU32(ResolveTint(bgColor, options.bgOpacity));
+    drawList:AddImage(ptr, {bgX, bgY}, {bgX + bgW, bgY + bgH}, {0, 0}, {1, 1}, tint);
 end
 
 --[[
-    Update border primitives position and visibility
-
-    @param borderHandle table: Border handle from createBorders()
-    @param x number: Window X position
-    @param y number: Window Y position
-    @param width number: Window width (content area)
-    @param height number: Window height (content area)
-    @param options table: {
-        theme = string,         -- Theme name (required)
-        padding = number,       -- Horizontal padding (default 8)
-        paddingY = number,      -- Vertical padding (defaults to padding)
-        borderSize = number,    -- Corner piece size (default 21)
-        bgOffset = number,      -- Border offset from background (default 1)
-        borderScale = number,   -- Border scale (default 1.0)
-        borderOpacity = number, -- Border opacity 0-1 (optional)
-        borderColor = number,   -- Border color ARGB (default 0xFFFFFFFF)
-    }
+    Render the four border pieces (Window themes only). Skips silently for
+    '-None-' and 'Plain'.
 ]]--
-function M.updateBorders(borderHandle, x, y, width, height, options)
+function M.DrawBorders(drawList, x, y, w, h, options)
+    if drawList == nil then return; end
     options = options or {};
-    local theme = options.theme or borderHandle.themeName or 'Window1';
-    local padding = options.padding or DEFAULT_PADDING;
-    local paddingY = options.paddingY or padding;
-    local borderSize = options.borderSize or DEFAULT_BORDER_SIZE;
-    local bgOffset = options.bgOffset or DEFAULT_BG_OFFSET;
-    local borderScale = options.borderScale or borderHandle.borderScale or DEFAULT_BORDER_SCALE;
-    local borderColor = options.borderColor or 0xFFFFFFFF;
+    local theme = options.theme or 'Window1';
+    if not IsWindowTheme(theme) then return; end
 
-    local isWindowTheme = IsWindowTheme(theme);
+    local padding      = options.padding      or DEFAULT_PADDING;
+    local paddingY     = options.paddingY     or padding;
+    local borderSize   = options.borderSize   or DEFAULT_BORDER_SIZE;
+    local bgOffset     = options.bgOffset     or DEFAULT_BG_OFFSET;
+    local borderScale  = options.borderScale  or 1.0;
+    local borderColor  = options.borderColor  or 0xFFFFFFFF;
 
-    -- Hide borders for non-Window themes
-    if not isWindowTheme then
-        M.hideBorders(borderHandle);
-        return;
+    local bgX, bgY, bgW, bgH = ComputeBgRect(x, y, w, h, padding, paddingY);
+    local tint = TintU32(ResolveTint(borderColor, options.borderOpacity));
+
+    local pieceSize = borderSize * borderScale;
+    local offset = bgOffset * borderScale;
+
+    -- Bottom-right (fixed pieceSize x pieceSize)
+    local brX = bgX + bgW - math.floor(pieceSize - offset);
+    local brY = bgY + bgH - math.floor(pieceSize - offset);
+    local brPtr = LoadPiecePtr(theme, 'br');
+    if brPtr ~= nil then
+        drawList:AddImage(brPtr, {brX, brY}, {brX + pieceSize, brY + pieceSize}, {0, 0}, {1, 1}, tint);
     end
 
-    -- Calculate background bounds
-    local bgWidth = width + (padding * 2);
-    local bgHeight = height + (paddingY * 2);
-    local bgX = x - padding;
-    local bgY = y - paddingY;
-
-    -- Apply color (with optional separate opacity)
-    local finalColor;
-    if options.borderOpacity ~= nil then
-        finalColor = ApplyOpacityToColor(borderColor, options.borderOpacity);
-    else
-        finalColor = borderColor;
+    -- Top-right (pieceSize wide, spans down to br)
+    local trX = brX;
+    local trY = bgY - offset;
+    local trH = brY - trY;
+    local trPtr = LoadPiecePtr(theme, 'tr');
+    if trPtr ~= nil then
+        drawList:AddImage(trPtr, {trX, trY}, {trX + pieceSize, trY + trH}, {0, 0}, {1, 1}, tint);
     end
 
-    -- Cache-guarded property sets
-    local c = borderHandle._cache;
-    if not c then c = {}; borderHandle._cache = c; end
+    -- Top-left (L-shape: spans top edge to tr, and left edge down to bl)
+    local tlX = bgX - offset;
+    local tlY = bgY - offset;
+    local tlW = trX - tlX;
+    local tlPtr = LoadPiecePtr(theme, 'tl');
+    if tlPtr ~= nil then
+        drawList:AddImage(tlPtr, {tlX, tlY}, {tlX + tlW, tlY + trH}, {0, 0}, {1, 1}, tint);
+    end
 
-    -- Bottom-right corner
-    local br = borderHandle.br;
-    local brPosX = bgX + bgWidth - math.floor((borderSize * borderScale) - (bgOffset * borderScale));
-    local brPosY = bgY + bgHeight - math.floor((borderSize * borderScale) - (bgOffset * borderScale));
-    set(c, br, 'br_px', 'position_x', brPosX);
-    set(c, br, 'br_py', 'position_y', brPosY);
-    set(c, br, 'br_w', 'width', borderSize);
-    set(c, br, 'br_h', 'height', borderSize);
-    set(c, br, 'br_color', 'color', finalColor);
-    set(c, br, 'br_sx', 'scale_x', borderScale);
-    set(c, br, 'br_sy', 'scale_y', borderScale);
-
-    -- Top-right edge (L-shaped from top to br)
-    local tr = borderHandle.tr;
-    local trPosX = brPosX;
-    local trPosY = bgY - (bgOffset * borderScale);
-    local trH = math.ceil((brPosY - trPosY) / borderScale);
-    set(c, tr, 'tr_px', 'position_x', trPosX);
-    set(c, tr, 'tr_py', 'position_y', trPosY);
-    set(c, tr, 'tr_w', 'width', borderSize);
-    set(c, tr, 'tr_h', 'height', trH);
-    set(c, tr, 'tr_color', 'color', finalColor);
-    set(c, tr, 'tr_sx', 'scale_x', borderScale);
-    set(c, tr, 'tr_sy', 'scale_y', borderScale);
-
-    -- Top-left (L-shaped: top and left edges)
-    local tl = borderHandle.tl;
-    local tlPosX = bgX - (bgOffset * borderScale);
-    local tlPosY = bgY - (bgOffset * borderScale);
-    local tlW = math.ceil((trPosX - tlPosX) / borderScale);
-    set(c, tl, 'tl_px', 'position_x', tlPosX);
-    set(c, tl, 'tl_py', 'position_y', tlPosY);
-    set(c, tl, 'tl_w', 'width', tlW);
-    set(c, tl, 'tl_h', 'height', trH);
-    set(c, tl, 'tl_color', 'color', finalColor);
-    set(c, tl, 'tl_sx', 'scale_x', borderScale);
-    set(c, tl, 'tl_sy', 'scale_y', borderScale);
-
-    -- Bottom-left edge (L-shaped from left to br)
-    local bl = borderHandle.bl;
-    local blPosX = tlPosX;
-    local blPosY = brPosY;
-    set(c, bl, 'bl_px', 'position_x', blPosX);
-    set(c, bl, 'bl_py', 'position_y', blPosY);
-    set(c, bl, 'bl_w', 'width', tlW);
-    set(c, bl, 'bl_h', 'height', borderSize);
-    set(c, bl, 'bl_color', 'color', finalColor);
-    set(c, bl, 'bl_sx', 'scale_x', borderScale);
-    set(c, bl, 'bl_sy', 'scale_y', borderScale);
-
-    -- Set visibility last for all borders
-    set(c, br, 'br_vis', 'visible', br.exists);
-    set(c, tr, 'tr_vis', 'visible', tr.exists);
-    set(c, tl, 'tl_vis', 'visible', tl.exists);
-    set(c, bl, 'bl_vis', 'visible', bl.exists);
-end
-
---[[
-    Update complete window background (background + borders)
-    Convenience function for combined handles from create()
-
-    @param handle table: Combined handle from create()
-    @param x number: Window X position
-    @param y number: Window Y position
-    @param width number: Window width (content area)
-    @param height number: Window height (content area)
-    @param options table: All options from updateBackground() and updateBorders()
-]]--
-function M.update(handle, x, y, width, height, options)
-    M.updateBackground(handle, x, y, width, height, options);
-    M.updateBorders(handle, x, y, width, height, options);
-end
-
--- ============================================
--- Hide Functions
--- ============================================
-
---[[
-    Hide background primitive
-    @param bgHandle table: Background handle
-]]--
-function M.hideBackground(bgHandle)
-    if bgHandle and bgHandle.bg then
-        bgHandle.bg.visible = false;
-        if bgHandle._cache then bgHandle._cache.bg_vis = false; end
+    -- Bottom-left (spans bottom edge to br)
+    local blX = tlX;
+    local blY = brY;
+    local blPtr = LoadPiecePtr(theme, 'bl');
+    if blPtr ~= nil then
+        drawList:AddImage(blPtr, {blX, blY}, {blX + tlW, blY + pieceSize}, {0, 0}, {1, 1}, tint);
     end
 end
 
 --[[
-    Hide border primitives
-    @param borderHandle table: Border handle
+    Render background + borders in one call.
+
+    Call once per frame inside DrawWindow. No state retained.
+
+    @param drawList ImGui draw list (e.g. from GetUIDrawList())
+    @param x, y     Content top-left in screen coords (does NOT include padding)
+    @param w, h     Content size (does NOT include padding)
+    @param options  table:
+        theme         = string   -- '-None-' | 'Plain' | 'Window1'..'Window8'
+        padding       = number   -- Horizontal pad (default 8)
+        paddingY      = number   -- Vertical pad (defaults to padding)
+        bgScale       = number   -- Reserved for future use (default 1.0)
+        borderScale   = number   -- Scales border piece size (default 1.0)
+        bgOpacity     = number   -- Optional 0..1; overrides bgColor's alpha
+        bgColor       = number   -- ARGB tint (default 0xFFFFFFFF)
+        borderSize    = number   -- Corner piece size in px (default 21)
+        bgOffset      = number   -- Border offset from bg edge (default 1)
+        borderOpacity = number   -- Optional 0..1; overrides borderColor's alpha
+        borderColor   = number   -- ARGB tint (default 0xFFFFFFFF)
 ]]--
-function M.hideBorders(borderHandle)
-    if not borderHandle then return; end
-    local cache = borderHandle._cache;
-    for _, k in ipairs(M.BORDER_KEYS) do
-        if borderHandle[k] then
-            borderHandle[k].visible = false;
-        end
-        if cache then cache[k .. '_vis'] = false; end
-    end
-end
-
---[[
-    Hide complete window background (combined handle)
-    @param handle table: Combined handle from create()
-]]--
-function M.hide(handle)
-    M.hideBackground(handle);
-    M.hideBorders(handle);
-end
-
--- ============================================
--- Theme Change Functions
--- ============================================
-
---[[
-    Change background theme (reloads texture only if theme changed)
-    @param bgHandle table: Background handle
-    @param themeName string: New theme name
-    @param bgScale number: Optional new scale
-]]--
-function M.setBackgroundTheme(bgHandle, themeName, bgScale)
-    if not bgHandle or not bgHandle.bg then return; end
-    bgHandle._cache = nil;
-
-    -- Always update scale if provided (lightweight operation)
-    if bgScale then
-        bgHandle.bgScale = bgScale;
-        bgHandle.bg.scale_x = bgScale;
-        bgHandle.bg.scale_y = bgScale;
-    end
-
-    -- Only reload texture if theme actually changed (expensive file I/O)
-    local themeChanged = bgHandle.themeName ~= themeName;
-    if themeChanged then
-        bgHandle.themeName = themeName;
-        if themeName == '-None-' then
-            bgHandle.bg.exists = false;
-            bgHandle.bg.visible = false;
-        else
-            local filepath = string.format('%s/assets/backgrounds/%s-bg.png', addon.path, themeName);
-            bgHandle.bg.texture = filepath;
-            bgHandle.bg.exists = ashita.fs.exists(filepath);
-        end
-    end
-end
-
---[[
-    Change border theme (reloads textures only if theme changed)
-    @param borderHandle table: Border handle
-    @param themeName string: New theme name
-    @param borderScale number: Optional new border scale
-]]--
-function M.setBordersTheme(borderHandle, themeName, borderScale)
-    if not borderHandle then return; end
-    borderHandle._cache = nil;
-
-    -- Always update scale if provided (lightweight operation)
-    if borderScale then
-        borderHandle.borderScale = borderScale;
-        for _, k in ipairs(M.BORDER_KEYS) do
-            local prim = borderHandle[k];
-            if prim then
-                prim.scale_x = borderScale;
-                prim.scale_y = borderScale;
-            end
-        end
-    end
-
-    -- Only reload textures if theme actually changed (expensive file I/O)
-    local themeChanged = borderHandle.themeName ~= themeName;
-    if themeChanged then
-        borderHandle.themeName = themeName;
-        local isWindow = IsWindowTheme(themeName);
-
-        for _, k in ipairs(M.BORDER_KEYS) do
-            local prim = borderHandle[k];
-            if prim then
-                if isWindow then
-                    local filepath = string.format('%s/assets/backgrounds/%s-%s.png', addon.path, themeName, k);
-                    prim.texture = filepath;
-                    prim.exists = ashita.fs.exists(filepath);
-                else
-                    prim.exists = false;
-                    prim.visible = false;
-                end
-            end
-        end
-    end
-end
-
---[[
-    Change theme for combined handle (optimized: skips file I/O if only scale changed)
-    @param handle table: Combined handle from create()
-    @param themeName string: New theme name
-    @param bgScale number: Optional new background scale
-    @param borderScale number: Optional new border scale
-]]--
-function M.setTheme(handle, themeName, bgScale, borderScale)
-    handle._cache = nil;
-    -- Save old themeName before sub-functions modify it
-    -- (setBackgroundTheme updates handle.themeName, which would cause
-    -- setBordersTheme's change detection to fail)
-    local oldThemeName = handle.themeName;
-
-    -- Temporarily restore old name for each check
-    M.setBackgroundTheme(handle, themeName, bgScale);
-    handle.themeName = oldThemeName; -- Restore for border check
-    M.setBordersTheme(handle, themeName, borderScale);
-
-    -- Now set final values
-    handle.themeName = themeName;
-    if bgScale then
-        handle.bgScale = bgScale;
-    end
-    if borderScale then
-        handle.borderScale = borderScale;
-    end
-end
-
---[[
-    Lightweight scale-only update (no file I/O, no texture changes)
-    Use this when only scale is changing, not theme.
-    @param handle table: Combined handle from create()
-    @param bgScale number: New background scale
-    @param borderScale number: New border scale
-]]--
-function M.setScale(handle, bgScale, borderScale)
-    if not handle then return; end
-
-    -- Update background scale
-    if bgScale and handle.bg then
-        handle.bgScale = bgScale;
-        handle.bg.scale_x = bgScale;
-        handle.bg.scale_y = bgScale;
-    end
-
-    -- Update border scale
-    if borderScale then
-        handle.borderScale = borderScale;
-        for _, k in ipairs(M.BORDER_KEYS) do
-            local prim = handle[k];
-            if prim then
-                prim.scale_x = borderScale;
-                prim.scale_y = borderScale;
-            end
-        end
-    end
-end
-
--- ============================================
--- Destroy Functions
--- ============================================
-
---[[
-    Destroy background primitive
-    @param bgHandle table: Background handle
-]]--
-function M.destroyBackground(bgHandle)
-    if bgHandle and bgHandle.bg then
-        bgHandle.bg:destroy();
-        bgHandle.bg = nil;
-        diagnostics.TrackPrimitiveDestroy();
-    end
-end
-
---[[
-    Destroy border primitives
-    @param borderHandle table: Border handle
-]]--
-function M.destroyBorders(borderHandle)
-    if borderHandle then
-        for _, k in ipairs(M.BORDER_KEYS) do
-            if borderHandle[k] then
-                borderHandle[k]:destroy();
-                borderHandle[k] = nil;
-                diagnostics.TrackPrimitiveDestroy();
-            end
-        end
-    end
-end
-
---[[
-    Destroy complete window background
-    @param handle table: Combined handle from create()
-]]--
-function M.destroy(handle)
-    M.destroyBackground(handle);
-    M.destroyBorders(handle);
+function M.Draw(drawList, x, y, w, h, options)
+    M.DrawBackground(drawList, x, y, w, h, options);
+    M.DrawBorders(drawList, x, y, w, h, options);
 end
 
 -- ============================================
@@ -585,108 +199,24 @@ end
 -- ============================================
 
 --[[
-    Check if a theme name is a Window theme (has borders)
-    @param themeName string: Theme name to check
-    @return boolean: True if Window theme
+    Compute the clip bounds for middle-layer content rendered between bg and
+    borders. Use with drawList:PushClipRect / PopClipRect.
+
+    @return table { left, top, right, bottom } in screen coords
 ]]--
-M.isWindowTheme = IsWindowTheme;
-
---[[
-    Get the primitive keys used for backgrounds
-    @return table: { 'bg', 'tl', 'tr', 'br', 'bl' }
-]]--
-function M.getImageKeys()
-    return M.BG_IMAGE_KEYS;
-end
-
---[[
-    Get clip bounds for middle-layer content (e.g., pet images)
-
-    Use this to calculate the visible area for content rendered between
-    the background and borders. Content outside these bounds should be
-    clipped or hidden. The clip region matches the background bounds exactly,
-    keeping content within the background area.
-
-    @param x number: Window content X position
-    @param y number: Window content Y position
-    @param width number: Window content width
-    @param height number: Window content height
-    @param options table: {
-        theme = string,     -- Theme name (unused, kept for API compatibility)
-        padding = number,   -- Horizontal padding (default 8)
-        paddingY = number,  -- Vertical padding (defaults to padding)
-    }
-    @return table: { left, top, right, bottom } - clip bounds in screen coordinates
-]]--
-function M.getClipBounds(x, y, width, height, options)
+function M.GetClipBounds(x, y, w, h, options)
     options = options or {};
-    local padding = options.padding or DEFAULT_PADDING;
+    local padding  = options.padding  or DEFAULT_PADDING;
     local paddingY = options.paddingY or padding;
-
-    -- Clip bounds match background bounds exactly (no border offset extension)
     return {
-        left = x - padding,
-        top = y - paddingY,
-        right = x + width + padding,
-        bottom = y + height + paddingY,
+        left   = x - padding,
+        top    = y - paddingY,
+        right  = x + w + padding,
+        bottom = y + h + paddingY,
     };
 end
 
---[[
-    Clip an image/primitive to the window background bounds
-
-    Calculates the visible portion of an image when clipped to the background.
-    Returns nil if the image is completely outside the clip bounds.
-
-    @param imgX number: Image X position
-    @param imgY number: Image Y position
-    @param imgWidth number: Image display width (after scaling)
-    @param imgHeight number: Image display height (after scaling)
-    @param clipBounds table: Clip bounds from getClipBounds()
-    @param imgScale number: Image scale factor (optional, default 1.0)
-    @return table or nil: {
-        x, y = clipped position,
-        width, height = clipped dimensions (in texture pixels),
-        texOffsetX, texOffsetY = texture offset (in texture pixels),
-        scaleX, scaleY = scale to apply
-    } or nil if completely clipped
-]]--
-function M.clipImageToBounds(imgX, imgY, imgWidth, imgHeight, clipBounds, imgScale)
-    imgScale = imgScale or 1.0;
-
-    -- Calculate image bounds
-    local imgRight = imgX + imgWidth;
-    local imgBottom = imgY + imgHeight;
-
-    -- Calculate intersection with clip bounds
-    local clipLeft = math.max(imgX, clipBounds.left);
-    local clipTop = math.max(imgY, clipBounds.top);
-    local clipRight = math.min(imgRight, clipBounds.right);
-    local clipBottom = math.min(imgBottom, clipBounds.bottom);
-
-    -- Check if there's any visible area
-    if clipLeft >= clipRight or clipTop >= clipBottom then
-        return nil; -- Completely outside bounds
-    end
-
-    -- Calculate texture offset in pixels (how much of the texture to skip)
-    local texOffsetX = (clipLeft - imgX) / imgScale;
-    local texOffsetY = (clipTop - imgY) / imgScale;
-
-    -- Calculate visible dimensions in texture pixels
-    local visibleWidth = (clipRight - clipLeft) / imgScale;
-    local visibleHeight = (clipBottom - clipTop) / imgScale;
-
-    return {
-        x = clipLeft,
-        y = clipTop,
-        width = visibleWidth,
-        height = visibleHeight,
-        texOffsetX = texOffsetX,
-        texOffsetY = texOffsetY,
-        scaleX = imgScale,
-        scaleY = imgScale,
-    };
-end
+-- Backward-compat alias (camelCase) for any external consumer still calling the old name.
+M.getClipBounds = M.GetClipBounds;
 
 return M;

--- a/XIUI/modules/castcost/display.lua
+++ b/XIUI/modules/castcost/display.lua
@@ -14,9 +14,6 @@ local defaultPositions = require('libs.defaultpositions');
 
 local M = {};
 
--- Background handle
-local bgHandle;
-
 -- Reference height cache keyed by fontSize to avoid re-measuring every frame
 local refHeightCache = {};
 local REF_STRING = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
@@ -42,9 +39,6 @@ local windowState = {
 -- ============================================
 
 function M.Initialize(settings)
-    -- Create window background (read scale directly from gConfig like partylist does)
-    local cc = gConfig.castCost or {};
-    bgHandle = windowBg.create(settings.prim_data, cc.backgroundTheme or 'Window1', cc.bgScale or 1.0, cc.borderScale or 1.0);
 end
 
 -- ============================================
@@ -54,12 +48,6 @@ end
 function M.UpdateVisuals(settings)
     imtext.Reset();
     refHeightCache = {};
-
-    -- Update background theme (read scale directly from gConfig like partylist does)
-    local cc = gConfig.castCost or {};
-    if bgHandle then
-        windowBg.setTheme(bgHandle, cc.backgroundTheme or 'Window1', cc.bgScale or 1.0, cc.borderScale or 1.0);
-    end
 end
 
 -- ============================================
@@ -67,9 +55,6 @@ end
 -- ============================================
 
 function M.SetHidden(hidden)
-    if bgHandle then
-        windowBg.hide(bgHandle);
-    end
     -- Reset window state when hidden so bottom alignment starts fresh
     if hidden then
         windowState.x = nil;
@@ -85,10 +70,6 @@ end
 -- ============================================
 
 function M.Cleanup()
-    if bgHandle then
-        windowBg.destroy(bgHandle);
-        bgHandle = nil;
-    end
 end
 
 -- ============================================
@@ -125,9 +106,6 @@ end
 
 function M.Render(itemInfo, itemType, settings, colors)
     if itemInfo == nil then
-        if bgHandle then
-            windowBg.hide(bgHandle);
-        end
         -- Clear shared state when no selection
         shared.Clear();
         return;
@@ -310,23 +288,21 @@ function M.Render(itemInfo, itemType, settings, colors)
         -- Create dummy for dragging
         imgui.Dummy({ contentWidth, contentHeight });
 
-        -- Update background (read scale directly from gConfig like partylist does)
+        -- Draw background + borders (read scale directly from gConfig like partylist does)
         local cc = gConfig.castCost or {};
-        if bgHandle then
-            windowBg.update(bgHandle, cursorX, cursorY, contentWidth, contentHeight, {
-                theme = cc.backgroundTheme or 'Window1',
-                padding = padding,
-                paddingY = paddingY,
-                bgScale = cc.bgScale or 1.0,
-                borderScale = cc.borderScale or 1.0,
-                bgOpacity = cc.backgroundOpacity or 1.0,
-                bgColor = colors.bgColor or 0xFFFFFFFF,
-                borderSize = settings.borderSize or 21,
-                bgOffset = settings.bgOffset or 1,
-                borderOpacity = cc.borderOpacity or 1.0,
-                borderColor = colors.borderColor or 0xFFFFFFFF,
-            });
-        end
+        windowBg.Draw(drawList, cursorX, cursorY, contentWidth, contentHeight, {
+            theme = cc.backgroundTheme or 'Window1',
+            padding = padding,
+            paddingY = paddingY,
+            bgScale = cc.bgScale or 1.0,
+            borderScale = cc.borderScale or 1.0,
+            bgOpacity = cc.backgroundOpacity or 1.0,
+            bgColor = colors.bgColor or 0xFFFFFFFF,
+            borderSize = settings.borderSize or 21,
+            bgOffset = settings.bgOffset or 1,
+            borderOpacity = cc.borderOpacity or 1.0,
+            borderColor = colors.borderColor or 0xFFFFFFFF,
+        });
 
         -- Position and render text using reference heights for consistent spacing
         local yPos = cursorY;

--- a/XIUI/modules/enemylist.lua
+++ b/XIUI/modules/enemylist.lua
@@ -2,7 +2,6 @@ require('common');
 require('handlers.helpers');
 local imgui = require('imgui');
 local imtext = require('libs.imtext');
-local primitives = require('primitives');
 local debuffHandler = require('handlers.debuffhandler');
 local statusHandler = require('handlers.statushandler');
 local actionTracker = require('handlers.actiontracker');
@@ -62,13 +61,6 @@ local previewTargets = {
     [9007] = 'Longtargetname',
     [9008] = 'Redmage',
 };
-
--- Track which enemy indices are currently active (for background visibility management)
-local activeEnemyIndices = {};
-
--- Background primitive objects (keyed by numeric enemy index)
-local enemyBackgrounds = {};  -- Background rectangles for each enemy entry
-local enemyTargetBackgrounds = {};  -- Background rectangles for target containers
 
 -- Cache for truncated names to avoid expensive binary search every frame
 -- Key: enemy index, Value: {name = original_name, maxWidth = width, fontHeight = height, truncated = result}
@@ -167,10 +159,6 @@ enemylist.DrawWindow = function(settings)
 
 		-- Cache entity manager once per frame (avoid repeated GetEntitySafe() calls)
 		local entityMgr = GetEntitySafe();
-
-		-- Track previous active indices and reset for this frame
-		local previousActiveIndices = activeEnemyIndices;
-		activeEnemyIndices = {};
 
 		-- Get draw list and configure imtext for this frame
 		local drawList = GetUIDrawList();
@@ -282,7 +270,7 @@ enemylist.DrawWindow = function(settings)
 				local barWidth = math.max(entryWidth - (padding * 2), 1);
 
 				-- ===== BACKGROUND & BORDER RENDERING =====
-				-- We need to draw these BEFORE the ImGui content so they appear behind progress bars
+				-- Draw bg fill first, then border on top; both before any content so progress bars / text overlay correctly.
 
 				-- Get entity name color based on type and claim status (ARGB format)
 				local nameColor;
@@ -292,6 +280,20 @@ enemylist.DrawWindow = function(settings)
 				else
 					nameColor = GetEntityNameColor(ent, k, gConfig.colorCustomization.shared);
 				end
+
+				-- Background fill
+				local bgColor = gConfig.colorCustomization.enemyList.backgroundColor;
+				local bgOpacity = gConfig.enemyListBackgroundOpacity;
+				if (bgOpacity ~= nil and bgOpacity < 1.0) then
+					bgColor = ApplyOpacityToColor(bgColor, bgOpacity);
+				end
+				drawList:AddRectFilled(
+					{entryStartX, entryStartY},
+					{entryStartX + entryWidth, entryStartY + entryHeight},
+					imgui.GetColorU32(ARGBToRGBA(bgColor)),
+					bgRadius,
+					ImDrawCornerFlags_All
+				);
 
 				if (gConfig.showEnemyListBorders) then
 					local borderColor;
@@ -307,9 +309,7 @@ enemylist.DrawWindow = function(settings)
 						borderColor = imgui.GetColorU32(ARGBToRGBA(gConfig.colorCustomization.enemyList.borderColor or 0xFF000000));
 					end
 
-					-- Draw border rectangle around the entire entry
-					-- Window margins ensure this won't be clipped
-					imgui.GetWindowDrawList():AddRect(
+					drawList:AddRect(
 						{entryStartX, entryStartY},
 						{entryStartX + entryWidth, entryStartY + entryHeight},
 						borderColor,
@@ -319,38 +319,10 @@ enemylist.DrawWindow = function(settings)
 					);
 				end
 
-				-- ===== PRIMITIVE BACKGROUND RENDERING =====
-				-- Create/get background primitive for this enemy
-				-- Primitives render in the correct layer (behind ImGui draw list)
-				if (enemyBackgrounds[k] == nil and settings.prim_data) then
-					enemyBackgrounds[k] = primitives.new(settings.prim_data);
-					enemyBackgrounds[k].can_focus = false;
-					enemyBackgrounds[k].locked = true;
-				end
-
-				if (enemyBackgrounds[k] ~= nil) then
-					local bg = enemyBackgrounds[k];
-					-- Set background position and size
-					bg.position_x = entryStartX;
-					bg.position_y = entryStartY;
-					bg.width = entryWidth;
-					bg.height = entryHeight;
-					local bgColor = gConfig.colorCustomization.enemyList.backgroundColor;
-					local bgOpacity = gConfig.enemyListBackgroundOpacity;
-					if (bgOpacity ~= nil and bgOpacity < 1.0) then
-						bgColor = ApplyOpacityToColor(bgColor, bgOpacity);
-					end
-					bg.color = bgColor;
-					bg.visible = true;
-				end
-
 				-- ===== CONTENT RENDERING =====
 				-- ROW 1: Enemy Name (colored based on entity type and claim status)
 				local nameX = entryStartX + padding;
 				local nameY = entryStartY + padding;
-
-				-- Mark this enemy index as active for background visibility management
-				activeEnemyIndices[k] = true;
 
 				-- Truncate name to fit within available width (use cache to avoid per-frame binary search)
 				local maxNameWidth = entryWidth - (padding * 2);
@@ -470,28 +442,19 @@ enemylist.DrawWindow = function(settings)
 						local targetNameHeight = settings.target_font_settings.font_height;
 						local targetTotalHeight = (targetPadding * 2) + targetNameHeight;
 
-						-- ===== PRIMITIVE BACKGROUND RENDERING =====
-						-- Create/get background primitive for this target container
-						if (enemyTargetBackgrounds[k] == nil and settings.prim_data) then
-							enemyTargetBackgrounds[k] = primitives.new(settings.prim_data);
-							enemyTargetBackgrounds[k].can_focus = false;
-							enemyTargetBackgrounds[k].locked = true;
+						-- Target container background fill
+						local targetBgColor = gConfig.colorCustomization.enemyList.targetBackgroundColor or gConfig.colorCustomization.enemyList.backgroundColor;
+						local targetBgOpacity = gConfig.enemyListTargetBackgroundOpacity;
+						if (targetBgOpacity ~= nil and targetBgOpacity < 1.0) then
+							targetBgColor = ApplyOpacityToColor(targetBgColor, targetBgOpacity);
 						end
-
-						if (enemyTargetBackgrounds[k] ~= nil) then
-							local targetBg = enemyTargetBackgrounds[k];
-							targetBg.position_x = targetContainerX;
-							targetBg.position_y = targetContainerY;
-							targetBg.width = targetWidth;
-							targetBg.height = targetTotalHeight;
-							local targetBgColor = gConfig.colorCustomization.enemyList.targetBackgroundColor or gConfig.colorCustomization.enemyList.backgroundColor;
-							local targetBgOpacity = gConfig.enemyListTargetBackgroundOpacity;
-							if (targetBgOpacity ~= nil and targetBgOpacity < 1.0) then
-								targetBgColor = ApplyOpacityToColor(targetBgColor, targetBgOpacity);
-							end
-							targetBg.color = targetBgColor;
-							targetBg.visible = true;
-						end
+						drawList:AddRectFilled(
+							{targetContainerX, targetContainerY},
+							{targetContainerX + targetWidth, targetContainerY + targetTotalHeight},
+							imgui.GetColorU32(ARGBToRGBA(targetBgColor)),
+							bgRadius,
+							ImDrawCornerFlags_All
+						);
 
 						-- Target name text
 						local targetTextColor = gConfig.colorCustomization.enemyList.targetNameTextColor or 0xFFFFAA00;
@@ -510,11 +473,6 @@ enemylist.DrawWindow = function(settings)
 						end
 
 						imtext.Draw(drawList, displayTargetName, targetContainerX + targetPadding, targetContainerY + targetPadding, targetTextColor, targetFontHeight);
-					else
-						-- Hide target background if enemy has no valid target (prevents stale overlays)
-						if (enemyTargetBackgrounds[k] ~= nil) then
-							enemyTargetBackgrounds[k].visible = false;
-						end
 					end
 				end
 
@@ -545,29 +503,6 @@ enemylist.DrawWindow = function(settings)
 				-- Only remove invalid entries in normal mode (not preview mode)
 				if not isPreviewMode then
 					allClaimedTargets[k] = nil;
-				end
-			end
-		end
-
-		-- Hide backgrounds for enemies that were active last frame but not this frame
-		-- Only iterate over previously active indices (avoids iterating all backgrounds)
-		for enemyIndex in pairs(previousActiveIndices) do
-			if not activeEnemyIndices[enemyIndex] then
-				-- This enemy was visible last frame but not this frame - hide its backgrounds
-				if enemyBackgrounds[enemyIndex] then
-					enemyBackgrounds[enemyIndex].visible = false;
-				end
-				if enemyTargetBackgrounds[enemyIndex] then
-					enemyTargetBackgrounds[enemyIndex].visible = false;
-				end
-			end
-		end
-
-		-- Hide target backgrounds for active enemies when showEnemyListTargets is disabled
-		if not gConfig.showEnemyListTargets then
-			for enemyIndex in pairs(activeEnemyIndices) do
-				if enemyTargetBackgrounds[enemyIndex] then
-					enemyTargetBackgrounds[enemyIndex].visible = false;
 				end
 			end
 		end
@@ -623,19 +558,6 @@ end
 enemylist.HandleZonePacket = function(e)
 	-- Empty all our claimed targets on zone
 	allClaimedTargets = T{};
-
-	-- Clear background primitives on zone
-	for k, v in pairs(enemyBackgrounds) do
-		if (v ~= nil) then v:destroy(); end
-	end
-	enemyBackgrounds = {};
-	for k, v in pairs(enemyTargetBackgrounds) do
-		if (v ~= nil) then v:destroy(); end
-	end
-	enemyTargetBackgrounds = {};
-
-	-- Reset active indices and name caches
-	activeEnemyIndices = {};
 	truncatedNameCache = {};
 	truncatedTargetNameCache = {};
 end
@@ -651,32 +573,9 @@ enemylist.UpdateVisuals = function(settings)
 end
 
 enemylist.SetHidden = function(hidden)
-	if hidden then
-		-- Hide all background primitives
-		for _, bgObj in pairs(enemyBackgrounds) do
-			bgObj.visible = false;
-		end
-		for _, bgObj in pairs(enemyTargetBackgrounds) do
-			bgObj.visible = false;
-		end
-		-- Clear active indices so next DrawWindow starts fresh
-		activeEnemyIndices = {};
-	end
 end
 
 enemylist.Cleanup = function()
-	-- Destroy all background primitives
-	for k, v in pairs(enemyBackgrounds) do
-		if (v ~= nil) then v:destroy(); end
-	end
-	for k, v in pairs(enemyTargetBackgrounds) do
-		if (v ~= nil) then v:destroy(); end
-	end
-
-	-- Clear all tables
-	enemyBackgrounds = {};
-	enemyTargetBackgrounds = {};
-	activeEnemyIndices = {};
 	truncatedNameCache = {};
 	truncatedTargetNameCache = {};
 end

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -1,7 +1,7 @@
 --[[
 * XIUI Crossbar - Display Module
 * Renders crossbar UI with controller-friendly layout
-* Uses windowBg for background, ImGui/imtext for text and icons
+* Uses windowBg.Draw (ImGui draw list) for background, ImGui/imtext for text and icons
 ]]--
 
 require('common');
@@ -9,6 +9,7 @@ require('handlers.helpers');
 local imgui = require('imgui');
 local ffi = require('ffi');
 local windowBg = require('libs.windowbackground');
+-- Note: windowBg is now an immediate-mode renderer; call windowBg.Draw() per frame.
 local drawing = require('libs.drawing');
 local imtext = require('libs.imtext');
 local dragdrop = require('libs.dragdrop');
@@ -284,15 +285,9 @@ end
 local state = {
     initialized = false,
 
-    -- Window background
-    bgHandle = nil,
-
     -- Window position (updated by ImGui window)
     windowX = 0,
     windowY = 0,
-
-    -- Loaded theme
-    loadedBgTheme = nil,
 
     -- Animation state for bar transitions
     animation = {
@@ -594,13 +589,6 @@ function M.Initialize(settings, moduleSettings)
     state.windowY = savedPos and savedPos.y or defaultY;
 
     local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
-
-    -- Create window background
-    local primData = moduleSettings and moduleSettings.prim_data or {};
-    state.bgHandle = windowBg.create(primData, settings.backgroundTheme, settings.bgScale, settings.borderScale);
-
-    -- Set loaded theme
-    state.loadedBgTheme = settings.backgroundTheme;
 
     state.initialized = true;
 end
@@ -1184,7 +1172,7 @@ function M.DrawWindow(settings, moduleSettings)
         SaveWindowPosition('Crossbar');
         windowPosX, windowPosY = imgui.GetWindowPos();
 
-        -- Update stored position 
+        -- Update stored position
         state.windowX = windowPosX;
         state.windowY = windowPosY;
 
@@ -1197,6 +1185,26 @@ function M.DrawWindow(settings, moduleSettings)
         -- Draw bar sets based on animation state and display mode
         -- NOTE: DrawSlot calls must be inside imgui.Begin/End for interactions to work
         local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
+
+        -- Draw window background FIRST so it sits beneath all slot content on the draw list.
+        -- In activeOnly mode, apply visibility opacity to background.
+        do
+            local bgOpacity = settings.backgroundOpacity;
+            local borderOpacity = settings.borderOpacity;
+            if isActiveOnlyMode then
+                bgOpacity = bgOpacity * visibilityOpacity;
+                borderOpacity = borderOpacity * visibilityOpacity;
+            end
+            windowBg.Draw(GetUIDrawList(), state.windowX, state.windowY, width, height, {
+                theme = settings.backgroundTheme,
+                bgScale = settings.bgScale,
+                borderScale = settings.borderScale,
+                bgOpacity = bgOpacity,
+                borderOpacity = borderOpacity,
+                bgColor = settings.bgColor,
+                borderColor = settings.borderColor,
+            });
+        end
 
         if state.animation.active then
             -- Get animation values for outgoing and incoming elements
@@ -1297,26 +1305,6 @@ function M.DrawWindow(settings, moduleSettings)
     local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
     local showCenterElements = not isActiveOnlyMode;
 
-    -- Update window background (can happen after window closes)
-    -- In activeOnly mode, apply visibility opacity to background
-    if state.bgHandle then
-        local bgOpacity = settings.backgroundOpacity;
-        local borderOpacity = settings.borderOpacity;
-        if isActiveOnlyMode then
-            bgOpacity = bgOpacity * visibilityOpacity;
-            borderOpacity = borderOpacity * visibilityOpacity;
-        end
-        windowBg.update(state.bgHandle, state.windowX, state.windowY, width, height, {
-            theme = settings.backgroundTheme,
-            bgScale = settings.bgScale,
-            borderScale = settings.borderScale,
-            bgOpacity = bgOpacity,
-            borderOpacity = borderOpacity,
-            bgColor = settings.bgColor,
-            borderColor = settings.borderColor,
-        });
-    end
-
     -- Draw center divider (optional, hidden in activeOnly mode)
     if settings.showDivider and drawList and showCenterElements then
         local dividerX = state.windowX + groupWidth + (groupSpacing / 2);
@@ -1382,13 +1370,6 @@ end
 -- ============================================
 
 function M.SetHidden(hidden)
-    -- Hide window background
-    if state.bgHandle then
-        if hidden then
-            windowBg.hide(state.bgHandle);
-        end
-        -- Note: Don't show bgHandle here - DrawWindow handles showing it after positioning
-    end
 end
 
 -- ============================================
@@ -1397,14 +1378,6 @@ end
 
 function M.UpdateVisuals(settings, moduleSettings)
     if not state.initialized then return; end
-
-    -- Update theme if changed
-    if settings.backgroundTheme ~= state.loadedBgTheme then
-        if state.bgHandle then
-            windowBg.setTheme(state.bgHandle, settings.backgroundTheme, settings.bgScale, settings.borderScale);
-        end
-        state.loadedBgTheme = settings.backgroundTheme;
-    end
 
     -- Reset imtext so it reloads fonts on next draw
     imtext.Reset();
@@ -1419,12 +1392,6 @@ end
 
 function M.Cleanup()
     if not state.initialized then return; end
-
-    -- Destroy window background
-    if state.bgHandle then
-        windowBg.destroy(state.bgHandle);
-        state.bgHandle = nil;
-    end
 
     -- Clear icon cache
     ClearCrossbarIconCache();

--- a/XIUI/modules/hotbar/data.lua
+++ b/XIUI/modules/hotbar/data.lua
@@ -99,13 +99,6 @@ M.LABEL_GAP = -8;  -- Default label position offset (was 4, moved up by 12px)
 M.ROW_GAP = 6;
 
 -- ============================================
--- Per-Bar State
--- ============================================
-
--- Background primitive handles (one per bar)
-M.bgHandles = {};
-
--- ============================================
 -- Job State
 -- ============================================
 
@@ -1080,7 +1073,6 @@ end
 -- Cleanup (call on addon unload)
 function M.Cleanup()
     M.Clear();
-    M.bgHandles = {};
 end
 
 return M;

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -37,9 +37,6 @@ local KEYBIND_OFFSET_Y = 2;
 -- State
 -- ============================================
 
--- Loaded theme tracking
-local loadedBgTheme = nil;
-
 -- Textures initialized flag
 local texturesInitialized = false;
 
@@ -334,9 +331,6 @@ local function DrawBarWindow(barIndex, settings)
 
     -- Check if bar is enabled
     if not barSettings.enabled then
-        if data.bgHandles[barIndex] then
-            windowBg.hide(data.bgHandles[barIndex]);
-        end
         return;
     end
 
@@ -407,9 +401,7 @@ local function DrawBarWindow(barIndex, settings)
             borderColor = borderColor,
         };
 
-        if data.bgHandles[barIndex] then
-            windowBg.update(data.bgHandles[barIndex], windowPosX, windowPosY, barWidth, barHeight, bgOptions);
-        end
+        windowBg.Draw(GetUIDrawList(), windowPosX, windowPosY, barWidth, barHeight, bgOptions);
 
         -- Draw hotbar number to the LEFT of the bar (outside container)
         local showNumber = barSettings.showHotbarNumber;
@@ -571,18 +563,6 @@ function M.DrawWindow(settings)
         texturesInitialized = true;
     end
 
-    -- Check if backgrounds are initialized
-    local anyInitialized = false;
-    for i = 1, data.NUM_BARS do
-        if data.bgHandles[i] then
-            anyInitialized = true;
-            break;
-        end
-    end
-    if not anyInitialized then
-        return;
-    end
-
     -- Draw each bar as its own window (per-bar themes handled in DrawBarWindow)
     for barIndex = 1, data.NUM_BARS do
         DrawBarWindow(barIndex, settings);
@@ -597,12 +577,6 @@ function M.DrawWindow(settings)
 end
 
 function M.HideWindow()
-    -- Hide all backgrounds
-    for barIndex = 1, data.NUM_BARS do
-        if data.bgHandles[barIndex] then
-            windowBg.hide(data.bgHandles[barIndex]);
-        end
-    end
 end
 
 -- ============================================
@@ -610,26 +584,11 @@ end
 -- ============================================
 
 function M.Initialize(settings)
-    local bgTheme = gConfig.hotbarBackgroundTheme or 'Plain';
-    loadedBgTheme = bgTheme;
-    -- Background primitives are now created in init.lua
-
     -- Register palette change callback for animation
     palette.OnPaletteChanged(OnPaletteChanged);
 end
 
 function M.UpdateVisuals(settings)
-    -- Update each bar's theme from per-bar settings
-    for barIndex = 1, data.NUM_BARS do
-        local barSettings = data.GetBarSettings(barIndex);
-        local bgTheme = barSettings.backgroundTheme or '-None-';
-        local bgScale = barSettings.bgScale or 1.0;
-        local borderScale = barSettings.borderScale or 1.0;
-
-        if data.bgHandles[barIndex] then
-            windowBg.setTheme(data.bgHandles[barIndex], bgTheme, bgScale, borderScale);
-        end
-    end
 end
 
 function M.SetHidden(hidden)
@@ -639,8 +598,6 @@ function M.SetHidden(hidden)
 end
 
 function M.Cleanup()
-    -- Background cleanup is handled in init.lua
-    loadedBgTheme = nil;
     texturesInitialized = false;
     -- Clear icon cache
     ClearIconCache();

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -35,7 +35,6 @@
 
 require('common');
 require('handlers.helpers');
-local windowBg = require('libs.windowbackground');
 local dragdrop = require('libs.dragdrop');
 local imtext = require('libs.imtext');
 
@@ -122,25 +121,6 @@ function M.Initialize(settings)
         ashita.tasks.once(0.3, function()
             ValidatePalettesWhenReady(1);
         end);
-    end
-
-    -- Create background primitives for each bar
-    local primData = {
-        visible = false,
-        can_focus = false,
-        locked = true,
-        width = 100,
-        height = 100,
-    };
-
-    for barIndex = 1, data.NUM_BARS do
-        -- Get per-bar settings
-        local barSettings = data.GetBarSettings(barIndex);
-        local bgTheme = barSettings.backgroundTheme or '-None-';
-        local bgScale = barSettings.bgScale or 1.0;
-        local borderScale = barSettings.borderScale or 1.0;
-
-        data.bgHandles[barIndex] = windowBg.create(primData, bgTheme, bgScale, borderScale);
     end
 
     -- Initialize display layer
@@ -378,13 +358,6 @@ end
 -- Set module visibility
 function M.SetHidden(hidden)
     M.visible = not hidden;
-    if hidden then
-        for barIndex = 1, data.NUM_BARS do
-            if data.bgHandles[barIndex] then
-                windowBg.hide(data.bgHandles[barIndex]);
-            end
-        end
-    end
     display.SetHidden(hidden);
     if crossbarInitialized then
         crossbar.SetHidden(hidden);
@@ -397,13 +370,6 @@ function M.Cleanup()
 
     -- Flush any pending slot saves before cleanup
     macropalette.FlushPendingSave();
-
-    for barIndex = 1, data.NUM_BARS do
-        -- Destroy background
-        if data.bgHandles[barIndex] then
-            windowBg.destroy(data.bgHandles[barIndex]);
-        end
-    end
 
     -- Cleanup display and data layers
     display.Cleanup();

--- a/XIUI/modules/notifications/data.lua
+++ b/XIUI/modules/notifications/data.lua
@@ -4,7 +4,6 @@
 ]]--
 
 require('common');
-local windowBg = require('libs.windowbackground');
 
 local M = {};
 
@@ -110,18 +109,11 @@ M.nextId = 1;
 M.settings = nil;
 
 -- ============================================
--- Per-Group Resource Storage
+-- Per-Group State
 -- ============================================
-
--- Per-group background primitives
-M.groupBgPrims = {};         -- groupBgPrims[groupNum][slot]
 
 -- Per-group window anchors (for bottom-anchoring in "stack up" mode)
 M.groupWindowAnchors = {};   -- groupWindowAnchors[groupNum] = {y, x, dragging}
-
-
--- Per-group loaded background themes (to detect when theme changes)
-M.groupLoadedBgThemes = {};  -- groupLoadedBgThemes[groupNum] = themeName
 
 -- Pre-cached U32 colors for progress bars (avoid hex parsing every frame)
 M.cachedBarColors = {};
@@ -132,77 +124,8 @@ M.cachedBarColors = {};
 M.windowAnchors = {};
 
 -- ============================================
--- Primitive Storage (following petbar pattern)
+-- Helpers
 -- ============================================
-
--- Background primitives for each notification slot
-M.bgPrims = {};  -- indexed by slot number
-
--- Split window placeholder primitives (indexed by split key)
-M.splitBgPrims = {};  -- splitKey -> primitive
-
--- Background theme tracking (to detect when theme changes and reload textures)
-M.loadedBgTheme = nil;
-
--- ============================================
--- Font/Primitive Helpers
--- ============================================
-
--- Hide all background primitives
-function M.HideAllBackgrounds()
-    -- Hide notification backgrounds
-    if M.bgPrims then
-        for i = 1, M.MAX_ACTIVE_NOTIFICATIONS do
-            if M.bgPrims[i] then
-                windowBg.hide(M.bgPrims[i]);
-            end
-        end
-    end
-    -- Hide split window backgrounds
-    if M.splitBgPrims then
-        for _, handle in pairs(M.splitBgPrims) do
-            if handle then
-                windowBg.hide(handle);
-            end
-        end
-    end
-end
-
--- Check if background theme changed and reload textures if needed
--- Returns true if theme was changed, false if unchanged
-function M.CheckAndUpdateTheme()
-    local bgTheme = gConfig.notificationsBackgroundTheme or 'Plain';
-    local bgScale = gConfig.notificationsBgScale or 1.0;
-    local borderScale = gConfig.notificationsBorderScale or 1.0;
-
-    -- Check if theme changed
-    if M.loadedBgTheme == bgTheme then
-        return false;
-    end
-
-    -- Theme changed - update all primitives
-    M.loadedBgTheme = bgTheme;
-
-    -- Update notification slot backgrounds
-    if M.bgPrims then
-        for i = 1, M.MAX_ACTIVE_NOTIFICATIONS do
-            if M.bgPrims[i] then
-                windowBg.setTheme(M.bgPrims[i], bgTheme, bgScale, borderScale);
-            end
-        end
-    end
-
-    -- Update split window backgrounds
-    if M.splitBgPrims then
-        for _, splitKey in ipairs(M.SPLIT_WINDOW_KEYS) do
-            if M.splitBgPrims[splitKey] then
-                windowBg.setTheme(M.splitBgPrims[splitKey], bgTheme, bgScale, borderScale);
-            end
-        end
-    end
-
-    return true;
-end
 
 -- Clear cached colors
 function M.ClearColorCache()
@@ -484,7 +407,6 @@ end
 function M.Initialize(settings)
     M.settings = settings;
     M.activeNotifications = {};
-    M.splitBgPrims = {};
     M.pinnedNotifications = {};
     M.pendingQueue = {};
     M.treasurePool = {};
@@ -493,9 +415,7 @@ function M.Initialize(settings)
     M.nextId = 1;
 
     -- Initialize per-group storage
-    M.groupBgPrims = {};
     M.groupWindowAnchors = {};
-    M.groupLoadedBgThemes = {};
 end
 
 -- Add a new notification
@@ -707,12 +627,9 @@ function M.Cleanup()
     M.treasurePool = {};
     M.awardedHistory = {};
     M.settings = nil;
-    M.splitBgPrims = {};
 
     -- Clear per-group storage
-    M.groupBgPrims = {};
     M.groupWindowAnchors = {};
-    M.groupLoadedBgThemes = {};
 end
 
 -- ============================================
@@ -1295,57 +1212,6 @@ end
 function M.GetInviteMinifyTimeoutForGroup(groupNum)
     local groupSettings = M.GetGroupSettings(groupNum);
     return groupSettings and groupSettings.inviteMinifyTimeout or gConfig and gConfig.notificationsInviteMinifyTimeout or 10.0;
-end
-
--- Check and update background theme for a specific group
--- Returns true if theme was changed, false if unchanged
-function M.CheckAndUpdateGroupTheme(groupNum)
-    local groupSettings = M.GetGroupSettings(groupNum);
-    if not groupSettings then return false; end
-
-    local bgTheme = groupSettings.backgroundTheme or 'Plain';
-    local bgScale = groupSettings.bgScale or 1.0;
-    local borderScale = groupSettings.borderScale or 1.0;
-
-    -- Check if theme changed for this group
-    if M.groupLoadedBgThemes[groupNum] == bgTheme then
-        return false;
-    end
-
-    -- Theme changed - update primitives for this group
-    M.groupLoadedBgThemes[groupNum] = bgTheme;
-
-    -- Update background primitives for all slots in this group
-    if M.groupBgPrims[groupNum] then
-        for slot = 1, M.MAX_NOTIFICATIONS_PER_GROUP do
-            if M.groupBgPrims[groupNum][slot] then
-                windowBg.setTheme(M.groupBgPrims[groupNum][slot], bgTheme, bgScale, borderScale);
-            end
-        end
-    end
-
-    return true;
-end
-
--- Hide all resources for a specific group
-function M.HideGroupResources(groupNum)
-    -- Hide backgrounds
-    if M.groupBgPrims[groupNum] then
-        for slot = 1, M.MAX_NOTIFICATIONS_PER_GROUP do
-            if M.groupBgPrims[groupNum][slot] then
-                windowBg.hide(M.groupBgPrims[groupNum][slot]);
-            end
-        end
-    end
-end
-
--- Hide all resources for all groups
-function M.HideAllGroupResources()
-    -- Always hide ALL groups up to MAX_GROUPS, not just configured count
-    -- This ensures groups are hidden when user reduces group count
-    for groupNum = 1, M.MAX_GROUPS do
-        M.HideGroupResources(groupNum);
-    end
 end
 
 -- Clear per-group color caches

--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -301,16 +301,15 @@ local function drawNotification(slot, notification, x, y, width, height, setting
     end
     local textY = baseTextY + textOffsetY;
 
-    -- Draw icons on the background draw list to avoid window clip rect issues
-    -- when multiple notifications are stacked in the same ImGui window.
-    local iconDrawList = imgui.GetBackgroundDrawList();
-    if icon and icon.image and iconDrawList then
-        -- Convert alpha to icon color with alpha
+    -- Draw icon on the same drawList as bg/text so call order (bg -> icon -> text)
+    -- determines z-order. Using a separate (lower) drawList would put the icon
+    -- behind the bg now that bg lives on this drawList too.
+    if icon and icon.image and drawList then
         local iconAlphaByte = math.floor(alpha * 255);
         local iconColor = bit.bor(bit.lshift(iconAlphaByte, 24), 0x00FFFFFF);  -- White with alpha
 
         pcall(function()
-            iconDrawList:AddImage(
+            drawList:AddImage(
                 tonumber(ffi.cast("uint32_t", icon.image)),
                 {iconX, iconY},
                 {iconX + iconSize, iconY + iconSize},
@@ -941,13 +940,13 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
     end
     local textY = baseTextY + textOffsetY;
 
-    local iconDrawList = imgui.GetBackgroundDrawList();
-    if icon and icon.image and iconDrawList then
+    -- Draw icon on the same drawList as bg/text (bg -> icon -> text via code order).
+    if icon and icon.image and drawList then
         local iconAlphaByte = math.floor(alpha * 255);
         local iconColor = bit.bor(bit.lshift(iconAlphaByte, 24), 0x00FFFFFF);
 
         pcall(function()
-            iconDrawList:AddImage(
+            drawList:AddImage(
                 tonumber(ffi.cast("uint32_t", icon.image)),
                 {iconX, iconY},
                 {iconX + iconSize, iconY + iconSize},

--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -184,12 +184,6 @@ local function drawNotification(slot, notification, x, y, width, height, setting
         return;
     end
 
-    -- Get primitive for this slot
-    local bgPrim = notificationData.bgPrims[slot];
-
-    if not bgPrim then
-        return;
-    end
     local containerOffsetX = notification.containerOffsetX or 0;
     local iconOffsetX = notification.iconOffsetX or 0;
     local textOffsetY = notification.textOffsetY or 0;
@@ -213,7 +207,7 @@ local function drawNotification(slot, notification, x, y, width, height, setting
     local bgOpacity = alpha * configBgOpacity;
     local borderOpacity = alpha * configBorderOpacity;
 
-    windowBg.update(bgPrim, x, y, scaledWidth, scaledHeight, {
+    windowBg.Draw(drawList, x, y, scaledWidth, scaledHeight, {
         theme = bgTheme,
         padding = 0,
         bgScale = bgScale,
@@ -762,22 +756,13 @@ local function drawNotificationWindow(windowName, notifications, settings, split
                 local titleHeight = gConfig.notificationsTitleFontSize or 14;
                 local subtitleHeight = gConfig.notificationsSubtitleFontSize or 12;
 
-                -- Get background primitive based on window type
-                local bgPrim;
-                if splitKey == nil then
-                    -- Only show if no other notifications are using slot 1 (currentSlot == 0)
-                    if currentSlot > 0 then
-                        -- Skip placeholder - slot 1 is in use by split window notifications
-                        -- Note: return from pcall, End() will be called below
-                        return;
-                    end
-                    bgPrim = notificationData.bgPrims and notificationData.bgPrims[1];
-                else
-                    bgPrim = notificationData.splitBgPrims and notificationData.splitBgPrims[splitKey];
+                if splitKey == nil and currentSlot > 0 then
+                    -- Skip placeholder - slot 1 is in use by split window notifications
+                    -- Note: return from pcall, End() will be called below
+                    return;
                 end
 
-                -- Draw background using windowbackground library
-                if bgPrim then
+                do
                     local bgTheme = gConfig.notificationsBackgroundTheme or 'Plain';
                     local bgScale = gConfig.notificationsBgScale or 1.0;
                     local borderScale = gConfig.notificationsBorderScale or 1.0;
@@ -786,7 +771,7 @@ local function drawNotificationWindow(windowName, notifications, settings, split
 
                     -- Placeholder uses reduced opacity (approximately 30% of normal)
                     local placeholderOpacity = 0.3;
-                    windowBg.update(bgPrim, windowPosX, windowPosY, notificationWidth, normalHeight, {
+                    windowBg.Draw(drawList, windowPosX, windowPosY, notificationWidth, normalHeight, {
                         theme = bgTheme,
                         padding = 0,
                         bgScale = bgScale,
@@ -861,13 +846,6 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
         return;
     end
 
-    -- Get primitive for this group/slot
-    local bgPrim = notificationData.groupBgPrims[groupNum] and notificationData.groupBgPrims[groupNum][slot];
-
-    if not bgPrim then
-        return;
-    end
-
     local containerOffsetX = notification.containerOffsetX or 0;
     local iconOffsetX = notification.iconOffsetX or 0;
     local textOffsetY = notification.textOffsetY or 0;
@@ -889,7 +867,7 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
     local bgOpacity = alpha * configBgOpacity;
     local borderOpacity = alpha * configBorderOpacity;
 
-    windowBg.update(bgPrim, x, y, scaledWidth, scaledHeight, {
+    windowBg.Draw(drawList, x, y, scaledWidth, scaledHeight, {
         theme = bgTheme,
         padding = 0,
         bgScale = bgScale,
@@ -1250,26 +1228,22 @@ local function drawGroupWindow(groupNum, settings)
                 end
             elseif configOpen then
                 -- Draw placeholder
-                local bgPrim = notificationData.groupBgPrims[groupNum] and notificationData.groupBgPrims[groupNum][1];
+                windowBg.Draw(drawList, windowPosX, windowPosY, notificationWidth, normalHeight, {
+                    theme = groupSettings.backgroundTheme or 'Plain',
+                    padding = 0,
+                    bgScale = groupSettings.bgScale or 1.0,
+                    borderScale = groupSettings.borderScale or 1.0,
+                    bgOpacity = 0.5,
+                    borderOpacity = 0.5,
+                    bgColor = 0xFF1A1A1A,
+                    borderColor = 0xFFFFFFFF,
+                });
 
-                if bgPrim then
-                    windowBg.update(bgPrim, windowPosX, windowPosY, notificationWidth, normalHeight, {
-                        theme = groupSettings.backgroundTheme or 'Plain',
-                        padding = 0,
-                        bgScale = groupSettings.bgScale or 1.0,
-                        borderScale = groupSettings.borderScale or 1.0,
-                        bgOpacity = 0.5,
-                        borderOpacity = 0.5,
-                        bgColor = 0xFF1A1A1A,
-                        borderColor = 0xFFFFFFFF,
-                    });
-
-                    if drawList then
-                        local textX = windowPosX + contentPadding;
-                        local titleY = windowPosY + contentPadding;
-                        imtext.Draw(drawList, GROUP_TITLES[groupNum] or ('Group ' .. groupNum), textX, titleY, 0x80FFFFFF, groupSettings.titleFontSize or 14);
-                        imtext.Draw(drawList, GROUP_PLACEHOLDERS[groupNum] or 'Drag to reposition', textX, titleY + (groupSettings.titleFontSize or 14) + 2, 0x80AAAAAA, groupSettings.subtitleFontSize or 12);
-                    end
+                if drawList then
+                    local textX = windowPosX + contentPadding;
+                    local titleY = windowPosY + contentPadding;
+                    imtext.Draw(drawList, GROUP_TITLES[groupNum] or ('Group ' .. groupNum), textX, titleY, 0x80FFFFFF, groupSettings.titleFontSize or 14);
+                    imtext.Draw(drawList, GROUP_PLACEHOLDERS[groupNum] or 'Drag to reposition', textX, titleY + (groupSettings.titleFontSize or 14) + 2, 0x80AAAAAA, groupSettings.subtitleFontSize or 12);
                 end
             end
         end);
@@ -1299,20 +1273,6 @@ end
 
 -- Main draw function
 function M.DrawWindow(settings, activeNotifications, pinnedNotifications)
-    -- Safety check - ensure group resources are initialized
-    if not notificationData.groupBgPrims or not next(notificationData.groupBgPrims) then
-        return;
-    end
-
-    -- Hide all group resources initially
-    notificationData.HideAllGroupResources();
-
-    -- Check per-group themes for changes
-    local maxGroups = gConfig.notificationGroupCount or 2;
-    for groupNum = 1, maxGroups do
-        notificationData.CheckAndUpdateGroupTheme(groupNum);
-    end
-
     -- Check if player exists and is not zoning
     local player = GetPlayerSafe();
     if not player or player.isZoning then
@@ -1323,6 +1283,7 @@ function M.DrawWindow(settings, activeNotifications, pinnedNotifications)
     notificationData.UpdateTreasurePool(os.clock());
 
     -- Draw notification groups
+    local maxGroups = gConfig.notificationGroupCount or 2;
     for groupNum = 1, maxGroups do
         drawGroupWindow(groupNum, settings);
     end
@@ -1330,9 +1291,6 @@ end
 
 -- Set visibility
 function M.SetHidden(hidden)
-    if hidden then
-        notificationData.HideAllGroupResources();
-    end
 end
 
 -- Cleanup

--- a/XIUI/modules/notifications/init.lua
+++ b/XIUI/modules/notifications/init.lua
@@ -7,8 +7,6 @@
 require('common');
 require('handlers.helpers');
 local imtext = require('libs.imtext');
-local primitives = require('primitives');
-local windowBg = require('libs.windowbackground');
 
 local data = require('modules.notifications.data');
 local display = require('modules.notifications.display');
@@ -31,33 +29,6 @@ notifications.Initialize = function(settings)
         -- Initialize data module (clears any leftover state)
         data.Initialize(settings);
 
-        -- Base primitive data for backgrounds
-        local prim_data = {
-            visible = false,
-            can_focus = false,
-            locked = true,
-            width = settings.width or 280,
-            height = 80,
-        };
-
-        -- Create per-group backgrounds
-        local maxGroups = gConfig.notificationGroupCount or 2;
-
-        for groupNum = 1, maxGroups do
-            local groupSettings = data.GetGroupSettings(groupNum);
-            local groupBgTheme = groupSettings and groupSettings.backgroundTheme or 'Plain';
-            local groupBgScale = groupSettings and groupSettings.bgScale or 1.0;
-            local groupBorderScale = groupSettings and groupSettings.borderScale or 1.0;
-
-            data.groupBgPrims[groupNum] = {};
-            data.groupLoadedBgThemes[groupNum] = groupBgTheme;
-
-            for slot = 1, data.MAX_NOTIFICATIONS_PER_GROUP do
-                -- Background primitive for this group/slot
-                data.groupBgPrims[groupNum][slot] = windowBg.create(prim_data, groupBgTheme, groupBgScale, groupBorderScale);
-            end
-        end
-
         -- Clear cached colors
         data.ClearGroupColorCaches();
 
@@ -78,38 +49,6 @@ notifications.UpdateVisuals = function(settings)
 
     -- Clear cached colors
     data.ClearGroupColorCaches();
-
-    -- Update per-group backgrounds
-    local maxGroups = gConfig.notificationGroupCount or 2;
-    for groupNum = 1, maxGroups do
-        local groupSettings = data.GetGroupSettings(groupNum);
-        local groupBgTheme = groupSettings and groupSettings.backgroundTheme or 'Plain';
-        local groupBgScale = groupSettings and groupSettings.bgScale or 1.0;
-        local groupBorderScale = groupSettings and groupSettings.borderScale or 1.0;
-
-        -- Initialize group tables if needed (for newly added groups)
-        if not data.groupBgPrims[groupNum] then
-            data.groupBgPrims[groupNum] = {};
-        end
-
-        for slot = 1, data.MAX_NOTIFICATIONS_PER_GROUP do
-            -- Create or update background primitive
-            if data.groupBgPrims[groupNum][slot] then
-                windowBg.setTheme(data.groupBgPrims[groupNum][slot], groupBgTheme, groupBgScale, groupBorderScale);
-            else
-                local prim_data = {
-                    visible = false,
-                    can_focus = false,
-                    locked = true,
-                    width = settings.width or 280,
-                    height = 80,
-                };
-                data.groupBgPrims[groupNum][slot] = windowBg.create(prim_data, groupBgTheme, groupBgScale, groupBorderScale);
-            end
-        end
-
-        data.groupLoadedBgThemes[groupNum] = groupBgTheme;
-    end
 
     -- Update display module
     display.UpdateVisuals(settings);
@@ -140,23 +79,8 @@ end
 -- Cleanup
 -- ============================================
 notifications.Cleanup = function()
-    -- Cleanup per-group background primitives
-    if data.groupBgPrims then
-        for groupNum, prims in pairs(data.groupBgPrims) do
-            if prims then
-                for slot, prim in pairs(prims) do
-                    if prim then
-                        windowBg.destroy(prim);
-                    end
-                end
-            end
-        end
-        data.groupBgPrims = {};
-    end
-
     -- Clear per-group caches
     data.groupWindowAnchors = {};
-    data.groupLoadedBgThemes = {};
 
     -- Clear cached colors
     data.ClearGroupColorCaches();

--- a/XIUI/modules/partylist/data.lua
+++ b/XIUI/modules/partylist/data.lua
@@ -6,7 +6,6 @@
 require('common');
 local ffi = require('ffi');
 local statusHandler = require('handlers.statushandler');
-local windowBg = require('libs.windowbackground');
 
 local data = {};
 
@@ -32,12 +31,6 @@ data.fullMenuWidth = {};
 data.fullMenuHeight = {};
 data.buffWindowX = {};
 data.debuffWindowX = {};
-
-data.partyWindowPrim = {
-    [1] = { background = {} },
-    [2] = { background = {} },
-    [3] = { background = {} },
-};
 
 data.cursorTextures = T{};
 data.currentCursorName = nil;
@@ -67,9 +60,6 @@ data.cachedFontSizes = {12, 12, 12};
 data.cachedFontFamily = '';
 data.cachedFontFlags = 0;
 data.cachedOutlineWidth = 2;
-
--- Track loaded backgrounds per party
-data.loadedBg = {};
 
 -- Debounce settings save
 data.lastSettingsSaveTime = 0;
@@ -608,19 +598,8 @@ function data.GetMemberInformation(memIdx)
 end
 
 function data.UpdateTextVisibility(visible, partyIndex)
-    -- Handle background visibility using windowbackground library
-    -- When visible=false, hide backgrounds; when visible=true, backgrounds
-    -- will be shown on next windowBg.update() call in DrawPartyWindow
-    if not visible then
-        for i = 1, 3 do
-            if (partyIndex == nil or i == partyIndex) then
-                local backgroundPrim = data.partyWindowPrim[i].background;
-                if backgroundPrim then
-                    windowBg.hide(backgroundPrim);
-                end
-            end
-        end
-    end
+    -- Immediate-mode rendering: backgrounds are not drawn when DrawPartyWindow isn't called.
+    -- This function is kept as a hook in case future consumers need to react to visibility changes.
 end
 
 -- ============================================
@@ -628,15 +607,9 @@ end
 -- ============================================
 
 function data.Reset()
-    data.partyWindowPrim = {
-        {background = {}},
-        {background = {}},
-        {background = {}}
-    };
     data.maxTpTextWidthCache = { [1] = nil, [2] = nil, [3] = nil };
     data.memberInterpolation = {};
     data.partyCasts = {};
-    data.loadedBg = {};
     data.partyConfigCacheValid = false;
     data.partyConfigCacheVersion = -1;
 end

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -1142,8 +1142,6 @@ function display.DrawPartyWindow(settings, party, partyIndex)
         return;
     end
 
-    local backgroundPrim = data.partyWindowPrim[partyIndex].background;
-
     local titleUV;
     if (partyIndex == 1) then
         titleUV = partyMemberCount == 1 and data.titleUVs.solo or data.titleUVs.party;
@@ -1176,6 +1174,27 @@ function display.DrawPartyWindow(settings, party, partyIndex)
     if (imgui.Begin(windowName, true, windowFlags)) then
         SaveWindowPosition(windowName);
         imguiPosX, imguiPosY = imgui.GetWindowPos();
+
+        -- Draw background + borders FIRST so they sit beneath member content on the draw list.
+        -- Window size depends on content rendered later, so we use the previous frame's cached
+        -- size from data.fullMenuWidth/Height. The cache is updated at the end of this function.
+        local cachedW = data.fullMenuWidth[partyIndex];
+        local cachedH = data.fullMenuHeight[partyIndex];
+        if cachedW and cachedH and cachedW > 0 and cachedH > 0 then
+            windowBg.Draw(GetUIDrawList(), imguiPosX, imguiPosY, cachedW, cachedH, {
+                theme = cache.backgroundName,
+                padding = settings.bgPadding,
+                paddingY = settings.bgPaddingY,
+                bgScale = cache.bgScale,
+                borderScale = cache.borderScale,
+                bgOpacity = cache.backgroundOpacity,
+                bgColor = cache.colors.bgColor,
+                borderSize = settings.borderSize,
+                bgOffset = settings.bgOffset,
+                borderOpacity = cache.borderOpacity,
+                borderColor = cache.colors.borderColor,
+            });
+        end
 
         local nameRefHeight = cache.fontSizes.name;
         local offsetSize = nameRefHeight > iconSize and nameRefHeight or iconSize;
@@ -1235,22 +1254,6 @@ function display.DrawPartyWindow(settings, party, partyIndex)
 
     -- Calculate background dimensions (needed for title positioning)
     local bgWidth = data.fullMenuWidth[partyIndex] + (settings.bgPadding * 2);
-
-    -- Update background and borders using windowbackground library
-    local bgOptions = {
-        theme = cache.backgroundName,
-        padding = settings.bgPadding,
-        paddingY = settings.bgPaddingY,
-        bgScale = cache.bgScale,
-        borderScale = cache.borderScale,
-        bgOpacity = cache.backgroundOpacity,
-        bgColor = cache.colors.bgColor,
-        borderSize = settings.borderSize,
-        bgOffset = settings.bgOffset,
-        borderOpacity = cache.borderOpacity,
-        borderColor = cache.colors.borderColor,
-    };
-    windowBg.update(backgroundPrim, imguiPosX, imguiPosY, data.fullMenuWidth[partyIndex], data.fullMenuHeight[partyIndex], bgOptions);
 
     -- Draw title (skip foreground rendering when modal is open to respect dim overlay)
     if (cache.showTitle and data.partyTitlesTexture ~= nil and not _XIUI_MODAL_OPEN) then

--- a/XIUI/modules/partylist/init.lua
+++ b/XIUI/modules/partylist/init.lua
@@ -6,7 +6,6 @@
 require('common');
 require('handlers.helpers');
 local ffi = require('ffi');
-local windowBg = require('libs.windowbackground');
 local encoding = require('libs.encoding');
 local TextureManager = require('libs.texturemanager');
 
@@ -42,22 +41,6 @@ partyList.Initialize = function(settings)
     data.partyTitlesTexture = TextureManager.getFileTexture('PartyList-Titles');
     if (data.partyTitlesTexture ~= nil) then
         data.partyTitlesTexture.width, data.partyTitlesTexture.height = GetTextureDimensions(data.partyTitlesTexture, 64, 64);
-    end
-
-    -- Initialize background primitives using windowbackground library
-    data.loadedBg = {};
-
-    for partyIndex = 1, 3 do
-        local cache = data.partyConfigCache[partyIndex];
-        data.loadedBg[partyIndex] = cache.backgroundName;
-
-        -- Create combined background + borders using windowbackground library
-        data.partyWindowPrim[partyIndex].background = windowBg.create(
-            settings.prim_data,
-            cache.backgroundName,
-            cache.bgScale,
-            cache.borderScale
-        );
     end
 
     -- Load cursor textures (via TextureManager)
@@ -106,19 +89,6 @@ partyList.UpdateVisuals = function(settings)
         end
     end
 
-    -- Update background primitives using windowbackground library
-    for partyIndex = 1, 3 do
-        local cache = data.partyConfigCache[partyIndex];
-        local backgroundPrim = data.partyWindowPrim[partyIndex].background;
-
-        -- Track loaded backgrounds per-party
-        local bgChanged = cache.backgroundName ~= data.loadedBg[partyIndex];
-        data.loadedBg[partyIndex] = cache.backgroundName;
-
-        if bgChanged then
-            windowBg.setTheme(backgroundPrim, cache.backgroundName, cache.bgScale, cache.borderScale);
-        end
-    end
 end
 
 -- ============================================
@@ -139,15 +109,6 @@ end
 -- Cleanup
 -- ============================================
 partyList.Cleanup = function()
-    -- Destroy background primitives using windowbackground library
-    for i = 1, 3 do
-        local backgroundPrim = data.partyWindowPrim[i].background;
-        if backgroundPrim then
-            windowBg.destroy(backgroundPrim);
-            data.partyWindowPrim[i].background = nil;
-        end
-    end
-
     -- Reset state
     data.Reset();
 end

--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -5,6 +5,8 @@
 
 require('common');
 require('handlers.helpers');
+local ffi = require('ffi');
+local imgui = require('imgui');
 local windowBg = require('libs.windowbackground');
 local packets = require('libs.packets');
 local abilityRecast = require('libs.abilityrecast');
@@ -512,18 +514,11 @@ data.charmState = 0;            -- Packet interception state
 data.charmTarget = nil;         -- Target ID for charm check
 data.charmTargetIdx = nil;      -- Target Index for charm check
 
--- Background primitives
-data.backgroundPrim = {};
-data.loadedBgName = nil;
-
--- Pet image primitive (overlay on background)
-data.petImagePrim = nil;
-
--- Pet image textures for ImGui rendering (used when clip mode enabled)
+-- Pet image textures (D3D textures rendered via drawList:AddImage)
 data.petImageTextures = {};
 
--- Clipped pet image render info (set by UpdateBackground, rendered by display)
-data.clippedPetImageInfo = nil;
+-- Pet image metadata: petKey -> { baseWidth, baseHeight, exists }
+data.petImageMeta = {};
 
 -- Recast timer tracking
 data.recastMaxTimers = {};
@@ -1133,59 +1128,79 @@ function data.GetPetRecasts()
 end
 
 -- ============================================
--- Background Primitive Helpers
+-- Background Rendering
 -- ============================================
 
--- Hide all background primitives
+-- No-op kept for backwards compatibility with callers — immediate-mode rendering means
+-- backgrounds simply aren't drawn when DrawWindow isn't called.
 function data.HideBackground()
-    -- Hide background and borders using windowbackground library
-    windowBg.hide(data.backgroundPrim);
-
-    -- Hide all pet image primitives (petbar-specific) - both layers
-    if data.petImagePrims then
-        for _, prim in pairs(data.petImagePrims) do
-            if prim then
-                prim.visible = false;
-            end
-        end
-    end
-    if data.petImagePrimsTop then
-        for _, prim in pairs(data.petImagePrimsTop) do
-            if prim then
-                prim.visible = false;
-            end
-        end
-    end
 end
 
--- Update background primitives position and visibility
-function data.UpdateBackground(x, y, width, height, settings)
+-- Resolve pet image settings (returns nil if no image should be shown)
+local function ResolvePetImageSettings()
+    if not data.currentPetName then return nil; end
+
+    local petKey = data.GetPetSettingsKey(data.currentPetName);
+    local petTypeKey = data.GetPetTypeKey();
+
+    if petTypeKey == 'wyvern' then
+        petKey = 'wyvern';
+        local s = gConfig.petBarWyvern or {};
+        if not s.showImage then return nil; end
+        return {
+            petKey = petKey,
+            scale = s.imageScale or 0.4,
+            opacity = s.imageOpacity or 0.3,
+            offsetX = s.imageOffsetX or 0,
+            offsetY = s.imageOffsetY or 0,
+            clipToBackground = s.imageClipToBackground or false,
+        };
+    end
+
+    if not gConfig.petBarShowImage then return nil; end
+    local avatarSettings = gConfig.petBarAvatarSettings and gConfig.petBarAvatarSettings[petKey];
+    if avatarSettings then
+        return {
+            petKey = petKey,
+            scale = avatarSettings.scale or 0.4,
+            opacity = avatarSettings.opacity or 0.3,
+            offsetX = avatarSettings.offsetX or 0,
+            offsetY = avatarSettings.offsetY or 0,
+            clipToBackground = avatarSettings.clipToBackground or false,
+        };
+    end
+    return {
+        petKey = petKey,
+        scale = gConfig.petBarImageScale or 0.4,
+        opacity = gConfig.petBarImageOpacity or 0.3,
+        offsetX = gConfig.petBarImageOffsetX or 0,
+        offsetY = gConfig.petBarImageOffsetY or 0,
+        clipToBackground = false,
+    };
+end
+
+-- Draw background, pet image (middle layer), and borders for the petbar window.
+-- Pet image rendering is interleaved: clipped pet images render between bg and borders;
+-- unclipped pet images render on top of borders (after).
+function data.UpdateBackground(drawList, x, y, width, height, settings)
+    if drawList == nil then return; end
+
     -- Get per-pet-type settings
     local petTypeKey = data.GetPetTypeKey();
-    local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);  -- 'petBarAvatar', etc.
+    local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);
     local typeSettings = gConfig[settingsKey] or {};
     local typeColors = gConfig.colorCustomization and gConfig.colorCustomization[settingsKey] or {};
 
-    -- Background theme/opacity from per-type settings with legacy fallback
     local bgTheme = typeSettings.backgroundTheme or gConfig.petBarBackgroundTheme or 'Window1';
     local bgOpacity = typeSettings.backgroundOpacity or gConfig.petBarBackgroundOpacity or 1.0;
     local borderOpacity = typeSettings.borderOpacity or gConfig.petBarBorderOpacity or 1.0;
 
-    -- Colors from per-type settings with legacy fallback
     local bgColor = typeColors.bgColor or (gConfig.colorCustomization and gConfig.colorCustomization.petBar and gConfig.colorCustomization.petBar.bgColor) or 0xFFFFFFFF;
     local borderColor = typeColors.borderColor or (gConfig.colorCustomization and gConfig.colorCustomization.petBar and gConfig.colorCustomization.petBar.borderColor) or 0xFFFFFFFF;
 
-    -- Get scale from per-type settings (like bgTheme, bgOpacity)
     local bgScale = typeSettings.bgScale or 1.0;
     local borderScale = typeSettings.borderScale or 1.0;
 
-    -- Check if theme changed and reload textures if needed
-    if data.loadedBgName ~= bgTheme then
-        data.loadedBgName = bgTheme;
-        windowBg.setTheme(data.backgroundPrim, bgTheme, bgScale, borderScale);
-    end
-
-    -- Common options for windowbackground library
     local bgOptions = {
         theme = bgTheme,
         padding = settings.bgPadding or data.PADDING,
@@ -1200,135 +1215,60 @@ function data.UpdateBackground(x, y, width, height, settings)
         borderColor = borderColor,
     };
 
-    -- Update background and borders using windowbackground library
-    windowBg.update(data.backgroundPrim, x, y, width, height, bgOptions);
+    -- 1. Background (renders first, sits at bottom)
+    windowBg.DrawBackground(drawList, x, y, width, height, bgOptions);
 
-    -- Pet image overlay (petbar-specific - show correct avatar based on current pet)
-    -- Clear clipped image info
-    data.clippedPetImageInfo = nil;
-
-    -- First hide all pet image primitives (both clipped and unclipped sets)
-    if data.petImagePrims then
-        for _, prim in pairs(data.petImagePrims) do
-            if prim then
-                prim.visible = false;
-            end
-        end
-    end
-    if data.petImagePrimsTop then
-        for _, prim in pairs(data.petImagePrimsTop) do
-            if prim then
-                prim.visible = false;
-            end
-        end
+    -- Compute pet image spec (if any)
+    local imageSpec = ResolvePetImageSettings();
+    local petKey = imageSpec and imageSpec.petKey;
+    local meta = petKey and data.petImageMeta[petKey];
+    local texture = petKey and data.petImageTextures[petKey];
+    local canDrawImage = imageSpec and meta and meta.exists and texture and texture.image;
+    local imageTint;
+    local imgX, imgY, imgW, imgH;
+    if canDrawImage then
+        local alphaByte = math.floor(imageSpec.opacity * 255);
+        local argb = bit.bor(bit.lshift(alphaByte, 24), 0x00FFFFFF);
+        imageTint = imgui.GetColorU32(ARGBToImGui(argb));
+        imgX = x + imageSpec.offsetX;
+        imgY = y + imageSpec.offsetY;
+        imgW = meta.baseWidth * imageSpec.scale;
+        imgH = meta.baseHeight * imageSpec.scale;
     end
 
-    -- Show current pet's image if we have one
-    -- Check if image should be shown based on pet type settings
-    local showImage = false;
-    local petImageScale, petImageOpacity, petImageOffsetX, petImageOffsetY, clipToBackground;
-
-    if data.currentPetName and data.petImagePrims then
-        local petKey = data.GetPetSettingsKey(data.currentPetName);
-        local petTypeKey = data.GetPetTypeKey();  -- Get type by job, not name
-
-        -- For wyvern, use wyvern-specific settings from petBarWyvern
-        -- Use petTypeKey (job-based) instead of petKey (name-based) to handle renamed wyverns
-        if petTypeKey == 'wyvern' then
-            -- Override petKey to 'wyvern' for primitive lookup (handles renamed wyverns)
-            petKey = 'wyvern';
-            local wyvernSettings = gConfig.petBarWyvern or {};
-            showImage = wyvernSettings.showImage or false;
-            petImageScale = wyvernSettings.imageScale or 0.4;
-            petImageOpacity = wyvernSettings.imageOpacity or 0.3;
-            petImageOffsetX = wyvernSettings.imageOffsetX or 0;
-            petImageOffsetY = wyvernSettings.imageOffsetY or 0;
-            clipToBackground = wyvernSettings.imageClipToBackground or false;
-        else
-            -- For avatars/spirits, use the existing avatar settings system
-            showImage = gConfig.petBarShowImage or false;
-            local avatarSettings = gConfig.petBarAvatarSettings and gConfig.petBarAvatarSettings[petKey];
-
-            if avatarSettings then
-                petImageScale = avatarSettings.scale or 0.4;
-                petImageOpacity = avatarSettings.opacity or 0.3;
-                petImageOffsetX = avatarSettings.offsetX or 0;
-                petImageOffsetY = avatarSettings.offsetY or 0;
-                clipToBackground = avatarSettings.clipToBackground or false;
-            else
-                -- Fall back to legacy global settings
-                petImageScale = gConfig.petBarImageScale or 0.4;
-                petImageOpacity = gConfig.petBarImageOpacity or 0.3;
-                petImageOffsetX = gConfig.petBarImageOffsetX or 0;
-                petImageOffsetY = gConfig.petBarImageOffsetY or 0;
-                clipToBackground = false;
-            end
-        end
+    -- 2. Middle-layer pet image (clipped) — renders between bg and borders
+    if canDrawImage and imageSpec.clipToBackground then
+        local clipBounds = windowBg.GetClipBounds(x, y, width, height, {
+            padding = settings.bgPadding or data.PADDING,
+            paddingY = settings.bgPaddingY or data.PADDING,
+        });
+        drawList:PushClipRect(
+            {clipBounds.left, clipBounds.top},
+            {clipBounds.right, clipBounds.bottom},
+            true
+        );
+        drawList:AddImage(
+            tonumber(ffi.cast('uint32_t', texture.image)),
+            {imgX, imgY},
+            {imgX + imgW, imgY + imgH},
+            {0, 0}, {1, 1},
+            imageTint
+        );
+        drawList:PopClipRect();
     end
 
-    if showImage and data.currentPetName and data.petImagePrims then
-        local petKey = data.GetPetSettingsKey(data.currentPetName);
-        local petTypeKey = data.GetPetTypeKey();
-        -- For wyvern, use 'wyvern' key to handle renamed wyverns
-        if petTypeKey == 'wyvern' then
-            petKey = 'wyvern';
-        end
-        local primMiddle = data.petImagePrims[petKey];  -- Middle layer (for clipped)
-        local primTop = data.petImagePrimsTop and data.petImagePrimsTop[petKey];  -- Top layer (for unclipped)
+    -- 3. Borders (renders on top of bg + middle-layer pet image)
+    windowBg.DrawBorders(drawList, x, y, width, height, bgOptions);
 
-        -- Use middle layer prim for dimensions, but choose which to show based on clip setting
-        local prim = primMiddle;
-        if prim and prim.exists then
-
-            -- Calculate base image position and dimensions
-            local imgX = x + petImageOffsetX;
-            local imgY = y + petImageOffsetY;
-            local baseWidth = prim.baseWidth or 256;
-            local baseHeight = prim.baseHeight or 256;
-
-            -- Convert 0-1 opacity to alpha byte (0x00-0xFF), keep RGB as white
-            local alphaByte = math.floor(petImageOpacity * 255);
-            local primColor = bit.bor(bit.lshift(alphaByte, 24), 0x00FFFFFF);
-
-            if clipToBackground then
-                -- Use middle layer primitive (renders behind borders), clipped to background
-                local clipBounds = windowBg.getClipBounds(x, y, width, height, {
-                    theme = bgTheme,
-                    padding = settings.bgPadding or data.PADDING,
-                    paddingY = settings.bgPaddingY or data.PADDING,
-                    bgOffset = settings.bgOffset or 1,
-                });
-
-                local clipped = windowBg.clipImageToBounds(imgX, imgY, baseWidth * petImageScale, baseHeight * petImageScale, clipBounds, petImageScale);
-
-                if clipped then
-                    primMiddle.visible = true;
-                    primMiddle.position_x = clipped.x;
-                    primMiddle.position_y = clipped.y;
-                    primMiddle.texture_offset_x = clipped.texOffsetX;
-                    primMiddle.texture_offset_y = clipped.texOffsetY;
-                    primMiddle.width = clipped.width;
-                    primMiddle.height = clipped.height;
-                    primMiddle.scale_x = clipped.scaleX;
-                    primMiddle.scale_y = clipped.scaleY;
-                    primMiddle.color = primColor;
-                end
-            else
-                -- Use top layer primitive (renders on top of borders), no clipping
-                if primTop then
-                    primTop.visible = true;
-                    primTop.position_x = imgX;
-                    primTop.position_y = imgY;
-                    primTop.texture_offset_x = 0;
-                    primTop.texture_offset_y = 0;
-                    primTop.width = baseWidth;
-                    primTop.height = baseHeight;
-                    primTop.scale_x = petImageScale;
-                    primTop.scale_y = petImageScale;
-                    primTop.color = primColor;
-                end
-            end
-        end
+    -- 4. Top-layer pet image (unclipped) — renders on top of borders
+    if canDrawImage and not imageSpec.clipToBackground then
+        drawList:AddImage(
+            tonumber(ffi.cast('uint32_t', texture.image)),
+            {imgX, imgY},
+            {imgX + imgW, imgY + imgH},
+            {0, 0}, {1, 1},
+            imageTint
+        );
     end
 end
 
@@ -1420,14 +1360,11 @@ end
 -- ============================================
 
 function data.Reset()
-    data.backgroundPrim = {};
-    data.petImagePrim = nil;
     data.petImageTextures = {};
-    data.clippedPetImageInfo = nil;
+    data.petImageMeta = {};
     data.petTargetServerId = nil;
     data.currentPetName = nil;
     data.recastMaxTimers = {};
-    data.loadedBgName = nil;
     -- Pet timer tracking reset
     data.petSummonTime = nil;
     data.petExpireTime = nil;

--- a/XIUI/modules/petbar/display.lua
+++ b/XIUI/modules/petbar/display.lua
@@ -20,11 +20,13 @@ local defaultPositions = require('libs.defaultpositions');
 
 local display = {};
 
--- Window state for bottom alignment
+-- Window state for bottom alignment + previous-frame size cache (used for bg layering)
 local windowState = {
     x = nil,
     y = nil,
     height = nil,
+    cachedWidth = nil,
+    cachedHeight = nil,
 };
 
 -- ============================================
@@ -626,7 +628,6 @@ function display.DrawWindow(settings)
 
     if petData == nil and not alwaysVisible then
         data.currentPetName = nil;
-        data.HideBackground();
         -- Reset window state when hidden so bottom alignment starts fresh
         windowState.x = nil;
         windowState.y = nil;
@@ -726,6 +727,12 @@ function display.DrawWindow(settings)
         SaveWindowPosition('PetBar');
         windowPosX, windowPosY = imgui.GetWindowPos();
         local startX, startY = imgui.GetCursorScreenPos();
+
+        -- Draw background + pet image + borders FIRST so they sit beneath text/icons on the draw list.
+        -- Window size only known after content; use the previous frame's cached size (updated below).
+        if windowState.cachedWidth and windowState.cachedHeight then
+            data.UpdateBackground(drawList, windowPosX, windowPosY, windowState.cachedWidth, windowState.cachedHeight, settings);
+        end
 
         if hasPet then
             -- Row 1: Pet Name (with optional level) (left) and HP% (right, same line)
@@ -1181,8 +1188,9 @@ function display.DrawWindow(settings)
         data.lastMainWindowTop = windowPosY;
         data.lastMainWindowBottom = windowPosY + windowHeight + 4;
 
-        -- Update background primitives
-        data.UpdateBackground(windowPosX, windowPosY, windowWidth, windowHeight, settings);
+        -- Cache window size for next frame's bg draw at the top of this function.
+        windowState.cachedWidth = windowWidth;
+        windowState.cachedHeight = windowHeight;
     end
     imgui.End();
 

--- a/XIUI/modules/petbar/init.lua
+++ b/XIUI/modules/petbar/init.lua
@@ -7,9 +7,7 @@
 require('common');
 require('handlers.helpers');
 local imtext = require('libs.imtext');
-local primitives = require('primitives');
 local ffi = require('ffi');
-local windowBg = require('libs.windowbackground');
 local abilityRecast = require('libs.abilityrecast');
 local TextureManager = require('libs.texturemanager');
 
@@ -29,83 +27,21 @@ petbar.Initialize = function(settings)
     -- Load jug icon texture (via TextureManager)
     data.jugIconTexture = TextureManager.getFileTexture('pets/jug');
 
-    -- Initialize primitives - creation order determines render order
-    -- Order: background -> pet images -> borders
-    local prim_data = settings.prim_data or {
-        visible = false,
-        can_focus = false,
-        locked = true,
-        width = 100,
-        height = 100,
-    };
-
-    local backgroundName = gConfig.petBarBackgroundTheme or 'Window1';
-    data.loadedBgName = backgroundName;
-
-    -- 1. Create background primitive first (renders at bottom)
-    local bgHandle = windowBg.createBackground(prim_data, backgroundName, settings.bgScale);
-    data.backgroundPrim['bg'] = bgHandle.bg;
-
-    -- 2. Create pet image primitives (render in middle - petbar specific)
-    data.petImagePrims = {};
+    -- Load pet image textures + base dimensions (rendered via drawList:AddImage in data.UpdateBackground)
     data.petImageTextures = {};
+    data.petImageMeta = {};
     for _, petName in ipairs(data.allPetsWithImages) do
         local key = data.GetPetSettingsKey(petName);
-        local imagePath = data.GetPetImagePath(petName);
-        if imagePath then
-            local prim = primitives:new(prim_data);
-            prim.visible = false;
-            prim.can_focus = false;
-            prim.texture = imagePath;
-            prim.exists = ashita.fs.exists(imagePath);
-            prim.scale_x = 1.0;
-            prim.scale_y = 1.0;
-            -- Store base dimensions for clipping calculations
-            prim.baseWidth = 256;
-            prim.baseHeight = 256;
-            -- Try to get actual texture dimensions and store texture for ImGui (via TextureManager)
-            if prim.exists then
-                local texture = TextureManager.getFileTexture(string.format('pets/%s', data.petImageMap[petName]:gsub('%.png$', '')));
-                if texture and texture.image then
-                    prim.baseWidth, prim.baseHeight = GetTextureDimensions(texture, 256, 256);
-                    -- Store full texture object for ImGui rendering (keeps reference alive)
-                    data.petImageTextures[key] = texture;
-                end
-            end
-            data.petImagePrims[key] = prim;
-        end
-    end
-
-    -- 3. Create border primitives (render on top of middle layer)
-    local borderHandle = windowBg.createBorders(prim_data, backgroundName, settings.borderScale);
-    data.backgroundPrim['tl'] = borderHandle.tl;
-    data.backgroundPrim['tr'] = borderHandle.tr;
-    data.backgroundPrim['bl'] = borderHandle.bl;
-    data.backgroundPrim['br'] = borderHandle.br;
-
-    -- 4. Create pet image primitives for TOP layer (render on top of borders - for unclipped mode)
-    data.petImagePrimsTop = {};
-    for _, petName in ipairs(data.allPetsWithImages) do
-        local key = data.GetPetSettingsKey(petName);
-        local imagePath = data.GetPetImagePath(petName);
-        if imagePath then
-            local prim = primitives:new(prim_data);
-            prim.visible = false;
-            prim.can_focus = false;
-            prim.texture = imagePath;
-            prim.exists = ashita.fs.exists(imagePath);
-            prim.scale_x = 1.0;
-            prim.scale_y = 1.0;
-            -- Copy base dimensions from middle layer prim
-            local middlePrim = data.petImagePrims[key];
-            if middlePrim then
-                prim.baseWidth = middlePrim.baseWidth;
-                prim.baseHeight = middlePrim.baseHeight;
+        local imageFile = data.petImageMap[petName];
+        if imageFile then
+            local texture = TextureManager.getFileTexture(string.format('pets/%s', imageFile:gsub('%.png$', '')));
+            if texture and texture.image then
+                local baseWidth, baseHeight = GetTextureDimensions(texture, 256, 256);
+                data.petImageTextures[key] = texture;
+                data.petImageMeta[key] = { baseWidth = baseWidth, baseHeight = baseHeight, exists = true };
             else
-                prim.baseWidth = 256;
-                prim.baseHeight = 256;
+                data.petImageMeta[key] = { baseWidth = 256, baseHeight = 256, exists = false };
             end
-            data.petImagePrimsTop[key] = prim;
         end
     end
 
@@ -196,36 +132,14 @@ end
 petbar.Cleanup = function()
     data.jugIconTexture = nil;
 
-    -- Cleanup background and border primitives using windowbackground library
-    windowBg.destroy(data.backgroundPrim);
-    data.backgroundPrim = {};
-
-    -- Cleanup pet image primitives (petbar specific) - both layers
-    if data.petImagePrims then
-        for _, prim in pairs(data.petImagePrims) do
-            if prim then
-                prim:destroy();
-            end
-        end
-        data.petImagePrims = nil;
-    end
-    if data.petImagePrimsTop then
-        for _, prim in pairs(data.petImagePrimsTop) do
-            if prim then
-                prim:destroy();
-            end
-        end
-        data.petImagePrimsTop = nil;
-    end
-
     -- Clear pet image textures - gc_safe_release handles D3D Release() via FFI finalizers
-    -- Clear each reference individually to help GC run finalizers promptly
     if data.petImageTextures then
         for key, _ in pairs(data.petImageTextures) do
             data.petImageTextures[key] = nil;
         end
         data.petImageTextures = {};
     end
+    data.petImageMeta = {};
 
     -- Cleanup pet target module
     pettarget.Cleanup();

--- a/XIUI/modules/petbar/pettarget.lua
+++ b/XIUI/modules/petbar/pettarget.lua
@@ -15,30 +15,13 @@ local data = require('modules.petbar.data');
 
 local pettarget = {};
 
--- ============================================
--- State Variables
--- ============================================
+-- Previous-frame window size cache (used for bg layering below content on the draw list)
+local cachedWindowSize = { width = nil, height = nil };
 
--- Background primitives (using windowbackground library)
-local backgroundPrim = nil;
-local loadedBgName = nil;
-
--- ============================================
--- Background Helpers
--- ============================================
-
-local function HideBackground()
-    if backgroundPrim then
-        windowBg.hide(backgroundPrim);
-    end
-end
-
-local function UpdateBackground(x, y, width, height, settings)
-    if not backgroundPrim then return; end
-
+local function DrawBackground(drawList, x, y, width, height, settings)
     -- Get scale from active pet type settings (same pattern as petbar data.lua)
     local petTypeKey = data.GetPetTypeKey();
-    local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);  -- 'petBarAvatar', etc.
+    local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);
     local typeSettings = gConfig[settingsKey] or {};
     local bgScale = typeSettings.bgScale or 1.0;
     local borderScale = typeSettings.borderScale or 1.0;
@@ -49,8 +32,7 @@ local function UpdateBackground(x, y, width, height, settings)
     local borderColor = gConfig.colorCustomization and gConfig.colorCustomization.petTarget and gConfig.colorCustomization.petTarget.borderColor or 0xFFFFFFFF;
     local borderOpacity = gConfig.petTargetBorderOpacity or gConfig.petBarBorderOpacity or 1.0;
 
-    -- Common options for windowbackground library
-    local bgOptions = {
+    windowBg.Draw(drawList, x, y, width, height, {
         theme = bgTheme,
         padding = (settings and settings.bgPadding) or data.PADDING,
         paddingY = (settings and settings.bgPaddingY) or data.PADDING,
@@ -62,10 +44,7 @@ local function UpdateBackground(x, y, width, height, settings)
         bgOffset = (settings and settings.bgOffset) or 1,
         borderOpacity = borderOpacity,
         borderColor = borderColor,
-    };
-
-    -- Update background and borders using windowbackground library
-    windowBg.update(backgroundPrim, x, y, width, height, bgOptions);
+    });
 end
 
 -- ============================================
@@ -76,7 +55,6 @@ function pettarget.DrawWindow(settings)
 
     -- Only show if we have a valid pet (prevents showing when "Always Visible" is on but no pet)
     if data.GetPetData() == nil then
-        HideBackground();
         return;
     end
 
@@ -90,20 +68,17 @@ function pettarget.DrawWindow(settings)
     else
         -- Only show if pet target tracking is enabled and we have a target
         if gConfig.petBarShowTarget == false or data.petTargetServerId == nil then
-            HideBackground();
             return;
         end
 
         -- Check if pet is targeting itself (e.g., after self-buff like Aerial Armor)
         local petEntity = data.GetPetEntity();
         if petEntity and petEntity.ServerId and data.petTargetServerId == petEntity.ServerId then
-            HideBackground();
             return;
         end
 
         local targetEnt = data.GetEntityByServerId(data.petTargetServerId);
         if targetEnt == nil or targetEnt.ActorPointer == 0 or targetEnt.HPPercent <= 0 then
-            HideBackground();
             data.petTargetServerId = nil;
             return;
         end
@@ -144,6 +119,12 @@ function pettarget.DrawWindow(settings)
         local targetWinPosX, targetWinPosY = imgui.GetWindowPos();
         local targetStartX, targetStartY = imgui.GetCursorScreenPos();
         local drawList = GetUIDrawList();
+
+        -- Draw background FIRST so it sits beneath text/bars on the draw list.
+        -- Window size only known after content; use previous frame's cached size (updated below).
+        if cachedWindowSize.width and cachedWindowSize.height then
+            DrawBackground(drawList, targetWinPosX, targetWinPosY, cachedWindowSize.width, cachedWindowSize.height, settings);
+        end
 
         imtext.SetConfigFromSettings(settings.vitals_font_settings);
 
@@ -229,80 +210,23 @@ function pettarget.DrawWindow(settings)
         end
         imtext.Draw(drawList, distStr, distDrawX, distDrawY, distanceColor, targetDistanceFontSize);
 
-        -- Update background
-        local targetWinWidth, targetWinHeight = imgui.GetWindowSize();
-        UpdateBackground(targetWinPosX, targetWinPosY, targetWinWidth, targetWinHeight, settings);
+        -- Cache window size for next frame's bg draw
+        cachedWindowSize.width, cachedWindowSize.height = imgui.GetWindowSize();
     end
     imgui.End();
 end
 
--- ============================================
--- Initialize
--- ============================================
 function pettarget.Initialize(settings)
-    -- Initialize background primitives using windowbackground library
-    local prim_data = settings.prim_data or {
-        visible = false,
-        can_focus = false,
-        locked = true,
-        width = 100,
-        height = 100,
-    };
-
-    -- Load background textures (use petTarget theme if set, otherwise petBar theme)
-    local backgroundName = gConfig.petTargetBackgroundTheme or gConfig.petBarBackgroundTheme or 'Window1';
-    loadedBgName = backgroundName;
-
-    -- Get scale from active pet type settings
-    local petTypeKey = data.GetPetTypeKey();
-    local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);
-    local typeSettings = gConfig[settingsKey] or {};
-    local bgScale = typeSettings.bgScale or 1.0;
-    local borderScale = typeSettings.borderScale or 1.0;
-
-    -- Create combined background + borders (no middle layer needed for pettarget)
-    backgroundPrim = windowBg.create(prim_data, backgroundName, bgScale, borderScale);
 end
 
--- ============================================
--- UpdateVisuals
--- ============================================
 function pettarget.UpdateVisuals(settings)
     imtext.Reset();
-
-    -- Get scale from active pet type settings
-    local petTypeKey = data.GetPetTypeKey();
-    local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);
-    local typeSettings = gConfig[settingsKey] or {};
-    local bgScale = typeSettings.bgScale or 1.0;
-    local borderScale = typeSettings.borderScale or 1.0;
-
-    -- Update background textures if theme changed (use petTarget theme if set, otherwise petBar theme)
-    local backgroundName = gConfig.petTargetBackgroundTheme or gConfig.petBarBackgroundTheme or 'Window1';
-    if loadedBgName ~= backgroundName then
-        loadedBgName = backgroundName;
-        windowBg.setTheme(backgroundPrim, backgroundName, bgScale, borderScale);
-    end
 end
 
--- ============================================
--- SetHidden
--- ============================================
 function pettarget.SetHidden(hidden)
-    if hidden then
-        HideBackground();
-    end
 end
 
--- ============================================
--- Cleanup
--- ============================================
 function pettarget.Cleanup()
-    -- Cleanup background primitives using windowbackground library
-    if backgroundPrim then
-        windowBg.destroy(backgroundPrim);
-        backgroundPrim = nil;
-    end
 end
 
 return pettarget;

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -327,7 +327,7 @@ playerbar.DrawWindow = function(settings)
 
 		-- Capture HP bar start position
 		local hpBarStartX, hpBarStartY = imgui.GetCursorScreenPos();
-		progressbar.ProgressBar(hpPercentData, {barSize, settings.barHeight}, {decorate = gConfig.showPlayerBarBookends});
+		progressbar.ProgressBar(hpPercentData, {barSize, settings.barHeight}, {decorate = gConfig.showPlayerBarBookends, drawList = drawList});
 
 		-- Draw resting ticker shimmer if enabled and player is resting
 		if gConfig.playerBarRestingTicker and playerEnt.Status == 33 then
@@ -437,7 +437,7 @@ playerbar.DrawWindow = function(settings)
 				mpPercentData = {{SelfMPPercent / 100, mpGradient}};
 			end
 
-			progressbar.ProgressBar(mpPercentData, {barSize, settings.barHeight}, {decorate = gConfig.showPlayerBarBookends});
+			progressbar.ProgressBar(mpPercentData, {barSize, settings.barHeight}, {decorate = gConfig.showPlayerBarBookends, drawList = drawList});
 			imgui.SameLine();
 		end
 
@@ -490,7 +490,7 @@ playerbar.DrawWindow = function(settings)
 			mainPercent = SelfTP / 1000;
 		end
 
-		progressbar.ProgressBar({{mainPercent, tpGradient}}, {barSize, settings.barHeight}, {overlayBar=tpOverlay, decorate = gConfig.showPlayerBarBookends});
+		progressbar.ProgressBar({{mainPercent, tpGradient}}, {barSize, settings.barHeight}, {overlayBar=tpOverlay, decorate = gConfig.showPlayerBarBookends, drawList = drawList});
 
 		imgui.SameLine();
 

--- a/XIUI/modules/treasurepool/display.lua
+++ b/XIUI/modules/treasurepool/display.lua
@@ -56,12 +56,6 @@ local BAR_HEIGHT = 3;
 -- State
 -- ============================================
 
--- Background primitive handle
-local bgPrimHandle = nil;
-
--- Theme tracking (for detecting changes like petbar)
-local loadedBgTheme = nil;
-
 -- Tab state: 1 = Pool view, 2 = History view
 local selectedTab = 1;
 
@@ -384,35 +378,23 @@ function M.DrawWindow(settings)
             contentHeightTotal = headerHeight + headerItemGap + visibleContentHeight;
         end
 
-        -- Update background (with safety checks)
-        if bgPrimHandle then
-            -- Check if theme changed
-            if loadedBgTheme ~= bgTheme then
-                loadedBgTheme = bgTheme;
-                pcall(function()
-                    windowBg.setTheme(bgPrimHandle, bgTheme, bgScale, borderScale);
-                end);
-            end
-
-            pcall(function()
-                -- For themed backgrounds (Window1-8), use white so texture shows through
-                -- For Plain backgrounds, use dark color with opacity
-                local bgColor = 0xFFFFFFFF;  -- White (no tint) for themed backgrounds
-                if bgTheme == 'Plain' then
-                    bgColor = 0xFF1A1A1A;  -- Dark gray for plain background
-                end
-
-                windowBg.update(bgPrimHandle, startX + padding, startY + padding, contentWidth, contentHeightTotal, {
-                    theme = bgTheme,
-                    padding = padding,
-                    bgScale = bgScale,
-                    borderScale = borderScale,
-                    bgOpacity = bgOpacity,
-                    borderOpacity = borderOpacity,
-                    bgColor = bgColor,
-                });
-            end);
+        -- Draw background + borders
+        -- For themed backgrounds (Window1-8), use white so texture shows through.
+        -- For Plain backgrounds, use dark color with opacity.
+        local bgColor = 0xFFFFFFFF;
+        if bgTheme == 'Plain' then
+            bgColor = 0xFF1A1A1A;
         end
+
+        windowBg.Draw(uiDrawList, startX + padding, startY + padding, contentWidth, contentHeightTotal, {
+            theme = bgTheme,
+            padding = padding,
+            bgScale = bgScale,
+            borderScale = borderScale,
+            bgOpacity = bgOpacity,
+            borderOpacity = borderOpacity,
+            bgColor = bgColor,
+        });
 
         local y = startY + padding;
 
@@ -1146,10 +1128,6 @@ function M.HideWindow()
         button.HidePrim(string.format('tpLotItem%d', slot));
         button.HidePrim(string.format('tpPassItem%d', slot));
     end
-
-    if bgPrimHandle then
-        windowBg.hide(bgPrimHandle);
-    end
 end
 
 -- ============================================
@@ -1157,32 +1135,9 @@ end
 -- ============================================
 
 function M.Initialize(settings)
-    -- Get background theme and scales from config (with defaults)
-    local bgTheme = gConfig.treasurePoolBackgroundTheme or 'Plain';
-    local bgScale = gConfig.treasurePoolBgScale or 1.0;
-    local borderScale = gConfig.treasurePoolBorderScale or 1.0;
-    loadedBgTheme = bgTheme;
-
-    -- Create background primitive
-    local primData = {
-        visible = false,
-        can_focus = false,
-        locked = true,
-        width = 100,
-        height = 100,
-    };
-    bgPrimHandle = windowBg.create(primData, bgTheme, bgScale, borderScale);
 end
 
 function M.UpdateVisuals(settings)
-    -- Check if theme changed
-    local bgTheme = gConfig.treasurePoolBackgroundTheme or 'Plain';
-    local bgScale = gConfig.treasurePoolBgScale or 1.0;
-    local borderScale = gConfig.treasurePoolBorderScale or 1.0;
-    if loadedBgTheme ~= bgTheme and bgPrimHandle then
-        loadedBgTheme = bgTheme;
-        windowBg.setTheme(bgPrimHandle, bgTheme, bgScale, borderScale);
-    end
 end
 
 function M.SetHidden(hidden)
@@ -1192,11 +1147,6 @@ function M.SetHidden(hidden)
 end
 
 function M.Cleanup()
-    if bgPrimHandle then
-        windowBg.destroy(bgPrimHandle);
-        bgPrimHandle = nil;
-    end
-
     -- Destroy primitive buttons
     button.DestroyPrim('tpToggle');
     button.DestroyPrim('tpMinimize');
@@ -1210,8 +1160,6 @@ function M.Cleanup()
         button.DestroyPrim(string.format('tpLotItem%d', slot));
         button.DestroyPrim(string.format('tpPassItem%d', slot));
     end
-
-    loadedBgTheme = nil;
     -- Icon cache handled by TextureManager
 end
 

--- a/XIUI/modules/treasurepool/init.lua
+++ b/XIUI/modules/treasurepool/init.lua
@@ -12,7 +12,6 @@
 require('common');
 require('handlers.helpers');
 local imtext = require('libs.imtext');
-local windowBg = require('libs.windowbackground');
 
 local data = require('modules.treasurepool.data');
 local display = require('modules.treasurepool.display');


### PR DESCRIPTION
## Summary

Replaces the persistent Ashita-primitive system with an immediate-mode renderer on ImGui draw lists. The old 5-piece primitive approach existed as a workaround for missing border radius; with everything on ImGui draw lists the rendering model unifies, z-order is controlled by call order, and the `primitives` import disappears from XIUI entirely.

- **23 files changed, +442 / -1953 lines** (net -1511)
- Final grep confirms zero remaining `primitives:new` / `primitives.new` / `require('primitives')` / `windowBg.create|update|setTheme|hide|destroy` across the addon

## What changed

### `libs/windowbackground.lua` — full rewrite
Stateless API. The old `create/update/setTheme/hide/destroy` lifecycle, the `_cache` property-guard pattern, and `clipImageToBounds` are gone.

```
Draw(drawList, x, y, w, h, options)        -- bg + borders in one call
DrawBackground(drawList, x, y, w, h, opts) -- bg only (middle-layer use)
DrawBorders(drawList, x, y, w, h, opts)    -- borders only
GetClipBounds(x, y, w, h, options)         -- pure math; use with PushClipRect
IsWindowTheme(theme)
```

### Consumers migrated
- `castcost`, `treasurepool`, `partylist`, `notifications`, `hotbar` (incl. `crossbar`), `petbar` (incl. `pettarget`) — all off the old API.
- `enemylist`: per-entry primitive rects → `drawList:AddRectFilled`.
- `petbar` pet images (two direct `primitives:new` layers, middle + top) → `drawList:AddImage` with `PushClipRect`/`PopClipRect` replacing `clipImageToBounds`.
- `libs/button.lua`: dropped `primitives` import; `*Prim` API names kept as thin drawList wrappers, `HidePrim`/`DestroyPrim` become no-ops (no persistent state to manage).
- `handlers/helpers.lua`: dropped unused `WindowBackground` global re-export.

### Layering fixes
Primitives always rendered below ImGui content regardless of call order, so several modules called `windowBg.update` at the end of `DrawWindow`. After migration, call order = z-order, so those calls were moved before content drawing. For modules where window size is only known after content (`partylist`, `petbar`, `pettarget`), bg uses the previous frame's cached size and the cache updates at end of frame.

### Playerbar text-under-bar fix
`progressbar.ProgressBar` defaulted to `GetWindowDrawList` while `imtext.Draw` uses `GetUIDrawList`. When the config menu is open and `imtext` switches to BackgroundDrawList, bars (on WindowDrawList) ended up above text. Playerbar HP/MP/TP bars now pass `drawList = drawList` explicitly so bars and text share the same list. Added a doc comment in `libs/progressbar.lua` flagging the trap for future module authors.

## Test plan

- [ ] `/addon reload xiui`
- [ ] Theme cycle (`-None-`, `Plain`, `Window1`..`Window8`) on each migrated module — backgrounds render correctly
- [ ] Open config menu while bars are visible — text sits above bars (playerbar regression check)
- [ ] Partylist: job icons render above the window background (not hidden)
- [ ] Petbar: text and bars render above the window background; pet image with `clipToBackground` enabled is clipped correctly
- [ ] Notifications: fade-in/fade-out alpha animations preserved
- [ ] Hotbar/crossbar: 6 bars with different themes simultaneously
- [ ] Test on Ashita 4.0 (main) and 4.3 (q3) before merging
- [ ] `/xiui cachestats` shows reasonable texture cache after a full theme cycle

## Known follow-ups

The same `progressbar` vs `imtext` drawList mismatch likely exists in other bar modules (`targetbar`, `castbar`, `partylist`, `petbar`, `pettarget`, `notifications`). They will hide text under bars when the config menu is open. Not addressed here to avoid widening the diff; can be fixed in follow-up PRs by passing `drawList = drawList` to each `ProgressBar` call.