### PR TITLE
fix: address tester feedback on outlines, scales, and borders

### DIFF
--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -690,10 +690,14 @@ config.DrawWindow = function(us)
             imgui.SetNextWindowPos({ 20, 20 }, ImGuiCond_Always);
         end
     end
-    if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
-        -- Per-window font scale so the config text grows with Global UI Scale
-        -- without affecting any other XIUI windows.
-        imgui.SetWindowFontScale(configScale);
+    local configVisible = imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking));
+    if configVisible then
+        -- SetWindowFontScale isn't part of Ashita's IGuiManager binding, so
+        -- feature-detect it. Without it the window dimensions still scale,
+        -- the font just stays at the default size on this Ashita build.
+        if imgui.SetWindowFontScale ~= nil then
+            pcall(imgui.SetWindowFontScale, configScale);
+        end
         local windowWidth = imgui.GetContentRegionAvail();
         local sidebarWidth = 180;
         local contentWidth = windowWidth - sidebarWidth - 20;

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -668,9 +668,12 @@ config.DrawWindow = function(us)
     -- Push theme styles AFTER validating DisplaySize to avoid leaking
     -- style/var pushes on early returns (which corrupt ImGui state).
     PushThemeStyles();
-    local maxW = math.min(900, sw - 40);
-    local maxH = math.min(650, sh - 40);
-    imgui.SetNextWindowSizeConstraints({ 400, 300 }, { sw, sh });
+    -- Global UI Scale extends to the config window: scale ideal/maximum size
+    -- (clamped to screen) and bump fonts via SetWindowFontScale below.
+    local configScale = math.max(0.5, gConfig.globalScale or 1.0);
+    local maxW = math.min(900 * configScale, sw - 40);
+    local maxH = math.min(650 * configScale, sh - 40);
+    imgui.SetNextWindowSizeConstraints({ 400 * configScale, 300 * configScale }, { sw, sh });
     -- On open: set ideal size for the current resolution and reset position if off-screen.
     if configJustOpened then
         if not configHasBeenOpened then
@@ -688,6 +691,9 @@ config.DrawWindow = function(us)
         end
     end
     if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
+        -- Per-window font scale so the config text grows with Global UI Scale
+        -- without affecting any other XIUI windows.
+        imgui.SetWindowFontScale(configScale);
         local windowWidth = imgui.GetContentRegionAvail();
         local sidebarWidth = 180;
         local contentWidth = windowWidth - sidebarWidth - 20;

--- a/XIUI/config/petbar.lua
+++ b/XIUI/config/petbar.lua
@@ -1213,6 +1213,10 @@ local function DrawPetTargetSettingsContent()
             DeferredUpdateVisuals();
         end);
         imgui.ShowHelp('Select the background window theme for pet target. Uses Pet Bar theme by default.');
+        components.DrawSlider('Background Scale##petTargetBg', 'petTargetBgScale', 0.1, 3.0, '%.2f');
+        imgui.ShowHelp('Scale of the background texture.');
+        components.DrawSlider('Border Scale##petTargetBg', 'petTargetBorderScale', 0.1, 3.0, '%.2f');
+        imgui.ShowHelp('Scale of the window borders (Window themes only).');
         components.DrawSlider('Background Opacity##petTargetBg', 'petTargetBackgroundOpacity', 0.0, 1.0, '%.2f');
         imgui.ShowHelp('Opacity of the background. Uses Pet Bar opacity by default.');
         components.DrawSlider('Border Opacity##petTargetBg', 'petTargetBorderOpacity', 0.0, 1.0, '%.2f');

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -775,6 +775,8 @@ function M.createUserSettingsDefaults()
         petBarHpDisplayMode = 'percent', -- 'percent', 'number'
         petBarTargetFontSize = 10,
         petTargetBackgroundTheme = nil,  -- Uses petBarBackgroundTheme by default
+        petTargetBgScale = 1.0,
+        petTargetBorderScale = 1.0,
         petTargetBackgroundOpacity = 1.0,
         petTargetBorderOpacity = 1.0,
         petTargetBarScaleX = 1.0,

--- a/XIUI/libs/imtext.lua
+++ b/XIUI/libs/imtext.lua
@@ -16,9 +16,10 @@ local imgui = require('imgui');
 
 local M = {};
 
