### PR TITLE
expbar: add Mastery Mode toggle for Exemplar Points (#170)

### DIFF
--- a/XIUI/config/expbar.lua
+++ b/XIUI/config/expbar.lua
@@ -19,6 +19,8 @@ function M.DrawSettings()
     if components.CollapsingSection('Display Options##expBar') then
         components.DrawCheckbox('Limit Points Mode', 'expBarLimitPointsMode');
         imgui.ShowHelp('Shows Limit Points if character is set to earn Limit Points in the game.');
+        components.DrawCheckbox('Mastery Mode', 'expBarMasteryMode');
+        imgui.ShowHelp('Shows Master Level Exemplar Points instead of Capacity Points once your main job is level 99. Useful when JP is capped at 500 and you want to track ML progress.');
         components.DrawCheckbox('Inline Mode', 'expBarInlineMode');
         components.DrawCheckbox('Show Bookends', 'showExpBarBookends');
         components.DrawCheckbox('Show Text', 'expBarShowText');

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -334,6 +334,7 @@ function M.createUserSettingsDefaults()
         expBarShowPercent = true,
         expBarInlineMode = false,
         expBarLimitPointsMode = false,
+        expBarMasteryMode = false,
         -- Text position offsets (relative to default positions)
         expBarJobTextOffsetX = 0,
         expBarJobTextOffsetY = 0,

--- a/XIUI/modules/expbar.lua
+++ b/XIUI/modules/expbar.lua
@@ -35,7 +35,7 @@ local function buildJobString(player, jobLevel, masteryEnabled, mlJobLevel)
     local subJobString = AshitaCore:GetResourceManager():GetString('jobs.names_abbr', player:GetSubJob());
 
     local jobLevelString = tostring(jobLevel);
-    if masteryEnabled then
+    if masteryEnabled and mlJobLevel > 0 then
         jobLevelString = 'ML' .. mlJobLevel;
     end
 
@@ -44,7 +44,7 @@ end
 
 local function buildExpString(separator, masteryEnabled, meritMode, jobLevel, jobPoints, meritPoints, limitPoints, capPoints, expPoints, mastery)
     if masteryEnabled then
-        return separator .. 'JP (' .. jobPoints[1] .. ' / ' .. jobPoints[2] .. ')' .. '  MP (' .. meritPoints[1] .. ' / ' .. meritPoints[2] .. ')' .. '  EXP (' .. mastery[1] .. ' / ' .. mastery[2] .. ')';
+        return separator .. 'JP (' .. jobPoints[1] .. ' / ' .. jobPoints[2] .. ')' .. '  MP (' .. meritPoints[1] .. ' / ' .. meritPoints[2] .. ')' .. '  EXEMP (' .. mastery[1] .. ' / ' .. mastery[2] .. ')';
     elseif meritMode then
         if jobLevel >= 99 then
             return separator .. 'JP (' .. jobPoints[1] .. '/' .. jobPoints[2] .. ') MP (' .. meritPoints[1] .. '/' .. meritPoints[2] .. ') LP (' .. limitPoints[1] .. '/' .. limitPoints[2] .. ')';
@@ -108,8 +108,9 @@ expbar.DrawWindow = function(settings)
     local capPointsProgress = expbar.capacityPoints[1] / expbar.capacityPoints[2];
     local jobPoints = expbar.jobPoints;
 
-    local mastered = player:GetJobPointsSpent(mainJob) == 2100;
-    local masteryEnabled = jobLevel >= 99 and mastered and player:HasKeyItem(expbar.mlBreakerItemId);
+    local mastered = player:GetJobPointsSpent(mainJob) >= 2100;
+    local autoMasteryEnabled = jobLevel >= 99 and mastered and player:HasKeyItem(expbar.mlBreakerItemId);
+    local masteryEnabled = jobLevel >= 99 and (autoMasteryEnabled or gConfig.expBarMasteryMode);
     local masteryProgress = 0;
     local mlJobLevel = 0;
     if masteryEnabled then


### PR DESCRIPTION
## Summary
- Adds a `Mastery Mode` checkbox under EXP Bar → Display Options that forces the bar into Exemplar Points display once the main job is level 99
- Loosens the auto-mastery `== 2100` JP-spent check to `>= 2100` so it doesn't break for players past the threshold
- Relabels the mastery readout from `EXP` to `EXEMP` since the value tracks Exemplar Points, not job EXP
- Hides `ML0` in the job name when mastery mode is on but ML is not actually unlocked

## Why
Closes #170. The existing mastery display only auto-triggered when the player had the `master breaker` key item **and** had spent exactly 2100 JP. Players whose JP is capped at 500 (but not fully mastered) — or anyone on a server where that key item isn't present — were stuck staring at `JP (500/500) MP (x/x) CP (x/x)` with no way to see Master Level progress. The new opt-in toggle lets them swap CP for Exemplar without touching the auto-detect path.

Display with toggle off (unchanged): `NIN 99 / WAR 55  JP (500/500) MP (75/75) CP (29999/30000)`
Display with toggle on: `NIN 99 / WAR 55  JP (500/500) MP (75/75) EXEMP (current/needed)` (job string shows `ML{n}` when ML is unlocked)

## Test plan
- [ ] Load addon with `expBarMasteryMode = false` → bar shows JP/MP/CP at level 99 (unchanged)
- [ ] Enable Mastery Mode in config → bar shows JP/MP/EXEMP at level 99
- [ ] Verify auto-mastery still kicks in when player has master breaker key item + 2100 JP spent
- [ ] Verify the `ML{n}` job-level label only appears when GetMasteryJobLevel > 0