### PR TITLE
petbar: fix global bookend toggle not affecting pet HP/MP/TP/recast bars

### DIFF
--- a/XIUI/config/global.lua
+++ b/XIUI/config/global.lua
@@ -114,11 +114,10 @@ function M.DrawSettings()
             if gConfig.partyA then gConfig.partyA.showBookends = gConfig.showBookends; end
             if gConfig.partyB then gConfig.partyB.showBookends = gConfig.showBookends; end
             if gConfig.partyC then gConfig.partyC.showBookends = gConfig.showBookends; end
-            -- Update pet bar type settings
-            if gConfig.petBarTypeSettings then
-                for _, petType in pairs(gConfig.petBarTypeSettings) do
-                    if petType then petType.showBookends = gConfig.showBookends; end
-                end
+            -- Update pet bar type settings (each pet type stores its own showBookends)
+            local petTypeTables = { gConfig.petBarAvatar, gConfig.petBarCharm, gConfig.petBarJug, gConfig.petBarAutomaton, gConfig.petBarWyvern };
+            for _, petType in ipairs(petTypeTables) do
+                if petType then petType.showBookends = gConfig.showBookends; end
             end
             SaveSettingsOnly();
         end


### PR DESCRIPTION
## Summary
- The global **Show Bookends** toggle in `config/global.lua` iterated over `gConfig.petBarTypeSettings`, which doesn't exist — per-pet-type settings actually live at `gConfig.petBarAvatar` / `petBarCharm` / `petBarJug` / `petBarAutomaton` / `petBarWyvern`, so the loop was a no-op.
- Pet HP/MP/TP/recast bars read `typeSettings.showBookends` first (`modules/petbar/display.lua:788-789, 995-996`) and only fall back to `gConfig.petBarShowBookends` when it's `nil` — and migration always populates it, so the fallback never fired.
- Pet *target* was unaffected because it reads `gConfig.petTargetShowBookends or gConfig.petBarShowBookends` directly (`modules/petbar/pettarget.lua:193`).

Fix: write `showBookends` to each per-pet-type table explicitly, matching how `partyA/B/C` are already handled a few lines above.

Fixes #290

## Test plan
- [ ] Open `/xiui` → Global → Bar Settings, toggle **Show Bookends** on
- [ ] Summon an avatar (or use preview) — pet HP/MP/TP bars now show bookends
- [ ] Toggle off — bookends disappear from pet HP/MP/TP
- [ ] Repeat with BST jug pet, PUP automaton, DRG wyvern to cover all type tables
- [ ] Confirm pet target bookends still toggle correctly (regression check)