### PR TITLE
hotbar: cut per-frame cost so XIUI + Metrics stays at 60 fps

### DIFF
--- a/XIUI/libs/imtext.lua
+++ b/XIUI/libs/imtext.lua
@@ -268,4 +268,32 @@ function M.DrawSimple(drawList, text, x, y, argbColor, fontSize)
     end
 end
 
+--- Draw text with a single drop-shadow (2 AddText calls vs Draw's 5).
+--- Used by hot per-frame paths (hotbar slots) where the full 4-cardinal
+--- outline is too expensive when stacked with another addon also issuing
+--- many ImGui primitives. Visually a bottom-right shadow; legibility on
+--- bright backgrounds is close to a full outline at a fraction of the cost.
+function M.DrawShadow(drawList, text, x, y, argbColor, fontSize)
+    if not drawList or not text or text == '' then return; end
+    if fontSize then fontSize = fontSize + GDI_SIZE_OFFSET; end
+    local font = M.GetFont();
+    local col = argbToU32(argbColor);
+    local ow = outlineWidth;
+    if ow > 0 then
+        local shadowCol = getOutlineCol();
+        pos[1] = x + ow; pos[2] = y + ow;
+        if fontSize and font then
+            drawList:AddText(font, fontSize, pos, shadowCol, text);
+        else
+            drawList:AddText(pos, shadowCol, text);
+        end
+    end
+    pos[1] = x; pos[2] = y;
+    if fontSize and font then
+        drawList:AddText(font, fontSize, pos, col, text);
+    else
+        drawList:AddText(pos, col, text);
+    end
+end
+
 return M;

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -1019,9 +1019,6 @@ end
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
 
-    -- Update recast timers once per frame
-    recast.Update();
-
     local slotSize = settings.slotSize or 48;
     local slotGapV = settings.slotGapV or 4;
     local slotGapH = settings.slotGapH or 4;

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -566,9 +566,6 @@ end
 function M.DrawWindow(settings)
     -- Note: dragdrop.Update() is called from init.lua before this
 
-    -- Update recast timers once per frame
-    recast.Update();
-
     -- Initialize textures on first draw
     if not texturesInitialized then
         textures:Initialize();

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -75,6 +75,28 @@ M.visible = true;
 -- Track hotbar enable/disable state for transitions
 local wasHotbarEnabled = nil;
 
+-- True if any hotbar bar or crossbar combo-mode has petAware enabled.
+-- Used to short-circuit the pet-change callback's cache wipes when no
+-- bar would actually rebind its slots in response.
+local function AnyBarIsPetAware()
+    for barIndex = 1, data.NUM_BARS do
+        local barSettings = data.GetBarSettings(barIndex);
+        if barSettings and barSettings.petAware then
+            return true;
+        end
+    end
+    local crossbarConfig = gConfig and gConfig.hotbarCrossbar;
+    local modeSettings = crossbarConfig and crossbarConfig.comboModeSettings;
+    if modeSettings then
+        for _, mode in pairs(modeSettings) do
+            if mode and mode.petAware then
+                return true;
+            end
+        end
+    end
+    return false;
+end
+
 -- ============================================
 -- Module Lifecycle
 -- ============================================
@@ -127,10 +149,23 @@ function M.Initialize(settings)
     -- Initialize display layer
     display.Initialize(settings);
 
-    -- Register pet change callback to clear slot caches
+    -- Register pet change callback to clear slot caches.
+    --
+    -- The wipes here are global (every hotbar slot, every crossbar slot,
+    -- macro palette pet commands). They're only meaningful for bars that
+    -- actually swap content on pet change — i.e. bars with petAware set.
+    -- If nothing on screen consumes pet state, summoning/releasing a pet
+    -- has no visible effect, and rebuilding every cache afterwards is pure
+    -- waste. The cost shows up most when another addon is also reacting
+    -- to combat traffic and the frame budget is tight.
     petpalette.OnPetChanged(function(oldPetKey, newPetKey)
-        -- Invalidate storage key cache (pet change affects storage keys)
+        -- Storage key cache is cheap to flip and is the only invalidation
+        -- whose absence could leave a bar showing pet-keyed slots after the
+        -- user toggled petAware off mid-pet. Always run it.
         data.InvalidateStorageKeyCache();
+
+        if not AnyBarIsPetAware() then return; end
+
         -- Clear ALL caches when pet changes to force full refresh
         slotrenderer.ClearAllCache();
         display.ClearIconCache();

--- a/XIUI/modules/hotbar/recast.lua
+++ b/XIUI/modules/hotbar/recast.lua
@@ -52,12 +52,14 @@ function M.GetPetCommandRecast(timerId)
     return abilityRecast.GetAbilityRecastSeconds(timerId);
 end
 
--- Cached spell recasts (refreshed periodically)
--- Key: spellId, Value: remaining seconds
+-- Cached spell recasts. Populated lazily by GetSpellRecast — only spell IDs
+-- actually queried during a frame get a memory hit. Previously this was a
+-- 1025-id scan every 50ms; with another action-heavy addon loaded that
+-- baseline ate frame budget that didn't need to be spent.
+-- Key: spellId, Value: remaining seconds (entry absent => 0).
 M.spellRecasts = {};
-
--- Frame tracking to prevent multiple updates per frame
-M.lastUpdateTime = 0;
+local spellRecastExpiry = {};      -- spellId -> os.clock() at which entry is stale
+local SPELL_RECAST_TTL = 0.05;     -- 20 Hz refresh, matches old prescan cadence
 
 -- Reusable result table for GetCooldownInfo to avoid GC pressure
 -- (Creating ~7200 tables/sec with 120 slots @ 60fps causes periodic GC hitches)
@@ -70,38 +72,26 @@ local cooldownResult = {
     itemId = nil,
 };
 
--- Update all spell recasts (call once per frame in DrawWindow)
-function M.Update()
-    local currentTime = os.clock();
-    -- Only update every 0.05 seconds (20 times per second)
-    if currentTime - M.lastUpdateTime < 0.05 then
-        return;
-    end
-    M.lastUpdateTime = currentTime;
-
-    -- Get spell recasts from Ashita memory
-    local recastMgr = AshitaCore:GetMemoryManager():GetRecast();
-    if not recastMgr then return; end
-
-    -- Clear table instead of replacing to avoid GC pressure
-    for k in pairs(M.spellRecasts) do
-        M.spellRecasts[k] = nil;
-    end
-
-    -- Scan spell recast timers (0-1024 covers all spells)
-    for spellId = 0, 1024 do
-        local timer = recastMgr:GetSpellTimer(spellId);
-        if timer and timer > 0 then
-            -- Timer is in 1/60th seconds, convert to seconds
-            M.spellRecasts[spellId] = timer / 60;
-        end
-    end
-end
-
--- Get spell recast by ID
--- Returns: remaining seconds, or 0 if ready
+-- Get spell recast by ID. Fetches from Ashita memory on cache miss / expiry,
+-- otherwise reuses the last value. TTL matches the old prescan interval so
+-- visible cooldown text refreshes at the same rate.
+-- Returns: remaining seconds, or 0 if ready.
 function M.GetSpellRecast(spellId)
     if not spellId then return 0; end
+    local now = os.clock();
+    local exp = spellRecastExpiry[spellId];
+    if exp and now < exp then
+        return M.spellRecasts[spellId] or 0;
+    end
+    local recastMgr = AshitaCore:GetMemoryManager():GetRecast();
+    if not recastMgr then return M.spellRecasts[spellId] or 0; end
+    local timer = recastMgr:GetSpellTimer(spellId);
+    if timer and timer > 0 then
+        M.spellRecasts[spellId] = timer / 60;
+    else
+        M.spellRecasts[spellId] = nil;
+    end
+    spellRecastExpiry[spellId] = now + SPELL_RECAST_TTL;
     return M.spellRecasts[spellId] or 0;
 end
 

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -828,7 +828,7 @@ function M.DrawSlot(params)
         -- Center position
         local abbrX = x + (size - abbrW) / 2;
         local abbrY = y + size / 2 - 6;
-        imtext.Draw(drawList, abbr, abbrX, abbrY, abbrColor, 12);
+        imtext.DrawShadow(drawList, abbr, abbrX, abbrY, abbrColor, 12);
     end
 
     -- ========================================
@@ -849,7 +849,7 @@ function M.DrawSlot(params)
         local timerW = imtext.Measure(recastText, timerFontSize);
         local timerX = x + (size - timerW) / 2;
         local timerY = y + size / 2 - 6;
-        imtext.Draw(drawList, recastText, timerX, timerY, timerColor, timerFontSize);
+        imtext.DrawShadow(drawList, recastText, timerX, timerY, timerColor, timerFontSize);
     end
 
     -- ========================================
@@ -884,7 +884,7 @@ function M.DrawSlot(params)
         local lblW = imtext.Measure(params.labelText, lblFontSize);
         local labelX = x + (size - lblW) / 2 + (params.labelOffsetX or 0);
         local labelY = y + size + 2 + (params.labelOffsetY or 0);
-        imtext.Draw(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
+        imtext.DrawShadow(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
     end
 
     -- ========================================


### PR DESCRIPTION
## Summary

Users reported FPS drops when XIUI runs alongside the [Metrics](https://github.com/RaraProjects/metrics) addon. Either alone is fine; together, weaker machines miss the frame budget. Disabling the XIUI hotbar restored 60 fps even with Metrics loaded.

Ashita v4 runs each addon in its own `lua_State`, so Lua GC / globals don't collide between addons. What's shared is the d3d8 device, the ImGui draw pass, and the game thread (Metrics does synchronous work in `packet_in` on every action packet). The hotbar was XIUI's largest per-frame draw-command contributor; once you add Metrics' table windows on top, the combined cost crosses the budget.

Three fixes targeting hotbar hot paths:

- **`imtext.DrawShadow` (2 `AddText`)** replaces the 5-pass cross outline on the hot per-slot text paths: abbreviation, recast timer, slot label. A fully-labeled hotbar drops from ~360 to ~144 label `AddText`/frame. Visual change: bottom-right drop shadow instead of 4-cardinal outline. Tooltips and crossbar combo text are not hot and keep the full outline.
- **Recast scan removed.** `recast.Update` is gone. `GetSpellRecast` now fetches lazily per spell with a 50 ms TTL, so a bar with ~20 bound spells issues ~400 `GetSpellTimer` calls/sec instead of scanning all 1025 spell IDs at 20 Hz.
- **Pet-change callback gated.** Skips the global cache wipes (`slotrenderer.ClearAllCache`, `display.ClearIconCache`, `actions.ClearNoIconCache`, `crossbar.ClearIconCache`, `macropalette.ClearPetCommandsCache`) when no hotbar bar or crossbar combo mode has `petAware` enabled. The cheap `data.InvalidateStorageKeyCache` flag flip still runs unconditionally so toggling `petAware` off mid-pet still reverts cleanly on the next pet event.

## Test plan

- [ ] Combat with full hotbar + Metrics loaded — FPS holds at the cap
- [ ] Slot text still readable (label, abbreviation when no icon resolves, recast countdown)
- [ ] Spells on cooldown count down smoothly
- [ ] SMN/BST pet summon/release with `petAware` enabled — bar rebinds to the new pet's slots
- [ ] SMN/BST pet summon/release with `petAware` disabled — no rebind, no FPS hitch
- [ ] Toggle `petAware` off while a pet is out, release pet — bar reverts to non-pet bindings