### PR TITLE
Shift progressbar text

### DIFF
--- a/XIUI/core/settings/modules.lua
+++ b/XIUI/core/settings/modules.lua
@@ -389,9 +389,9 @@ function M.createModuleDefaults()
             bgOffset = 1,
 
             cursorPaddingX1 = 8,
-            cursorPaddingX2 = 8,
-            cursorPaddingY1 = 7,
-            cursorPaddingY2 = 10,
+            cursorPaddingX2 = 14,
+            cursorPaddingY1 = 11,
+            cursorPaddingY2 = 20,
             dotRadius = 3,
 
             arrowSize = 1,

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -37,6 +37,12 @@ end
 -- ============================================
 function display.DrawMember(memIdx, settings, isLastVisibleMember)
     local textDrawList = GetUIDrawList();
+    -- Bar borders draw outside the requested barHeight; shift text below to clear them.
+    local barBorderExtent;
+    do
+        local t = gConfig.barBorderThickness or 1;
+        barBorderExtent = (t > 0) and (t / 2 + 0.5) or 0;
+    end
     local memInfo = data.GetMemberInformation(memIdx);
     if (memInfo == nil) then
         memInfo = {
@@ -478,18 +484,18 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         local zoneBarWidth = allBarsLengths;
         local zoneBarHeight;
         if layout == 1 then
-            zoneBarHeight = hpBarHeight + 1 + mpBarHeight;
+            zoneBarHeight = hpBarHeight + 1 + mpBarHeight + barBorderExtent;
         else
-            zoneBarHeight = hpBarHeight;
+            zoneBarHeight = hpBarHeight + barBorderExtent;
         end
         imgui.Dummy({zoneBarWidth, zoneBarHeight});
     else
         local zoneBarWidth = allBarsLengths;
         local zoneBarHeight;
         if layout == 1 then
-            zoneBarHeight = hpBarHeight + 1 + mpBarHeight;
+            zoneBarHeight = hpBarHeight + 1 + mpBarHeight + barBorderExtent;
         else
-            zoneBarHeight = hpBarHeight;
+            zoneBarHeight = hpBarHeight + barBorderExtent;
         end
 
         local zoneBarStartX, zoneBarStartY = imgui.GetCursorScreenPos();
@@ -519,7 +525,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
         hpTextY = hpStartY - nameRefHeight - settings.nameTextOffsetY + hpBaselineOffset + textOffsets.hpY;
     else
         hpTextX = hpStartX + hpBarWidth - hpTextWidth + settings.hpTextOffsetX + textOffsets.hpX;
-        hpTextY = hpStartY + hpBarHeight + settings.hpTextOffsetY + hpBaselineOffset + textOffsets.hpY;
+        hpTextY = hpStartY + hpBarHeight + barBorderExtent + settings.hpTextOffsetY + hpBaselineOffset + textOffsets.hpY;
     end
     if memInfo.inzone then
         imtext.Draw(textDrawList, hpDisplayText, hpTextX, hpTextY, hpColor, fontSizes.hp);
@@ -912,7 +918,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                 local currentMpTextWidth = showingCastInMpSlot and imtext.Measure(mpDisplayText, fontSizes.mp) or mpTextWidth;
                 local mpBaselineOffset = mpRefHeight - mpHeight;
                 local mpTextX = mpStartX + mpBarWidth - currentMpTextWidth + textOffsets.mpX;
-                local mpTextY = mpStartY + mpBarHeight + settings.mpTextOffsetY + mpBaselineOffset + textOffsets.mpY;
+                local mpTextY = mpStartY + mpBarHeight + barBorderExtent + settings.mpTextOffsetY + mpBaselineOffset + textOffsets.mpY;
                 if memInfo.inzone then
                     imtext.Draw(textDrawList, mpDisplayText, mpTextX, mpTextY, mpColor, fontSizes.mp);
                 end
@@ -962,7 +968,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                 local currentTpTextWidth = showingCastInTpSlot and imtext.Measure(tpText, fontSizes.tp) or tpTextWidth;
                 local tpBaselineOffset = tpRefHeight - tpHeight;
                 local tpTextX = tpStartX + tpBarWidth - currentTpTextWidth + textOffsets.tpX;
-                local tpTextY = tpStartY + tpBarHeight + settings.tpTextOffsetY + tpBaselineOffset + textOffsets.tpY;
+                local tpTextY = tpStartY + tpBarHeight + barBorderExtent + settings.tpTextOffsetY + tpBaselineOffset + textOffsets.tpY;
                 if memInfo.inzone then
                     imtext.Draw(textDrawList, tpText, tpTextX, tpTextY, tpColor, fontSizes.tp);
                 end

--- a/XIUI/modules/playerbar.lua
+++ b/XIUI/modules/playerbar.lua
@@ -349,8 +349,8 @@ playerbar.DrawWindow = function(settings)
 			local width = barSize - shimmerBookendWidth * 2 - (padding * 2);
 			local waveWidth = width * 0.06;
 			local x = hpBarStartX + shimmerBookendWidth + padding;
-			local y1 = hpBarStartY + padding;
-			local y2 = hpBarStartY + settings.barHeight - padding;
+			local y1 = hpBarStartY;
+			local y2 = hpBarStartY + settings.barHeight;
 			local waveLeft = x + (progress * (width - waveWidth));
 			local waveRight = waveLeft + waveWidth;
 			
@@ -494,6 +494,13 @@ playerbar.DrawWindow = function(settings)
 
 		imgui.SameLine();
 
+		-- Bar borders draw outside the requested barHeight; shift text below to clear them.
+		local barBorderExtent;
+		do
+			local t = gConfig.barBorderThickness or 1;
+			barBorderExtent = (t > 0) and (t / 2 + 0.5) or 0;
+		end
+
 		-- Draw HP text
 		local hpDisplayMode = gConfig.playerBarHpDisplayMode or 'number';
 		local hpDisplayText;
@@ -524,7 +531,7 @@ playerbar.DrawWindow = function(settings)
 		-- Apply user offset (scaled by global UI scale)
 		local gs = gConfig.globalScale or 1.0;
 		hpTextX = hpTextX + (gConfig.playerBarHpTextOffsetX or 0) * gs;
-		local hpTextY = hpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarHpTextOffsetY or 0) * gs;
+		local hpTextY = hpBarStartY + settings.barHeight + barBorderExtent + settings.textYOffset + (gConfig.playerBarHpTextOffsetY or 0) * gs;
 		imtext.Draw(drawList, hpDisplayText, hpTextX, hpTextY, gConfig.colorCustomization.playerBar.hpTextColor, fontSize);
 
 		if (bShowMp) then
