### PR TITLE
Fix buff zscale

### DIFF
--- a/XIUI/libs/statusicons.lua
+++ b/XIUI/libs/statusicons.lua
@@ -233,6 +233,12 @@ local debuff_font_settings = T{
 -- @param buffTable: the bufftable module
 function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOffset, buffTimes, settings, statusHandler, buffTableLib)
     if (statusIds ~= nil and #statusIds > 0) then
+        -- Render onto the shared UI draw list (same list as window backgrounds,
+        -- progress bars, and text). Using imgui.Image() here puts icons on the
+        -- per-window draw list, which sits BELOW the foreground draw list where
+        -- the window bg now lives -- so the bg would visually cover the icons.
+        -- Cursor advancement and hover are still handled by imgui.Dummy() below.
+        local drawList = GetUIDrawList();
         local currentRow = 1;
         local currentColumn = 0;
         if (xOffset ~= nil) then
@@ -247,21 +253,33 @@ function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOf
             if (icon ~= nil) then
                 if (drawBg == true) then
                     local resetX, resetY = imgui.GetCursorScreenPos();
-                    local bgIcon;
                     local isBuff = buffTableLib.IsBuff(statusIds[i]);
                     local bgSize = iconSize * 1.1;
                     local yOffset = bgSize * -0.1;
                     if (isBuff) then
                         yOffset = bgSize * -0.3;
                     end
-                    imgui.SetCursorScreenPos({resetX - ((bgSize - iconSize) / 1.5), resetY + yOffset});
-                    bgIcon = statusHandler.GetBackground(isBuff);
-                    imgui.Image(bgIcon, { bgSize + 1, bgSize  / .75});
-                    imgui.SetCursorScreenPos({resetX, resetY});
+                    local bgX = resetX - ((bgSize - iconSize) / 1.5);
+                    local bgY = resetY + yOffset;
+                    local bgIcon = statusHandler.GetBackground(isBuff);
+                    if bgIcon then
+                        drawList:AddImage(
+                            bgIcon,
+                            {bgX, bgY},
+                            {bgX + bgSize + 1, bgY + bgSize / 0.75}
+                        );
+                    end
                 end
                 -- Capture position BEFORE drawing icon to get accurate position
                 local iconPosX, iconPosY = imgui.GetCursorScreenPos();
-                imgui.Image(icon, { iconSize, iconSize }, { 0, 0 }, { 1, 1 });
+                drawList:AddImage(
+                    icon,
+                    {iconPosX, iconPosY},
+                    {iconPosX + iconSize, iconPosY + iconSize}
+                );
+                -- Advance the cursor and register a hover region so tooltips,
+                -- SameLine, and row layout below all keep working unchanged.
+                imgui.Dummy({iconSize, iconSize});
                 if buffTimes ~= nil and buffTimes[i] ~= nil then
                     local font_base = settings or debuff_font_settings;
                     -- When no explicit font settings are provided (target bar buffs, pet bar buffs)
@@ -277,7 +295,6 @@ function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOf
                     local gs = gConfig.globalScale or 1.0;
                     local scaledFontHeight = (gConfig.targetBarIconFontSize and gConfig.targetBarIconFontSize * gs) or font_base.font_height;
                     local timerW, _ = imtext.Measure(timerText, scaledFontHeight);
-                    local drawList = GetUIDrawList();
                     local timerColor = font_base.font_color or 0xFFFFFFFF;
                     imtext.Draw(drawList, timerText, textPosX - timerW / 2, textPosY, timerColor, scaledFontHeight);
                 end

--- a/XIUI/libs/statusicons.lua
+++ b/XIUI/libs/statusicons.lua
@@ -233,11 +233,7 @@ local debuff_font_settings = T{
 -- @param buffTable: the bufftable module
 function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOffset, buffTimes, settings, statusHandler, buffTableLib)
     if (statusIds ~= nil and #statusIds > 0) then
-        -- Render onto the shared UI draw list (same list as window backgrounds,
-        -- progress bars, and text). Using imgui.Image() here puts icons on the
-        -- per-window draw list, which sits BELOW the foreground draw list where
-        -- the window bg now lives -- so the bg would visually cover the icons.
-        -- Cursor advancement and hover are still handled by imgui.Dummy() below.
+        -- Draw onto the same list as window bgs so icons aren't hidden behind them.
         local drawList = GetUIDrawList();
         local currentRow = 1;
         local currentColumn = 0;
@@ -255,30 +251,14 @@ function M.DrawStatusIcons(statusIds, iconSize, maxColumns, maxRows, drawBg, xOf
                     local resetX, resetY = imgui.GetCursorScreenPos();
                     local isBuff = buffTableLib.IsBuff(statusIds[i]);
                     local bgSize = iconSize * 1.1;
-                    local yOffset = bgSize * -0.1;
-                    if (isBuff) then
-                        yOffset = bgSize * -0.3;
-                    end
+                    local yOffset = isBuff and (bgSize * -0.3) or (bgSize * -0.1);
                     local bgX = resetX - ((bgSize - iconSize) / 1.5);
                     local bgY = resetY + yOffset;
-                    local bgIcon = statusHandler.GetBackground(isBuff);
-                    if bgIcon then
-                        drawList:AddImage(
-                            bgIcon,
-                            {bgX, bgY},
-                            {bgX + bgSize + 1, bgY + bgSize / 0.75}
-                        );
-                    end
+                    drawList:AddImage(statusHandler.GetBackground(isBuff),
+                        {bgX, bgY}, {bgX + bgSize + 1, bgY + bgSize / 0.75});
                 end
-                -- Capture position BEFORE drawing icon to get accurate position
                 local iconPosX, iconPosY = imgui.GetCursorScreenPos();
-                drawList:AddImage(
-                    icon,
-                    {iconPosX, iconPosY},
-                    {iconPosX + iconSize, iconPosY + iconSize}
-                );
-                -- Advance the cursor and register a hover region so tooltips,
-                -- SameLine, and row layout below all keep working unchanged.
+                drawList:AddImage(icon, {iconPosX, iconPosY}, {iconPosX + iconSize, iconPosY + iconSize});
                 imgui.Dummy({iconSize, iconSize});
                 if buffTimes ~= nil and buffTimes[i] ~= nil then
                     local font_base = settings or debuff_font_settings;

--- a/XIUI/modules/castcost/display.lua
+++ b/XIUI/modules/castcost/display.lua
@@ -383,15 +383,17 @@ function M.Render(itemInfo, itemType, settings, colors)
                 -- Center bar vertically within cooldownRowHeight
                 local barYOffset = (cooldownRowHeight - barHeight) / 2;
 
-                -- Draw the progress bar using the progressbar library
-                local pbDrawList = imgui.GetWindowDrawList();
+                -- Share the same draw list as the window bg/text (GetUIDrawList,
+                -- resolved at line 217) so call order = z-order. WindowDrawList
+                -- sits below ForegroundDrawList in ImGui, so leaving the bar on
+                -- WindowDrawList would hide it behind the window bg.
                 progressbar.ProgressBar(
                     {{cooldownPercent, barGradient}},
                     {barWidth, barHeight},
                     {
                         absolutePosition = {barStartX, yPos + barYOffset},
                         decorate = false,
-                        drawList = pbDrawList,
+                        drawList = drawList,
                     }
                 );
             elseif isWeaponSkill and not hasEnoughTp then

--- a/XIUI/modules/castcost/display.lua
+++ b/XIUI/modules/castcost/display.lua
@@ -383,10 +383,7 @@ function M.Render(itemInfo, itemType, settings, colors)
                 -- Center bar vertically within cooldownRowHeight
                 local barYOffset = (cooldownRowHeight - barHeight) / 2;
 
-                -- Share the same draw list as the window bg/text (GetUIDrawList,
-                -- resolved at line 217) so call order = z-order. WindowDrawList
-                -- sits below ForegroundDrawList in ImGui, so leaving the bar on
-                -- WindowDrawList would hide it behind the window bg.
+                -- Reuse the UI draw list so the bar isn't hidden behind the window bg.
                 progressbar.ProgressBar(
                     {{cooldownPercent, barGradient}},
                     {barWidth, barHeight},

--- a/XIUI/modules/mobinfo/display.lua
+++ b/XIUI/modules/mobinfo/display.lua
@@ -125,8 +125,15 @@ local function DrawIconWithTooltip(texture, size, tooltipText)
     -- Always use Dummy to advance cursor and enable hover detection
     imgui.Dummy({size, size});
 
+    -- Draw on foreground draw list so the tooltip renders above XIUI's bars,
+    -- which sit on the foreground layer and would otherwise hide SetTooltip.
     if tooltipText and imgui.IsItemHovered() then
-        imgui.SetTooltip(tooltipText);
+        local t = tooltipText:gsub('%%%%', '%%');
+        local mx, my = imgui.GetMousePos();
+        local tw, th = imgui.CalcTextSize(t);
+        local dl = imgui.GetForegroundDrawList();
+        dl:AddRectFilled({mx + 12, my + 12}, {mx + 24 + tw, my + 20 + th}, 0xE0000000, 3);
+        dl:AddText({mx + 18, my + 16}, 0xFFFFFFFF, t);
     end
 
     return size;


### PR DESCRIPTION
Fix: buffs/debuffs and cast-cost recast bar hidden behind window background

Window backgrounds now render on the shared foreground draw list (GetUIDrawList),
but status icons and the cast-cost cooldown bar were still drawing via
imgui.Image() / imgui.GetWindowDrawList(), which ImGui z-orders beneath the
foreground. Result: pet/target/party/enemy-list buffs and debuffs sat behind
the plate (visible only at low opacity), and the cast-cost recast bar was
behind its panel.

Route both onto the same shared draw list as the bg so code order = z-order.
imgui.Dummy() keeps cursor advancement, SameLine, IsItemHovered tooltips, and
auto-resize working. Same single batch, no extra cost.


Also fixes mobdb tooltip