### PR TITLE
Fix beta issues

### DIFF
--- a/XIUI/config/components.lua
+++ b/XIUI/config/components.lua
@@ -404,7 +404,7 @@ end
 function components.DrawNestedSliderFloat(label, parentTable, key, min, max, format, helpText)
     if not parentTable then return; end
     local value = { parentTable[key] or min };
-    if imgui.SliderFloat(label, value, min, max, format or '%.1f') then
+    if imgui.SliderFloat(label, value, min, max, format or '%.1f', ImGuiSliderFlags_AlwaysClamp) then
         parentTable[key] = value[1];
     end
     if (imgui.IsItemDeactivatedAfterEdit()) then SaveSettingsOnly(); end
@@ -468,13 +468,13 @@ function components.DrawSlider(label, configKey, min, max, format, callback)
     -- Use SliderFloat if format is specified, otherwise check if value is integer
     if format ~= nil then
         -- Format specified, use float slider
-        changed = imgui.SliderFloat(label, value, min, max, format);
+        changed = imgui.SliderFloat(label, value, min, max, format, ImGuiSliderFlags_AlwaysClamp);
     elseif type(gConfig[configKey]) == 'number' and math.floor(gConfig[configKey]) == gConfig[configKey] then
         -- No format and value is integer, use int slider
-        changed = imgui.SliderInt(label, value, min, max);
+        changed = imgui.SliderInt(label, value, min, max, '%d', ImGuiSliderFlags_AlwaysClamp);
     else
         -- No format but value is float, use float slider with default format
-        changed = imgui.SliderFloat(label, value, min, max, '%.2f');
+        changed = imgui.SliderFloat(label, value, min, max, '%.2f', ImGuiSliderFlags_AlwaysClamp);
     end
 
     if changed then
@@ -498,7 +498,7 @@ function components.SliderInt(label, parentTable, key, min, max, default)
     local value = { currentValue };
 
     imgui.SetNextItemWidth(CONTENT_MAX_WIDTH);
-    if imgui.SliderInt(label, value, min, max) then
+    if imgui.SliderInt(label, value, min, max, '%d', ImGuiSliderFlags_AlwaysClamp) then
         parentTable[key] = value[1];
         UpdateUserSettings();
     end
