### PR TITLE
Remove dupe hotbar action lines

### DIFF
--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -942,6 +942,116 @@ function M.MigrateLegacyPositionFields(gConfig)
     return migrated;
 end
 
+-- Migrates legacy slot data so macroDB is the single source of truth:
+--   1. Fills in missing macroPaletteKey on slots that have macroRef.
+--      Uses the macroDB to determine which palette the macro lives in.
+--      Disambiguates ambiguous matches via the slot's storage-key job context,
+--      then 'global', then leaves it for the cross-palette fallback.
+--   2. Strips the duplicated cached macro fields (action, macroText, etc.)
+--      from any slot that has a macroRef.
+-- Idempotent and cheap: safe to run on every load. Doubles as an integrity
+-- check in case external tools or future bugs re-introduce duplicate fields.
+function M.MigrateSlotMacroRefs(gConfig)
+    if not gConfig or not gConfig.macroDB then return 0, 0; end
+
+    -- Build id -> { palette_key, ... } map from macroDB
+    local idToKeys = {};
+    for paletteKey, palette in pairs(gConfig.macroDB) do
+        if type(palette) == 'table' then
+            for _, macro in ipairs(palette) do
+                if macro and macro.id then
+                    if not idToKeys[macro.id] then
+                        idToKeys[macro.id] = {};
+                    end
+                    table.insert(idToKeys[macro.id], paletteKey);
+                end
+            end
+        end
+    end
+
+    local FIELDS_TO_STRIP = {
+        'actionType', 'action', 'target', 'displayName',
+        'equipSlot', 'macroText', 'itemId',
+        'customIconType', 'customIconId', 'customIconPath',
+        'recastSourceType', 'recastSourceAction', 'recastSourceItemId',
+    };
+
+    local keysAdded = 0;
+    local fieldsStripped = 0;
+
+    local function migrateSlot(slot, contextStorageKey)
+        if type(slot) ~= 'table' then return; end
+        if not slot.macroRef then return; end
+
+        -- Fill in missing macroPaletteKey
+        if not slot.macroPaletteKey then
+            local candidates = idToKeys[slot.macroRef];
+            local chosen = nil;
+            if candidates and #candidates == 1 then
+                chosen = candidates[1];
+            elseif candidates and #candidates > 1 then
+                -- Disambiguate using storage key job context (e.g. '14:0:palette:Default')
+                local jobId = contextStorageKey
+                    and tonumber(tostring(contextStorageKey):match('^(%d+)'));
+                if jobId then
+                    for _, k in ipairs(candidates) do
+                        if k == jobId then chosen = k; break; end
+                    end
+                end
+                if not chosen then
+                    for _, k in ipairs(candidates) do
+                        if k == 'global' then chosen = k; break; end
+                    end
+                end
+                -- Else: too ambiguous, leave for runtime cross-palette fallback
+            end
+            if chosen ~= nil then
+                slot.macroPaletteKey = chosen;
+                keysAdded = keysAdded + 1;
+            end
+        end
+
+        -- Strip duplicated macro fields (macroDB is now the source of truth)
+        for _, field in ipairs(FIELDS_TO_STRIP) do
+            if slot[field] ~= nil then
+                slot[field] = nil;
+                fieldsStripped = fieldsStripped + 1;
+            end
+        end
+    end
+
+    -- Hotbar slots: gConfig.hotbarBarN.slotActions[storageKey][slotIndex]
+    for barIndex = 1, 6 do
+        local barCfg = gConfig['hotbarBar' .. barIndex];
+        if barCfg and type(barCfg.slotActions) == 'table' then
+            for storageKey, slots in pairs(barCfg.slotActions) do
+                if type(slots) == 'table' then
+                    for _, slot in pairs(slots) do
+                        migrateSlot(slot, storageKey);
+                    end
+                end
+            end
+        end
+    end
+
+    -- Crossbar slots: gConfig.hotbarCrossbar.slotActions[storageKey][comboMode][slotIndex]
+    if gConfig.hotbarCrossbar and type(gConfig.hotbarCrossbar.slotActions) == 'table' then
+        for storageKey, comboModes in pairs(gConfig.hotbarCrossbar.slotActions) do
+            if type(comboModes) == 'table' then
+                for _, slots in pairs(comboModes) do
+                    if type(slots) == 'table' then
+                        for _, slot in pairs(slots) do
+                            migrateSlot(slot, storageKey);
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return keysAdded, fieldsStripped;
+end
+
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
 function M.RunStructureMigrations(gConfig, defaults)
