### PR TITLE
notifications: honor lockPositions even while config is open

### DIFF
--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -525,7 +525,7 @@ local function drawNotificationWindow(windowName, notifications, settings, split
 
     -- Build window flags
     local windowFlags = notificationData.getBaseWindowFlags();
-    if gConfig.lockPositions and not configOpen then
+    if gConfig.lockPositions then
         windowFlags = bit.bor(windowFlags, ImGuiWindowFlags_NoMove);
     end
 
@@ -1106,7 +1106,7 @@ local function drawGroupWindow(groupNum, settings)
 
     -- Build window flags
     local windowFlags = notificationData.getBaseWindowFlags();
-    if gConfig.lockPositions and not configOpen then
+    if gConfig.lockPositions then
         windowFlags = bit.bor(windowFlags, ImGuiWindowFlags_NoMove);
     end
 


### PR DESCRIPTION
## Summary
- `modules/notifications/display.lua` gated `NoMove` behind `gConfig.lockPositions and not configOpen`, so notification windows stayed draggable whenever the XIUI config was open.
- Every other module (`playerbar`, `targetbar`, `castbar`, `partylist`, `enemylist`, `castcost`, `mobinfo`, `inventory`, `giltracker`, `expbar`, `hotbar`, `treasurepool`) treats Lock HUD Position as absolute and ignores config state.
- The natural way to verify the lock toggle is to flip it in the config and immediately try to drag the window — which made it look like the lock did nothing for the notifications bar.

Dropped the `not configOpen` exception so lock means lock for notifications too. Applied to both the active `drawGroupWindow` path and the (currently dead) `drawNotificationWindow` path so they don't drift.

Fixes #272

## Test plan
- [ ] Open `/xiui` → Global → enable **Lock HUD Position**, leave config open
- [ ] Trigger a notification (e.g. \`/xiui notifications testtreasurepool10\` or party invite test) — confirm the notification window cannot be dragged
- [ ] Disable Lock HUD Position with config still open — confirm the window can be dragged again
- [ ] Repeat with config closed (use a real notification trigger) — same behavior
- [ ] Sanity-check other modules (playerbar/targetbar/partylist) still lock/unlock correctly