### PR TITLE
Add stack counts option

### DIFF
--- a/XIUI/config/hotbar.lua
+++ b/XIUI/config/hotbar.lua
@@ -1569,6 +1569,10 @@ local function DrawVisualSettingsContent(settings, configKey)
         end
         imgui.ShowHelp('Display item quantity on item slots. Choose anchor position and fine-tune with X/Y offsets.');
 
+        -- Show full-stack count above the item quantity (only counts complete stacks)
+        components.DrawPartyCheckbox(settings, 'Show Stack Quantity##' .. configKey, 'showStackQuantity');
+        imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
+
         -- Show Action Labels with offsets
         components.DrawPartyCheckbox(settings, 'Show Action Labels##' .. configKey, 'showActionLabels');
         if settings.showActionLabels then
@@ -2250,6 +2254,10 @@ local function DrawCrossbarSettings(selectedCrossbarTab)
                     components.DrawInlineOffsets(crossbarSettings, 'crossbarqty', 'quantityOffsetX', 'quantityOffsetY', 35);
                 end
                 imgui.ShowHelp('Display item quantity on item slots. X/Y offsets adjust position.');
+
+                -- Show full-stack count above the item quantity (only counts complete stacks)
+                components.DrawPartyCheckbox(crossbarSettings, 'Show Stack Quantity##crossbar', 'showStackQuantity');
+                imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
 
                 -- Show Combo Text with X/Y offsets
                 components.DrawPartyCheckbox(crossbarSettings, 'Show Combo Text##crossbar', 'showComboText');

--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -337,6 +337,7 @@ function M.createHotbarGlobalDefaults()
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
+        showStackQuantity = false,
         quantityAnchor = 'bottomRight',
         quantityOffsetX = 0,
         quantityOffsetY = 0,
@@ -423,6 +424,7 @@ function M.createHotbarBarDefaults(overrides)
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
+        showStackQuantity = false,
         quantityAnchor = 'bottomRight',
         quantityOffsetX = 0,
         quantityOffsetY = 0,
@@ -530,6 +532,7 @@ function M.createCrossbarDefaults()
 
         -- Item quantity display
         showQuantity = true,                -- Show item quantity on item slots
+        showStackQuantity = false,          -- Show full-stack count above the item quantity
         quantityFontSize = 10,              -- Font size for item quantity
         quantityFontColor = 0xFFFFFFFF,     -- Item quantity text color
         quantityOffsetX = 0,                -- X offset for quantity position

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -714,6 +714,7 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.mpCostOffsetX = settings.mpCostOffsetX or 0;
     p.mpCostOffsetY = settings.mpCostOffsetY or 0;
     p.showQuantity = settings.showQuantity ~= false;
+    p.showStackQuantity = settings.showStackQuantity == true;
     p.quantityFontSize = settings.quantityFontSize or 10;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
     p.quantityOffsetX = settings.quantityOffsetX or 0;

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -311,6 +311,7 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
     p.mpCostOffsetX = barSettings and barSettings.mpCostOffsetX or 0;
     p.mpCostOffsetY = barSettings and barSettings.mpCostOffsetY or 0;
     p.showQuantity = barSettings and barSettings.showQuantity ~= false;