@@ -957,6 +1067,7 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateNotificationGroups(gConfig, defaults);
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
+    M.MigrateSlotMacroRefs(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/handlers/tbar_migration.lua
+++ b/XIUI/handlers/tbar_migration.lua
@@ -1015,23 +1015,11 @@ function M.ImportHotbarBinding(barIndex, slotIndex, xiuiAction, storageKey)
         macroId = CreateMacroInPalette(xiuiAction, macroPaletteKey);
     end
 
-    -- Set the slot data with macro reference
-    local slotData = {
-        actionType = xiuiAction.actionType,
-        action = xiuiAction.action,
-        target = xiuiAction.target,
-        displayName = xiuiAction.displayName or xiuiAction.action,
-        macroText = xiuiAction.macroText,
-        itemId = xiuiAction.itemId,
-        customIconType = xiuiAction.customIconType,
-        customIconId = xiuiAction.customIconId,
-        customIconPath = xiuiAction.customIconPath,
-        -- Reference the macro in the palette
+    -- Set the slot data with macro reference (lean form - macroDB is source of truth)
+    gConfig[configKey].slotActions[storageKey][slotIndex] = {
         macroRef = macroId,
         macroPaletteKey = macroPaletteKey,
     };
-
-    gConfig[configKey].slotActions[storageKey][slotIndex] = slotData;
     return true;
 end
 
@@ -1065,23 +1053,11 @@ function M.ImportCrossbarBinding(comboMode, slotIndex, xiuiAction, storageKey)
         macroId = CreateMacroInPalette(xiuiAction, macroPaletteKey);
     end
 
-    -- Set the slot data with macro reference
-    local slotData = {
-        actionType = xiuiAction.actionType,
-        action = xiuiAction.action,
-        target = xiuiAction.target,
-        displayName = xiuiAction.displayName or xiuiAction.action,
-        macroText = xiuiAction.macroText,
-        itemId = xiuiAction.itemId,
-        customIconType = xiuiAction.customIconType,
-        customIconId = xiuiAction.customIconId,
-        customIconPath = xiuiAction.customIconPath,
-        -- Reference the macro in the palette
+    -- Set the slot data with macro reference (lean form - macroDB is source of truth)
+    gConfig.hotbarCrossbar.slotActions[storageKey][comboMode][slotIndex] = {
         macroRef = macroId,
         macroPaletteKey = macroPaletteKey,
     };
-
-    gConfig.hotbarCrossbar.slotActions[storageKey][comboMode][slotIndex] = slotData;
     return true;
 end
 

--- a/XIUI/modules/hotbar/data.lua
+++ b/XIUI/modules/hotbar/data.lua
@@ -47,9 +47,17 @@ end
 
 local macroIdLookup = {};  -- macroIdLookup[paletteKey][macroId] = macro
 local macroIdLookupDirty = true;
+-- Identity reference of the macroDB the lookup was built against. If gConfig
+-- gets reassigned (profile switch / character swap), this will no longer
+-- match gConfig.macroDB and we'll rebuild automatically. This prevents the
+-- "globals from old profile" bug where switching characters left stale
+-- macros (e.g. Ramrock's macroDB[3]="Heel") in the lookup while the new
+-- profile (Mazungu) had macroDB[3]="SendPep".
+local macroIdLookupSource = nil;
 
 local function RebuildMacroLookup()
     macroIdLookup = {};
+    macroIdLookupSource = (gConfig and gConfig.macroDB) or nil;
     if gConfig and gConfig.macroDB then
         for paletteKey, macros in pairs(gConfig.macroDB) do
             macroIdLookup[paletteKey] = {};
@@ -66,7 +74,9 @@ local function RebuildMacroLookup()
 end
 
 local function GetMacroFromLookup(macroId, paletteKey)
-    if macroIdLookupDirty then
+    -- Rebuild if explicitly dirty OR if gConfig.macroDB has been reassigned
+    -- (i.e. profile switched out from under us).
+    if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
         RebuildMacroLookup();
     end
     local paletteLookup = macroIdLookup[paletteKey];
@@ -83,6 +93,11 @@ end
 
 local storageKeyCache = {};  -- storageKeyCache[barIndex] = storageKey
 local storageKeyCacheDirty = true;
+-- Identity reference of the gConfig the storage key cache was built against.
+-- If gConfig is reassigned (profile switch) the cached keys could be stale
+-- (jobSpecific / petAware / palette names are profile-specific), so we
+-- detect the swap and invalidate.
+local storageKeyCacheSource = nil;
 
 -- ============================================
 -- Constants
@@ -231,6 +246,13 @@ local PER_BAR_ONLY_KEYS = {
 -- NOTE: Palettes can be subjob-specific or shared (subjob 0), with fallback to shared if no subjob-specific exist
 -- OPTIMIZED: Results are cached to avoid 72+ string allocations per frame
 function M.GetStorageKeyForBar(barIndex)
+    -- If gConfig was swapped out (profile change), invalidate.
+    if storageKeyCacheSource ~= gConfig then
+        storageKeyCache = {};
+        storageKeyCacheDirty = true;
+        storageKeyCacheSource = gConfig;
+    end
+
     -- Check cache first (major optimization for runtime rendering)
     if not storageKeyCacheDirty and storageKeyCache[barIndex] then
         return storageKeyCache[barIndex];
@@ -649,20 +671,37 @@ end
 -- Helper to look up a macro from macroDB by id
 -- paletteKey can be a job ID (number) or composite key (string like "15:avatar:ifrit")
 -- OPTIMIZED: Uses O(1) lookup map instead of linear search
+-- Falls back to scanning all palettes for legacy slots that don't have macroPaletteKey set
 local function GetMacroById(macroId, paletteKey)
     if not gConfig or not gConfig.macroDB then return nil; end
 
     -- Try the specific palette key first using O(1) lookup
-    local macro = GetMacroFromLookup(macroId, paletteKey);
-    if macro then
-        return macro;
+    if paletteKey ~= nil then
+        local macro = GetMacroFromLookup(macroId, paletteKey);
+        if macro then
+            return macro;
+        end
+
+        -- If paletteKey is a composite key and macro not found, try base job palette
+        if type(paletteKey) == 'string' then
+            local baseJobId = tonumber(paletteKey:match('^(%d+)'));
+            if baseJobId then
+                macro = GetMacroFromLookup(macroId, baseJobId);
+                if macro then
+                    return macro;
+                end
+            end
+        end
     end
 
-    -- If paletteKey is a composite key and macro not found, try base job palette
-    if type(paletteKey) == 'string' then
-        local baseJobId = tonumber(paletteKey:match('^(%d+)'));
-        if baseJobId then
-            macro = GetMacroFromLookup(macroId, baseJobId);
+    -- Fallback for legacy slots missing macroPaletteKey: scan all palettes
+    -- (rebuild lookup if dirty OR if gConfig.macroDB was swapped under us)
+    if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
+        RebuildMacroLookup();
+    end
+    for key, paletteLookup in pairs(macroIdLookup) do
+        if key ~= paletteKey then
+            local macro = paletteLookup[macroId];
             if macro then
                 return macro;
             end
@@ -695,17 +734,19 @@ function M.GetKeybindForSlot(barIndex, slotIndex)
                     return nil;  -- Don't fall back to defaults
                 end
 
-                -- If this slot has a macro reference, look up the current macro data
-                -- This ensures icon changes in the palette are reflected on the hotbar
-                local macroData = slotAction;
+                -- If this slot has a macro reference, the macroDB is the single source of truth.
+                -- Old configs may have duplicated macro fields cached on the slot - we ignore them.
+                -- If the live lookup fails (orphaned macro), the slot is treated as unavailable.
+                local macroData;
                 if slotAction.macroRef then
-                    -- Use stored palette key if available, otherwise fall back to job ID
                     local paletteKey = slotAction.macroPaletteKey or M.jobId;
-                    local liveMacro = GetMacroById(slotAction.macroRef, paletteKey);
-                    if liveMacro then
-                        macroData = liveMacro;
+                    macroData = GetMacroById(slotAction.macroRef, paletteKey);
+                    if not macroData then
+                        return nil;  -- Macro reference is orphaned
                     end
-                    -- If macro was deleted, fall back to the cached slotAction data
+                else
+                    -- Custom non-macro slot - use inline fields directly
+                    macroData = slotAction;
                 end
 
                 -- Return slot action in the same format as parsed keybinds
@@ -824,37 +865,70 @@ function M.GetCrossbarSlotData(comboMode, slotIndex)
     local slotAction = jobSlotActions[effectiveComboMode][slotIndex];
     if not slotAction then return nil; end
 
-    -- If this slot has a macro reference, look up the current macro data
-    -- This ensures icon changes in the palette are reflected on the crossbar
+    -- If this slot has a macro reference, the macroDB is the single source of truth.
+    -- Old configs may have duplicated macro fields cached on the slot - we ignore them.
+    -- If the live lookup fails (orphaned macro), the slot is treated as unavailable.
     if slotAction.macroRef then
-        -- Use stored palette key if available, otherwise fall back to job ID
         local paletteKey = slotAction.macroPaletteKey or jobId;
         local liveMacro = GetMacroById(slotAction.macroRef, paletteKey);
-        if liveMacro then
-            -- Return fresh macro data (preserving any slot-specific overrides if needed)
-            return {
-                actionType = liveMacro.actionType,
-                action = liveMacro.action,
-                target = liveMacro.target,
-                displayName = liveMacro.displayName,
-                equipSlot = liveMacro.equipSlot,
-                macroText = liveMacro.macroText,
-                itemId = liveMacro.itemId,
-                customIconType = liveMacro.customIconType,
-                customIconId = liveMacro.customIconId,
-                customIconPath = liveMacro.customIconPath,
-                macroRef = slotAction.macroRef,
-                macroPaletteKey = slotAction.macroPaletteKey,
-                -- Recast source override (for macros showing cooldown from different action)
-                recastSourceType = liveMacro.recastSourceType,
-                recastSourceAction = liveMacro.recastSourceAction,
-                recastSourceItemId = liveMacro.recastSourceItemId,
-            };
+        if not liveMacro then
+            return nil;  -- Macro reference is orphaned
         end
-        -- If macro was deleted, fall back to cached slotAction data
+        return {
+            actionType = liveMacro.actionType,
+            action = liveMacro.action,
+            target = liveMacro.target,
+            displayName = liveMacro.displayName,
+            equipSlot = liveMacro.equipSlot,
+            macroText = liveMacro.macroText,
+            itemId = liveMacro.itemId,
+            customIconType = liveMacro.customIconType,
+            customIconId = liveMacro.customIconId,
+            customIconPath = liveMacro.customIconPath,
+            macroRef = slotAction.macroRef,
+            macroPaletteKey = slotAction.macroPaletteKey,
+            -- Recast source override (for macros showing cooldown from different action)
+            recastSourceType = liveMacro.recastSourceType,
+            recastSourceAction = liveMacro.recastSourceAction,
+            recastSourceItemId = liveMacro.recastSourceItemId,
+        };
     end
 
+    -- Custom non-macro slot - return inline data directly
     return slotAction;
+end
+
+-- Build the persisted form of slot data.
+-- When the slot references a macro (macroRef or id), only the reference is stored;
+-- the macroDB is the single source of truth for action/macroText/displayName/etc.
+-- When the slot has no macro reference, inline fields are stored as-is (custom slots).
+-- This is exposed on M so external writers (macropalette, migrations) can reuse it.
+function M.BuildSlotDataForWrite(slotData)
+    if not slotData then return nil; end
+
+    local macroRef = slotData.macroRef or slotData.id;
+    if macroRef then
+        return {
+            macroRef = macroRef,
+            macroPaletteKey = slotData.macroPaletteKey,
+        };
+    end
+
+    return {
+        actionType = slotData.actionType,
+        action = slotData.action,
+        target = slotData.target,
+        displayName = slotData.displayName,
+        equipSlot = slotData.equipSlot,
+        macroText = slotData.macroText,
+        itemId = slotData.itemId,
+        customIconType = slotData.customIconType,
+        customIconId = slotData.customIconId,
+        customIconPath = slotData.customIconPath,
+        recastSourceType = slotData.recastSourceType,
+        recastSourceAction = slotData.recastSourceAction,
+        recastSourceItemId = slotData.recastSourceItemId,
+    };
 end
 
 -- Set slot data for a crossbar slot
@@ -881,26 +955,7 @@ function M.SetCrossbarSlotData(comboMode, slotIndex, slotData)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
     local comboSlots = ensureCrossbarSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
 
-    -- Store the slot data
-    -- Use macroRef if present (from slot swap), otherwise use id (from macro palette drop)
-    comboSlots[slotIndex] = {
-        actionType = slotData.actionType,
-        action = slotData.action,
-        target = slotData.target,
-        displayName = slotData.displayName,
-        equipSlot = slotData.equipSlot,
-        macroText = slotData.macroText,
-        itemId = slotData.itemId,
-        customIconType = slotData.customIconType,
-        customIconId = slotData.customIconId,
-        customIconPath = slotData.customIconPath,
-        macroRef = slotData.macroRef or slotData.id,  -- Store reference to source macro for live updates
-        macroPaletteKey = slotData.macroPaletteKey,  -- Store which palette the macro came from
-        -- Recast source override (for macros showing cooldown from different action)
-        recastSourceType = slotData.recastSourceType,
-        recastSourceAction = slotData.recastSourceAction,
-        recastSourceItemId = slotData.recastSourceItemId,
-    };
+    comboSlots[slotIndex] = M.BuildSlotDataForWrite(slotData);
 
     NotifySlotDataChanged();
 end
@@ -959,24 +1014,7 @@ function M.SetSlotData(barIndex, slotIndex, slotData)
     local jobSlotActions = ensureSlotActionsStructure(barSettings, storageKey);
 
     if slotData then
-        jobSlotActions[slotIndex] = {
-            actionType = slotData.actionType,
-            action = slotData.action,
-            target = slotData.target,
-            displayName = slotData.displayName,
-            equipSlot = slotData.equipSlot,
-            macroText = slotData.macroText,
-            itemId = slotData.itemId,
-            customIconType = slotData.customIconType,
-            customIconId = slotData.customIconId,
-            customIconPath = slotData.customIconPath,
-            macroRef = slotData.macroRef or slotData.id,
-            macroPaletteKey = slotData.macroPaletteKey,  -- Store which palette the macro came from
-            -- Recast source override (for macros showing cooldown from different action)
-            recastSourceType = slotData.recastSourceType,
-            recastSourceAction = slotData.recastSourceAction,
-            recastSourceItemId = slotData.recastSourceItemId,
-        };
+        jobSlotActions[slotIndex] = M.BuildSlotDataForWrite(slotData);
     else
         -- Mark as explicitly cleared
         jobSlotActions[slotIndex] = { cleared = true };

--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -1234,6 +1234,9 @@ end
 
 -- Start dragging from a hotbar slot
 function M.StartDragSlot(barIndex, slotIndex, slotData)
+    -- Empty/orphaned slot - nothing to drag
+    if not slotData then return; end
+
     -- Get icon for this slot
     local icon = actions.GetBindIcon(slotData);
 
@@ -1296,25 +1299,14 @@ function M.HandleDropOnSlot(payload, targetBarIndex, targetSlotIndex)
     local jobSlotActions = ensureSlotActionsStructure(gConfig[configKey], storageKey);
 
     if payload.type == 'macro' then
-        -- Dragging from palette to slot
+        -- Dragging from palette to slot - store only the macro reference.
+        -- macroDB is the single source of truth for action/macroText/displayName/etc.
         local macroData = payload.data;
         if macroData then
-            -- Get the current macro palette key to store with the reference
-            local macroPaletteKey = GetEffectivePaletteType();
-            jobSlotActions[targetSlotIndex] = {
-                actionType = macroData.actionType,
-                action = macroData.action,
-                target = macroData.target,
-                displayName = macroData.displayName,
-                equipSlot = macroData.equipSlot,
-                macroText = macroData.macroText,
-                itemId = macroData.itemId,  -- Store item ID for fast icon lookup
-                customIconType = macroData.customIconType,  -- Custom icon override
-                customIconId = macroData.customIconId,
-                customIconPath = macroData.customIconPath,  -- Custom icon path for 'custom' type
-                macroRef = macroData.id,  -- Store reference to source macro for live updates
-                macroPaletteKey = macroPaletteKey,  -- Store which palette the macro came from
-            };
+            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite({
+                macroRef = macroData.id,
+                macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType(),
+            });
             MarkHotbarDirty();
         end
 
@@ -1324,44 +1316,13 @@ function M.HandleDropOnSlot(payload, targetBarIndex, targetSlotIndex)
         local sourceSlotIndex = payload.slotIndex;
         local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
 
-        -- Use the source data from payload (already contains the action info)
-        local sourceBindData = payload.data;
-        local sourceData = nil;
-        if sourceBindData then
-            sourceData = {
-                actionType = sourceBindData.actionType,
-                action = sourceBindData.action,
-                target = sourceBindData.target,
-                displayName = sourceBindData.displayName or sourceBindData.action,
-                equipSlot = sourceBindData.equipSlot,
-                macroText = sourceBindData.macroText,
-                itemId = sourceBindData.itemId,  -- Preserve item ID for icon lookup
-                customIconType = sourceBindData.customIconType,  -- Preserve custom icon
-                customIconId = sourceBindData.customIconId,
-                customIconPath = sourceBindData.customIconPath,  -- Preserve custom icon path
-                macroRef = sourceBindData.macroRef,  -- Preserve macro reference
-                macroPaletteKey = sourceBindData.macroPaletteKey,  -- Preserve palette key
-            };
-        end
+        local sourceData = data.BuildSlotDataForWrite(payload.data);
 
         -- Get target slot data
         local targetBind = data.GetKeybindForSlot(targetBarIndex, targetSlotIndex);
-        local targetData = nil;
+        local targetData;
         if targetBind then
-            targetData = {
-                actionType = targetBind.actionType,
-                action = targetBind.action,
-                target = targetBind.target,
-                displayName = targetBind.displayName or targetBind.action,
-                equipSlot = targetBind.equipSlot,
-                macroText = targetBind.macroText,
-                itemId = targetBind.itemId,  -- Preserve item ID for icon lookup
-                customIconType = targetBind.customIconType,  -- Preserve custom icon
-                customIconId = targetBind.customIconId,
-                customIconPath = targetBind.customIconPath,  -- Preserve custom icon path
-                macroRef = targetBind.macroRef,  -- Preserve macro reference
-                macroPaletteKey = targetBind.macroPaletteKey,  -- Preserve palette key
-            };
+            targetData = data.BuildSlotDataForWrite(targetBind);
         else
             -- Target slot is empty - mark as cleared
             targetData = { cleared = true };
@@ -1383,22 +1344,8 @@ function M.HandleDropOnSlot(payload, targetBarIndex, targetSlotIndex)
 
     elseif payload.type == 'crossbar_slot' then
         -- Dragging from crossbar to hotbar (one-way copy, doesn't clear source)
-        local sourceBindData = payload.data;
-        if sourceBindData then
-            jobSlotActions[targetSlotIndex] = {
-                actionType = sourceBindData.actionType,
-                action = sourceBindData.action,
-                target = sourceBindData.target,
-                displayName = sourceBindData.displayName or sourceBindData.action,
-                equipSlot = sourceBindData.equipSlot,
-                macroText = sourceBindData.macroText,
-                itemId = sourceBindData.itemId,
-                customIconType = sourceBindData.customIconType,
-                customIconId = sourceBindData.customIconId,
-                customIconPath = sourceBindData.customIconPath,  -- Preserve custom icon path
-                macroRef = sourceBindData.macroRef,  -- Preserve macro reference
-                macroPaletteKey = sourceBindData.macroPaletteKey,  -- Preserve palette key
-            };
+        if payload.data then
+            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite(payload.data);
             MarkHotbarDirty();
         end
     end


### PR DESCRIPTION
## Macro deduplication

Slot data was being written four times: once on `macroDB`, again on `hotbarBarN.slotActions`, and a second copy of each as `macroText`. Edits to a macro in `macroDB` would silently drift from the cached copies on slots, leading to "the icon updated but the slot still casts the old version" bugs.

### Fix

`macroDB` is now the single source of truth.

- Slots referencing a macro are persisted as `{ macroRef, macroPaletteKey }` only.
- `GetKeybindForSlot` / `GetCrossbarSlotData` read action/macroText/icon/target/displayName live from `macroDB`. Any cached inline fields on a slot are ignored.
- New `BuildSlotDataForWrite` is used by every write path (`SetSlotData`, `SetCrossbarSlotData`, `HandleDropOnSlot`, `ImportHotbarBinding`, `ImportCrossbarBinding`) so duplicates can't be re-introduced.
- A new migration (`MigrateSlotMacroRefs`) runs on every load, fills in any missing `macroPaletteKey` from `macroDB`, and strips the duplicated fields from existing profiles. Idempotent.

### Backward compatibility

Forward and backward compatible:

- Older versions also do the `macroDB` lookup when `macroRef` is set, so a deduplicated profile loads correctly on older XIUI.
- If the user edits a slot on an older version after migrating, the inline fields come back; the next load on the new version strips them again. No data loss.

### Character-swap cache fix

The `macroIdLookup` and `storageKeyCache` module-level caches in `hotbar/data.lua` are now invalidated by **identity** of `gConfig` / `gConfig.macroDB`, not just on explicit dirty flags. Switching characters reassigns `gConfig`, so the caches now rebuild automatically and a new character no longer sees the previous character's globals.