@@ -515,7 +515,7 @@ function components.SliderFloat(label, parentTable, key, min, max, format, defau
     local value = { currentValue };
 
     imgui.SetNextItemWidth(CONTENT_MAX_WIDTH);
-    if imgui.SliderFloat(label, value, min, max, format or '%.2f') then
+    if imgui.SliderFloat(label, value, min, max, format or '%.2f', ImGuiSliderFlags_AlwaysClamp) then
         parentTable[key] = value[1];
         UpdateUserSettings();
     end
@@ -585,13 +585,13 @@ function components.DrawPartyLayoutSlider(label, configKey, min, max, format, ca
     -- Use SliderFloat if format is specified, otherwise check if value is integer
     if format ~= nil then
         -- Format specified, use float slider
-        changed = imgui.SliderFloat(uniqueLabel, value, min, max, format);
+        changed = imgui.SliderFloat(uniqueLabel, value, min, max, format, ImGuiSliderFlags_AlwaysClamp);
     elseif type(currentLayout[configKey]) == 'number' and math.floor(currentLayout[configKey]) == currentLayout[configKey] then
         -- No format and value is integer, use int slider
-        changed = imgui.SliderInt(uniqueLabel, value, min, max);
+        changed = imgui.SliderInt(uniqueLabel, value, min, max, '%d', ImGuiSliderFlags_AlwaysClamp);
     else
         -- No format but value is float, use float slider with default format
-        changed = imgui.SliderFloat(uniqueLabel, value, min, max, '%.2f');
+        changed = imgui.SliderFloat(uniqueLabel, value, min, max, '%.2f', ImGuiSliderFlags_AlwaysClamp);
     end
 
     if changed then
@@ -657,11 +657,11 @@ function components.DrawPartySlider(partyTable, label, configKey, min, max, form
     imgui.SetNextItemWidth(CONTENT_MAX_WIDTH);
 
     if format ~= nil then
-        changed = imgui.SliderFloat(uniqueLabel, value, min, max, format);
+        changed = imgui.SliderFloat(uniqueLabel, value, min, max, format, ImGuiSliderFlags_AlwaysClamp);
     elseif type(currentValue) == 'number' and math.floor(currentValue) == currentValue then
-        changed = imgui.SliderInt(uniqueLabel, value, min, max);
+        changed = imgui.SliderInt(uniqueLabel, value, min, max, '%d', ImGuiSliderFlags_AlwaysClamp);
     else
-        changed = imgui.SliderFloat(uniqueLabel, value, min, max, '%.2f');
+        changed = imgui.SliderFloat(uniqueLabel, value, min, max, '%.2f', ImGuiSliderFlags_AlwaysClamp);
     end
 
     if changed then
@@ -687,7 +687,7 @@ function components.DrawPartySliderInt(partyTable, label, configKey, min, max, f
     local uniqueLabel = label .. '##party_' .. configKey;
 
     imgui.SetNextItemWidth(CONTENT_MAX_WIDTH);
-    local changed = imgui.SliderInt(uniqueLabel, value, min, max, format);
+    local changed = imgui.SliderInt(uniqueLabel, value, min, max, format, ImGuiSliderFlags_AlwaysClamp);
 
     if changed then
         partyTable[configKey] = value[1];

--- a/XIUI/config/partylist.lua
+++ b/XIUI/config/partylist.lua
@@ -97,9 +97,6 @@ local function DrawPartyTabContent(party, partyName)
         components.DrawPartyCheckbox(party, 'Show Bookends', 'showBookends');
         components.DrawPartyCheckbox(party, 'Show Title', 'showTitle');
         components.DrawPartyCheckbox(party, 'Align Bottom', 'alignBottom');
-        components.DrawPartyCheckbox(party, 'Expand Height', 'expandHeight');
-        components.DrawPartyCheckbox(party, 'Expand Height In Alliance', 'expandHeightInAlliance');
-        imgui.ShowHelp('When enabled, Party A will use expanded height only while in an alliance.');
 
         -- HP Display Mode dropdown
         components.DrawDisplayModeDropdown('HP Display##party' .. partyName, party, 'hpDisplayMode',
@@ -114,7 +111,13 @@ local function DrawPartyTabContent(party, partyName)
     end
 
     if components.CollapsingSection('Scale & Spacing##party' .. partyName) then
-        components.DrawPartySlider(party, 'Min Rows', 'minRows', 1, 6);
+        components.DrawPartyCheckbox(party, 'Expand Height In Alliance', 'expandHeightInAlliance');
+        imgui.ShowHelp('When enabled, the party list expands to full height only while in an alliance.');
+        components.DrawPartyCheckbox(party, 'Expand Height', 'expandHeight');
+        imgui.ShowHelp('When enabled, the party list always shows all 6 rows. Overrides Min Rows.');
+        if not party.expandHeight then
+            components.DrawPartySlider(party, 'Min Rows', 'minRows', 1, 6);
+        end
         components.DrawPartySlider(party, 'Entry Spacing', 'entrySpacing', -50, 50);
         components.DrawPartyCheckbox(party, 'Show Selection Box', 'showSelectionBox');
         imgui.ShowHelp('When disabled, only the cursor arrow is shown without the selection box background.');

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -614,7 +614,7 @@ function display.DrawMember(memIdx, settings, isLastVisibleMember)
                     -- rendered: namePosX + textOffsets.nameX, not namePosX alone).
                     castBarX = nameTextX + spellNameWidth + 4 + castBarOffsetX;
                 end
-                local castBarY = hpStartY - nameRefHeight - settings.nameTextOffsetY + (nameRefHeight - castBarHeight) / 2 + castBarOffsetY;
+                local castBarY = hpStartY - nameRefHeight - settings.nameTextOffsetY + textOffsets.nameY + (nameRefHeight - castBarHeight) / 2 + castBarOffsetY;
                 local castGradient = GetCustomGradient(cache.colors, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
                 progressbar.ProgressBar(
                     {{castProgress, castGradient}},

--- a/XIUI/modules/petbar/display.lua
+++ b/XIUI/modules/petbar/display.lua
@@ -846,11 +846,12 @@ function display.DrawWindow(settings)
             local actualMpWidth = mpBarWidth;
             local actualTpWidth = tpBarWidth;
             if displayMpBar and not displayTpBar then
-                -- MP bar takes full width when no TP bar
-                actualMpWidth = hpBarWidth;
+                -- MP bar takes the full base row width, scaled by its own MP X
+                -- (not HP X — otherwise the HP slider would resize the lone MP bar).
+                actualMpWidth = barWidth * mpScaleX;
             elseif not displayMpBar and displayTpBar then
-                -- TP bar takes full width when no MP bar
-                actualTpWidth = hpBarWidth;
+                -- TP bar takes the full base row width, scaled by its own TP X.
+                actualTpWidth = barWidth * tpScaleX;
             end
 
             if displayMpBar then

--- a/XIUI/modules/petbar/pettarget.lua
+++ b/XIUI/modules/petbar/pettarget.lua
@@ -141,10 +141,12 @@ function pettarget.DrawWindow(settings)
         local rawTargetDistanceFontSize = gConfig.petBarTargetDistanceFontSize or gConfig.petBarDistanceFontSize;
         local targetDistanceFontSize = rawTargetDistanceFontSize and (rawTargetDistanceFontSize * gs) or settings.distance_font_settings.font_height;
 
-        -- Bar dimensions with scale settings (totalRowWidth and settings.barHeight come from updater, already gs-scaled)
+        -- Bar dimensions with scale settings (settings.barWidth/Height come from updater, already gs-scaled)
+        -- Use the un-HP-scaled base pet bar width so the target HP X slider is
+        -- independent of the pet HP X slider.
         local barScaleX = gConfig.petTargetBarScaleX or 1.0;
         local barScaleY = gConfig.petTargetBarScaleY or 1.0;
-        local barWidth = totalRowWidth * barScaleX;
+        local barWidth = (settings.barWidth or 150) * barScaleX;
         local barHeight = (settings.barHeight or 12) * barScaleY;
 
         -- Get positioning settings (offsets scale with gs)
@@ -210,8 +212,11 @@ function pettarget.DrawWindow(settings)
             distDrawX = targetWinPosX + distanceOffsetX;
             distDrawY = targetWinPosY + distanceOffsetY;
         else
-            -- Inline positioning: below HP bar in layout flow
-            local distanceY = targetStartY + targetNameFontSize + 4 + barHeight + 2;
+            -- Inline positioning: below HP bar in layout flow.
+            -- Add the bar's border extent so the text clears the additive border.
+            local borderThickness = gConfig.barBorderThickness or 1;
+            local barBorderExtent = (borderThickness > 0) and (borderThickness / 2 + 0.5) or 0;
+            local distanceY = targetStartY + targetNameFontSize + 4 + barHeight + barBorderExtent + 2;
             distDrawX = targetStartX + distanceOffsetX;
             distDrawY = distanceY + distanceOffsetY;
             -- Add dummy for inline layout

--- a/XIUI/modules/readycheck/ui.lua
+++ b/XIUI/modules/readycheck/ui.lua
@@ -12,6 +12,12 @@ local statusHandler = require('handlers.statushandler')
 
 local ui = {}
 
+-- SetWindowFontScale is missing on some older Ashita builds and is being
+-- obsoleted upstream. Resolve once and fall back to a no-op so a nil lookup
+-- can't abort a render mid-window (which would leave Begin/PushStyle*
+-- unmatched and surface as "missing End()" / "missing popStyleColor()").
+local SetWindowFontScale = imgui.SetWindowFontScale or function() end
+
 -- ── Job icon loader ────────────────────────────────────────────────────────────
 -- Delegate to XIUI's statusHandler so we reuse its TextureManager cache and
 -- respect the user's chosen job icon theme (gConfig.jobIconTheme).
@@ -137,7 +143,7 @@ local function render_prompt(state, handlers)
     imgui.SetNextWindowBgAlpha(0.95)
 
     if imgui.Begin('Ready Check##prompt', state.prompt_open, PROMPT_FLAGS) then
-        imgui.SetWindowFontScale(FONT_SCALE)
+        SetWindowFontScale(FONT_SCALE)
         local sender = state.prompt_sender or 'Someone'
         imgui.Spacing()
         imgui.PushStyleColor(ImGuiCol_Text, COLOR_GOLD_BRIGHT)
@@ -198,7 +204,7 @@ local function render_tracker(state, handlers)
     imgui.SetNextWindowBgAlpha(0.90)
 
     if imgui.Begin('Ready Check##tracker', state.checker_open, TRACKER_FLAGS) then
-        imgui.SetWindowFontScale(FONT_SCALE)
+        SetWindowFontScale(FONT_SCALE)
         imgui.Text('Party / Alliance Status')
         imgui.SameLine()
         local secs_left = state.checker_deadline
@@ -318,7 +324,7 @@ local function render_config(state, handlers)
     imgui.SetNextWindowBgAlpha(0.95)
 
     if imgui.Begin('ReadyCheck Config##config', state.config_open, CONFIG_FLAGS) then
-        imgui.SetWindowFontScale(FONT_SCALE)
+        SetWindowFontScale(FONT_SCALE)
 
         imgui.PushStyleColor(ImGuiCol_Text, COLOR_GOLD_BRIGHT)
         imgui.Text('Sound Settings')


### PR DESCRIPTION
## Fixes

- **Party list**: fixed anchored cast bar not following the *Name Text Y Offset* (only the X offset was applied).
- **Pet bar**: decoupled the HP X scale from MP X, TP X, and target HP X — each now resizes only its own bar.
- **Pet bar target**: pet target distance text no longer overlaps the HP bar's bottom border (now accounts for the additive border extent).
- **Config sliders**: typing a value outside a slider's min/max (e.g. Ctrl+Click → `0` into the HP bar X scale) no longer escapes the bounds and causes runaway behavior like infinite bar growth. All shared slider helpers now use `ImGuiSliderFlags_AlwaysClamp`.
- **Ready check (older Ashita builds, e.g. 4.3)**: fixed `attempt to call field 'SetWindowFontScale' (a nil value)` and the cascade warnings it produced (`Ready Check##tracker: missing End()`, `Debug##Default: missing popStyleColor()`). `SetWindowFontScale` is now resolved once at load time with a no-op fallback when the binding is missing; no change on builds where it exists.