--- GDI visual parity offsets (ImGui fonts render smaller than GDI at same size)
-local GDI_SIZE_OFFSET = 2;
-local GDI_OUTLINE_OFFSET = -1;
+-- ImGui fonts render visibly smaller than GDI at the same size; the +2
+-- compensates so existing font_height settings (carried over from the GDI
+-- era) keep matching their on-screen look. Outline width is taken literally.
+local SIZE_OFFSET = 2;
 
 -- Font cache: fontKey -> font handle (loaded once, reused across modules)
 local fontCache = {};
@@ -129,7 +130,7 @@ end
 --- @param ow number Outline width in pixels
 function M.SetConfig(fontFamily, isBold, ow)
     loadFont(fontFamily, isBold);
-    outlineWidth = math.max(0, (ow or 2) + GDI_OUTLINE_OFFSET);
+    outlineWidth = math.max(0, ow or 2);
 end
 
 --- Apply font settings from a font_settings table (as used by gAdjustedSettings).
@@ -181,7 +182,7 @@ end
 --- @return number width, number height
 function M.Measure(text, fontSize)
     if not text or text == '' then return 0, 0; end
-    if fontSize then fontSize = fontSize + GDI_SIZE_OFFSET; end
+    if fontSize then fontSize = fontSize + SIZE_OFFSET; end
 
     local font = activeFont;
     if font and fontSize then
@@ -214,7 +215,7 @@ end
 --- @param fontSize number|nil Pixel size (nil uses ImGui default)
 function M.Draw(drawList, text, x, y, argbColor, fontSize)
     if not drawList or not text or text == '' then return; end
-    if fontSize then fontSize = fontSize + GDI_SIZE_OFFSET; end
+    if fontSize then fontSize = fontSize + SIZE_OFFSET; end
     local font = M.GetFont();
     local col = argbToU32(argbColor);
     local ow = outlineWidth;
@@ -257,7 +258,7 @@ end
 --- @param fontSize number|nil
 function M.DrawSimple(drawList, text, x, y, argbColor, fontSize)
     if not drawList or not text or text == '' then return; end
-    if fontSize then fontSize = fontSize + GDI_SIZE_OFFSET; end
+    if fontSize then fontSize = fontSize + SIZE_OFFSET; end
     local font = M.GetFont();
     local col = argbToU32(argbColor);
     pos[1] = x; pos[2] = y;
@@ -275,7 +276,7 @@ end
 --- bright backgrounds is close to a full outline at a fraction of the cost.
 function M.DrawShadow(drawList, text, x, y, argbColor, fontSize)
     if not drawList or not text or text == '' then return; end
-    if fontSize then fontSize = fontSize + GDI_SIZE_OFFSET; end
+    if fontSize then fontSize = fontSize + SIZE_OFFSET; end
     local font = M.GetFont();
     local col = argbToU32(argbColor);
     local ow = outlineWidth;

--- a/XIUI/libs/progressbar.lua
+++ b/XIUI/libs/progressbar.lua
@@ -582,13 +582,13 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 	end
 
 	-- Draw the outer border wrapping the bar. Skipped at thickness 0.
-	-- Offset by the full thickness (not half) so AA bleed from the centered
-	-- stroke lands entirely outside the bar — half-thickness offset caused
-	-- the line to read as "inside the bar" because the AA tail crossed the
-	-- bar's edge pixels.
+	-- innerOffset = thickness/2 + 0.5 places ImGui's centered, anti-aliased
+	-- stroke so its inner AA fringe lands exactly at the bar's outer edge:
+	-- no gap to the bar (which `thickness` produced) and no AA bleed onto the
+	-- fill (which `thickness/2` produced).
 	local innerBorderThickness = gConfig.barBorderThickness or 2;
 	if innerBorderThickness > 0 then
