### PR TITLE
petbar: add Coldblood Como to jug pet data

### DIFF
--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -126,6 +126,7 @@ data.jugPets = {
     {name = 'PanzerGalahad', maxLevel = 75, duration = 60},
     {name = 'ChopsueyChucky', maxLevel = 75, duration = 60},
     {name = 'AmigoSabotender', maxLevel = 75, duration = 60},
+    {name = 'ColdbloodComo', maxLevel = 75, duration = 60},
 
     -- 30 minute pets (high level)
     {name = 'CraftyClyvonne', maxLevel = 75, duration = 30},


### PR DESCRIPTION
Fixes #276

Adds Coldblood Como to the jug pet dataset so it's properly recognized as a jug pet instead of being treated as a charmed monster in the UI.

```lua
{name = 'ColdbloodComo', maxLevel = 75, duration = 60}
```

Thanks to @kaluaabyss for the report.