### PR TITLE
Fix font and scale issues

### DIFF
--- a/XIUI/libs/statusicons.lua
+++ b/XIUI/libs/statusicons.lua
@@ -264,7 +264,11 @@ function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOf
                 imgui.Image(icon, { iconSize, iconSize }, { 0, 0 }, { 1, 1 });
                 if buffTimes ~= nil and buffTimes[i] ~= nil then
                     local font_base = settings or debuff_font_settings;
-                    imtext.SetConfig(gConfig.fontFamily, bit.band(font_base.font_flags or 0, 1) ~= 0, font_base.outline_width or 2);
+                    -- When no explicit font settings are provided (target bar buffs, pet bar buffs)
+                    -- honor the global Font Outline slider so timer text matches the rest of the UI.
+                    local outlineW = (not settings and gConfig and gConfig.fontOutlineWidth)
+                        or font_base.outline_width or 2;
+                    imtext.SetConfig(gConfig.fontFamily, bit.band(font_base.font_flags or 0, 1) ~= 0, outlineW);
                     local textPosX = iconPosX + iconSize / 2;
                     local textPosY = iconPosY + iconSize;
                     local timerText = tostring(buffTimes[i]);

--- a/XIUI/modules/hotbar/actions.lua
+++ b/XIUI/modules/hotbar/actions.lua
@@ -409,6 +409,17 @@ end
 ---@return number|nil mpCost The MP cost, or nil if not applicable
 function M.GetMPCost(bind)
     if not bind then return nil; end
+
+    -- Macros with a magic recast source surface that spell's MP cost so the
+    -- slot shows the underlying spell's mana alongside its cooldown.
+    if bind.actionType == 'macro' and bind.recastSourceType == 'ma' and bind.recastSourceAction then
+        local spell = GetSpellByName(bind.recastSourceAction);
+        if spell and spell.mp_cost and spell.mp_cost > 0 then
+            return spell.mp_cost;
+        end
+        return nil;
+    end
+
     if bind.actionType ~= 'ma' then return nil; end
 
     local spell = GetSpellByName(bind.action);

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -341,11 +341,12 @@ end
 
 -- Calculate crossbar window dimensions based on settings
 local function GetCrossbarDimensions(settings)
-    local slotSize = settings.slotSize or 48;
-    local slotGapV = settings.slotGapV or 4;
-    local slotGapH = settings.slotGapH or 4;
-    local diamondSpacing = settings.diamondSpacing or 20;
-    local groupSpacing = settings.groupSpacing or 40;
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local slotSize = (settings.slotSize or 48) * gs;
+    local slotGapV = (settings.slotGapV or 4) * gs;
+    local slotGapH = (settings.slotGapH or 4) * gs;
+    local diamondSpacing = (settings.diamondSpacing or 20) * gs;
+    local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate group dimensions using layout functions
     local groupWidth, groupHeight = CalculateGroupDimensions(slotSize, slotGapV, slotGapH, diamondSpacing);
@@ -559,11 +560,12 @@ end
 
 -- Get slot position within the crossbar window
 local function GetSlotPositionInWindow(side, slotIndex, windowX, windowY, settings)
-    local slotSize = settings.slotSize or 48;
-    local slotGapV = settings.slotGapV or 4;
-    local slotGapH = settings.slotGapH or 4;
-    local diamondSpacing = settings.diamondSpacing or 20;
-    local groupSpacing = settings.groupSpacing or 40;
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local slotSize = (settings.slotSize or 48) * gs;
+    local slotGapV = (settings.slotGapV or 4) * gs;
+    local slotGapH = (settings.slotGapH or 4) * gs;
+    local diamondSpacing = (settings.diamondSpacing or 20) * gs;
+    local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate group width for positioning
     local groupWidth = CalculateGroupDimensions(slotSize, slotGapV, slotGapH, diamondSpacing);
@@ -691,6 +693,10 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     -- Get icon + cached abbreviation for this action (cached - only rebuilds when bind changes)
     local icon, cachedAbbr, cachedAbbrW = GetCachedCrossbarIcon(comboMode, slotIndex, slotData);
 
+    -- Global UI scale (slotSize/x/y come in already scaled; we apply gs here to
+    -- font sizes and pixel offsets that come straight from settings).
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+
     -- Update reusable params table in-place
     local p = cbParams;
     p.x = x;