-		local innerOffset = innerBorderThickness;
+		local innerOffset = innerBorderThickness / 2 + 0.5;
 		drawList:AddRect(
 			{positionStartX - innerOffset, positionStartY - innerOffset},
 			{positionStartX + width + innerOffset, positionStartY + height + innerOffset},
@@ -612,9 +612,9 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 			local middleOffset = innerOffset + innerBorderThickness;
 			borderExtent = middleOffset + middleBorderThickness / 2;
 		elseif innerBorderThickness > 0 then
-			-- innerOffset is now the full thickness (see border draw above) plus
-			-- half-thickness for the AA tail
-			borderExtent = innerBorderThickness * 1.5;
+			-- innerOffset is thickness/2 + 0.5 (centered stroke + AA fringe),
+			-- so the total extent past the bar edge is thickness + 1
+			borderExtent = innerBorderThickness + 1;
 		end
 		-- Add border extent to width/height to prevent right/bottom clipping
 		imgui.Dummy({width + borderExtent, height + borderExtent});

--- a/XIUI/libs/progressbar.lua
+++ b/XIUI/libs/progressbar.lua
@@ -420,18 +420,15 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 	rounding = options.decorate and progressbar.backgroundRounding or gConfig.noBookendRounding;
 	progressbar.DrawBar({contentPositionStartX, contentPositionStartY}, {contentPositionStartX + contentWidth, contentPositionStartY + height}, bgGradientStart, bgGradientEnd, rounding, nil, drawList);
 	
-	-- Compute the actual progress bar's width and height.
-	-- foregroundPadding leaves a band of bg color visible around the fill so the
-	-- thickness slider's outline has something to outline. When the user sets
-	-- thickness to 0 they want zero visible frame, so collapse the inset too.
-	local fgPadding = ((gConfig.barBorderThickness or 0) > 0) and progressbar.foregroundPadding or 0;
-	local paddingHalf = fgPadding / 2;
+	-- The fill matches the bg's footprint exactly so the bar's visible edge is
+	-- the bg edge. The Bar Border Thickness slider then draws an outline strictly
+	-- outside that edge — each pixel of thickness adds 1px of wrap, with 0 truly
+	-- meaning no frame.
+	local progressPositionStartX = contentPositionStartX;
+	local progressPositionStartY = contentPositionStartY;
 
-	local progressPositionStartX = contentPositionStartX + paddingHalf;
-	local progressPositionStartY = contentPositionStartY + paddingHalf;
-
-	local progressTotalWidth = contentWidth - fgPadding;
-	local progressHeight = height - fgPadding;
+	local progressTotalWidth = contentWidth;
+	local progressHeight = height;
 	
 	-- Draw the progress bar(s)
 	local progressOffset = 0;
@@ -584,10 +581,14 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 		);
 	end
 
-	-- Draw default inner background border - always drawn for all bars (unless thickness is 0)
+	-- Draw the outer border wrapping the bar. Skipped at thickness 0.
+	-- Offset by the full thickness (not half) so AA bleed from the centered
+	-- stroke lands entirely outside the bar — half-thickness offset caused
+	-- the line to read as "inside the bar" because the AA tail crossed the
+	-- bar's edge pixels.
 	local innerBorderThickness = gConfig.barBorderThickness or 2;
 	if innerBorderThickness > 0 then