@@ -557,7 +564,7 @@ playerbar.DrawWindow = function(settings)
 			end
 			-- Apply user offset (scaled by global UI scale)
 			mpTextX = mpTextX + (gConfig.playerBarMpTextOffsetX or 0) * gs;
-			local mpTextY = mpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarMpTextOffsetY or 0) * gs;
+			local mpTextY = mpBarStartY + settings.barHeight + barBorderExtent + settings.textYOffset + (gConfig.playerBarMpTextOffsetY or 0) * gs;
 			imtext.Draw(drawList, mpDisplayText, mpTextX, mpTextY, gConfig.colorCustomization.playerBar.mpTextColor, fontSize);
 		end
 
@@ -576,7 +583,7 @@ playerbar.DrawWindow = function(settings)
 		end
 		-- Apply user offset (scaled by global UI scale)
 		tpTextX = tpTextX + (gConfig.playerBarTpTextOffsetX or 0) * gs;
-		local tpTextY = tpBarStartY + settings.barHeight + settings.textYOffset + (gConfig.playerBarTpTextOffsetY or 0) * gs;
+		local tpTextY = tpBarStartY + settings.barHeight + barBorderExtent + settings.textYOffset + (gConfig.playerBarTpTextOffsetY or 0) * gs;
 		local tpTextColor = (SelfTP >= 1000) and gConfig.colorCustomization.playerBar.tpFullTextColor or gConfig.colorCustomization.playerBar.tpEmptyTextColor;
 		imtext.Draw(drawList, tpDisplayText, tpTextX, tpTextY, tpTextColor, fontSize);
 


### PR DESCRIPTION
## Fix UI alignment after additive border change

### Changes

- **HP/MP/TP text Y** in `playerbar.lua` and `partylist/display.lua` now adds a `barBorderExtent` derived from `gConfig.barBorderThickness` so text clears the bar's additive bottom border. Tracks the border slider automatically.
- **Out-of-zone rectangle** height in the party list also extended by `barBorderExtent` so the bottom edge matches where the bars would visually end.
- **Selection-box cursor paddings** bumped (X2: 8→14, Y1: 7→11, Y2: 10→20) so the box doesn't look short after the bar shrink and border-extent shift.
- **Resting ticker** now spans the full HP bar height (removed 3px top/bottom inset that left only ~8px of vertical ticker in the new 14px bar).