### PR TITLE
Fix Z-order issue

### DIFF
--- a/XIUI/libs/button.lua
+++ b/XIUI/libs/button.lua
@@ -195,6 +195,7 @@ function DrawImpl(id, x, y, width, height, options)
     local borderThickness = options.borderThickness or 1;
     local disabled = options.disabled or false;
 
+    -- Get draw list
     local drawList = options.drawList or GetUIDrawList();
 
     -- Set cursor position for invisible button
@@ -298,6 +299,7 @@ function DrawArrowImpl(id, x, y, size, direction, options)
     local arrowColor = options.arrowColor or arrowColors.normal or 0xFFCCCCCC;
     local arrowHoverColor = options.arrowHoverColor or arrowColors.hovered or 0xFFFFFFFF;
 
+    -- Get draw list
     local drawList = options.drawList or GetUIDrawList();
 
     -- Set cursor position for invisible button

--- a/XIUI/libs/button.lua
+++ b/XIUI/libs/button.lua
@@ -195,8 +195,7 @@ function DrawImpl(id, x, y, width, height, options)
     local borderThickness = options.borderThickness or 1;
     local disabled = options.disabled or false;
 
-    -- Get draw list (default to background so it renders behind other UI)
-    local drawList = options.drawList or imgui.GetBackgroundDrawList();
+    local drawList = options.drawList or GetUIDrawList();
 
     -- Set cursor position for invisible button
     imgui.SetCursorScreenPos({x, y});
@@ -299,8 +298,7 @@ function DrawArrowImpl(id, x, y, size, direction, options)
     local arrowColor = options.arrowColor or arrowColors.normal or 0xFFCCCCCC;
     local arrowHoverColor = options.arrowHoverColor or arrowColors.hovered or 0xFFFFFFFF;
 
-    -- Get draw list
-    local drawList = options.drawList or imgui.GetBackgroundDrawList();
+    local drawList = options.drawList or GetUIDrawList();
 
     -- Set cursor position for invisible button
     imgui.SetCursorScreenPos({x, y});
@@ -437,7 +435,7 @@ function M.DrawMinimize(id, x, y, size, isMinimized, options, drawList)
         bgColor = colors.normal or M.DEFAULT_COLORS.normal;
     end
 
-    drawList = drawList or imgui.GetForegroundDrawList();
+    drawList = drawList or GetUIDrawList();
 
     -- Background
     drawList:AddRectFilled({x, y}, {x + size, y + size}, ARGBToU32(bgColor));

--- a/XIUI/libs/progressbar.lua
+++ b/XIUI/libs/progressbar.lua
@@ -361,12 +361,9 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 		options.decorate = false;
 	end
 
-	-- Get custom draw list if provided, otherwise use window draw list.
-	-- Note: if your module draws text via imtext.Draw on GetUIDrawList() and the
-	-- text needs to sit on top of bars, pass `drawList = GetUIDrawList()` here too
-	-- so both render to the same list (otherwise bars render above text when the
-	-- config menu is open and imtext switches to the background drawlist).
-	local drawList = options.drawList or imgui.GetWindowDrawList();
+	-- Get draw list (defaults to GetUIDrawList() so bars share the same list
+	-- as window backgrounds and text; pass options.drawList to override).
+	local drawList = options.drawList or GetUIDrawList();
 
 	-- Get position from options or cursor
 	local positionStartX, positionStartY;

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -473,7 +473,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
 
     -- Draw HP bar
     if (memInfo.inzone) then