-		local innerOffset = innerBorderThickness / 2;
+		local innerOffset = innerBorderThickness;
 		drawList:AddRect(
 			{positionStartX - innerOffset, positionStartY - innerOffset},
 			{positionStartX + width + innerOffset, positionStartY + height + innerOffset},
@@ -611,7 +612,9 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 			local middleOffset = innerOffset + innerBorderThickness;
 			borderExtent = middleOffset + middleBorderThickness / 2;
 		elseif innerBorderThickness > 0 then
-			borderExtent = innerBorderThickness / 2;
+			-- innerOffset is now the full thickness (see border draw above) plus
+			-- half-thickness for the AA tail
+			borderExtent = innerBorderThickness * 1.5;
 		end
 		-- Add border extent to width/height to prevent right/bottom clipping
 		imgui.Dummy({width + borderExtent, height + borderExtent});

--- a/XIUI/libs/progressbar.lua
+++ b/XIUI/libs/progressbar.lua
@@ -420,14 +420,18 @@ progressbar.ProgressBar  = function(percentList, dimensions, options)
 	rounding = options.decorate and progressbar.backgroundRounding or gConfig.noBookendRounding;
 	progressbar.DrawBar({contentPositionStartX, contentPositionStartY}, {contentPositionStartX + contentWidth, contentPositionStartY + height}, bgGradientStart, bgGradientEnd, rounding, nil, drawList);
 	
-	-- Compute the actual progress bar's width and height
-	local paddingHalf = progressbar.foregroundPadding / 2;
-	
+	-- Compute the actual progress bar's width and height.
+	-- foregroundPadding leaves a band of bg color visible around the fill so the
+	-- thickness slider's outline has something to outline. When the user sets
+	-- thickness to 0 they want zero visible frame, so collapse the inset too.
+	local fgPadding = ((gConfig.barBorderThickness or 0) > 0) and progressbar.foregroundPadding or 0;
+	local paddingHalf = fgPadding / 2;
+
 	local progressPositionStartX = contentPositionStartX + paddingHalf;
 	local progressPositionStartY = contentPositionStartY + paddingHalf;
-	
-	local progressTotalWidth = contentWidth - progressbar.foregroundPadding;
-	local progressHeight = height - progressbar.foregroundPadding;
+
+	local progressTotalWidth = contentWidth - fgPadding;
+	local progressHeight = height - fgPadding;
 	
 	-- Draw the progress bar(s)
 	local progressOffset = 0;

--- a/XIUI/libs/progressbar.lua
+++ b/XIUI/libs/progressbar.lua
@@ -16,7 +16,11 @@ local progressbar = {
 	backgroundRounding = 0,
 
 	-- Foreground
-	foregroundRounding = 3,
+	-- Rounding stays at 0 so the bookended fill's inner corners meet the
+	-- bookends' flat inner edges flush. A non-zero radius here would carve a
+	-- triangular notch out of the bar at each bookend boundary, visible as a
+	-- choppy edge once foregroundPadding stopped masking it.
+	foregroundRounding = 0,
 	foregroundPadding = 5,
 
 	-- Gradient texture cache (hash table for O(1) lookup)

--- a/XIUI/libs/windowbackground.lua
+++ b/XIUI/libs/windowbackground.lua
@@ -32,6 +32,14 @@ local DEFAULT_PADDING = 8;
 local DEFAULT_BORDER_SIZE = 21;
 local DEFAULT_BG_OFFSET = 1;
 
+-- The tl corner image is laid out as: 21x21 native corner artwork in the
+-- top-left, then a 21px-tall top arm and 21px-wide left arm extending out to
+-- 491x491. We split rendering into three UV-sliced pieces so the corner stays
+-- pixel-correct and the arms stretch only along their long axis.
+local SOURCE_CORNER_SIZE = 21;
+local SOURCE_FULL_SIZE = 491;
+local CORNER_UV = SOURCE_CORNER_SIZE / SOURCE_FULL_SIZE;
+
 -- ============================================
 -- Internal Helpers
 -- ============================================
@@ -100,6 +108,7 @@ function M.DrawBackground(drawList, x, y, w, h, options)
     local padding  = options.padding  or DEFAULT_PADDING;
     local paddingY = options.paddingY or padding;
     local bgColor  = options.bgColor  or 0xFFFFFFFF;
+    local bgScale  = options.bgScale  or 1.0;
 
     local bgX, bgY, bgW, bgH = ComputeBgRect(x, y, w, h, padding, paddingY);
 
@@ -107,7 +116,11 @@ function M.DrawBackground(drawList, x, y, w, h, options)
     if ptr == nil then return; end
 
     local tint = TintU32(ResolveTint(bgColor, options.bgOpacity));
-    drawList:AddImage(ptr, {bgX, bgY}, {bgX + bgW, bgY + bgH}, {0, 0}, {1, 1}, tint);
+    -- bgScale > 1 zooms in (less of the texture covers the same area), matching
+    -- the old primitive scale_x/y behavior. UVs are clamped at the sampler so
+    -- bgScale < 1 just shows edge pixels past UV=1 rather than tiling.
+    local uvMax = 1.0 / bgScale;
+    drawList:AddImage(ptr, {bgX, bgY}, {bgX + bgW, bgY + bgH}, {0, 0}, {uvMax, uvMax}, tint);
 end
 
 --[[
@@ -150,13 +163,42 @@ function M.DrawBorders(drawList, x, y, w, h, options)
         drawList:AddImage(trPtr, {trX, trY}, {trX + pieceSize, trY + trH}, {0, 0}, {1, 1}, tint);
     end
 
-    -- Top-left (L-shape: spans top edge to tr, and left edge down to bl)
+    -- Top-left: rendered as three UV-sliced pieces so the 21x21 source corner
+    -- and the 21px-thick arms keep their native proportions. Stretching the
+    -- whole 491x491 tl image into a smaller-than-source area used to compress
+    -- the top and left border lines, which testers saw as "squished" edges.
     local tlX = bgX - offset;
     local tlY = bgY - offset;
     local tlW = trX - tlX;
     local tlPtr = LoadPiecePtr(theme, 'tl');
     if tlPtr ~= nil then
-        drawList:AddImage(tlPtr, {tlX, tlY}, {tlX + tlW, tlY + trH}, {0, 0}, {1, 1}, tint);
+        -- Corner (top-left 21x21 of source -> pieceSize x pieceSize)
+        drawList:AddImage(
+            tlPtr,
+            {tlX, tlY}, {tlX + pieceSize, tlY + pieceSize},
+            {0, 0}, {CORNER_UV, CORNER_UV},
+            tint
+        );
+        -- Top arm: source spans right past the corner, stretched horizontally only
+        local armW = tlW - pieceSize;
+        if armW > 0 then
+            drawList:AddImage(
+                tlPtr,
+                {tlX + pieceSize, tlY}, {tlX + tlW, tlY + pieceSize},
+                {CORNER_UV, 0}, {1, CORNER_UV},
+                tint
+            );
+        end
+        -- Left arm: source spans down past the corner, stretched vertically only
+        local armH = trH - pieceSize;
+        if armH > 0 then
+            drawList:AddImage(
+                tlPtr,
+                {tlX, tlY + pieceSize}, {tlX + pieceSize, tlY + trH},
+                {0, CORNER_UV}, {CORNER_UV, 1},
+                tint
+            );
+        end
     end
 
     -- Bottom-left (spans bottom edge to br)
@@ -180,7 +222,8 @@ end
         theme         = string   -- '-None-' | 'Plain' | 'Window1'..'Window8'
         padding       = number   -- Horizontal pad (default 8)
         paddingY      = number   -- Vertical pad (defaults to padding)
-        bgScale       = number   -- Reserved for future use (default 1.0)
+        bgScale       = number   -- Zoom factor on the bg texture (UV scaling)
+                                  -- >1 zooms in, default 1.0
         borderScale   = number   -- Scales border piece size (default 1.0)
         bgOpacity     = number   -- Optional 0..1; overrides bgColor's alpha
         bgColor       = number   -- ARGB tint (default 0xFFFFFFFF)

--- a/XIUI/modules/notifications/display.lua
+++ b/XIUI/modules/notifications/display.lua
@@ -787,10 +787,16 @@ local function drawNotificationWindow(windowName, notifications, settings, split
                     });
                 end
 
-                -- Draw placeholder text
+                -- Draw placeholder text, truncated to fit the placeholder width
                 if drawList then
-                    imtext.Draw(drawList, placeholderTitle or 'Notification Area', windowPosX + placeholderPadding, windowPosY + placeholderPadding, 0xFFFFFFFF, titleHeight);
-                    imtext.Draw(drawList, placeholderSubtitle or 'Drag to reposition', windowPosX + placeholderPadding, windowPosY + placeholderPadding + titleHeight + 2 * gs, 0xFFCCCCCC, subtitleHeight);
+                    local placeholderMaxTextWidth = math.max(1, notificationWidth - 2 * placeholderPadding);
+                    local title = placeholderTitle or 'Notification Area';
+                    local subtitle = placeholderSubtitle or 'Drag to reposition';
+                    local placeholderKey = (splitKey or 'split') .. '_placeholder';
+                    local displayTitle = GetTruncatedText(title, placeholderMaxTextWidth, titleHeight, placeholderKey .. '_title');
+                    local displaySubtitle = GetTruncatedText(subtitle, placeholderMaxTextWidth, subtitleHeight, placeholderKey .. '_subtitle');
+                    imtext.Draw(drawList, displayTitle, windowPosX + placeholderPadding, windowPosY + placeholderPadding, 0xFFFFFFFF, titleHeight);
+                    imtext.Draw(drawList, displaySubtitle, windowPosX + placeholderPadding, windowPosY + placeholderPadding + titleHeight + 2 * gs, 0xFFCCCCCC, subtitleHeight);
                 end
             end
         end);
@@ -1250,8 +1256,16 @@ local function drawGroupWindow(groupNum, settings)
                 if drawList then
                     local textX = windowPosX + contentPadding;
                     local titleY = windowPosY + contentPadding;
-                    imtext.Draw(drawList, GROUP_TITLES[groupNum] or ('Group ' .. groupNum), textX, titleY, 0x80FFFFFF, groupSettings.titleFontSize or 14);
-                    imtext.Draw(drawList, GROUP_PLACEHOLDERS[groupNum] or 'Drag to reposition', textX, titleY + (groupSettings.titleFontSize or 14) + 2, 0x80AAAAAA, groupSettings.subtitleFontSize or 12);
+                    local titleFs = groupSettings.titleFontSize or 14;
+                    local subtitleFs = groupSettings.subtitleFontSize or 12;
+                    local placeholderMaxTextWidth = math.max(1, notificationWidth - 2 * contentPadding);
+                    local title = GROUP_TITLES[groupNum] or ('Group ' .. groupNum);
+                    local subtitle = GROUP_PLACEHOLDERS[groupNum] or 'Drag to reposition';
+                    local placeholderKey = 'group' .. groupNum .. '_placeholder';
+                    local displayTitle = GetTruncatedText(title, placeholderMaxTextWidth, titleFs, placeholderKey .. '_title');
+                    local displaySubtitle = GetTruncatedText(subtitle, placeholderMaxTextWidth, subtitleFs, placeholderKey .. '_subtitle');
+                    imtext.Draw(drawList, displayTitle, textX, titleY, 0x80FFFFFF, titleFs);
+                    imtext.Draw(drawList, displaySubtitle, textX, titleY + titleFs + 2, 0x80AAAAAA, subtitleFs);
                 end
             end
         end);

--- a/XIUI/modules/petbar/pettarget.lua
+++ b/XIUI/modules/petbar/pettarget.lua
@@ -23,8 +23,10 @@ local function DrawBackground(drawList, x, y, width, height, settings)
     local petTypeKey = data.GetPetTypeKey();
     local settingsKey = 'petBar' .. petTypeKey:gsub("^%l", string.upper);
     local typeSettings = gConfig[settingsKey] or {};
-    local bgScale = typeSettings.bgScale or 1.0;
-    local borderScale = typeSettings.borderScale or 1.0;
+    -- Prefer pet target's own scale sliders; fall back to the parent pet type
+    -- so existing users see no change until they touch the pet target sliders.
+    local bgScale = gConfig.petTargetBgScale or typeSettings.bgScale or 1.0;
+    local borderScale = gConfig.petTargetBorderScale or typeSettings.borderScale or 1.0;
 
     local bgTheme = gConfig.petTargetBackgroundTheme or gConfig.petBarBackgroundTheme or 'Window1';
     local bgOpacity = gConfig.petTargetBackgroundOpacity or gConfig.petBarBackgroundOpacity or 1.0;


### PR DESCRIPTION
## Summary
Follow-up to #312. Addresses the remaining items from the tester's batch report:

- **Font Outline slider** — dropped the leftover GDI parity offset in `libs/imtext.lua` so slider value = literal pixel width (was rendering `n-1`).
- **Window borders squished on top/left** — `libs/windowbackground.lua` now renders the `tl` piece as three UV-sliced sub-pieces (corner + top arm + left arm) so the 21px native border thickness no longer compresses on windows smaller than the 491×491 source image. `tr` and `bl` already only stretch along their non-line axis so they're unchanged.
- **Background Scale slider did nothing** — `bgScale` is now applied via UV scaling in `DrawBackground`, matching the old primitive `scale_x`/`scale_y` behavior.
- **Pet Target missing bg/border scale sliders** — added them under `Background##petTarget`, defaulted to `1.0` in `core/settings/user.lua`, and wired the keys into `modules/petbar/pettarget.lua` with a fallback to the parent pet type so existing users see no change until they touch the sliders.
- **Global UI Scale ignored config window** — `config.lua` now scales the ideal window size and applies `imgui.SetWindowFontScale(globalScale)` inside the config Begin so config text grows with the slider without affecting any other XIUI windows.
- **Notification empty-state text cut off** — placeholder title/subtitle (`'Group 1 notifications appear here'`, etc.) now go through `GetTruncatedText` so they fit narrow notification group windows.

PR #312 already fixed the hotbar keybind/MP/label text outlines and the buff-timer outline routing in `libs/statusicons.lua`; those visually came through once the imtext offset above was removed.

## Test plan
- [ ] With **Font Outline Width = 1**, all text (player bar HP/MP/TP, hotbar keybinds + MP cost + labels, target/pet buff timers, pet bar recast timers) renders a 1px outline.
- [ ] Open any module with a `Window1`–`Window8` background at default scale (player bar, target bar, hotbar): top + left borders are the same thickness as bottom + right.
- [ ] Drag **Background Scale** in a module's Background section: the bg texture visibly zooms in/out.
- [ ] Pet Target → Background section now shows **Background Scale** and **Border Scale** sliders; moving them affects the pet target window only.
- [ ] Bump **Global UI Scale** to 2.0: the config menu text and layout grow with it (other XIUI windows already scaled before).
- [ ] Open the config menu with no notifications: the placeholder title/subtitle text truncates with `…` instead of overflowing the placeholder card.