### PR TITLE
global: add Global UI Scale slider (0.5x - 5.0x)

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -1147,9 +1147,10 @@ ashita.events.register('command', 'command_cb', function (e)
             return;
         end
 
-        -- Palette commands: /xiui palette <name|next|prev> [bar|all]
-        -- Switch between named palettes for hotbars
-        -- Use "all" to affect all bars at once (like tHotBar behavior)
+        -- Palette commands: /xiui palette <name|next|prev|list|first> [bar|all|crossbar]
+        -- Switch between named palettes. Hotbar palettes (bars 1-6) and the crossbar
+        -- have separate palette pools; "all" applies across both, "crossbar"/"cb"/"xb"
+        -- targets the crossbar only, a bar number targets a single hotbar.
         if (command_args[2] == 'palette' or command_args[2] == 'pal') then
             local paletteModule = require('modules.hotbar.palette');
             local hotbarData = require('modules.hotbar.data');
@@ -1157,14 +1158,15 @@ ashita.events.register('command', 'command_cb', function (e)
             local subjobId = hotbarData.subjobId or 0;
 
             if #command_args < 3 then
-                -- No argument - show current palette info and help
                 print('[XIUI] Palette commands:');
-                print('  /xiui palette <name> - Switch to a named palette');
-                print('  /xiui palette next - Cycle to next palette');
-                print('  /xiui palette prev - Cycle to previous palette');
-                print('  /xiui palette list - List available palettes');
-                print('  /xiui palette first - Switch to first palette');
+                print('  /xiui palette <name> [bar|all|crossbar] - Switch to a named palette');
+                print('  /xiui palette next [crossbar]            - Cycle to next palette');
+                print('  /xiui palette prev [crossbar]            - Cycle to previous palette');
+                print('  /xiui palette list [crossbar]            - List available palettes');
+                print('  /xiui palette first [crossbar]           - Switch to first palette');
                 print('');
+                print('Target: omit for hotbars + crossbar, "crossbar"/"cb"/"xb" for crossbar only,');
+                print('or a bar number 1-6 to target a single hotbar.');
                 print('Keybinds: Ctrl+Up/Down (configure in Hotbar > Palette Cycling)');
                 print('Controller: RB + Dpad Up/Down cycles palettes');
                 return;
@@ -1172,38 +1174,86 @@ ashita.events.register('command', 'command_cb', function (e)
 
             local action = command_args[3];
             local barArg = command_args[4];
-            local affectAll = (barArg == 'all');
-            local barIndex = affectAll and 1 or (tonumber(barArg) or 1);
 
-            -- Helper to apply action to bar(s)
-            local function applyToBar(idx)
-                return paletteModule.CyclePalette(idx, action == 'next' and 1 or -1, jobId, subjobId);
+            local function isCrossbarTarget(arg)
+                if not arg then return false; end
+                local lower = arg:lower();
+                return lower == 'crossbar' or lower == 'cb' or lower == 'xb';
             end
+
+            local affectAll = (barArg == 'all');
+            local affectCrossbar = isCrossbarTarget(barArg);
+            local barIndex = (affectAll or affectCrossbar) and 1 or (tonumber(barArg) or 1);
 
             if action == 'next' or action == 'prev' or action == 'previous' then
                 local direction = (action == 'next') and 1 or -1;
-                -- Global palette cycling - affects all bars at once
-                local result = paletteModule.CyclePalette(1, direction, jobId, subjobId);
-                if result then
-                    print('[XIUI] Palette: ' .. result);
+                local results = {};
+
+                if not affectCrossbar then
+                    -- Cycle hotbar palettes (global - bar 1 represents all hotbars)
+                    local hotbarResult = paletteModule.CyclePalette(1, direction, jobId, subjobId);
+                    if hotbarResult then
+                        table.insert(results, 'Hotbar: ' .. hotbarResult);
+                    end
+                end
+
+                -- Cycle crossbar palette (global across combo modes)
+                local crossbarResult = paletteModule.CyclePaletteForCombo(nil, direction, jobId, subjobId);
+                if crossbarResult then
+                    table.insert(results, 'Crossbar: ' .. crossbarResult);
+                end
+
+                if #results > 0 then
+                    print('[XIUI] Palette -> ' .. table.concat(results, ', '));
                 else
                     print('[XIUI] No palettes to cycle');
                 end
             elseif action == 'list' then
-                -- List available palettes
-                local palettes = paletteModule.GetAvailablePalettes(barIndex, jobId, subjobId);
-                local currentPalette = paletteModule.GetActivePaletteDisplayName(barIndex);
-                print('[XIUI] Bar ' .. barIndex .. ' palettes:');
-                for _, name in ipairs(palettes) do
-                    local marker = (name == currentPalette) and ' *' or '';
-                    print('  - ' .. name .. marker);
+                if not affectCrossbar then
+                    local palettes = paletteModule.GetAvailablePalettes(barIndex, jobId, subjobId);
+                    local currentPalette = paletteModule.GetActivePaletteDisplayName(barIndex);
+                    print('[XIUI] Bar ' .. barIndex .. ' palettes:');
+                    for _, name in ipairs(palettes) do
+                        local marker = (name == currentPalette) and ' *' or '';
+                        print('  - ' .. name .. marker);
+                    end
+                end
+
+                -- List crossbar palettes (omitted only when targeting a specific hotbar)
+                if affectCrossbar or not tonumber(barArg) then
+                    local crossbarPalettes = paletteModule.GetCrossbarAvailablePalettes(jobId, subjobId);
+                    local activeCrossbar = paletteModule.GetActivePaletteDisplayNameForCombo();
+                    print('[XIUI] Crossbar palettes:');
+                    if #crossbarPalettes == 0 then
+                        print('  (none defined)');
+                    else
+                        for _, name in ipairs(crossbarPalettes) do
+                            local marker = (name == activeCrossbar) and ' *' or '';
+                            print('  - ' .. name .. marker);
+                        end
+                    end
                 end
             elseif action == 'base' or action == 'reset' or action == 'first' then
-                -- Switch to first palette
-                local palettes = paletteModule.GetAvailablePalettes(1, jobId, subjobId);
-                if #palettes > 0 then
-                    paletteModule.SetActivePalette(1, palettes[1]);
-                    print('[XIUI] Palette: ' .. palettes[1]);
+                local firstNames = {};
+
+                if not affectCrossbar then
+                    local palettes = paletteModule.GetAvailablePalettes(1, jobId, subjobId);
+                    if #palettes > 0 then
+                        for i = 1, 6 do
+                            paletteModule.SetActivePalette(i, palettes[1]);
+                        end
+                        table.insert(firstNames, 'Hotbar: ' .. palettes[1]);
+                    end
+                end
+
+                local crossbarPalettes = paletteModule.GetCrossbarAvailablePalettes(jobId, subjobId);
+                if #crossbarPalettes > 0 then
+                    paletteModule.SetActivePaletteForCombo(nil, crossbarPalettes[1]);
+                    table.insert(firstNames, 'Crossbar: ' .. crossbarPalettes[1]);
+                end
+
+                if #firstNames > 0 then
+                    print('[XIUI] Palette -> ' .. table.concat(firstNames, ', '));
                 else
                     print('[XIUI] No palettes available');
                 end
@@ -1213,22 +1263,25 @@ ashita.events.register('command', 'command_cb', function (e)
                 local originalArgs = e.command:args();
                 local paletteName = originalArgs[3];  -- Use original case
                 local targetIsAll = false;
+                local targetIsCrossbar = false;
 
                 if #originalArgs >= 4 then
                     local lastArg = originalArgs[#originalArgs];
-                    if lastArg:lower() == 'all' then
+                    local lastLower = lastArg:lower();
+                    local isAllSuffix = (lastLower == 'all');
+                    local isCrossbarSuffix = isCrossbarTarget(lastArg);
+                    local isBarSuffix = tonumber(lastArg) ~= nil;
+
+                    if isAllSuffix then
                         targetIsAll = true;
-                        -- Palette name is everything between arg 3 and "all"
-                        if #originalArgs > 4 then
-                            local nameParts = {};
-                            for i = 3, #originalArgs - 1 do
-                                table.insert(nameParts, originalArgs[i]);
-                            end
-                            paletteName = table.concat(nameParts, ' ');
-                        end
-                    elseif tonumber(lastArg) then
+                    elseif isCrossbarSuffix then
+                        targetIsCrossbar = true;
+                    elseif isBarSuffix then
                         barIndex = tonumber(lastArg);
-                        -- Palette name is everything between arg 3 and the bar number
+                    end
+
+                    if isAllSuffix or isCrossbarSuffix or isBarSuffix then
+                        -- Palette name is everything between arg 3 and the suffix
                         if #originalArgs > 4 then
                             local nameParts = {};
                             for i = 3, #originalArgs - 1 do
@@ -1237,7 +1290,7 @@ ashita.events.register('command', 'command_cb', function (e)
                             paletteName = table.concat(nameParts, ' ');
                         end
                     else
-                        -- No bar number or "all", palette name is all remaining args
+                        -- No suffix, palette name is all remaining args
                         local nameParts = {};
                         for i = 3, #originalArgs do
                             table.insert(nameParts, originalArgs[i]);
@@ -1246,8 +1299,15 @@ ashita.events.register('command', 'command_cb', function (e)
                     end
                 end
 
-                if targetIsAll then
-                    -- Apply to all bars
+                if targetIsCrossbar then
+                    if paletteModule.CrossbarPaletteExists(paletteName, jobId, subjobId) then
+                        paletteModule.SetActivePaletteForCombo(nil, paletteName);
+                        print('[XIUI] Crossbar palette: ' .. paletteName);
+                    else
+                        print('[XIUI] Crossbar palette "' .. paletteName .. '" not found');
+                    end
+                elseif targetIsAll then
+                    -- Apply across all hotbars and the crossbar
                     local anyFound = false;
                     for i = 1, 6 do
                         if paletteModule.PaletteExists(i, paletteName, jobId, subjobId) then
@@ -1255,13 +1315,17 @@ ashita.events.register('command', 'command_cb', function (e)
                             anyFound = true;
                         end
                     end
+                    if paletteModule.CrossbarPaletteExists(paletteName, jobId, subjobId) then
+                        paletteModule.SetActivePaletteForCombo(nil, paletteName);
+                        anyFound = true;
+                    end
                     if anyFound then
                         print('[XIUI] All bars palette: ' .. paletteName);
                     else
                         print('[XIUI] Palette "' .. paletteName .. '" not found');
                     end
                 else
-                    -- Apply to single bar
+                    -- Apply to single hotbar
                     if paletteModule.PaletteExists(barIndex, paletteName, jobId, subjobId) then
                         paletteModule.SetActivePalette(barIndex, paletteName);
                         print('[XIUI] Bar ' .. barIndex .. ' palette: ' .. paletteName);

--- a/XIUI/config/global.lua
+++ b/XIUI/config/global.lua
@@ -40,6 +40,9 @@ function M.DrawSettings()
         end);
         imgui.ShowHelp('The folder to pull job icons from. [XIUI\\assets\\jobs]');
 
+        components.DrawSlider('Global UI Scale', 'globalScale', 0.5, 5.0, '%.2f');
+        imgui.ShowHelp('Scales all XIUI elements proportionally. Stacks on top of individual module scale settings.');
+
         components.DrawSlider('Tooltip Scale', 'tooltipScale', 0.1, 3.0, '%.2f');
         imgui.ShowHelp('Scales the size of the tooltip. Note that text may appear blured if scaled too large.');
 

--- a/XIUI/core/settings/updater.lua
+++ b/XIUI/core/settings/updater.lua
@@ -30,6 +30,10 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     local ds = default_settings;
     local us = gConfig;
 
+    -- Global UI scale multiplier. Stacks on top of per-module scales so individual
+    -- sliders still work. Range enforced by config slider (0.5 - 5.0).
+    local gs = us.globalScale or 1.0;
+
     -- Apply global font family, weight, and outline width to all font settings
     local fontWeightFlags = GetFontWeightFlags(us.fontWeight);
 
@@ -124,14 +128,14 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     applyGlobalFontSettings(gAdjustedSettings.hotbarSettings.keybind_font_settings, us.fontFamily, fontWeightFlags, 1);
     applyGlobalFontSettings(gAdjustedSettings.hotbarSettings.label_font_settings, us.fontFamily, fontWeightFlags, us.fontOutlineWidth);
     -- Apply font heights from user settings (ensure minimum)
-    gAdjustedSettings.hotbarSettings.font_settings.font_height = math.max(us.hotbarFontSize or 10, 8);
-    gAdjustedSettings.hotbarSettings.keybind_font_settings.font_height = math.max(us.hotbarKeybindFontSize or 8, 6);
-    gAdjustedSettings.hotbarSettings.label_font_settings.font_height = math.max(us.hotbarLabelFontSize or 10, 8);
+    gAdjustedSettings.hotbarSettings.font_settings.font_height = math.max(us.hotbarFontSize or 10, 8) * gs;
+    gAdjustedSettings.hotbarSettings.keybind_font_settings.font_height = math.max(us.hotbarKeybindFontSize or 8, 6) * gs;
+    gAdjustedSettings.hotbarSettings.label_font_settings.font_height = math.max(us.hotbarLabelFontSize or 10, 8) * gs;
     -- Hotbar background and scaling settings (mirrors config defaults)
-    gAdjustedSettings.hotbarSettings.scaleX = us.hotbarScaleX or 1.0;
-    gAdjustedSettings.hotbarSettings.scaleY = us.hotbarScaleY or 1.0;
-    gAdjustedSettings.hotbarSettings.bgScale = us.hotbarBgScale or 1.0;
-    gAdjustedSettings.hotbarSettings.borderScale = us.hotbarBorderScale or 1.0;
+    gAdjustedSettings.hotbarSettings.scaleX = (us.hotbarScaleX or 1.0) * gs;
+    gAdjustedSettings.hotbarSettings.scaleY = (us.hotbarScaleY or 1.0) * gs;
+    gAdjustedSettings.hotbarSettings.bgScale = (us.hotbarBgScale or 1.0) * gs;
+    gAdjustedSettings.hotbarSettings.borderScale = (us.hotbarBorderScale or 1.0) * gs;
     gAdjustedSettings.hotbarSettings.background_opacity = us.hotbarBackgroundOpacity or 0.87;
     gAdjustedSettings.hotbarSettings.border_opacity = us.hotbarBorderOpacity or 1.0;
 
@@ -141,36 +145,36 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     applyGlobalFontSettings(gAdjustedSettings.crossbarSettings.trigger_font_settings, us.fontFamily, fontWeightFlags, us.fontOutlineWidth);
 
     -- Target Bar dimensions and settings
-    gAdjustedSettings.targetBarSettings.barWidth = ds.targetBarSettings.barWidth * us.targetBarScaleX;
-    gAdjustedSettings.targetBarSettings.barHeight = ds.targetBarSettings.barHeight * us.targetBarScaleY;
-    gAdjustedSettings.targetBarSettings.totBarHeight = ds.targetBarSettings.totBarHeight * us.targetBarScaleY;
-    gAdjustedSettings.targetBarSettings.name_font_settings.font_height = math.max(us.targetBarNameFontSize, 8);
-    gAdjustedSettings.targetBarSettings.totName_font_settings.font_height = math.max(us.targetBarNameFontSize, 8);
-    gAdjustedSettings.targetBarSettings.distance_font_settings.font_height = math.max(us.targetBarDistanceFontSize, 8);
-    gAdjustedSettings.targetBarSettings.distanceOffsetX = us.targetBarDistanceOffsetX or 0;
-    gAdjustedSettings.targetBarSettings.distanceOffsetY = us.targetBarDistanceOffsetY or 0;
-    gAdjustedSettings.targetBarSettings.percent_font_settings.font_height = math.max(us.targetBarPercentFontSize, 8);
-    gAdjustedSettings.targetBarSettings.percentOffsetX = us.targetBarPercentOffsetX or 0;
-    gAdjustedSettings.targetBarSettings.percentOffsetY = us.targetBarPercentOffsetY or 0;
-    gAdjustedSettings.targetBarSettings.cast_font_settings.font_height = math.max(us.targetBarCastFontSize, 8);
-    gAdjustedSettings.targetBarSettings.iconSize = ds.targetBarSettings.iconSize * us.targetBarIconScale;
-    gAdjustedSettings.targetBarSettings.arrowSize = ds.targetBarSettings.arrowSize * us.targetBarScaleY;
+    gAdjustedSettings.targetBarSettings.barWidth = ds.targetBarSettings.barWidth * us.targetBarScaleX * gs;
+    gAdjustedSettings.targetBarSettings.barHeight = ds.targetBarSettings.barHeight * us.targetBarScaleY * gs;
+    gAdjustedSettings.targetBarSettings.totBarHeight = ds.targetBarSettings.totBarHeight * us.targetBarScaleY * gs;
+    gAdjustedSettings.targetBarSettings.name_font_settings.font_height = math.max(us.targetBarNameFontSize, 8) * gs;
+    gAdjustedSettings.targetBarSettings.totName_font_settings.font_height = math.max(us.targetBarNameFontSize, 8) * gs;
+    gAdjustedSettings.targetBarSettings.distance_font_settings.font_height = math.max(us.targetBarDistanceFontSize, 8) * gs;
+    gAdjustedSettings.targetBarSettings.distanceOffsetX = (us.targetBarDistanceOffsetX or 0) * gs;
+    gAdjustedSettings.targetBarSettings.distanceOffsetY = (us.targetBarDistanceOffsetY or 0) * gs;
+    gAdjustedSettings.targetBarSettings.percent_font_settings.font_height = math.max(us.targetBarPercentFontSize, 8) * gs;
+    gAdjustedSettings.targetBarSettings.percentOffsetX = (us.targetBarPercentOffsetX or 0) * gs;
+    gAdjustedSettings.targetBarSettings.percentOffsetY = (us.targetBarPercentOffsetY or 0) * gs;
+    gAdjustedSettings.targetBarSettings.cast_font_settings.font_height = math.max(us.targetBarCastFontSize, 8) * gs;
+    gAdjustedSettings.targetBarSettings.iconSize = ds.targetBarSettings.iconSize * us.targetBarIconScale * gs;
+    gAdjustedSettings.targetBarSettings.arrowSize = ds.targetBarSettings.arrowSize * us.targetBarScaleY * gs;
     -- Buff/Debuff positioning
-    gAdjustedSettings.targetBarSettings.buffsOffsetY = us.targetBarBuffsOffsetY;
+    gAdjustedSettings.targetBarSettings.buffsOffsetY = (us.targetBarBuffsOffsetY or 0) * gs;
     -- Cast bar positioning and scaling
-    gAdjustedSettings.targetBarSettings.castBarOffsetY = us.targetBarCastBarOffsetY;
-    gAdjustedSettings.targetBarSettings.castBarOffsetX = ds.targetBarSettings.castBarOffsetX;
-    gAdjustedSettings.targetBarSettings.castBarWidth = (gAdjustedSettings.targetBarSettings.barWidth - (ds.targetBarSettings.castBarOffsetX * 2)) * us.targetBarCastBarScaleX;
-    gAdjustedSettings.targetBarSettings.castBarHeight = 8 * us.targetBarCastBarScaleY;
+    gAdjustedSettings.targetBarSettings.castBarOffsetY = (us.targetBarCastBarOffsetY or 0) * gs;
+    gAdjustedSettings.targetBarSettings.castBarOffsetX = ds.targetBarSettings.castBarOffsetX * gs;
+    gAdjustedSettings.targetBarSettings.castBarWidth = (gAdjustedSettings.targetBarSettings.barWidth - (ds.targetBarSettings.castBarOffsetX * 2 * gs)) * us.targetBarCastBarScaleX;
+    gAdjustedSettings.targetBarSettings.castBarHeight = 8 * us.targetBarCastBarScaleY * gs;
 
     -- Target of Target Bar (separate scaling when split is enabled)
-    gAdjustedSettings.targetBarSettings.totBarWidth = (ds.targetBarSettings.barWidth / 3) * us.totBarScaleX;
-    gAdjustedSettings.targetBarSettings.totBarHeightSplit = ds.targetBarSettings.totBarHeight * us.totBarScaleY;
+    gAdjustedSettings.targetBarSettings.totBarWidth = (ds.targetBarSettings.barWidth / 3) * us.totBarScaleX * gs;
+    gAdjustedSettings.targetBarSettings.totBarHeightSplit = ds.targetBarSettings.totBarHeight * us.totBarScaleY * gs;
     gAdjustedSettings.targetBarSettings.totName_font_settings_split = {
         visible = ds.targetBarSettings.totName_font_settings.visible,
         locked = ds.targetBarSettings.totName_font_settings.locked,
         font_family = us.fontFamily,
-        font_height = math.max(us.totBarFontSize, 8),
+        font_height = math.max(us.totBarFontSize, 8) * gs,
         color = us.colorCustomization.totBar.nameTextColor,
         bold = ds.targetBarSettings.totName_font_settings.bold,
         color_outline = ds.targetBarSettings.totName_font_settings.color_outline,
@@ -180,13 +184,13 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     };
 
     -- Subtarget Bar (shows original target while subtargeting)
-    gAdjustedSettings.targetBarSettings.subtargetBarWidth = ds.targetBarSettings.barWidth * us.subtargetBarScaleX;
-    gAdjustedSettings.targetBarSettings.subtargetBarHeight = ds.targetBarSettings.barHeight * us.subtargetBarScaleY;
+    gAdjustedSettings.targetBarSettings.subtargetBarWidth = ds.targetBarSettings.barWidth * us.subtargetBarScaleX * gs;
+    gAdjustedSettings.targetBarSettings.subtargetBarHeight = ds.targetBarSettings.barHeight * us.subtargetBarScaleY * gs;
     gAdjustedSettings.targetBarSettings.subtargetName_font_settings = {
         visible = ds.targetBarSettings.name_font_settings.visible,
         locked = ds.targetBarSettings.name_font_settings.locked,
         font_family = us.fontFamily,
-        font_height = math.max(us.subtargetBarFontSize, 8),
+        font_height = math.max(us.subtargetBarFontSize, 8) * gs,
         font_flags = fontWeightFlags,
         color = us.colorCustomization.targetBar.nameTextColor,
         color_outline = ds.targetBarSettings.name_font_settings.color_outline,
@@ -199,7 +203,7 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
         visible = ds.targetBarSettings.percent_font_settings.visible,
         locked = ds.targetBarSettings.percent_font_settings.locked,
         font_family = us.fontFamily,
-        font_height = math.max(us.subtargetBarPercentFontSize or us.subtargetBarFontSize, 8),
+        font_height = math.max(us.subtargetBarPercentFontSize or us.subtargetBarFontSize, 8) * gs,
         font_flags = fontWeightFlags,
         color = ds.targetBarSettings.percent_font_settings.color,
         color_outline = ds.targetBarSettings.percent_font_settings.color_outline,
@@ -231,79 +235,79 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
         us.partyC.splitFontSizes and getFontSizeHash(us.partyC) or (us.partyC.fontSize or 12),
     };
 
-    gAdjustedSettings.partyListSettings.title_font_settings.font_height = math.max(us.partyListTitleFontSize, 8);
+    gAdjustedSettings.partyListSettings.title_font_settings.font_height = math.max(us.partyListTitleFontSize, 8) * gs;
 
     gAdjustedSettings.partyListSettings.entrySpacing = {
-        ds.partyListSettings.entrySpacing + (us.partyA.entrySpacing or 0),
-        ds.partyListSettings.entrySpacing + (us.partyB.entrySpacing or 0),
-        ds.partyListSettings.entrySpacing + (us.partyC.entrySpacing or 0),
+        (ds.partyListSettings.entrySpacing + (us.partyA.entrySpacing or 0)) * gs,
+        (ds.partyListSettings.entrySpacing + (us.partyB.entrySpacing or 0)) * gs,
+        (ds.partyListSettings.entrySpacing + (us.partyC.entrySpacing or 0)) * gs,
     };
 
     -- Backwards compatibility - read from party A's layout
     local layoutA = us.partyA.layout == 1 and us.layoutCompact or us.layoutHorizontal;
-    gAdjustedSettings.partyListSettings.hpBarWidth = layoutA.hpBarWidth or 150;
-    gAdjustedSettings.partyListSettings.mpBarWidth = layoutA.mpBarWidth or 100;
-    gAdjustedSettings.partyListSettings.tpBarWidth = layoutA.tpBarWidth or 100;
-    gAdjustedSettings.partyListSettings.barHeight = layoutA.barHeight or 20;
-    gAdjustedSettings.partyListSettings.barSpacing = layoutA.barSpacing or 8;
+    gAdjustedSettings.partyListSettings.hpBarWidth = (layoutA.hpBarWidth or 150) * gs;
+    gAdjustedSettings.partyListSettings.mpBarWidth = (layoutA.mpBarWidth or 100) * gs;
+    gAdjustedSettings.partyListSettings.tpBarWidth = (layoutA.tpBarWidth or 100) * gs;
+    gAdjustedSettings.partyListSettings.barHeight = (layoutA.barHeight or 20) * gs;
+    gAdjustedSettings.partyListSettings.barSpacing = (layoutA.barSpacing or 8) * gs;
     gAdjustedSettings.partyListSettings.hpBarScaleX = us.partyA.hpBarScaleX or 1;
     gAdjustedSettings.partyListSettings.mpBarScaleX = us.partyA.mpBarScaleX or 1;
     gAdjustedSettings.partyListSettings.hpBarScaleY = us.partyA.hpBarScaleY or 1;
     gAdjustedSettings.partyListSettings.mpBarScaleY = us.partyA.mpBarScaleY or 1;
 
-    gAdjustedSettings.partyListSettings.nameTextOffsetX = layoutA.nameTextOffsetX or 1;
-    gAdjustedSettings.partyListSettings.nameTextOffsetY = layoutA.nameTextOffsetY or 0;
-    gAdjustedSettings.partyListSettings.hpTextOffsetX = layoutA.hpTextOffsetX or -2;
-    gAdjustedSettings.partyListSettings.hpTextOffsetY = layoutA.hpTextOffsetY or -1;
-    gAdjustedSettings.partyListSettings.mpTextOffsetX = layoutA.mpTextOffsetX or -2;
-    gAdjustedSettings.partyListSettings.mpTextOffsetY = layoutA.mpTextOffsetY or -1;
-    gAdjustedSettings.partyListSettings.tpTextOffsetX = layoutA.tpTextOffsetX or -2;
-    gAdjustedSettings.partyListSettings.tpTextOffsetY = layoutA.tpTextOffsetY or -1;
+    gAdjustedSettings.partyListSettings.nameTextOffsetX = (layoutA.nameTextOffsetX or 1) * gs;
+    gAdjustedSettings.partyListSettings.nameTextOffsetY = (layoutA.nameTextOffsetY or 0) * gs;
+    gAdjustedSettings.partyListSettings.hpTextOffsetX = (layoutA.hpTextOffsetX or -2) * gs;
+    gAdjustedSettings.partyListSettings.hpTextOffsetY = (layoutA.hpTextOffsetY or -1) * gs;
+    gAdjustedSettings.partyListSettings.mpTextOffsetX = (layoutA.mpTextOffsetX or -2) * gs;
+    gAdjustedSettings.partyListSettings.mpTextOffsetY = (layoutA.mpTextOffsetY or -1) * gs;
+    gAdjustedSettings.partyListSettings.tpTextOffsetX = (layoutA.tpTextOffsetX or -2) * gs;
+    gAdjustedSettings.partyListSettings.tpTextOffsetY = (layoutA.tpTextOffsetY or -1) * gs;
 
     -- Legacy compatibility
-    gAdjustedSettings.partyListSettings.iconSize = ds.partyListSettings.iconSize * (us.partyA.buffScale or 1);
+    gAdjustedSettings.partyListSettings.iconSize = ds.partyListSettings.iconSize * (us.partyA.buffScale or 1) * gs;
     gAdjustedSettings.partyListSettings.expandHeight = us.partyA.expandHeight or false;
     gAdjustedSettings.partyListSettings.expandHeightInAlliance = us.partyA.expandHeightInAlliance or false;
     gAdjustedSettings.partyListSettings.alignBottom = us.partyA.alignBottom or false;
     gAdjustedSettings.partyListSettings.minRows = us.partyA.minRows or 1;
 
     -- Player Bar
-    gAdjustedSettings.playerBarSettings.barWidth = ds.playerBarSettings.barWidth * us.playerBarScaleX;
-    gAdjustedSettings.playerBarSettings.barSpacing = ds.playerBarSettings.barSpacing * us.playerBarScaleX;
-    gAdjustedSettings.playerBarSettings.barHeight = ds.playerBarSettings.barHeight * us.playerBarScaleY;
-    gAdjustedSettings.playerBarSettings.font_settings.font_height = math.max(us.playerBarFontSize, 8);
+    gAdjustedSettings.playerBarSettings.barWidth = ds.playerBarSettings.barWidth * us.playerBarScaleX * gs;
+    gAdjustedSettings.playerBarSettings.barSpacing = ds.playerBarSettings.barSpacing * us.playerBarScaleX * gs;
+    gAdjustedSettings.playerBarSettings.barHeight = ds.playerBarSettings.barHeight * us.playerBarScaleY * gs;
+    gAdjustedSettings.playerBarSettings.font_settings.font_height = math.max(us.playerBarFontSize, 8) * gs;
 
     -- Exp Bar
-    gAdjustedSettings.expBarSettings.barWidth = ds.expBarSettings.barWidth * us.expBarScaleX;
-    gAdjustedSettings.expBarSettings.barHeight = ds.expBarSettings.barHeight * us.expBarScaleY;
-    gAdjustedSettings.expBarSettings.job_font_settings.font_height = math.max(us.expBarFontSize, 8);
-    gAdjustedSettings.expBarSettings.exp_font_settings.font_height = math.max(us.expBarFontSize, 8);
-    gAdjustedSettings.expBarSettings.percent_font_settings.font_height = math.max(us.expBarFontSize, 8);
+    gAdjustedSettings.expBarSettings.barWidth = ds.expBarSettings.barWidth * us.expBarScaleX * gs;
+    gAdjustedSettings.expBarSettings.barHeight = ds.expBarSettings.barHeight * us.expBarScaleY * gs;
+    gAdjustedSettings.expBarSettings.job_font_settings.font_height = math.max(us.expBarFontSize, 8) * gs;
+    gAdjustedSettings.expBarSettings.exp_font_settings.font_height = math.max(us.expBarFontSize, 8) * gs;
+    gAdjustedSettings.expBarSettings.percent_font_settings.font_height = math.max(us.expBarFontSize, 8) * gs;
     -- Text position offsets
-    gAdjustedSettings.expBarSettings.jobTextOffsetX = us.expBarJobTextOffsetX or 0;
-    gAdjustedSettings.expBarSettings.jobTextOffsetY = us.expBarJobTextOffsetY or 0;
-    gAdjustedSettings.expBarSettings.expTextOffsetX = us.expBarExpTextOffsetX or 0;
-    gAdjustedSettings.expBarSettings.expTextOffsetY = us.expBarExpTextOffsetY or 0;
-    gAdjustedSettings.expBarSettings.percentTextOffsetX = us.expBarPercentTextOffsetX or 0;
-    gAdjustedSettings.expBarSettings.percentTextOffsetY = us.expBarPercentTextOffsetY or 0;
+    gAdjustedSettings.expBarSettings.jobTextOffsetX = (us.expBarJobTextOffsetX or 0) * gs;
+    gAdjustedSettings.expBarSettings.jobTextOffsetY = (us.expBarJobTextOffsetY or 0) * gs;
+    gAdjustedSettings.expBarSettings.expTextOffsetX = (us.expBarExpTextOffsetX or 0) * gs;
+    gAdjustedSettings.expBarSettings.expTextOffsetY = (us.expBarExpTextOffsetY or 0) * gs;
+    gAdjustedSettings.expBarSettings.percentTextOffsetX = (us.expBarPercentTextOffsetX or 0) * gs;
+    gAdjustedSettings.expBarSettings.percentTextOffsetY = (us.expBarPercentTextOffsetY or 0) * gs;
 
     -- Gil Tracker
-    gAdjustedSettings.gilTrackerSettings.iconScale = ds.gilTrackerSettings.iconScale * us.gilTrackerScale;
-    gAdjustedSettings.gilTrackerSettings.font_settings.font_height = math.max(us.gilTrackerFontSize, 8);
+    gAdjustedSettings.gilTrackerSettings.iconScale = ds.gilTrackerSettings.iconScale * us.gilTrackerScale * gs;
+    gAdjustedSettings.gilTrackerSettings.font_settings.font_height = math.max(us.gilTrackerFontSize, 8) * gs;
     gAdjustedSettings.gilTrackerSettings.font_settings.font_alignment = us.gilTrackerRightAlign and fontconst.ALIGN_RIGHT or fontconst.ALIGN_LEFT;
     gAdjustedSettings.gilTrackerSettings.rightAlign = us.gilTrackerRightAlign;
     gAdjustedSettings.gilTrackerSettings.iconRight = us.gilTrackerIconRight;
     gAdjustedSettings.gilTrackerSettings.showIcon = us.gilTrackerShowIcon;
-    gAdjustedSettings.gilTrackerSettings.textOffsetX = us.gilTrackerTextOffsetX or 0;
-    gAdjustedSettings.gilTrackerSettings.textOffsetY = us.gilTrackerTextOffsetY or 0;
-    gAdjustedSettings.gilTrackerSettings.gilPerHourOffsetX = us.gilTrackerGilPerHourOffsetX or 0;
-    gAdjustedSettings.gilTrackerSettings.gilPerHourOffsetY = us.gilTrackerGilPerHourOffsetY or 0;
+    gAdjustedSettings.gilTrackerSettings.textOffsetX = (us.gilTrackerTextOffsetX or 0) * gs;
+    gAdjustedSettings.gilTrackerSettings.textOffsetY = (us.gilTrackerTextOffsetY or 0) * gs;
+    gAdjustedSettings.gilTrackerSettings.gilPerHourOffsetX = (us.gilTrackerGilPerHourOffsetX or 0) * gs;
+    gAdjustedSettings.gilTrackerSettings.gilPerHourOffsetY = (us.gilTrackerGilPerHourOffsetY or 0) * gs;
 
     -- Inventory Tracker
-    gAdjustedSettings.inventoryTrackerSettings.dotRadius = ds.inventoryTrackerSettings.dotRadius * us.inventoryTrackerScale;
-    gAdjustedSettings.inventoryTrackerSettings.dotSpacing = ds.inventoryTrackerSettings.dotSpacing * us.inventoryTrackerScale;
-    gAdjustedSettings.inventoryTrackerSettings.groupSpacing = ds.inventoryTrackerSettings.groupSpacing * us.inventoryTrackerScale;
-    gAdjustedSettings.inventoryTrackerSettings.font_settings.font_height = math.max(us.inventoryTrackerFontSize, 8);
+    gAdjustedSettings.inventoryTrackerSettings.dotRadius = ds.inventoryTrackerSettings.dotRadius * us.inventoryTrackerScale * gs;
+    gAdjustedSettings.inventoryTrackerSettings.dotSpacing = ds.inventoryTrackerSettings.dotSpacing * us.inventoryTrackerScale * gs;
+    gAdjustedSettings.inventoryTrackerSettings.groupSpacing = ds.inventoryTrackerSettings.groupSpacing * us.inventoryTrackerScale * gs;
+    gAdjustedSettings.inventoryTrackerSettings.font_settings.font_height = math.max(us.inventoryTrackerFontSize, 8) * gs;
     gAdjustedSettings.inventoryTrackerSettings.columnCount = us.inventoryTrackerColumnCount;
     gAdjustedSettings.inventoryTrackerSettings.rowCount = us.inventoryTrackerRowCount;
     gAdjustedSettings.inventoryTrackerSettings.showText = us.inventoryShowCount;
@@ -312,10 +316,10 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.inventoryTrackerSettings.textUseThresholdColor = us.inventoryTextUseThresholdColor;
 
     -- Satchel Tracker
-    gAdjustedSettings.satchelTrackerSettings.dotRadius = ds.satchelTrackerSettings.dotRadius * us.satchelTrackerScale;
-    gAdjustedSettings.satchelTrackerSettings.dotSpacing = ds.satchelTrackerSettings.dotSpacing * us.satchelTrackerScale;
-    gAdjustedSettings.satchelTrackerSettings.groupSpacing = ds.satchelTrackerSettings.groupSpacing * us.satchelTrackerScale;
-    gAdjustedSettings.satchelTrackerSettings.font_settings.font_height = math.max(us.satchelTrackerFontSize, 8);
+    gAdjustedSettings.satchelTrackerSettings.dotRadius = ds.satchelTrackerSettings.dotRadius * us.satchelTrackerScale * gs;
+    gAdjustedSettings.satchelTrackerSettings.dotSpacing = ds.satchelTrackerSettings.dotSpacing * us.satchelTrackerScale * gs;
+    gAdjustedSettings.satchelTrackerSettings.groupSpacing = ds.satchelTrackerSettings.groupSpacing * us.satchelTrackerScale * gs;
+    gAdjustedSettings.satchelTrackerSettings.font_settings.font_height = math.max(us.satchelTrackerFontSize, 8) * gs;
     gAdjustedSettings.satchelTrackerSettings.columnCount = us.satchelTrackerColumnCount;
     gAdjustedSettings.satchelTrackerSettings.rowCount = us.satchelTrackerRowCount;
     gAdjustedSettings.satchelTrackerSettings.showText = us.satchelShowCount;
@@ -324,10 +328,10 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.satchelTrackerSettings.textUseThresholdColor = us.satchelTextUseThresholdColor;
 
     -- Locker Tracker
-    gAdjustedSettings.lockerTrackerSettings.dotRadius = ds.lockerTrackerSettings.dotRadius * us.lockerTrackerScale;
-    gAdjustedSettings.lockerTrackerSettings.dotSpacing = ds.lockerTrackerSettings.dotSpacing * us.lockerTrackerScale;
-    gAdjustedSettings.lockerTrackerSettings.groupSpacing = ds.lockerTrackerSettings.groupSpacing * us.lockerTrackerScale;
-    gAdjustedSettings.lockerTrackerSettings.font_settings.font_height = math.max(us.lockerTrackerFontSize, 8);
+    gAdjustedSettings.lockerTrackerSettings.dotRadius = ds.lockerTrackerSettings.dotRadius * us.lockerTrackerScale * gs;
+    gAdjustedSettings.lockerTrackerSettings.dotSpacing = ds.lockerTrackerSettings.dotSpacing * us.lockerTrackerScale * gs;
+    gAdjustedSettings.lockerTrackerSettings.groupSpacing = ds.lockerTrackerSettings.groupSpacing * us.lockerTrackerScale * gs;
+    gAdjustedSettings.lockerTrackerSettings.font_settings.font_height = math.max(us.lockerTrackerFontSize, 8) * gs;
     gAdjustedSettings.lockerTrackerSettings.columnCount = us.lockerTrackerColumnCount;
     gAdjustedSettings.lockerTrackerSettings.rowCount = us.lockerTrackerRowCount;
     gAdjustedSettings.lockerTrackerSettings.showText = us.lockerShowCount;
@@ -336,10 +340,10 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.lockerTrackerSettings.textUseThresholdColor = us.lockerTextUseThresholdColor;
 
     -- Safe Tracker
-    gAdjustedSettings.safeTrackerSettings.dotRadius = ds.safeTrackerSettings.dotRadius * us.safeTrackerScale;
-    gAdjustedSettings.safeTrackerSettings.dotSpacing = ds.safeTrackerSettings.dotSpacing * us.safeTrackerScale;
-    gAdjustedSettings.safeTrackerSettings.groupSpacing = ds.safeTrackerSettings.groupSpacing * us.safeTrackerScale;
-    gAdjustedSettings.safeTrackerSettings.font_settings.font_height = math.max(us.safeTrackerFontSize, 8);
+    gAdjustedSettings.safeTrackerSettings.dotRadius = ds.safeTrackerSettings.dotRadius * us.safeTrackerScale * gs;
+    gAdjustedSettings.safeTrackerSettings.dotSpacing = ds.safeTrackerSettings.dotSpacing * us.safeTrackerScale * gs;
+    gAdjustedSettings.safeTrackerSettings.groupSpacing = ds.safeTrackerSettings.groupSpacing * us.safeTrackerScale * gs;
+    gAdjustedSettings.safeTrackerSettings.font_settings.font_height = math.max(us.safeTrackerFontSize, 8) * gs;
     gAdjustedSettings.safeTrackerSettings.columnCount = us.safeTrackerColumnCount;
     gAdjustedSettings.safeTrackerSettings.rowCount = us.safeTrackerRowCount;
     gAdjustedSettings.safeTrackerSettings.showText = us.safeShowCount;
@@ -349,10 +353,10 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.safeTrackerSettings.textUseThresholdColor = us.safeTextUseThresholdColor;
 
     -- Storage Tracker
-    gAdjustedSettings.storageTrackerSettings.dotRadius = ds.storageTrackerSettings.dotRadius * us.storageTrackerScale;
-    gAdjustedSettings.storageTrackerSettings.dotSpacing = ds.storageTrackerSettings.dotSpacing * us.storageTrackerScale;
-    gAdjustedSettings.storageTrackerSettings.groupSpacing = ds.storageTrackerSettings.groupSpacing * us.storageTrackerScale;
-    gAdjustedSettings.storageTrackerSettings.font_settings.font_height = math.max(us.storageTrackerFontSize, 8);
+    gAdjustedSettings.storageTrackerSettings.dotRadius = ds.storageTrackerSettings.dotRadius * us.storageTrackerScale * gs;
+    gAdjustedSettings.storageTrackerSettings.dotSpacing = ds.storageTrackerSettings.dotSpacing * us.storageTrackerScale * gs;
+    gAdjustedSettings.storageTrackerSettings.groupSpacing = ds.storageTrackerSettings.groupSpacing * us.storageTrackerScale * gs;
+    gAdjustedSettings.storageTrackerSettings.font_settings.font_height = math.max(us.storageTrackerFontSize, 8) * gs;
     gAdjustedSettings.storageTrackerSettings.columnCount = us.storageTrackerColumnCount;
     gAdjustedSettings.storageTrackerSettings.rowCount = us.storageTrackerRowCount;
     gAdjustedSettings.storageTrackerSettings.showText = us.storageShowCount;
@@ -361,10 +365,10 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.storageTrackerSettings.textUseThresholdColor = us.storageTextUseThresholdColor;
 
     -- Wardrobe Tracker
-    gAdjustedSettings.wardrobeTrackerSettings.dotRadius = ds.wardrobeTrackerSettings.dotRadius * us.wardrobeTrackerScale;
-    gAdjustedSettings.wardrobeTrackerSettings.dotSpacing = ds.wardrobeTrackerSettings.dotSpacing * us.wardrobeTrackerScale;
-    gAdjustedSettings.wardrobeTrackerSettings.groupSpacing = ds.wardrobeTrackerSettings.groupSpacing * us.wardrobeTrackerScale;
-    gAdjustedSettings.wardrobeTrackerSettings.font_settings.font_height = math.max(us.wardrobeTrackerFontSize, 8);
+    gAdjustedSettings.wardrobeTrackerSettings.dotRadius = ds.wardrobeTrackerSettings.dotRadius * us.wardrobeTrackerScale * gs;
+    gAdjustedSettings.wardrobeTrackerSettings.dotSpacing = ds.wardrobeTrackerSettings.dotSpacing * us.wardrobeTrackerScale * gs;
+    gAdjustedSettings.wardrobeTrackerSettings.groupSpacing = ds.wardrobeTrackerSettings.groupSpacing * us.wardrobeTrackerScale * gs;
+    gAdjustedSettings.wardrobeTrackerSettings.font_settings.font_height = math.max(us.wardrobeTrackerFontSize, 8) * gs;
     gAdjustedSettings.wardrobeTrackerSettings.columnCount = us.wardrobeTrackerColumnCount;
     gAdjustedSettings.wardrobeTrackerSettings.rowCount = us.wardrobeTrackerRowCount;
     gAdjustedSettings.wardrobeTrackerSettings.showText = us.wardrobeShowCount;
@@ -374,58 +378,58 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.wardrobeTrackerSettings.textUseThresholdColor = us.wardrobeTextUseThresholdColor;
 
     -- Enemy List
-    gAdjustedSettings.enemyListSettings.barWidth = ds.enemyListSettings.barWidth * us.enemyListScaleX;
-    gAdjustedSettings.enemyListSettings.barHeight = ds.enemyListSettings.barHeight * us.enemyListScaleY;
-    gAdjustedSettings.enemyListSettings.iconSize = ds.enemyListSettings.iconSize * us.enemyListIconScale;
-    gAdjustedSettings.enemyListSettings.debuffOffsetX = us.enemyListDebuffOffsetX;
-    gAdjustedSettings.enemyListSettings.debuffOffsetY = us.enemyListDebuffOffsetY;
-    gAdjustedSettings.enemyListSettings.name_font_settings.font_height = math.max(us.enemyListNameFontSize, 8);
-    gAdjustedSettings.enemyListSettings.distance_font_settings.font_height = math.max(us.enemyListDistanceFontSize, 8);
-    gAdjustedSettings.enemyListSettings.percent_font_settings.font_height = math.max(us.enemyListPercentFontSize, 8);
-    gAdjustedSettings.enemyListSettings.target_font_settings.font_height = math.max(us.enemyListTargetFontSize or 12, 8);
+    gAdjustedSettings.enemyListSettings.barWidth = ds.enemyListSettings.barWidth * us.enemyListScaleX * gs;
+    gAdjustedSettings.enemyListSettings.barHeight = ds.enemyListSettings.barHeight * us.enemyListScaleY * gs;
+    gAdjustedSettings.enemyListSettings.iconSize = ds.enemyListSettings.iconSize * us.enemyListIconScale * gs;
+    gAdjustedSettings.enemyListSettings.debuffOffsetX = (us.enemyListDebuffOffsetX or 0) * gs;
+    gAdjustedSettings.enemyListSettings.debuffOffsetY = (us.enemyListDebuffOffsetY or 0) * gs;
+    gAdjustedSettings.enemyListSettings.name_font_settings.font_height = math.max(us.enemyListNameFontSize, 8) * gs;
+    gAdjustedSettings.enemyListSettings.distance_font_settings.font_height = math.max(us.enemyListDistanceFontSize, 8) * gs;
+    gAdjustedSettings.enemyListSettings.percent_font_settings.font_height = math.max(us.enemyListPercentFontSize, 8) * gs;
+    gAdjustedSettings.enemyListSettings.target_font_settings.font_height = math.max(us.enemyListTargetFontSize or 12, 8) * gs;
 
     -- Cast Bar
-    gAdjustedSettings.castBarSettings.barWidth = ds.castBarSettings.barWidth * us.castBarScaleX;
-    gAdjustedSettings.castBarSettings.barHeight = ds.castBarSettings.barHeight * us.castBarScaleY;
-    gAdjustedSettings.castBarSettings.spell_font_settings.font_height = math.max(us.castBarFontSize, 8);
-    gAdjustedSettings.castBarSettings.percent_font_settings.font_height = math.max(us.castBarFontSize, 8);
+    gAdjustedSettings.castBarSettings.barWidth = ds.castBarSettings.barWidth * us.castBarScaleX * gs;
+    gAdjustedSettings.castBarSettings.barHeight = ds.castBarSettings.barHeight * us.castBarScaleY * gs;
+    gAdjustedSettings.castBarSettings.spell_font_settings.font_height = math.max(us.castBarFontSize, 8) * gs;
+    gAdjustedSettings.castBarSettings.percent_font_settings.font_height = math.max(us.castBarFontSize, 8) * gs;
 
     -- Cast Cost (uses nested gConfig.castCost structure)
     local cc = us.castCost or ds.castCost;
-    gAdjustedSettings.castCostSettings.bgScale = cc.bgScale or 1.0;
-    gAdjustedSettings.castCostSettings.borderScale = cc.borderScale or 1.0;
+    gAdjustedSettings.castCostSettings.bgScale = (cc.bgScale or 1.0) * gs;
+    gAdjustedSettings.castCostSettings.borderScale = (cc.borderScale or 1.0) * gs;
     gAdjustedSettings.castCostSettings.backgroundTheme = cc.backgroundTheme or 'Window1';
     gAdjustedSettings.castCostSettings.backgroundOpacity = cc.backgroundOpacity or 1.0;
     gAdjustedSettings.castCostSettings.borderOpacity = cc.borderOpacity or 1.0;
     gAdjustedSettings.castCostSettings.showName = cc.showName;
     gAdjustedSettings.castCostSettings.showMpCost = cc.showMpCost;
     gAdjustedSettings.castCostSettings.showRecast = cc.showRecast;
-    gAdjustedSettings.castCostSettings.name_font_settings.font_height = math.max(cc.nameFontSize or 12, 8);
-    gAdjustedSettings.castCostSettings.cost_font_settings.font_height = math.max(cc.costFontSize or 12, 8);
-    gAdjustedSettings.castCostSettings.time_font_settings.font_height = math.max(cc.timeFontSize or 10, 8);
-    gAdjustedSettings.castCostSettings.minWidth = cc.minWidth or 100;
-    gAdjustedSettings.castCostSettings.bgPadding = cc.padding or 8;
-    gAdjustedSettings.castCostSettings.bgPaddingY = cc.paddingY or 8;
+    gAdjustedSettings.castCostSettings.name_font_settings.font_height = math.max(cc.nameFontSize or 12, 8) * gs;
+    gAdjustedSettings.castCostSettings.cost_font_settings.font_height = math.max(cc.costFontSize or 12, 8) * gs;
+    gAdjustedSettings.castCostSettings.time_font_settings.font_height = math.max(cc.timeFontSize or 10, 8) * gs;
+    gAdjustedSettings.castCostSettings.minWidth = (cc.minWidth or 100) * gs;
+    gAdjustedSettings.castCostSettings.bgPadding = (cc.padding or 8) * gs;
+    gAdjustedSettings.castCostSettings.bgPaddingY = (cc.paddingY or 8) * gs;
     gAdjustedSettings.castCostSettings.alignBottom = cc.alignBottom or false;
     gAdjustedSettings.castCostSettings.showCooldown = cc.showCooldown;
     if gAdjustedSettings.castCostSettings.showCooldown == nil then
         gAdjustedSettings.castCostSettings.showCooldown = true;
     end
-    gAdjustedSettings.castCostSettings.barScaleY = cc.barScaleY or 1.0;
-    gAdjustedSettings.castCostSettings.recast_font_settings.font_height = math.max(cc.recastFontSize or 10, 8);
-    gAdjustedSettings.castCostSettings.cooldown_font_settings.font_height = math.max(cc.recastFontSize or 10, 8);
+    gAdjustedSettings.castCostSettings.barScaleY = (cc.barScaleY or 1.0) * gs;
+    gAdjustedSettings.castCostSettings.recast_font_settings.font_height = math.max(cc.recastFontSize or 10, 8) * gs;
+    gAdjustedSettings.castCostSettings.cooldown_font_settings.font_height = math.max(cc.recastFontSize or 10, 8) * gs;
 
     -- Mob Info
-    gAdjustedSettings.mobInfoSettings.level_font_settings.font_height = math.max(us.mobInfoFontSize, 8);
+    gAdjustedSettings.mobInfoSettings.level_font_settings.font_height = math.max(us.mobInfoFontSize, 8) * gs;
 
     -- Pet Bar (base dimensions from legacy flat settings)
-    gAdjustedSettings.petBarSettings.barWidth = ds.petBarSettings.barWidth * us.petBarScaleX;
-    gAdjustedSettings.petBarSettings.barHeight = ds.petBarSettings.barHeight * us.petBarScaleY;
-    gAdjustedSettings.petBarSettings.barSpacing = ds.petBarSettings.barSpacing * us.petBarScaleY;
-    gAdjustedSettings.petBarSettings.name_font_settings.font_height = math.max(us.petBarNameFontSize, 8);
-    gAdjustedSettings.petBarSettings.distance_font_settings.font_height = math.max(us.petBarDistanceFontSize, 8);
-    gAdjustedSettings.petBarSettings.vitals_font_settings.font_height = math.max(us.petBarVitalsFontSize, 8);
-    gAdjustedSettings.petBarSettings.timer_font_settings.font_height = math.max(us.petBarTimerFontSize, 8);
+    gAdjustedSettings.petBarSettings.barWidth = ds.petBarSettings.barWidth * us.petBarScaleX * gs;
+    gAdjustedSettings.petBarSettings.barHeight = ds.petBarSettings.barHeight * us.petBarScaleY * gs;
+    gAdjustedSettings.petBarSettings.barSpacing = ds.petBarSettings.barSpacing * us.petBarScaleY * gs;
+    gAdjustedSettings.petBarSettings.name_font_settings.font_height = math.max(us.petBarNameFontSize, 8) * gs;
+    gAdjustedSettings.petBarSettings.distance_font_settings.font_height = math.max(us.petBarDistanceFontSize, 8) * gs;
+    gAdjustedSettings.petBarSettings.vitals_font_settings.font_height = math.max(us.petBarVitalsFontSize, 8) * gs;
+    gAdjustedSettings.petBarSettings.timer_font_settings.font_height = math.max(us.petBarTimerFontSize, 8) * gs;
 
     -- Per-pet-type settings (display module uses these based on active pet)
     gAdjustedSettings.petBarSettings.petTypeSettings = {

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -14,6 +14,7 @@ local M = {};
 function M.createUserSettingsDefaults()
     return T{
         lockPositions = false,
+        globalScale = 1.0,
         tooltipScale = 1.0,
         hideDuringEvents = true,
 

--- a/XIUI/libs/statusicons.lua
+++ b/XIUI/libs/statusicons.lua
@@ -268,7 +268,10 @@ function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOf
                     local textPosX = iconPosX + iconSize / 2;
                     local textPosY = iconPosY + iconSize;
                     local timerText = tostring(buffTimes[i]);
-                    local scaledFontHeight = gConfig.targetBarIconFontSize or font_base.font_height;
+                    -- Raw gConfig.targetBarIconFontSize needs gs scaling; font_base.font_height is from
+                    -- gAdjustedSettings (already scaled in updater).
+                    local gs = gConfig.globalScale or 1.0;
+                    local scaledFontHeight = (gConfig.targetBarIconFontSize and gConfig.targetBarIconFontSize * gs) or font_base.font_height;
                     local timerW, _ = imtext.Measure(timerText, scaledFontHeight);
                     local drawList = GetUIDrawList();
                     local timerColor = font_base.font_color or 0xFFFFFFFF;

--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -184,6 +184,9 @@ local function drawNotification(slot, notification, x, y, width, height, setting
         return;
     end
 
+    -- Global UI scale (multiplied into raw gConfig.notifications* dimensional reads).
+    local gs = gConfig.globalScale or 1.0;
+
     local containerOffsetX = notification.containerOffsetX or 0;
     local iconOffsetX = notification.iconOffsetX or 0;
     local textOffsetY = notification.textOffsetY or 0;
@@ -198,8 +201,8 @@ local function drawNotification(slot, notification, x, y, width, height, setting
     -- Update background using windowbackground library
     -- Get background settings from config
     local bgTheme = gConfig.notificationsBackgroundTheme or 'Plain';
-    local bgScale = gConfig.notificationsBgScale or 1.0;
-    local borderScale = gConfig.notificationsBorderScale or 1.0;
+    local bgScale = (gConfig.notificationsBgScale or 1.0) * gs;
+    local borderScale = (gConfig.notificationsBorderScale or 1.0) * gs;
     local configBgOpacity = gConfig.notificationsBgOpacity or 0.87;
     local configBorderOpacity = gConfig.notificationsBorderOpacity or 1.0;
 
@@ -239,9 +242,9 @@ local function drawNotification(slot, notification, x, y, width, height, setting
             dotColorTable = {1.0, 0.65, 0.0, finalPulseAlpha};  -- #FFA500
         end
 
-        -- Draw pulsing dot on right side
-        local dotRadius = 4;
-        local dotX = x + scaledWidth - 10;
+        -- Draw pulsing dot on right side (scaled by gs to match scaled background)
+        local dotRadius = 4 * gs;
+        local dotX = x + scaledWidth - 10 * gs;
         local dotY = y + (scaledHeight / 2);
         local dotU32 = imgui.GetColorU32(dotColorTable);
         drawList:AddCircleFilled({dotX, dotY}, dotRadius, dotU32, 12);
@@ -253,11 +256,11 @@ local function drawNotification(slot, notification, x, y, width, height, setting
     local minifyProgress = notificationData.GetMinifyProgress(notification);
 
     -- Content padding from config (countdown bar excluded)
-    local contentPadding = gConfig.notificationsPadding or 8;
+    local contentPadding = (gConfig.notificationsPadding or 8) * gs;
 
-    -- Interpolate icon size (32px -> 16px) during minify
-    local normalIconSize = 32;
-    local minifiedIconSize = 16;
+    -- Interpolate icon size (32px -> 16px) during minify (both scaled by gs)
+    local normalIconSize = 32 * gs;
+    local minifiedIconSize = 16 * gs;
 
     local iconSize;
     if isMinifying then
@@ -278,12 +281,12 @@ local function drawNotification(slot, notification, x, y, width, height, setting
     local icon = getNotificationIcon(notification);
 
     -- Get font sizes from config (user-adjustable) with fallback to settings
-    -- No scaling - fonts fade in/out with opacity instead
-    local titleFontHeight = gConfig.notificationsTitleFontSize or (settings.title_font_settings and settings.title_font_settings.font_height) or 14;
-    local subtitleFontHeight = gConfig.notificationsSubtitleFontSize or (settings.font_settings and settings.font_settings.font_height) or 12;
+    -- All paths are raw values; multiply by gs for global scale.
+    local titleFontHeight = (gConfig.notificationsTitleFontSize or (settings.title_font_settings and settings.title_font_settings.font_height) or 14) * gs;
+    local subtitleFontHeight = (gConfig.notificationsSubtitleFontSize or (settings.font_settings and settings.font_settings.font_height) or 12) * gs;
 
     -- Calculate text position (shifts right if icon exists)
-    local iconTextGap = 6;  -- Gap between icon and text
+    local iconTextGap = 6 * gs;  -- Gap between icon and text
     local textX = x + contentPadding;
     if icon then
         textX = x + contentPadding + iconSize + iconTextGap;  -- Shift right past icon (use base x, not iconX with offset)
@@ -295,8 +298,8 @@ local function drawNotification(slot, notification, x, y, width, height, setting
         -- Minified: center single line of text (subtract 1px for visual alignment)
         baseTextY = y + math.floor((contentHeight - subtitleFontHeight) / 2) - 1;
     else
-        -- Normal: center text block (title + 2px gap + subtitle)
-        local textBlockHeight = titleFontHeight + 2 + subtitleFontHeight;
+        -- Normal: center text block (title + scaled 2px gap + subtitle)
+        local textBlockHeight = titleFontHeight + 2 * gs + subtitleFontHeight;
         baseTextY = y + math.floor((contentHeight - textBlockHeight) / 2);
     end
     local textY = baseTextY + textOffsetY;
@@ -359,7 +362,7 @@ local function drawNotification(slot, notification, x, y, width, height, setting
         end
 
         -- Subtitle moves from normal position to centered position
-        local normalSubtitleY = textY + titleFontHeight + 2;  -- Small gap between title and subtitle
+        local normalSubtitleY = textY + titleFontHeight + 2 * gs;  -- Small gap between title and subtitle
         local minifiedSubtitleY = y + math.floor((scaledHeight - subtitleFontHeight) / 2);
         local interpolatedSubtitleY = normalSubtitleY + (minifyProgress * (minifiedSubtitleY - normalSubtitleY));
 
@@ -386,7 +389,7 @@ local function drawNotification(slot, notification, x, y, width, height, setting
         local subtitleCacheKey = notification.id .. "_subtitle";
         local displaySubtitle = GetTruncatedText(subtitle, maxTextWidth, subtitleFontHeight, subtitleCacheKey);
         if drawList and alpha > 0.01 then
-            imtext.Draw(drawList, displaySubtitle, textX, textY + titleFontHeight + 2, fadedSubtitleColor, subtitleFontHeight);
+            imtext.Draw(drawList, displaySubtitle, textX, textY + titleFontHeight + 2 * gs, fadedSubtitleColor, subtitleFontHeight);
         end
     end
 
@@ -420,7 +423,7 @@ local function drawNotification(slot, notification, x, y, width, height, setting
 
         -- Progress bar settings
         -- Use direct coordinates (not bgPrim.bg) to avoid any offset from windowbackground library
-        local barScaleY = gConfig.notificationsProgressBarScaleY or 1.0;
+        local barScaleY = (gConfig.notificationsProgressBarScaleY or 1.0) * gs;
         local barHeight = math.floor(4 * barScaleY);
         local barX = x;
         local barWidth = scaledWidth;
@@ -530,15 +533,17 @@ local function drawNotificationWindow(windowName, notifications, settings, split
     end
 
     -- Calculate notification dimensions using separate X/Y scale
-    local scaleX = gConfig.notificationsScaleX or 1.0;
-    local scaleY = gConfig.notificationsScaleY or 1.0;
+    -- Global UI scale multiplied into raw gConfig.notifications* dimensions.
+    local gs = gConfig.globalScale or 1.0;
+    local scaleX = (gConfig.notificationsScaleX or 1.0) * gs;
+    local scaleY = (gConfig.notificationsScaleY or 1.0) * gs;
     local contentPadding = gConfig.notificationsPadding or 8;
     local notificationWidth = math.floor((settings.width or 280) * scaleX);
     -- Normal height: padding + icon(32) + padding + progress bar(4)
     local normalHeight = math.floor((contentPadding * 2 + 32 + 4) * scaleY);
     -- Minified height: padding + minified icon(16) + padding (no progress bar)
     local minifiedHeight = math.floor((contentPadding * 2 + 16) * scaleY);
-    local spacing = gConfig.notificationsSpacing or 8;
+    local spacing = (gConfig.notificationsSpacing or 8) * gs;
 
     -- Calculate total content height
     local totalHeight = 0;
@@ -751,9 +756,9 @@ local function drawNotificationWindow(windowName, notifications, settings, split
                 end
             elseif configOpen then
                 -- Show placeholder when config is open
-                local placeholderPadding = gConfig.notificationsPadding or 8;
-                local titleHeight = gConfig.notificationsTitleFontSize or 14;
-                local subtitleHeight = gConfig.notificationsSubtitleFontSize or 12;
+                local placeholderPadding = (gConfig.notificationsPadding or 8) * gs;
+                local titleHeight = (gConfig.notificationsTitleFontSize or 14) * gs;
+                local subtitleHeight = (gConfig.notificationsSubtitleFontSize or 12) * gs;
 
                 if splitKey == nil and currentSlot > 0 then
                     -- Skip placeholder - slot 1 is in use by split window notifications
@@ -763,8 +768,8 @@ local function drawNotificationWindow(windowName, notifications, settings, split
 
                 do
                     local bgTheme = gConfig.notificationsBackgroundTheme or 'Plain';
-                    local bgScale = gConfig.notificationsBgScale or 1.0;
-                    local borderScale = gConfig.notificationsBorderScale or 1.0;
+                    local bgScale = (gConfig.notificationsBgScale or 1.0) * gs;
+                    local borderScale = (gConfig.notificationsBorderScale or 1.0) * gs;
                     local configBgOpacity = gConfig.notificationsBgOpacity or 0.87;
                     local configBorderOpacity = gConfig.notificationsBorderOpacity or 1.0;
 
@@ -785,7 +790,7 @@ local function drawNotificationWindow(windowName, notifications, settings, split
                 -- Draw placeholder text
                 if drawList then
                     imtext.Draw(drawList, placeholderTitle or 'Notification Area', windowPosX + placeholderPadding, windowPosY + placeholderPadding, 0xFFFFFFFF, titleHeight);
-                    imtext.Draw(drawList, placeholderSubtitle or 'Drag to reposition', windowPosX + placeholderPadding, windowPosY + placeholderPadding + titleHeight + 2, 0xFFCCCCCC, subtitleHeight);
+                    imtext.Draw(drawList, placeholderSubtitle or 'Drag to reposition', windowPosX + placeholderPadding, windowPosY + placeholderPadding + titleHeight + 2 * gs, 0xFFCCCCCC, subtitleHeight);
                 end
             end
         end);
@@ -845,6 +850,9 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
         return;
     end
 
+    -- Global UI scale multiplied into raw groupSettings/gConfig dimensional reads.
+    local gs = gConfig.globalScale or 1.0;
+
     local containerOffsetX = notification.containerOffsetX or 0;
     local iconOffsetX = notification.iconOffsetX or 0;
     local textOffsetY = notification.textOffsetY or 0;
@@ -857,8 +865,8 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
 
     -- Get background settings from group settings
     local bgTheme = groupSettings.backgroundTheme or 'Plain';
-    local bgScale = groupSettings.bgScale or 1.0;
-    local borderScale = groupSettings.borderScale or 1.0;
+    local bgScale = (groupSettings.bgScale or 1.0) * gs;
+    local borderScale = (groupSettings.borderScale or 1.0) * gs;
     local configBgOpacity = groupSettings.bgOpacity or 0.87;
     local configBorderOpacity = groupSettings.borderOpacity or 1.0;
 
@@ -892,8 +900,8 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
             dotColorTable = {1.0, 0.65, 0.0, finalPulseAlpha};
         end
 
-        local dotRadius = 4;
-        local dotX = x + scaledWidth - 10;
+        local dotRadius = 4 * gs;
+        local dotX = x + scaledWidth - 10 * gs;
         local dotY = y + (scaledHeight / 2);
         local dotU32 = imgui.GetColorU32(dotColorTable);
         drawList:AddCircleFilled({dotX, dotY}, dotRadius, dotU32, 12);
@@ -903,11 +911,11 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
     local isMinifying = notificationData.IsMinifying(notification);
     local minifyProgress = notificationData.GetMinifyProgress(notification);
 
-    local contentPadding = groupSettings.padding or 8;
+    local contentPadding = (groupSettings.padding or 8) * gs;
 
-    -- Icon size interpolation
-    local normalIconSize = 32;
-    local minifiedIconSize = 16;
+    -- Icon size interpolation (both scaled by gs)
+    local normalIconSize = 32 * gs;
+    local minifiedIconSize = 16 * gs;
     local iconSize;
     if isMinifying then
         iconSize = math.floor(normalIconSize - (minifyProgress * (normalIconSize - minifiedIconSize)));
@@ -921,11 +929,11 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
 
     local icon = getNotificationIcon(notification);
 
-    local titleFontHeight = groupSettings.titleFontSize or 14;
-    local subtitleFontHeight = groupSettings.subtitleFontSize or 12;
+    local titleFontHeight = (groupSettings.titleFontSize or 14) * gs;
+    local subtitleFontHeight = (groupSettings.subtitleFontSize or 12) * gs;
 
     -- Calculate text position
-    local iconTextGap = 6;
+    local iconTextGap = 6 * gs;
     local textX = x + contentPadding;
     if icon then
         textX = x + contentPadding + iconSize + iconTextGap;
@@ -935,7 +943,7 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
     if isMinified then
         baseTextY = y + math.floor((contentHeight - subtitleFontHeight) / 2) - 1;
     else
-        local textBlockHeight = titleFontHeight + 2 + subtitleFontHeight;
+        local textBlockHeight = titleFontHeight + 2 * gs + subtitleFontHeight;
         baseTextY = y + math.floor((contentHeight - textBlockHeight) / 2);
     end
     local textY = baseTextY + textOffsetY;
@@ -987,7 +995,7 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
             imtext.Draw(drawList, displayTitle, textX, textY, minifyTitleColor, titleFontHeight);
         end
 
-        local subtitleY = textY + titleFontHeight + 2;
+        local subtitleY = textY + titleFontHeight + 2 * gs;
         local targetSubtitleY = y + math.floor((contentHeight - subtitleFontHeight) / 2) - 1;
         local currentSubtitleY = subtitleY + ((targetSubtitleY - subtitleY) * minifyProgress);
 
@@ -1010,7 +1018,7 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
         local subtitleCacheKey = 'g' .. groupNum .. '_' .. notification.id .. "_subtitle";
         local displaySubtitle = GetTruncatedText(subtitle, maxTextWidth, subtitleFontHeight, subtitleCacheKey);
         if drawList and alpha > 0.01 then
-            imtext.Draw(drawList, displaySubtitle, textX, textY + titleFontHeight + 2, fadedSubtitleColor, subtitleFontHeight);
+            imtext.Draw(drawList, displaySubtitle, textX, textY + titleFontHeight + 2 * gs, fadedSubtitleColor, subtitleFontHeight);
         end
     end
 
@@ -1018,7 +1026,7 @@ local function drawNotificationForGroup(groupNum, slot, notification, x, y, widt
     local isExiting = notification.state == notificationData.STATE.EXITING;
     local isEntering = notification.state == notificationData.STATE.ENTERING;
     if not isMinified and not isMinifying and not isExiting and drawList then
-        local progressBarHeight = math.floor(4 * (groupSettings.progressBarScaleY or 1.0));
+        local progressBarHeight = math.floor(4 * (groupSettings.progressBarScaleY or 1.0) * gs);
         local progressBarY = y + scaledHeight - progressBarHeight;
         local progressBarWidth = scaledWidth;
 
@@ -1110,14 +1118,15 @@ local function drawGroupWindow(groupNum, settings)
         windowFlags = bit.bor(windowFlags, ImGuiWindowFlags_NoMove);
     end
 
-    -- Get group-specific settings
-    local scaleX = groupSettings.scaleX or 1.0;
-    local scaleY = groupSettings.scaleY or 1.0;
+    -- Get group-specific settings (gs scales every dimension proportionally)
+    local gs = gConfig.globalScale or 1.0;
+    local scaleX = (groupSettings.scaleX or 1.0) * gs;
+    local scaleY = (groupSettings.scaleY or 1.0) * gs;
     local contentPadding = groupSettings.padding or 8;
     local notificationWidth = math.floor((settings.width or 280) * scaleX);
     local normalHeight = math.floor((contentPadding * 2 + 32 + 4) * scaleY);
     local minifiedHeight = math.floor((contentPadding * 2 + 16) * scaleY);
-    local spacing = groupSettings.spacing or 8;
+    local spacing = (groupSettings.spacing or 8) * gs;
     local maxVisible = groupSettings.maxVisible or 5;
     local stackUp = groupSettings.direction == 'up';
 

--- a/XIUI/modules/partylist/data.lua
+++ b/XIUI/modules/partylist/data.lua
@@ -131,6 +131,9 @@ end
 function data.updatePartyConfigCache()
     if data.partyConfigCacheValid then return; end
 
+    -- Global UI scale multiplier (stacks on top of per-party scales)
+    local globalScale = gConfig.globalScale or 1.0;
+
     for partyIndex = 1, 3 do
         local cache = data.partyConfigCache[partyIndex];
         local party = data.getPartySettings(partyIndex);
@@ -138,9 +141,9 @@ function data.updatePartyConfigCache()
 
         -- Scale
         if cache.scale == nil then cache.scale = {}; end
-        cache.scale.x = party.scaleX or 1;
-        cache.scale.y = party.scaleY or 1;
-        cache.scale.icon = party.jobIconScale or 1;
+        cache.scale.x = (party.scaleX or 1) * globalScale;
+        cache.scale.y = (party.scaleY or 1) * globalScale;
+        cache.scale.icon = (party.jobIconScale or 1) * globalScale;
 
         -- ShowTP
         cache.showTP = party.showTP;
@@ -160,16 +163,16 @@ function data.updatePartyConfigCache()
         cache.showCastBars = party.showCastBars;
         cache.castBarScaleX = party.castBarScaleX or 1.0;
         cache.castBarScaleY = party.castBarScaleY or 0.6;
-        cache.castBarOffsetX = party.castBarOffsetX or 0;
-        cache.castBarOffsetY = party.castBarOffsetY or 0;
+        cache.castBarOffsetX = (party.castBarOffsetX or 0) * globalScale;
+        cache.castBarOffsetY = (party.castBarOffsetY or 0) * globalScale;
         cache.castBarAnchor = party.castBarAnchor ~= false;
         cache.castBarStyle = party.castBarStyle or 'name';
         cache.showBookends = party.showBookends;
         cache.showTitle = party.showTitle;
         cache.flashTP = party.flashTP;
         cache.backgroundName = party.backgroundName;
-        cache.bgScale = party.bgScale or 1;
-        cache.borderScale = party.borderScale or 1;
+        cache.bgScale = (party.bgScale or 1) * globalScale;
+        cache.borderScale = (party.borderScale or 1) * globalScale;
         cache.backgroundOpacity = party.backgroundOpacity or 1;
         cache.borderOpacity = party.borderOpacity or 1;
         cache.cursor = party.cursor;
@@ -178,8 +181,8 @@ function data.updatePartyConfigCache()
         cache.statusTheme = party.statusTheme or 0;
         cache.statusSide = party.statusSide or 0;
         cache.buffScale = party.buffScale or 1;
-        cache.statusOffsetX = party.statusOffsetX or 0;
-        cache.statusOffsetY = party.statusOffsetY or 0;
+        cache.statusOffsetX = (party.statusOffsetX or 0) * globalScale;
+        cache.statusOffsetY = (party.statusOffsetY or 0) * globalScale;
         cache.expandHeight = party.expandHeight;
         cache.expandHeightInAlliance = party.expandHeightInAlliance;
         cache.alignBottom = party.alignBottom;
@@ -187,7 +190,7 @@ function data.updatePartyConfigCache()
         cache.entrySpacing = party.entrySpacing or 0;
         cache.showSelectionBox = party.showSelectionBox ~= false;
         cache.selectionBoxScaleY = party.selectionBoxScaleY or 1;
-        cache.selectionBoxOffsetY = party.selectionBoxOffsetY or 0;
+        cache.selectionBoxOffsetY = (party.selectionBoxOffsetY or 0) * globalScale;
 
         -- HP/MP display modes
         cache.hpDisplayMode = party.hpDisplayMode or 'number';
@@ -197,15 +200,15 @@ function data.updatePartyConfigCache()
         -- FontSizes
         if cache.fontSizes == nil then cache.fontSizes = {}; end
         if party.splitFontSizes then
-            cache.fontSizes.name = party.nameFontSize or party.fontSize or 12;
-            cache.fontSizes.hp = party.hpFontSize or party.fontSize or 12;
-            cache.fontSizes.mp = party.mpFontSize or party.fontSize or 12;
-            cache.fontSizes.tp = party.tpFontSize or party.fontSize or 12;
-            cache.fontSizes.distance = party.distanceFontSize or party.fontSize or 12;
-            cache.fontSizes.job = party.jobFontSize or party.fontSize or 12;
-            cache.fontSizes.zone = party.zoneFontSize or 10;
+            cache.fontSizes.name = (party.nameFontSize or party.fontSize or 12) * globalScale;
+            cache.fontSizes.hp = (party.hpFontSize or party.fontSize or 12) * globalScale;
+            cache.fontSizes.mp = (party.mpFontSize or party.fontSize or 12) * globalScale;
+            cache.fontSizes.tp = (party.tpFontSize or party.fontSize or 12) * globalScale;
+            cache.fontSizes.distance = (party.distanceFontSize or party.fontSize or 12) * globalScale;
+            cache.fontSizes.job = (party.jobFontSize or party.fontSize or 12) * globalScale;
+            cache.fontSizes.zone = (party.zoneFontSize or 10) * globalScale;
         else
-            local fontSize = party.fontSize or 12;
+            local fontSize = (party.fontSize or 12) * globalScale;
             cache.fontSizes.name = fontSize;
             cache.fontSizes.hp = fontSize;
             cache.fontSizes.mp = fontSize;
@@ -226,18 +229,18 @@ function data.updatePartyConfigCache()
 
         -- Text position offsets (per-party)
         if cache.textOffsets == nil then cache.textOffsets = {}; end
-        cache.textOffsets.nameX = party.nameTextOffsetX or 0;
-        cache.textOffsets.nameY = party.nameTextOffsetY or 0;
-        cache.textOffsets.hpX = party.hpTextOffsetX or 0;
-        cache.textOffsets.hpY = party.hpTextOffsetY or 0;
-        cache.textOffsets.mpX = party.mpTextOffsetX or 0;
-        cache.textOffsets.mpY = party.mpTextOffsetY or 0;
-        cache.textOffsets.tpX = party.tpTextOffsetX or 0;
-        cache.textOffsets.tpY = party.tpTextOffsetY or 0;
-        cache.textOffsets.distanceX = party.distanceTextOffsetX or 0;
-        cache.textOffsets.distanceY = party.distanceTextOffsetY or 0;
-        cache.textOffsets.jobX = party.jobTextOffsetX or 0;
-        cache.textOffsets.jobY = party.jobTextOffsetY or 0;
+        cache.textOffsets.nameX = (party.nameTextOffsetX or 0) * globalScale;
+        cache.textOffsets.nameY = (party.nameTextOffsetY or 0) * globalScale;
+        cache.textOffsets.hpX = (party.hpTextOffsetX or 0) * globalScale;
+        cache.textOffsets.hpY = (party.hpTextOffsetY or 0) * globalScale;
+        cache.textOffsets.mpX = (party.mpTextOffsetX or 0) * globalScale;
+        cache.textOffsets.mpY = (party.mpTextOffsetY or 0) * globalScale;
+        cache.textOffsets.tpX = (party.tpTextOffsetX or 0) * globalScale;
+        cache.textOffsets.tpY = (party.tpTextOffsetY or 0) * globalScale;
+        cache.textOffsets.distanceX = (party.distanceTextOffsetX or 0) * globalScale;
+        cache.textOffsets.distanceY = (party.distanceTextOffsetY or 0) * globalScale;
+        cache.textOffsets.jobX = (party.jobTextOffsetX or 0) * globalScale;
+        cache.textOffsets.jobY = (party.jobTextOffsetY or 0) * globalScale;
 
         -- Color settings reference
         if partyIndex == 1 then

--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -126,6 +126,7 @@ data.jugPets = {
     {name = 'PanzerGalahad', maxLevel = 75, duration = 60},
     {name = 'ChopsueyChucky', maxLevel = 75, duration = 60},
     {name = 'AmigoSabotender', maxLevel = 75, duration = 60},
+    {name = 'ColdbloodComo', maxLevel = 75, duration = 60},
 
     -- 30 minute pets (high level)
     {name = 'CraftyClyvonne', maxLevel = 75, duration = 30},

--- a/XIUI/modules/petbar/display.lua
+++ b/XIUI/modules/petbar/display.lua
@@ -611,6 +611,10 @@ end
 -- DrawWindow - Main Pet Bar Rendering
 -- ============================================
 function display.DrawWindow(settings)
+    -- Global UI scale multiplier. Applied to raw gConfig.petBar* fallbacks so they
+    -- match dimensions coming from gAdjustedSettings (which is already gs-scaled in updater).
+    local gs = gConfig.globalScale or 1.0;
+
     -- Get pet data from data module (handles preview internally)
     local petData = data.GetPetData();
 
@@ -736,10 +740,15 @@ function display.DrawWindow(settings)
 
         if hasPet then
             -- Row 1: Pet Name (with optional level) (left) and HP% (right, same line)
-            local nameFontSize = typeSettings.nameFontSize or gConfig.petBarNameFontSize or settings.name_font_settings.font_height;
-            local hpFontSize = typeSettings.hpFontSize or typeSettings.vitalsFontSize or gConfig.petBarVitalsFontSize or settings.vitals_font_settings.font_height;
-            local mpFontSize = typeSettings.mpFontSize or typeSettings.vitalsFontSize or gConfig.petBarVitalsFontSize or settings.vitals_font_settings.font_height;
-            local tpFontSize = typeSettings.tpFontSize or typeSettings.vitalsFontSize or gConfig.petBarVitalsFontSize or settings.vitals_font_settings.font_height;
+            -- First two fallbacks are raw user values (need gs); third is from adjusted settings (already scaled).
+            local rawNameFontSize = typeSettings.nameFontSize or gConfig.petBarNameFontSize;
+            local nameFontSize = rawNameFontSize and (rawNameFontSize * gs) or settings.name_font_settings.font_height;
+            local rawHpFontSize = typeSettings.hpFontSize or typeSettings.vitalsFontSize or gConfig.petBarVitalsFontSize;
+            local hpFontSize = rawHpFontSize and (rawHpFontSize * gs) or settings.vitals_font_settings.font_height;
+            local rawMpFontSize = typeSettings.mpFontSize or typeSettings.vitalsFontSize or gConfig.petBarVitalsFontSize;
+            local mpFontSize = rawMpFontSize and (rawMpFontSize * gs) or settings.vitals_font_settings.font_height;
+            local rawTpFontSize = typeSettings.tpFontSize or typeSettings.vitalsFontSize or gConfig.petBarVitalsFontSize;
+            local tpFontSize = rawTpFontSize and (rawTpFontSize * gs) or settings.vitals_font_settings.font_height;
 
             -- Format name with level if available and enabled
             local showLevel = typeSettings.showLevel;
@@ -756,9 +765,10 @@ function display.DrawWindow(settings)
             local showDistance = typeSettings.showDistance;
             if showDistance == nil then showDistance = gConfig.petBarShowDistance; end
             if showDistance then
-                local distanceFontSize = typeSettings.distanceFontSize or gConfig.petBarDistanceFontSize or settings.distance_font_settings.font_height;
-                local distanceOffsetX = typeSettings.distanceOffsetX or gConfig.petBarDistanceOffsetX or 0;
-                local distanceOffsetY = typeSettings.distanceOffsetY or gConfig.petBarDistanceOffsetY or 0;
+                local rawDistanceFontSize = typeSettings.distanceFontSize or gConfig.petBarDistanceFontSize;
+                local distanceFontSize = rawDistanceFontSize and (rawDistanceFontSize * gs) or settings.distance_font_settings.font_height;
+                local distanceOffsetX = (typeSettings.distanceOffsetX or gConfig.petBarDistanceOffsetX or 0) * gs;
+                local distanceOffsetY = (typeSettings.distanceOffsetY or gConfig.petBarDistanceOffsetY or 0) * gs;
 
                 local distStr = string.format('%.1f', petDistance);
                 local distColor = colorConfig.distanceTextColor or 0xFFFFFFFF;
@@ -924,7 +934,7 @@ function display.DrawWindow(settings)
                 end
                 if effectIds and #effectIds > 0 then
                     -- Clamp so 0/invalid from saved config doesn't hide icons (default 16)
-                    local statusIconSize = math.max(8, tonumber(gConfig.petBarStatusIconSize) or 16);
+                    local statusIconSize = math.max(8, tonumber(gConfig.petBarStatusIconSize) or 16) * gs;
 
                     -- Position icons at left side, same Y as MP/TP text
                     imgui.SetCursorScreenPos({barsStartX, textRowY});
@@ -963,14 +973,14 @@ function display.DrawWindow(settings)
             -- Get recasts from data module (handles preview internally)
             local timers = data.GetPetRecasts();
             if #timers > 0 then
-                local iconOffsetX = typeSettings.iconsOffsetX or gConfig.petBarIconsOffsetX or 0;
-                local iconOffsetY = typeSettings.iconsOffsetY or gConfig.petBarIconsOffsetY or 0;
+                local iconOffsetX = (typeSettings.iconsOffsetX or gConfig.petBarIconsOffsetX or 0) * gs;
+                local iconOffsetY = (typeSettings.iconsOffsetY or gConfig.petBarIconsOffsetY or 0) * gs;
                 local iconsAbsolute = typeSettings.iconsAbsolute;
                 if iconsAbsolute == nil then iconsAbsolute = gConfig.petBarIconsAbsolute; end
                 local fillStyle = typeSettings.timerFillStyle or 'square';
                 local displayStyle = typeSettings.recastDisplayStyle or 'compact';
-                -- Scale only applies to compact mode; full mode always uses 1.0
-                local iconScale = (displayStyle == 'full') and 1.0 or (typeSettings.iconsScale or gConfig.petBarIconsScale or 1.0);
+                -- Scale only applies to compact mode; full mode always uses 1.0. Multiplied by gs (global scale).
+                local iconScale = (displayStyle == 'full') and 1.0 or ((typeSettings.iconsScale or gConfig.petBarIconsScale or 1.0) * gs);
                 local scaledIconSize = data.RECAST_ICON_SIZE * iconScale;
                 local iconSpacing = typeSettings.recastFullSpacing or 4;
 
@@ -1081,10 +1091,10 @@ function display.DrawWindow(settings)
 
             if showJugTimer then
                 -- Jug-specific settings
-                iconSize = gConfig.petBarJugIconSize or 16;
-                local offsetX = gConfig.petBarJugOffsetX or 0;
-                local offsetY = gConfig.petBarJugOffsetY or -20;
-                timerFontSize = gConfig.petBarJugTimerFontSize or 12;
+                iconSize = (gConfig.petBarJugIconSize or 16) * gs;
+                local offsetX = (gConfig.petBarJugOffsetX or 0) * gs;
+                local offsetY = (gConfig.petBarJugOffsetY or -20) * gs;
+                timerFontSize = (gConfig.petBarJugTimerFontSize or 12) * gs;
                 timerX = windowPosX + offsetX;
                 timerY = windowPosY + offsetY;
 
@@ -1107,10 +1117,10 @@ function display.DrawWindow(settings)
                 end
             elseif showCharmTimer then
                 -- Charm-specific settings
-                iconSize = gConfig.petBarCharmIconSize or 16;
-                local offsetX = gConfig.petBarCharmOffsetX or 0;
-                local offsetY = gConfig.petBarCharmOffsetY or -20;
-                timerFontSize = gConfig.petBarCharmTimerFontSize or 12;
+                iconSize = (gConfig.petBarCharmIconSize or 16) * gs;
+                local offsetX = (gConfig.petBarCharmOffsetX or 0) * gs;
+                local offsetY = (gConfig.petBarCharmOffsetY or -20) * gs;
+                timerFontSize = (gConfig.petBarCharmTimerFontSize or 12) * gs;
                 timerX = windowPosX + offsetX;
                 timerY = windowPosY + offsetY;
 

--- a/XIUI/modules/petbar/display.lua
+++ b/XIUI/modules/petbar/display.lua
@@ -441,7 +441,7 @@ local function DrawRecastFull(drawList, x, y, timerInfo, colorConfig, fullSettin
     -- Progress bar settings (configurable)
     local barHeight = fullSettings.barHeight or 4;
     local barWidth = fullSettings.barWidth or 150;
-    local barY = textY + maxFontSize + 2;  -- Position below the text
+    local barY = textY + maxFontSize + (fullSettings.textBarGap or 2);  -- Position below the text
 
     -- Track where text/bar should start
     local barStartX = x;
@@ -530,7 +530,7 @@ local function DrawRecastFullCharged(drawList, x, y, timerInfo, colorConfig, ful
     -- Progress bar settings (configurable)
     local barHeight = fullSettings.barHeight or 4;
     local barWidth = fullSettings.barWidth or 150;
-    local barY = textY + maxFontSize + 2;  -- Position below the text
+    local barY = textY + maxFontSize + (fullSettings.textBarGap or 2);  -- Position below the text
 
     -- Track where text/bar should start
     local barStartX = x;
@@ -958,7 +958,7 @@ function display.DrawWindow(settings)
             end
             -- Add spacing for text row if any vitals text is shown
             -- recastTopSpacing controls the gap between vitals text and recast section (anchored mode)
-            local recastTopSpacing = typeSettings.recastTopSpacing or 2;
+            local recastTopSpacing = (typeSettings.recastTopSpacing or 2) * gs;
             if displayMpBar or displayTpBar then
                 local maxVitalsFontSize = math.max(displayMpBar and mpFontSize or 0, displayTpBar and tpFontSize or 0);
                 imgui.Dummy({totalRowWidth, maxVitalsFontSize + recastTopSpacing});
@@ -982,7 +982,7 @@ function display.DrawWindow(settings)
                 -- Scale only applies to compact mode; full mode always uses 1.0. Multiplied by gs (global scale).
                 local iconScale = (displayStyle == 'full') and 1.0 or ((typeSettings.iconsScale or gConfig.petBarIconsScale or 1.0) * gs);
                 local scaledIconSize = data.RECAST_ICON_SIZE * iconScale;
-                local iconSpacing = typeSettings.recastFullSpacing or 4;
+                local iconSpacing = (typeSettings.recastFullSpacing or 4) * gs;
 
                 local iconX, iconY;
 
@@ -993,7 +993,7 @@ function display.DrawWindow(settings)
                 else
                     -- Anchored: flow within the pet bar container
                     -- Use recastTopSpacing for vertical offset, no X offset in anchored mode
-                    local topSpacing = typeSettings.recastTopSpacing or 2;
+                    local topSpacing = (typeSettings.recastTopSpacing or 2) * gs;
                     iconX, iconY = imgui.GetCursorScreenPos();
                     iconY = iconY + topSpacing;
                 end
@@ -1008,8 +1008,8 @@ function display.DrawWindow(settings)
                     local fullSettings = {
                         showName = typeSettings.recastFullShowName ~= false,
                         showRecast = typeSettings.recastFullShowTimer ~= false,
-                        nameFontSize = typeSettings.recastFullNameFontSize or 10,
-                        recastFontSize = typeSettings.recastFullTimerFontSize or 10,
+                        nameFontSize = (typeSettings.recastFullNameFontSize or 10) * gs,
+                        recastFontSize = (typeSettings.recastFullTimerFontSize or 10) * gs,
                         alignment = 'left',
                         iconSize = scaledIconSize,
                         barWidth = recastBarWidth,
@@ -1017,6 +1017,7 @@ function display.DrawWindow(settings)
                         showBookends = recastShowBookends,
                         progressStyle = typeSettings.recastProgressStyle or 'Fill',
                         isJug = isJug,
+                        textBarGap = 2 * gs,
                     };
 
                     -- Calculate row height based on what's visible
@@ -1029,7 +1030,7 @@ function display.DrawWindow(settings)
                         textRowHeight = math.max(textRowHeight, fullSettings.recastFontSize);
                     end
                     -- Entry height = text row + gap + bar height
-                    local textBarGap = 2;
+                    local textBarGap = 2 * gs;
                     local contentHeight = textRowHeight + textBarGap + recastBarHeight;
                     -- If nothing visible (no text), just use bar height
                     if textRowHeight == 0 then

--- a/XIUI/modules/petbar/pettarget.lua
+++ b/XIUI/modules/petbar/pettarget.lua
@@ -53,6 +53,9 @@ end
 function pettarget.DrawWindow(settings)
     local isPreview = showConfig and showConfig[1] and gConfig.petBarPreview;
 
+    -- Global UI scale multiplier; applied to raw gConfig.petTarget* / petBarTarget* fallbacks.
+    local gs = gConfig.globalScale or 1.0;
+
     -- Only show if we have a valid pet (prevents showing when "Always Visible" is on but no pet)
     if data.GetPetData() == nil then
         return;
@@ -102,8 +105,8 @@ function pettarget.DrawWindow(settings)
     local anchor = gConfig.petTargetSnapAnchor or 'bottom';
     local anchorY = (anchor == 'top' and data.lastMainWindowTop) or data.lastMainWindowBottom;
     if snapEnabled and data.lastMainWindowPosX ~= nil and anchorY ~= nil then
-        local snapOffsetX = gConfig.petTargetSnapOffsetX or 0;
-        local snapOffsetY = gConfig.petTargetSnapOffsetY or 16;
+        local snapOffsetX = (gConfig.petTargetSnapOffsetX or 0) * gs;
+        local snapOffsetY = (gConfig.petTargetSnapOffsetY or 16) * gs;
         local snapX = data.lastMainWindowPosX + snapOffsetX;
         local snapY = anchorY + snapOffsetY;
         imgui.SetNextWindowPos({snapX, snapY}, ImGuiCond_Always);
@@ -128,26 +131,30 @@ function pettarget.DrawWindow(settings)
 
         imtext.SetConfigFromSettings(settings.vitals_font_settings);
 
-        local targetNameFontSize = gConfig.petBarTargetNameFontSize or gConfig.petBarTargetFontSize or settings.vitals_font_settings.font_height;
-        local targetHpFontSize = gConfig.petBarTargetHpFontSize or gConfig.petBarVitalsFontSize or settings.vitals_font_settings.font_height;
-        local targetDistanceFontSize = gConfig.petBarTargetDistanceFontSize or gConfig.petBarDistanceFontSize or settings.distance_font_settings.font_height;
+        -- Font sizes: first two fallbacks are raw user values (gs-scaled); third is from adjusted settings (already scaled).
+        local rawTargetNameFontSize = gConfig.petBarTargetNameFontSize or gConfig.petBarTargetFontSize;
+        local targetNameFontSize = rawTargetNameFontSize and (rawTargetNameFontSize * gs) or settings.vitals_font_settings.font_height;
+        local rawTargetHpFontSize = gConfig.petBarTargetHpFontSize or gConfig.petBarVitalsFontSize;
+        local targetHpFontSize = rawTargetHpFontSize and (rawTargetHpFontSize * gs) or settings.vitals_font_settings.font_height;
+        local rawTargetDistanceFontSize = gConfig.petBarTargetDistanceFontSize or gConfig.petBarDistanceFontSize;
+        local targetDistanceFontSize = rawTargetDistanceFontSize and (rawTargetDistanceFontSize * gs) or settings.distance_font_settings.font_height;
 
-        -- Bar dimensions with scale settings
+        -- Bar dimensions with scale settings (totalRowWidth and settings.barHeight come from updater, already gs-scaled)
         local barScaleX = gConfig.petTargetBarScaleX or 1.0;
         local barScaleY = gConfig.petTargetBarScaleY or 1.0;
         local barWidth = totalRowWidth * barScaleX;
         local barHeight = (settings.barHeight or 12) * barScaleY;
 
-        -- Get positioning settings
+        -- Get positioning settings (offsets scale with gs)
         local nameAbsolute = gConfig.petTargetNameAbsolute;
-        local nameOffsetX = gConfig.petTargetNameOffsetX or 0;
-        local nameOffsetY = gConfig.petTargetNameOffsetY or 0;
+        local nameOffsetX = (gConfig.petTargetNameOffsetX or 0) * gs;
+        local nameOffsetY = (gConfig.petTargetNameOffsetY or 0) * gs;
         local hpAbsolute = gConfig.petTargetHpAbsolute;
-        local hpOffsetX = gConfig.petTargetHpOffsetX or 0;
-        local hpOffsetY = gConfig.petTargetHpOffsetY or 0;
+        local hpOffsetX = (gConfig.petTargetHpOffsetX or 0) * gs;
+        local hpOffsetY = (gConfig.petTargetHpOffsetY or 0) * gs;
         local distanceAbsolute = gConfig.petTargetDistanceAbsolute;
-        local distanceOffsetX = gConfig.petTargetDistanceOffsetX or 0;
-        local distanceOffsetY = gConfig.petTargetDistanceOffsetY or 0;
+        local distanceOffsetX = (gConfig.petTargetDistanceOffsetX or 0) * gs;
+        local distanceOffsetY = (gConfig.petTargetDistanceOffsetY or 0) * gs;
 
         -- Row 1: Target Name (left-aligned)
         local targetColor = colorConfig.targetTextColor or petBarColorConfig.targetTextColor or 0xFFFFFFFF;

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -521,9 +521,10 @@ playerbar.DrawWindow = function(settings)
 		else -- right alignment (default)
 			hpTextX = hpBarStartX + barSize - bookendWidth - textPadding - hpTextW;
 		end
-		-- Apply user offset
-		hpTextX = hpTextX + (gConfig.playerBarHpTextOffsetX or 0);
-		local hpTextY = hpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarHpTextOffsetY or 0);
+		-- Apply user offset (scaled by global UI scale)
+		local gs = gConfig.globalScale or 1.0;
+		hpTextX = hpTextX + (gConfig.playerBarHpTextOffsetX or 0) * gs;
+		local hpTextY = hpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarHpTextOffsetY or 0) * gs;
 		imtext.Draw(drawList, hpDisplayText, hpTextX, hpTextY, gConfig.colorCustomization.playerBar.hpTextColor, fontSize);
 
 		if (bShowMp) then
@@ -554,9 +555,9 @@ playerbar.DrawWindow = function(settings)
 			else -- right alignment (default)
 				mpTextX = mpBarStartX + barSize - bookendWidth - textPadding - mpTextW;
 			end
-			-- Apply user offset
-			mpTextX = mpTextX + (gConfig.playerBarMpTextOffsetX or 0);
-			local mpTextY = mpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarMpTextOffsetY or 0);
+			-- Apply user offset (scaled by global UI scale)
+			mpTextX = mpTextX + (gConfig.playerBarMpTextOffsetX or 0) * gs;
+			local mpTextY = mpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarMpTextOffsetY or 0) * gs;
 			imtext.Draw(drawList, mpDisplayText, mpTextX, mpTextY, gConfig.colorCustomization.playerBar.mpTextColor, fontSize);
 		end
 
@@ -573,9 +574,9 @@ playerbar.DrawWindow = function(settings)
 		else -- right alignment (default)
 			tpTextX = tpBarStartX + barSize - bookendWidth - textPadding - tpTextW;
 		end
-		-- Apply user offset
-		tpTextX = tpTextX + (gConfig.playerBarTpTextOffsetX or 0);
-		local tpTextY = tpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarTpTextOffsetY or 0);
+		-- Apply user offset (scaled by global UI scale)
+		tpTextX = tpTextX + (gConfig.playerBarTpTextOffsetX or 0) * gs;
+		local tpTextY = tpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarTpTextOffsetY or 0) * gs;
 		local tpTextColor = (SelfTP >= 1000) and gConfig.colorCustomization.playerBar.tpFullTextColor or gConfig.colorCustomization.playerBar.tpEmptyTextColor;
 		imtext.Draw(drawList, tpDisplayText, tpTextX, tpTextY, tpTextColor, fontSize);
 

--- a/XIUI/modules/treasurepool/display.lua
+++ b/XIUI/modules/treasurepool/display.lua
@@ -174,32 +174,36 @@ function M.DrawWindow(settings)
     -- Don't auto-switch tabs - let users control which tab they're viewing
     -- Each tab will show an appropriate empty state message if it has no content
 
-    -- Get settings with validation
+    -- Get settings with validation. globalScale (gs) stacks on top of per-module scales.
+    local gs = gConfig.globalScale or 1.0;
     local scaleX = gConfig.treasurePoolScaleX;
     if scaleX == nil or scaleX < 0.5 then scaleX = 1.0; end
+    scaleX = scaleX * gs;
 
     local scaleY = gConfig.treasurePoolScaleY;
     if scaleY == nil or scaleY < 0.5 then scaleY = 1.0; end
+    scaleY = scaleY * gs;
 
     local fontSize = gConfig.treasurePoolFontSize;
     if fontSize == nil or fontSize < 8 then fontSize = 10; end
+    fontSize = fontSize * gs;
 
     local showTitle = true;  -- Always show title
     local showTimerBar = gConfig.treasurePoolShowTimerBar ~= false;
     local showTimerText = gConfig.treasurePoolShowTimerText ~= false;
     local showLots = gConfig.treasurePoolShowLots ~= false;
-    -- Split background/border settings
-    local bgScale = gConfig.treasurePoolBgScale or 1.0;
-    local borderScale = gConfig.treasurePoolBorderScale or 1.0;
+    -- Split background/border settings (also scaled by gs so textures grow with rest of UI)
+    local bgScale = (gConfig.treasurePoolBgScale or 1.0) * gs;
+    local borderScale = (gConfig.treasurePoolBorderScale or 1.0) * gs;
     local bgOpacity = gConfig.treasurePoolBackgroundOpacity or 0.87;
     local borderOpacity = gConfig.treasurePoolBorderOpacity or 1.0;
     local bgTheme = gConfig.treasurePoolBackgroundTheme or 'Plain';
     local isExpanded = gConfig.treasurePoolExpanded == true;
     local isMinimized = gConfig.treasurePoolMinimized == true;
 
-    -- Calculate dimensions (different for expanded vs collapsed)
+    -- Calculate dimensions (different for expanded vs collapsed). scaleX/scaleY already include gs.
     local iconSize = math.floor(ICON_SIZE * scaleY);
-    local padding = PADDING;
+    local padding = math.floor(PADDING * gs);
     local iconTextGap = math.floor(ICON_TEXT_GAP * scaleX);
     local rowSpacing = math.floor(ROW_SPACING * scaleY);
     local barHeight = math.floor(BAR_HEIGHT * scaleY);


### PR DESCRIPTION
## Summary
- Resolves #294 — adds a Global UI Scale slider to the Global tab so users on 4K displays don't have to tune every module individually.
- New `gConfig.globalScale` (default 1.0, range 0.5–5.0) is a multiplicative scale that stacks on top of every per-module scale; individual sliders still work as before.
- Applied centrally in `core/settings/updater.lua` for modules that route through `gAdjustedSettings`, plus targeted touch-ups in `modules/partylist/data.lua` and `modules/petbar/*.lua` which read raw `gConfig` values directly.

## What scales together
Main bars (player / target / exp / cast / party list / pet bar / hotbar / enemy list), all font heights, all icon sizes (job/status/tracker dots), per-party fonts and offsets, pet bar HP/MP/TP + jug/charm timer icons + pet target, cast cost, gil tracker, inventory/satchel/locker/safe/storage/wardrobe trackers.

## What's intentionally out of scope
`treasurepool` and `notifications` already expose their own scale sliders that the user can adjust directly; they don't pick up `globalScale`. If users want those to track the rest of the UI, that can ship as a follow-up.

## Test plan
- [ ] `/addon reload xiui`
- [ ] `/xiui` → Global tab → confirm Global UI Scale slider appears (range 0.5–5.0, default 1.0)
- [ ] Drag to 2.0: main bars, fonts, icons all double in size; layout stays proportional
- [ ] Drag to 0.5: everything halves
- [ ] Back to 1.0: rendering matches pre-PR (no 1.0-case regressions)
- [ ] Tweak a per-module slider (e.g. Player Bar > Scale X) while globalScale = 1.5 — confirm the multiplier stacks
- [ ] Save profile, reload addon, confirm globalScale persists
- [ ] Spot-check pet bar with jug pet, party list with full alliance, status icons on target