-        progressbar.ProgressBar(hpPercentData, {hpBarWidth, hpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+        progressbar.ProgressBar(hpPercentData, {hpBarWidth, hpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
     elseif (memInfo.zone == '' or memInfo.zone == nil) then
         local zoneBarWidth = allBarsLengths;
         local zoneBarHeight;
@@ -615,8 +615,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                     {
                         decorate = false,
                         absolutePosition = {castBarX, castBarY},
-                        borderColorOverride = data.getBarBorderOverride(partyIndex),
-                        drawList = textDrawList,
+                        borderColorOverride = data.getBarBorderOverride(partyIndex)
                     }
                 );
             end
@@ -762,7 +761,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
             if showMpBar then
                 if showingCastInMpSlot then
                     local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
                     -- Set MP text to spell name with cast text color
                     mpDisplayText = castData.spellName;
                     mpColor = cache.colors.castTextColor or 0xFFFFCC44;
@@ -819,7 +818,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                         mpPercentData = {{memInfo.mpp, mpGradient}};
                     end
 
-                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
                     mpColor = cache.colors.mpTextColor;
                 end
 
@@ -841,7 +840,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                 -- Render cast bar or MP bar based on style and job type
                 if showingCastInMpSlot then
                     local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
                     -- Set MP text to spell name with cast text color
                     mpDisplayText = castData.spellName;
                     mpColor = cache.colors.castTextColor or 0xFFFFCC44;
@@ -898,7 +897,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                         mpPercentData = {{memInfo.mpp, mpGradient}};
                     end
 
-                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
                     mpColor = cache.colors.mpTextColor;
                 end
 
@@ -921,7 +920,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                 if showingCastInTpSlot then
                     -- Render cast bar in TP slot
                     local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-                    progressbar.ProgressBar({{castProgress, castGradient}}, {tpBarWidth, tpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+                    progressbar.ProgressBar({{castProgress, castGradient}}, {tpBarWidth, tpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
                     -- Set TP text to spell name with cast text color
                     local castTextColor = cache.colors.castTextColor or 0xFFFFCC44;
                     tpText = castData.spellName;
@@ -946,7 +945,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                         mainPercent = memInfo.tp / 1000;
                     end
 
-                    progressbar.ProgressBar({{mainPercent, tpGradient}}, {tpBarWidth, tpBarHeight}, {overlayBar=tpOverlay, decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
+                    progressbar.ProgressBar({{mainPercent, tpGradient}}, {tpBarWidth, tpBarHeight}, {overlayBar=tpOverlay, decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
 
                     local desiredTpColor = (memInfo.tp >= 1000) and cache.colors.tpFullTextColor or cache.colors.tpEmptyTextColor;
                     tpColor = desiredTpColor;

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -36,7 +36,12 @@ end
 -- DrawMember - Render a single party member
 -- ============================================
 function display.DrawMember(memIdx, settings, isLastVisibleMember)
-    local textDrawList = imgui.GetWindowDrawList();
+    -- Must share the same draw list as the window background (drawn in
+    -- DrawPartyWindow via GetUIDrawList()) so call order = z-order.
+    -- WindowDrawList always renders below ForegroundDrawList regardless of
+    -- call order, so leaving content on WindowDrawList puts the bg on top
+    -- of HP/MP/TP bars, names, etc.
+    local textDrawList = GetUIDrawList();
     local memInfo = data.GetMemberInformation(memIdx);
     if (memInfo == nil) then
         memInfo = {
@@ -186,7 +191,8 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
 
     -- Draw selection box
     if memInfo.targeted then
-        local drawList = imgui.GetBackgroundDrawList();
+        -- Share the bg/bars draw list so the selection isn't hidden behind the foreground bg.
+        local drawList = textDrawList;
 
         local selectionWidth = allBarsLengths + settings.cursorPaddingX1 + settings.cursorPaddingX2;
         local selectionScaleY = cache.selectionBoxScaleY or 1;
@@ -297,9 +303,10 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         if (jobIcon ~= nil) then
             namePosX = namePosX + jobIconSize + settings.nameTextOffsetX;
             distanceBaseX = distanceBaseX + jobIconSize; -- Only add job icon width, not name offset
-            -- Use background draw list to render outside window clipping
+            -- Share the bg/bars draw list so the icon isn't hidden behind the foreground bg
+            -- (and so it batches with other party-list draws on the same list).
             local jobIconPtr = tonumber(ffi.cast("uint32_t", jobIcon));
-            local draw_list = imgui.GetBackgroundDrawList();
+            local draw_list = textDrawList;
             draw_list:AddImage(
                 jobIconPtr,
                 {hpStartX, offsetStartY},
@@ -474,7 +481,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
 
     -- Draw HP bar
     if (memInfo.inzone) then
-        progressbar.ProgressBar(hpPercentData, {hpBarWidth, hpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+        progressbar.ProgressBar(hpPercentData, {hpBarWidth, hpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
     elseif (memInfo.zone == '' or memInfo.zone == nil) then
         local zoneBarWidth = allBarsLengths;
         local zoneBarHeight;
@@ -496,7 +503,8 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         local zoneBarStartX, zoneBarStartY = imgui.GetCursorScreenPos();
         imgui.Dummy({zoneBarWidth, zoneBarHeight});
 
-        local drawList = imgui.GetWindowDrawList();
+        -- Share the bg/bars draw list so the rect isn't hidden behind the foreground bg.
+        local drawList = textDrawList;
         drawList:AddRect(
             {zoneBarStartX, zoneBarStartY},
             {zoneBarStartX + zoneBarWidth, zoneBarStartY + zoneBarHeight},
@@ -616,7 +624,8 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                     {
                         decorate = false,
                         absolutePosition = {castBarX, castBarY},
-                        borderColorOverride = data.getBarBorderOverride(partyIndex)
+                        borderColorOverride = data.getBarBorderOverride(partyIndex),
+                        drawList = textDrawList,
                     }
                 );
             end
@@ -762,7 +771,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
             if showMpBar then
                 if showingCastInMpSlot then
                     local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
                     -- Set MP text to spell name with cast text color
                     mpDisplayText = castData.spellName;
                     mpColor = cache.colors.castTextColor or 0xFFFFCC44;
@@ -819,7 +828,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                         mpPercentData = {{memInfo.mpp, mpGradient}};
                     end
 
-                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
                     mpColor = cache.colors.mpTextColor;
                 end
 
@@ -841,7 +850,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                 -- Render cast bar or MP bar based on style and job type
                 if showingCastInMpSlot then
                     local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+                    progressbar.ProgressBar({{castProgress, castGradient}}, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
                     -- Set MP text to spell name with cast text color
                     mpDisplayText = castData.spellName;
                     mpColor = cache.colors.castTextColor or 0xFFFFCC44;
@@ -898,7 +907,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                         mpPercentData = {{memInfo.mpp, mpGradient}};
                     end
 
-                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+                    progressbar.ProgressBar(mpPercentData, {mpBarWidth, mpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
                     mpColor = cache.colors.mpTextColor;
                 end
 
@@ -921,7 +930,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                 if showingCastInTpSlot then
                     -- Render cast bar in TP slot
                     local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-                    progressbar.ProgressBar({{castProgress, castGradient}}, {tpBarWidth, tpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+                    progressbar.ProgressBar({{castProgress, castGradient}}, {tpBarWidth, tpBarHeight}, {decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
                     -- Set TP text to spell name with cast text color
                     local castTextColor = cache.colors.castTextColor or 0xFFFFCC44;
                     tpText = castData.spellName;
@@ -946,7 +955,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                         mainPercent = memInfo.tp / 1000;
                     end
 
-                    progressbar.ProgressBar({{mainPercent, tpGradient}}, {tpBarWidth, tpBarHeight}, {overlayBar=tpOverlay, decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex)});
+                    progressbar.ProgressBar({{mainPercent, tpGradient}}, {tpBarWidth, tpBarHeight}, {overlayBar=tpOverlay, decorate = cache.showBookends, backgroundGradientOverride = data.getBarBackgroundOverride(partyIndex), borderColorOverride = data.getBarBorderOverride(partyIndex), drawList = textDrawList});
 
                     local desiredTpColor = (memInfo.tp >= 1000) and cache.colors.tpFullTextColor or cache.colors.tpEmptyTextColor;
                     tpColor = desiredTpColor;

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -36,11 +36,6 @@ end
 -- DrawMember - Render a single party member
 -- ============================================
 function display.DrawMember(memIdx, settings, isLastVisibleMember)
-    -- Must share the same draw list as the window background (drawn in
-    -- DrawPartyWindow via GetUIDrawList()) so call order = z-order.
-    -- WindowDrawList always renders below ForegroundDrawList regardless of
-    -- call order, so leaving content on WindowDrawList puts the bg on top
-    -- of HP/MP/TP bars, names, etc.
     local textDrawList = GetUIDrawList();
     local memInfo = data.GetMemberInformation(memIdx);
     if (memInfo == nil) then
@@ -191,7 +186,6 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
 
     -- Draw selection box
     if memInfo.targeted then
-        -- Share the bg/bars draw list so the selection isn't hidden behind the foreground bg.
         local drawList = textDrawList;
 
         local selectionWidth = allBarsLengths + settings.cursorPaddingX1 + settings.cursorPaddingX2;
@@ -303,8 +297,6 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         if (jobIcon ~= nil) then
             namePosX = namePosX + jobIconSize + settings.nameTextOffsetX;
             distanceBaseX = distanceBaseX + jobIconSize; -- Only add job icon width, not name offset
-            -- Share the bg/bars draw list so the icon isn't hidden behind the foreground bg
-            -- (and so it batches with other party-list draws on the same list).
             local jobIconPtr = tonumber(ffi.cast("uint32_t", jobIcon));
             local draw_list = textDrawList;
             draw_list:AddImage(
@@ -503,7 +495,6 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         local zoneBarStartX, zoneBarStartY = imgui.GetCursorScreenPos();
         imgui.Dummy({zoneBarWidth, zoneBarHeight});
 
-        -- Share the bg/bars draw list so the rect isn't hidden behind the foreground bg.
         local drawList = textDrawList;
         drawList:AddRect(
             {zoneBarStartX, zoneBarStartY},

--- a/XIUI/modules/treasurepool/display.lua
+++ b/XIUI/modules/treasurepool/display.lua
@@ -344,9 +344,6 @@ function M.DrawWindow(settings)
     if imgui.Begin('TreasurePool', true, windowFlags) then
         SaveWindowPosition('TreasurePool');
         local startX, startY = imgui.GetCursorScreenPos();
-        -- Single shared draw list: bg, icons, scroll bar, clip rects all batch
-        -- on the same list. Required so call order = z-order; using a separate
-        -- BackgroundDrawList here would put icons/buttons under the foreground bg.
         local uiDrawList = GetUIDrawList();
         local drawList = uiDrawList;
 
@@ -431,7 +428,6 @@ function M.DrawWindow(settings)
             local poolTabClicked = button.DrawPrim('tpTabPool', poolTabX, btnY, tabBtnWidth, btnHeight, {
                 colors = poolTabColors,
                 tooltip = 'Treasure Pool',
-                drawList = uiDrawList,
             });
             if poolTabClicked then
                 debugLog('Pool tab clicked, setting selectedTab = 1');
@@ -451,7 +447,6 @@ function M.DrawWindow(settings)
             local historyTabClicked = button.DrawPrim('tpTabHistory', historyTabX, btnY, tabBtnWidth, btnHeight, {
                 colors = historyTabColors,
                 tooltip = 'Recent Winners',
-                drawList = uiDrawList,
             });
             if historyTabClicked then
                 debugLog('History tab clicked, setting selectedTab = 2');
@@ -478,7 +473,7 @@ function M.DrawWindow(settings)
                 local minimizeClicked = button.DrawMinimizePrim('tpMinimize', minimizeX, btnY, toggleSize, isMinimized, {
                     colors = button.COLORS_NEUTRAL,
                     tooltip = isMinimized and 'Maximize window' or 'Minimize to header only',
-                }, GetUIDrawList());
+                });
                 if minimizeClicked then
                     gConfig.treasurePoolMinimized = not gConfig.treasurePoolMinimized;
                     SaveSettingsToDisk();
@@ -491,7 +486,7 @@ function M.DrawWindow(settings)
                     tooltip = isMinimized
                         and (isExpanded and 'Maximize and collapse' or 'Maximize and expand')
                         or (isExpanded and 'Collapse' or 'Expand'),
-                }, GetUIDrawList());
+                });
                 if toggleClicked then
                     -- If minimized, maximize first then apply expand/collapse
                     if isMinimized then
@@ -508,7 +503,6 @@ function M.DrawWindow(settings)
                     local passAllClicked = button.DrawPrim('tpPassAll', passAllX, btnY, textBtnWidth, btnHeight, {
                         colors = button.COLORS_NEGATIVE,
                         tooltip = 'Pass on all items',
-                        drawList = uiDrawList,
                     });
                     if passAllClicked then
                         actions.PassAll();
@@ -526,7 +520,6 @@ function M.DrawWindow(settings)
                         local lotAllClicked = button.DrawPrim('tpLotAll', lotAllX, btnY, textBtnWidth, btnHeight, {
                             colors = button.COLORS_POSITIVE,
                             tooltip = 'Lot on all items',
-                            drawList = uiDrawList,
                         });
                         if lotAllClicked then
                             actions.LotAll();
@@ -560,7 +553,7 @@ function M.DrawWindow(settings)
                 local minimizeClicked = button.DrawMinimizePrim('tpMinimize', minimizeX, btnY, toggleSize, isMinimized, {
                     colors = button.COLORS_NEUTRAL,
                     tooltip = isMinimized and 'Maximize window' or 'Minimize to header only',
-                }, GetUIDrawList());
+                });
                 if minimizeClicked then
                     gConfig.treasurePoolMinimized = not gConfig.treasurePoolMinimized;
                     SaveSettingsToDisk();
@@ -573,7 +566,7 @@ function M.DrawWindow(settings)
                     tooltip = isMinimized
                         and (isExpanded and 'Maximize and collapse' or 'Maximize and expand')
                         or (isExpanded and 'Collapse' or 'Expand'),
-                }, GetUIDrawList());
+                });
                 if toggleClicked then
                     -- If minimized, maximize first then apply expand/collapse
                     if isMinimized then
@@ -790,7 +783,6 @@ function M.DrawWindow(settings)
                                 colors = button.COLORS_POSITIVE,
                                 tooltip = lotTooltip,
                                 disabled = lotDisabled,
-                                drawList = uiDrawList,
                             });
                             if lotItemClicked and not lotDisabled then
                                 actions.LotItem(slot);
@@ -817,7 +809,6 @@ function M.DrawWindow(settings)
                                 colors = button.COLORS_NEGATIVE,
                                 tooltip = passTooltip,
                                 disabled = passDisabled,
-                                drawList = uiDrawList,
                             });
                             if passItemClicked and not passDisabled then
                                 actions.PassItem(slot);

--- a/XIUI/modules/treasurepool/display.lua
+++ b/XIUI/modules/treasurepool/display.lua
@@ -344,11 +344,14 @@ function M.DrawWindow(settings)
     if imgui.Begin('TreasurePool', true, windowFlags) then
         SaveWindowPosition('TreasurePool');
         local startX, startY = imgui.GetCursorScreenPos();
-        local drawList = imgui.GetBackgroundDrawList();
+        -- Single shared draw list: bg, icons, scroll bar, clip rects all batch
+        -- on the same list. Required so call order = z-order; using a separate
+        -- BackgroundDrawList here would put icons/buttons under the foreground bg.
         local uiDrawList = GetUIDrawList();
+        local drawList = uiDrawList;
 
         -- Safety check for draw lists
-        if not drawList or not uiDrawList then
+        if not uiDrawList then
             imgui.End();
             return;
         end
@@ -428,6 +431,7 @@ function M.DrawWindow(settings)
             local poolTabClicked = button.DrawPrim('tpTabPool', poolTabX, btnY, tabBtnWidth, btnHeight, {
                 colors = poolTabColors,
                 tooltip = 'Treasure Pool',
+                drawList = uiDrawList,
             });
             if poolTabClicked then
                 debugLog('Pool tab clicked, setting selectedTab = 1');
@@ -447,6 +451,7 @@ function M.DrawWindow(settings)
             local historyTabClicked = button.DrawPrim('tpTabHistory', historyTabX, btnY, tabBtnWidth, btnHeight, {
                 colors = historyTabColors,
                 tooltip = 'Recent Winners',
+                drawList = uiDrawList,
             });
             if historyTabClicked then
                 debugLog('History tab clicked, setting selectedTab = 2');
@@ -503,6 +508,7 @@ function M.DrawWindow(settings)
                     local passAllClicked = button.DrawPrim('tpPassAll', passAllX, btnY, textBtnWidth, btnHeight, {
                         colors = button.COLORS_NEGATIVE,
                         tooltip = 'Pass on all items',
+                        drawList = uiDrawList,
                     });
                     if passAllClicked then
                         actions.PassAll();
@@ -520,6 +526,7 @@ function M.DrawWindow(settings)
                         local lotAllClicked = button.DrawPrim('tpLotAll', lotAllX, btnY, textBtnWidth, btnHeight, {
                             colors = button.COLORS_POSITIVE,
                             tooltip = 'Lot on all items',
+                            drawList = uiDrawList,
                         });
                         if lotAllClicked then
                             actions.LotAll();
@@ -783,6 +790,7 @@ function M.DrawWindow(settings)
                                 colors = button.COLORS_POSITIVE,
                                 tooltip = lotTooltip,
                                 disabled = lotDisabled,
+                                drawList = uiDrawList,
                             });
                             if lotItemClicked and not lotDisabled then
                                 actions.LotItem(slot);
@@ -809,6 +817,7 @@ function M.DrawWindow(settings)
                                 colors = button.COLORS_NEGATIVE,
                                 tooltip = passTooltip,
                                 disabled = passDisabled,
+                                drawList = uiDrawList,
                             });
                             if passItemClicked and not passDisabled then
                                 actions.PassItem(slot);


### PR DESCRIPTION
## Z-order issue

ImGui's draw lists have a fixed Z order:

​```
BackgroundDrawList  <  WindowDrawList  <  ForegroundDrawList
​```

So everything drawn on `Background` / `Window` rendered **underneath** the bg, regardless of code order. The bg painted over bars, text, icons, buttons, scroll bars, selection boxes, etc.

`playerbar` (in the same migration commit) and `notifications` (in `4e200d9`) were already patched for this. `partylist` and `treasurepool` were missed.

### Fix

Route every draw inside each module to the **same draw list** as the bg. Then code order = Z order, and the bg sits beneath the content like it should.

**`libs/progressbar.lua`** and **`libs/button.lua`**

Both libraries defaulted to a list that doesn't co-exist with `GetUIDrawList()`-based backgrounds (`progressbar.lua` → `GetWindowDrawList()`, `button.lua` → `GetBackgroundDrawList()` / `GetForegroundDrawList()` inconsistently). Defaults changed to `GetUIDrawList()` so bars and buttons share the same list as the bg without each caller having to opt in. Modules that need a different list (e.g. `expbar` deliberately uses `BackgroundDrawList` for clipping reasons) still pass `drawList = ...` explicitly.

This fix also covers latent same-bug Z-order issues in `targetbar`, `castbar`, `enemylist`, `petbar/display`, `petbar/pettarget` — they all draw their bg on `GetUIDrawList()` but had bars on `GetWindowDrawList()` by default.

**`partylist/display.lua`**

- `local textDrawList = imgui.GetWindowDrawList()` → `local textDrawList = GetUIDrawList()`
- Selection box: `imgui.GetBackgroundDrawList()` → `textDrawList`
- Job icon: `imgui.GetBackgroundDrawList()` → `textDrawList`
- Out-of-zone rect: `imgui.GetWindowDrawList()` → `textDrawList`
- `imtext.Draw` calls already used `textDrawList`, and `progressbar.ProgressBar` calls inherit `GetUIDrawList()` from the new lib default.

**`treasurepool/display.lua`**

- `local drawList = imgui.GetBackgroundDrawList()` → `local drawList = uiDrawList` (= `GetUIDrawList()`). One alias change lifts every existing `drawList:AddImage` / `AddRect` / `AddRectFilled` / `PushClipRect` / `PopClipRect` and the item progress bars onto the shared list.
- The trailing `, GetUIDrawList()` positional override was dropped from the 4 `DrawArrowPrim` / `DrawMinimizePrim` callsites; they now inherit `GetUIDrawList()` from the new `button.lua` default along with the 6 `button.DrawPrim` callsites.

### Result

- `partylist` and `treasurepool` each render into a single shared draw list per frame.
- Call order becomes Z order: `bg → bars/icons/buttons → text → arrows/dots → title`.
- Bonus: ImGui can now batch consecutive same-texture draws across the bg/content boundary, which trims some GPU draw calls.