### PR TITLE
fix: render gil tracker when gil is 0 (#319)

### DIFF
--- a/XIUI/modules/giltracker.lua
+++ b/XIUI/modules/giltracker.lua
@@ -115,15 +115,9 @@ giltracker.DrawWindow = function(settings)
 
 	local currentGil = gilAmount.Count;
 
-	-- Skip invalid reads during zoning (inventory returns 0 or garbage)
-	-- This preserves tracking state so we continue where we left off after zoning
-	if currentGil == 0 then
-		return;
-	end
-
 	-- Detect invalid reads: if gil changes by millions in a single frame, it's likely
 	-- garbage data from zoning - skip this frame but don't reset tracking
-	if lastKnownGil ~= nil and lastKnownGil > 0 then
+	if lastKnownGil ~= nil then
 		local frameDiff = math.abs(currentGil - lastKnownGil);
 		-- If changed by more than 10 million in one frame, skip (likely zone garbage)
 		if frameDiff > 10000000 then


### PR DESCRIPTION
## Summary
- Removes the `currentGil == 0` early return in `giltracker.DrawWindow` that hid the module entirely when a player legitimately had zero gil, making it impossible to see or reposition the tracker from `/xiui`.
- Relaxes the per-frame garbage-spike guard from `lastKnownGil > 0` to `lastKnownGil ~= nil` so the >10M framediff check keeps applying after gil legitimately reaches 0.

Existing safeguards already filter genuinely invalid reads:
- `player.isZoning` skips zoning frames
- `gilAmount == nil` skips before inventory has loaded
- The >10M framediff check skips garbage spikes
- The 3-second stabilization window before locking in `trackingStartGil` absorbs transient post-login 0 reads

Fixes #319.

## Test plan
- [ ] Log in with a character that has 0 gil → gil tracker window renders showing `0`, can be dragged/configured from `/xiui`.
- [ ] Spend all gil down to 0 in-session → tracker continues to render as `0` (does not vanish).
- [ ] Earn gil from 0 → counter increases as expected, session/gph values update.
- [ ] Zone change with non-zero gil → tracker does not reset and does not flicker through garbage values.