@@ -708,23 +714,23 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.isPressed = isPressed and isActive;
     p.iconPressScale = iconPressScale;
     p.showMpCost = settings.showMpCost ~= false;
-    p.mpCostFontSize = settings.mpCostFontSize or 10;
+    p.mpCostFontSize = (settings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = settings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = settings.mpCostNoMpColor or 0xFFFF4444;
-    p.mpCostOffsetX = settings.mpCostOffsetX or 0;
-    p.mpCostOffsetY = settings.mpCostOffsetY or 0;
+    p.mpCostOffsetX = (settings.mpCostOffsetX or 0) * gs;
+    p.mpCostOffsetY = (settings.mpCostOffsetY or 0) * gs;
     p.showQuantity = settings.showQuantity ~= false;
     p.showStackQuantity = settings.showStackQuantity == true;
-    p.quantityFontSize = settings.quantityFontSize or 10;
+    p.quantityFontSize = (settings.quantityFontSize or 10) * gs;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
-    p.quantityOffsetX = settings.quantityOffsetX or 0;
-    p.quantityOffsetY = settings.quantityOffsetY or 0;
+    p.quantityOffsetX = (settings.quantityOffsetX or 0) * gs;
+    p.quantityOffsetY = (settings.quantityOffsetY or 0) * gs;
     p.showLabel = settings.showActionLabels or false;
     p.labelText = slotData and (slotData.displayName or slotData.action or '') or '';
-    p.labelOffsetX = settings.actionLabelOffsetX or 0;
-    p.labelOffsetY = (settings.actionLabelOffsetY or 0) + 2;
-    p.labelFontSize = settings.labelFontSize or 10;
-    p.recastTimerFontSize = settings.recastTimerFontSize or 11;
+    p.labelOffsetX = (settings.actionLabelOffsetX or 0) * gs;
+    p.labelOffsetY = ((settings.actionLabelOffsetY or 0) + 2) * gs;
+    p.labelFontSize = (settings.labelFontSize or 10) * gs;
+    p.recastTimerFontSize = (settings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = settings.recastTimerFontColor or 0xFFFFFFFF;
     p.flashCooldownUnder5 = settings.flashCooldownUnder5 or false;
     p.useHHMMCooldownFormat = settings.useHHMMCooldownFormat or false;
@@ -755,13 +761,14 @@ local function DrawDiamondCenterIconsImGui(diamondType, groupX, groupY, settings
     animOpacity = animOpacity or 1.0;
     if animOpacity <= 0.01 then return; end
 
-    local slotSize = settings.slotSize or 48;
-    local slotGapV = settings.slotGapV or 4;
-    local slotGapH = settings.slotGapH or 4;
-    local diamondSpacing = settings.diamondSpacing or 20;
-    local iconSize = settings.buttonIconSize or 24;
-    local iconGapH = settings.buttonIconGapH or 2;
-    local iconGapV = settings.buttonIconGapV or 2;
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local slotSize = (settings.slotSize or 48) * gs;
+    local slotGapV = (settings.slotGapV or 4) * gs;
+    local slotGapH = (settings.slotGapH or 4) * gs;
+    local diamondSpacing = (settings.diamondSpacing or 20) * gs;
+    local iconSize = (settings.buttonIconSize or 24) * gs;
+    local iconGapH = (settings.buttonIconGapH or 2) * gs;
+    local iconGapV = (settings.buttonIconGapV or 2) * gs;
     local controllerTheme = settings.controllerTheme or 'Xbox';
 
     -- Get diamond center position using layout calculation
@@ -909,10 +916,11 @@ local function DrawComboText(activeCombo, centerX, topY, settings)
 
     if not comboText then return; end
 
-    -- Get font size and offsets from settings
-    local fontSize = settings.comboTextFontSize or 10;
-    local offsetX = settings.comboTextOffsetX or 0;
-    local offsetY = settings.comboTextOffsetY or 0;
+    -- Get font size and offsets from settings (scaled by globalScale)
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local fontSize = (settings.comboTextFontSize or 10) * gs;
+    local offsetX = (settings.comboTextOffsetX or 0) * gs;
+    local offsetY = (settings.comboTextOffsetY or 0) * gs;
 
     -- Draw centered text via imtext
     local drawList = GetUIDrawList();
@@ -939,9 +947,10 @@ local function DrawPaletteName(centerX, bottomY, settings)
     local total = palette.GetCrossbarPaletteCount(jobId, subjobId) or 1;
 
     local displayText = string.format('%s (%d/%d)', paletteName, index, total);
-    local fontSize = settings.paletteNameFontSize or 10;
-    local offsetX = settings.paletteNameOffsetX or 0;
-    local offsetY = settings.paletteNameOffsetY or 0;
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local fontSize = (settings.paletteNameFontSize or 10) * gs;
+    local offsetX = (settings.paletteNameOffsetX or 0) * gs;
+    local offsetY = (settings.paletteNameOffsetY or 0) * gs;
 
     local drawList = GetUIDrawList();
     if drawList then
@@ -1020,11 +1029,12 @@ end
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
 
-    local slotSize = settings.slotSize or 48;
-    local slotGapV = settings.slotGapV or 4;
-    local slotGapH = settings.slotGapH or 4;
-    local diamondSpacing = settings.diamondSpacing or 20;
-    local groupSpacing = settings.groupSpacing or 40;
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local slotSize = (settings.slotSize or 48) * gs;
+    local slotGapV = (settings.slotGapV or 4) * gs;
+    local slotGapH = (settings.slotGapH or 4) * gs;
+    local diamondSpacing = (settings.diamondSpacing or 20) * gs;
+    local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate dimensions using layout functions
     local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -199,11 +199,12 @@ end
 -- Calculate bar dimensions using per-bar settings
 local function GetBarDimensions(barIndex)
     local barSettings = data.GetBarSettings(barIndex);
-    local slotSize = barSettings.slotSize or 32;
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local slotSize = (barSettings.slotSize or 32) * gs;
     -- Use per-bar slot padding settings
-    local slotGap = barSettings.slotXPadding or data.BUTTON_GAP;
-    local padding = data.PADDING;
-    local rowGap = barSettings.slotYPadding or data.ROW_GAP;
+    local slotGap = (barSettings.slotXPadding or data.BUTTON_GAP) * gs;
+    local padding = data.PADDING * gs;
+    local rowGap = (barSettings.slotYPadding or data.ROW_GAP) * gs;
 
     local layout = data.GetBarLayout(barIndex);
 
@@ -268,6 +269,11 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
     -- Get pre-created interaction closures and IDs
     local interaction = GetSlotInteraction(barIndex, slotIndex);
 
+    -- Global UI scale (applied to font sizes and pixel offsets that aren't
+    -- already pre-scaled via GetBarDimensions). Position/size args (x, y,
+    -- buttonSize) come in already scaled by the caller.
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+
     -- Update reusable params table in-place
     local p = slotParams;
     -- Position/Size
@@ -283,17 +289,17 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
     p.slotBgColor = barSettings and barSettings.slotBackgroundColor or 0xFFFFFFFF;
     p.slotOpacity = barSettings and barSettings.slotOpacity or 1.0;
     p.keybindText = (barSettings and barSettings.showKeybinds ~= false) and data.GetKeybindDisplay(barIndex, slotIndex) or nil;
-    p.keybindFontSize = barSettings and barSettings.keybindFontSize or 10;
+    p.keybindFontSize = (barSettings and barSettings.keybindFontSize or 10) * gs;
     p.keybindFontColor = barSettings and barSettings.keybindFontColor or 0xFFFFFFFF;
     p.keybindAnchor = barSettings and barSettings.keybindAnchor or 'topLeft';
-    p.keybindOffsetX = barSettings and barSettings.keybindOffsetX or 0;
-    p.keybindOffsetY = barSettings and barSettings.keybindOffsetY or 0;
+    p.keybindOffsetX = (barSettings and barSettings.keybindOffsetX or 0) * gs;
+    p.keybindOffsetY = (barSettings and barSettings.keybindOffsetY or 0) * gs;
     p.showLabel = barSettings and barSettings.showActionLabels or false;
     p.labelText = bind and (bind.displayName or bind.action or '') or '';
-    p.labelOffsetX = barSettings and barSettings.actionLabelOffsetX or 0;
-    p.labelOffsetY = (barSettings and barSettings.actionLabelOffsetY or 0) + data.LABEL_GAP;
-    p.labelFontSize = barSettings and barSettings.labelFontSize or 10;
-    p.recastTimerFontSize = barSettings and barSettings.recastTimerFontSize or 11;
+    p.labelOffsetX = (barSettings and barSettings.actionLabelOffsetX or 0) * gs;
+    p.labelOffsetY = ((barSettings and barSettings.actionLabelOffsetY or 0) + data.LABEL_GAP) * gs;
+    p.labelFontSize = (barSettings and barSettings.labelFontSize or 10) * gs;
+    p.recastTimerFontSize = (barSettings and barSettings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = barSettings and barSettings.recastTimerFontColor or 0xFFFFFFFF;
     p.flashCooldownUnder5 = barSettings and barSettings.flashCooldownUnder5 or false;
     p.useHHMMCooldownFormat = barSettings and barSettings.useHHMMCooldownFormat or false;
@@ -304,19 +310,19 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
     p.customFramePath = barSettings and barSettings.customFramePath or '';
     p.isPressed = (pressedHotbar == barIndex and pressedSlot == slotIndex);
     p.showMpCost = barSettings and barSettings.showMpCost ~= false;
-    p.mpCostFontSize = barSettings and barSettings.mpCostFontSize or 10;
+    p.mpCostFontSize = (barSettings and barSettings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = barSettings and barSettings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = barSettings and barSettings.labelNoMpColor or 0xFFFF4444;
     p.mpCostAnchor = barSettings and barSettings.mpCostAnchor or 'topRight';
-    p.mpCostOffsetX = barSettings and barSettings.mpCostOffsetX or 0;
-    p.mpCostOffsetY = barSettings and barSettings.mpCostOffsetY or 0;
+    p.mpCostOffsetX = (barSettings and barSettings.mpCostOffsetX or 0) * gs;
+    p.mpCostOffsetY = (barSettings and barSettings.mpCostOffsetY or 0) * gs;
     p.showQuantity = barSettings and barSettings.showQuantity ~= false;
     p.showStackQuantity = barSettings and barSettings.showStackQuantity == true;
-    p.quantityFontSize = barSettings and barSettings.quantityFontSize or 10;
+    p.quantityFontSize = (barSettings and barSettings.quantityFontSize or 10) * gs;
     p.quantityFontColor = barSettings and barSettings.quantityFontColor or 0xFFFFFFFF;
     p.quantityAnchor = barSettings and barSettings.quantityAnchor or 'bottomRight';
-    p.quantityOffsetX = barSettings and barSettings.quantityOffsetX or 0;
-    p.quantityOffsetY = barSettings and barSettings.quantityOffsetY or 0;
+    p.quantityOffsetX = (barSettings and barSettings.quantityOffsetX or 0) * gs;
+    p.quantityOffsetY = (barSettings and barSettings.quantityOffsetY or 0) * gs;
     -- Interaction Config
     p.buttonId = interaction.buttonId;
     p.dropZoneId = interaction.dropZoneId;
@@ -433,7 +439,8 @@ local function DrawBarWindow(barIndex, settings)
         end
 
         -- Draw slots based on layout (rows x columns)
-        local padding = data.PADDING;
+        local gs = (gConfig and gConfig.globalScale) or 1.0;
+        local padding = data.PADDING * gs;
         local slotCount = layout.slots;
         local slotIndex = 1;
 

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -703,10 +703,15 @@ function M.DrawSlot(params)
     local isOnCooldown = cooldown.isOnCooldown;
     local recastText = cooldown.recastText;
 
-    -- Check if player has enough MP for spells
+    -- Check if player has enough MP for spells (also includes macros whose
+    -- recast source is a spell — they show the source spell's MP cost).
     local notEnoughMp = false;
     local bindKey = bind and ((bind.actionType or '') .. ':' .. (bind.action or '')) or '';
-    if bind and bind.actionType == 'ma' then
+    local hasMpCost = bind and (
+        bind.actionType == 'ma'
+        or (bind.actionType == 'macro' and bind.recastSourceType == 'ma' and bind.recastSourceAction)
+    );
+    if hasMpCost then
         local mpCost = mpCostCache[bindKey];
         if mpCost == nil then
             mpCost = actions.GetMPCost(bind) or false;

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -891,7 +891,7 @@ function M.DrawSlot(params)
             local kbW = imtext.Measure(params.keybindText, kbFontSize);
             kbX = kbX - kbW;
         end
-        imtext.DrawSimple(drawList, params.keybindText, kbX, kbY, kbColor, kbFontSize);
+        imtext.Draw(drawList, params.keybindText, kbX, kbY, kbColor, kbFontSize);
     end
 
     -- ========================================
@@ -911,7 +911,7 @@ function M.DrawSlot(params)
         local lblW = imtext.Measure(params.labelText, lblFontSize);
         local labelX = x + (size - lblW) / 2 + (params.labelOffsetX or 0);
         local labelY = y + size + 2 + (params.labelOffsetY or 0);
-        imtext.DrawShadow(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
+        imtext.Draw(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
     end
 
     -- ========================================
@@ -933,7 +933,7 @@ function M.DrawSlot(params)
                     local w = imtext.Measure(xText, mpFontSize);
                     mpX = mpX - w;
                 end
-                imtext.DrawSimple(drawList, xText, mpX, mpY, xColor, mpFontSize);
+                imtext.Draw(drawList, xText, mpX, mpY, xColor, mpFontSize);
             else
                 local mpCost = mpCostCache[bindKey];
                 if mpCost == nil then
@@ -950,7 +950,7 @@ function M.DrawSlot(params)
                         local w = imtext.Measure(mpText, mpFontSize);
                         mpX = mpX - w;
                     end
-                    imtext.DrawSimple(drawList, mpText, mpX, mpY, mpCostColor, mpFontSize);
+                    imtext.Draw(drawList, mpText, mpX, mpY, mpCostColor, mpFontSize);
                 end
             end
         end
@@ -993,7 +993,7 @@ function M.DrawSlot(params)
             local qtyX, qtyY = GetAnchoredPosition(x, y, size, qtyAnchor, params.quantityOffsetX, params.quantityOffsetY);
             local qtyW = imtext.Measure(qtyText, qtyFontSize);
             if isRight then qtyX = qtyX - qtyW; end
-            imtext.DrawSimple(drawList, qtyText, qtyX, qtyY, qtyColor, qtyFontSize);
+            imtext.Draw(drawList, qtyText, qtyX, qtyY, qtyColor, qtyFontSize);
 
             -- Optional: full-stack count, drawn just above (or below for top
             -- anchors) the quantity text. Only shown for stackable items
@@ -1007,7 +1007,7 @@ function M.DrawSlot(params)
                     local stackX = isRight
                         and (qtyX + qtyW - imtext.Measure(stackText, qtyFontSize))
                         or qtyX;
-                    imtext.DrawSimple(drawList, stackText, stackX, stackY, qtyColor, qtyFontSize);
+                    imtext.Draw(drawList, stackText, stackX, stackY, qtyColor, qtyFontSize);
                 end
             end
         end

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -358,7 +358,7 @@ playerbar.DrawWindow = function(settings)
 			local tickerColor = gConfig.colorCustomization.playerBar.restingTickerColor or 0xFF00E6FF;
 			local tickerRGBA = ARGBToImGui(tickerColor);
 			local r, g, b, a = tickerRGBA[1], tickerRGBA[2], tickerRGBA[3], tickerRGBA[4];
-			imgui.GetWindowDrawList():AddRectFilledMultiColor(
+			drawList:AddRectFilledMultiColor(
 				{waveLeft, y1}, {waveRight, y2},
 				imgui.GetColorU32({r, g, b, 0.0}),
 				imgui.GetColorU32({r, g, b, a}),


### PR DESCRIPTION
### Fixes

- Hotbar text now respects the Font Outline slider (keybind, label, MP cost, item quantity, full-stack count) — matches the 4-cardinal outline used by player bar, target bar, etc.
- Status icon timers (target bar buffs / debuffs, pet bar buffs) now honor the global Font Outline width instead of a hardcoded value. Side effect: pet bar recast text picks up the correct outline too.
- Global UI Scale now actually scales the hotbar — window size, slot size, slot gaps, padding, font sizes, and per-slot text offsets.
- Global UI Scale now actually scales the crossbar — window size, slot/diamond layout, button icons, font sizes, slot text offsets, combo label, and palette name label.
- Background Scale now works on modules
- Resting ticker now has proper z-scale
- When using a macro with spell cooldown source also show that spell's mana cost