+    p.showStackQuantity = barSettings and barSettings.showStackQuantity == true;
     p.quantityFontSize = barSettings and barSettings.quantityFontSize or 10;
     p.quantityFontColor = barSettings and barSettings.quantityFontColor or 0xFFFFFFFF;
     p.quantityAnchor = barSettings and barSettings.quantityAnchor or 'bottomRight';

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -48,6 +48,11 @@ local availabilityCache = {};
 local itemQuantityCache = {};
 local ITEM_QUANTITY_CACHE_TTL = 2.0;  -- Cache for 2 seconds (inventory doesn't change that often)
 
+-- Cache for item stack size lookups (keyed by itemId).
+-- Stack size is static resource data, so cache forever for the session.
+-- Stored value: number (StackSize) or false (lookup failed / not stackable).
+local stackSizeCache = {};
+
 -- Containers to search for item quantities
 local ITEM_CONTAINERS = { 0, 8, 10, 11, 12, 13, 14, 15, 16 };  -- Inventory, wardrobes, satchel, etc.
 
@@ -299,6 +304,27 @@ function M.GetItemQuantity(itemId, itemName)
     return result;
 end
 
+-- Get the stack size of an item (max items per stack).
+-- Returns nil if the item isn't stackable (StackSize <= 1) or can't be resolved.
+function M.GetItemStackSize(itemId)
+    if not itemId then return nil; end
+    local cached = stackSizeCache[itemId];
+    if cached ~= nil then
+        return cached or nil;  -- false sentinel -> nil
+    end
+
+    local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then return nil; end
+    local itemRes = resMgr:GetItemById(itemId);
+    local stackSize = itemRes and itemRes.StackSize;
+    if stackSize and stackSize > 1 then
+        stackSizeCache[itemId] = stackSize;
+        return stackSize;
+    end
+    stackSizeCache[itemId] = false;
+    return nil;
+end
+
 -- Get the ninja tool ID required for a ninjutsu spell
 -- @param spellName: The spell name (e.g., "Utsusemi: Ni", "Katon: San")
 -- @return: Tool item ID or nil if not a ninjutsu spell
@@ -377,6 +403,7 @@ function M.ClearAllCache()
     equipmentCheckCache = {};
     ninjutsuCache = {};
     itemQuantityCache = {};
+    stackSizeCache = {};
     ammoStatusCache = {};
     texturePtrCache = {};
 end
@@ -961,12 +988,28 @@ function M.DrawSlot(params)
             local qtyFontSize = params.quantityFontSize or 10;
             local qtyColor = quantity == 0 and 0xFFFF4444 or (params.quantityFontColor or 0xFFFFFFFF);
             local qtyAnchor = params.quantityAnchor or 'bottomRight';
+            local isRight = (qtyAnchor == 'topRight' or qtyAnchor == 'bottomRight');
+            local isTop = (qtyAnchor == 'topLeft' or qtyAnchor == 'topRight');
             local qtyX, qtyY = GetAnchoredPosition(x, y, size, qtyAnchor, params.quantityOffsetX, params.quantityOffsetY);
-            if qtyAnchor == 'topRight' or qtyAnchor == 'bottomRight' then
-                local w = imtext.Measure(qtyText, qtyFontSize);
-                qtyX = qtyX - w;
-            end
+            local qtyW = imtext.Measure(qtyText, qtyFontSize);
+            if isRight then qtyX = qtyX - qtyW; end
             imtext.DrawSimple(drawList, qtyText, qtyX, qtyY, qtyColor, qtyFontSize);
+
+            -- Optional: full-stack count, drawn just above (or below for top
+            -- anchors) the quantity text. Only shown for stackable items
+            -- with at least one full stack; ninjutsu tools are excluded.
+            if params.showStackQuantity and bind.actionType == 'item' and bind.itemId then
+                local stackSize = M.GetItemStackSize(bind.itemId);
+                local stacks = stackSize and math.floor(quantity / stackSize) or 0;
+                if stacks > 0 then
+                    local stackText = '(' .. stacks .. ')';
+                    local stackY = isTop and (qtyY + qtyFontSize + 1) or (qtyY - qtyFontSize - 1);
+                    local stackX = isRight
+                        and (qtyX + qtyW - imtext.Measure(stackText, qtyFontSize))
+                        or qtyX;
+                    imtext.DrawSimple(drawList, stackText, stackX, stackY, qtyColor, qtyFontSize);
+                end
+            end
         end
     end
 


### PR DESCRIPTION
## Show Stack Quantity

New per-bar / crossbar option in **Hotbar Settings**, sitting right below *Show Item Quantity*.

When enabled, item slots show the number of **full stacks** alongside the existing item count.

- Counts complete stacks only — partials are ignored
- Hidden when there isn't at least one full stack
- Skips unstackable items and ninjutsu tools
- Off by default; uses the same color/font/anchor as the existing quantity text

This is helpful for gathering/crafting when you want to make sure you have x amount of stacks.

<img width="116" height="71" alt="stacks" src="https://github.com/user-attachments/assets/289ee470-1336-4717-a49d-acf4d5fe3084" />

