### PR TITLE
Player data: Show All lists, spell sort, availability, equipment WS c…

### DIFF
--- a/XIUI/handlers/statushandler.lua
+++ b/XIUI/handlers/statushandler.lua
@@ -11,6 +11,18 @@ local TextureManager = require('libs.texturemanager');
 -- Party buffs table, populated by packet 0x076 via ReadPartyBuffsFromPacket()
 local partyBuffs = {};
 
+local LEVEL_SYNC_BUFF_ID = 269;
+
+local function partyBuffListHas(buffList, statusId)
+    if not buffList then return false; end
+    for i = 1, #buffList do
+        if buffList[i] == statusId then
+            return true;
+        end
+    end
+    return false;
+end
+
 -------------------------------------------------------------------------------
 -- exported functions
 -------------------------------------------------------------------------------
@@ -172,7 +184,35 @@ statusHandler.ReadPartyBuffsFromPacket = function(e)
             partyBuffTable[memberId] = buffs;
         end
     end
-    partyBuffs =  partyBuffTable;
+
+    local hadLevelSync = false;
+    local hasLevelSync = false;
+    local memMgr = AshitaCore:GetMemoryManager();
+    local party = memMgr and memMgr:GetParty();
+    if party and party:GetMemberIsActive(0) == 1 then
+        local sid = party:GetMemberServerId(0);
+        if sid and sid > 0 then
+            hadLevelSync = partyBuffListHas(partyBuffs[sid], LEVEL_SYNC_BUFF_ID);
+            hasLevelSync = partyBuffListHas(partyBuffTable[sid], LEVEL_SYNC_BUFF_ID);
+        end
+    end
+
+    partyBuffs = partyBuffTable;
+
+    if hadLevelSync ~= hasLevelSync then
+        pcall(function()
+            local playerdata = require('modules.hotbar.playerdata');
+            if playerdata.ClearCache then
+                playerdata.ClearCache();
+            end
+        end);
+        pcall(function()
+            local slotrenderer = require('modules.hotbar.slotrenderer');
+            if slotrenderer.ClearAvailabilityCache then
+                slotrenderer.ClearAvailabilityCache();
+            end
+        end);
+    end
 end
 
 return statusHandler;

--- a/XIUI/modules/hotbar/actiondb.lua
+++ b/XIUI/modules/hotbar/actiondb.lua
@@ -9,6 +9,10 @@ local M = {};
 M.spellNameToId = nil;
 M.abilityNameToId = nil;
 M.itemNameToId = nil;
+-- Lazy list of all ability IDs whose ability.Type == 3 (WeaponSkill). The resource manager's
+-- ability list is static for the session, so this is built once on first call. Callers
+-- iterating WS abilities should use this rather than scanning all 1024 ids per call.
+M.weaponSkillAbilityIds = nil;
 
 -- Build spell name lookup table
 local function BuildSpellLookup()
@@ -82,11 +86,34 @@ function M.GetItemId(itemName)
     return M.itemNameToId[itemName:lower()];
 end
 
+-- Build a list of all weapon-skill ability IDs (resource Type == 3). Static for the session.
+-- Avoids the per-call O(1024) scans in playerdata's GetPlayerWeaponskills and
+-- DiscoverNewWeaponskills, which previously iterated every ability id and only kept WS ones.
+local function BuildWeaponSkillIdList()
+    if M.weaponSkillAbilityIds then return; end
+    M.weaponSkillAbilityIds = {};
+    local resourceMgr = AshitaCore:GetResourceManager();
+    if not resourceMgr then return; end
+    for id = 0, 1024 do
+        local ability = resourceMgr:GetAbilityById(id);
+        if ability and ability.Type and ability.Type == 3 then
+            M.weaponSkillAbilityIds[#M.weaponSkillAbilityIds + 1] = id;
+        end
+    end
+end
+
+-- Get the list of all weapon-skill ability IDs (caller still filters by player:HasAbility).
+function M.GetWeaponSkillAbilityIds()
+    BuildWeaponSkillIdList();
+    return M.weaponSkillAbilityIds;
+end
+
 -- Clear caches (call on zone if needed)
 function M.Clear()
     M.spellNameToId = nil;
     M.abilityNameToId = nil;
     M.itemNameToId = nil;
+    M.weaponSkillAbilityIds = nil;
 end
 
 return M;

--- a/XIUI/modules/hotbar/equipment_ws.lua
+++ b/XIUI/modules/hotbar/equipment_ws.lua
@@ -1,0 +1,79 @@
+--[[
+ * Cache-bust signature for weaponskill lists: job, levels, level sync, equipped item ids.
+ * We do not interpret weapon type — WS availability comes from HasAbility only.
+ * Including main/sub/range item ids forces a refresh when gear changes so caches stay in sync
+ * with the client without modeling main-hand vs sub-hand weapon families.
+ *
+ * Equip slots: IInventory:GetEquippedItem(index) — main=0, sub=1, range=2 (FFXI layout).
+]]--
+
+local M = {};
+
+local EQUIP_MAIN = 0;
+local EQUIP_SUB = 1;
+local EQUIP_RANGE = 2;
+
+local function getEquippedItemId(inventory, equipSlot)
+    if not inventory then return 0; end
+    local equipped = inventory:GetEquippedItem(equipSlot);
+    if not equipped then return 0; end
+    local idx = bit.band(equipped.Index or 0, 0x00FF);
+    if idx == 0 then return 0; end
+    local container = bit.rshift(bit.band(equipped.Index or 0, 0xFF00), 8);
+    local item = inventory:GetContainerItem(container, idx);
+    if not item or not item.Id then return 0; end
+    return item.Id;
+end
+
+--- Stable signature for invalidating cached spells/abilities/WS: no weapon-category logic.
+---@return string
+function M.GetPlayerWeaponskillCacheSignature(player)
+    if not player then return ''; end
+    local memMgr = AshitaCore:GetMemoryManager();
+    local inventory = memMgr and memMgr:GetInventory() or nil;
+
+    local mainId = getEquippedItemId(inventory, EQUIP_MAIN);
+    local subId = getEquippedItemId(inventory, EQUIP_SUB);
+    local rangeId = getEquippedItemId(inventory, EQUIP_RANGE);
+
+    local hasSync = false;
+    local buffs = player.GetBuffs and player:GetBuffs() or nil;
+    if buffs then
+        for i = 1, 32 do
+            if buffs[i] == 269 then
+                hasSync = true;
+                break;
+            end
+        end
+    end
+
+    -- Party slot 0 often reflects effective (level sync) job levels as soon as packets update; Player
+    -- API can lag briefly. Including both avoids stale spell/WS caches when the sync cap moves (e.g.
+    -- sync target levels up) while buff 269 stays on.
+    local partyMainLv = 0;
+    local partySubLv = 0;
+    local party = memMgr and memMgr:GetParty() or nil;
+    if party and party.GetMemberIsActive and party:GetMemberIsActive(0) == 1 then
+        partyMainLv = party:GetMemberMainJobLevel(0) or 0;
+        partySubLv = party:GetMemberSubJobLevel(0) or 0;
+    end
+
+    return string.format(
+        '%d:%d:%d:%d:%d:%d:%d:%d:%d:%d',
+        player:GetMainJob() or 0,
+        player:GetSubJob() or 0,
+        player:GetMainJobLevel() or 0,
+        player:GetSubJobLevel() or 0,
+        mainId,
+        subId,
+        rangeId,
+        hasSync and 1 or 0,
+        partyMainLv,
+        partySubLv
+    );
+end
+
+-- Back-compat alias (same signature, clearer name going forward)
+M.GetPlayerEquipmentWeaponskillSignature = M.GetPlayerWeaponskillCacheSignature;
+
+return M;

--- a/XIUI/modules/hotbar/playerdata.lua
+++ b/XIUI/modules/hotbar/playerdata.lua
@@ -19,6 +19,23 @@ local cachedItems = nil;
 local cacheJobId = nil;
 local cacheSubJobId = nil;
 
+-- Full invalidation signature (job/level/equip/level sync) + periodic WS-count poll
+local cacheFullSignature = nil;
+local lastWsCountPollClock = 0;
+local lastCachedWsAbilityCount = -1;
+local WS_ABILITY_COUNT_POLL_INTERVAL = 0.75;
+local lastEquipSignaturePollClock = 0;
+local EQUIP_SIGNATURE_POLL_INTERVAL = 0.6;
+
+local equipmentWs = require('modules.hotbar.equipment_ws');
+local horizonRetailOnlyJa = require('modules.hotbar.database.horizon_retail_only_job_abilities');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
+-- Pre-existing name->id hashmap module (built lazily, session-cached). Replaces several
+-- per-call O(1024) `for abilityId = 1, 1024 do ... resMgr:GetAbilityById(...)` scans for
+-- name-based lookups. Audit pass: both 1.8.0 and Ferris kept this module but neither
+-- propagated it into playerdata.lua's scans.
+local actiondb = require('modules.hotbar.actiondb');
+
 -- ============================================
 -- Container Definitions
 -- ============================================
@@ -58,6 +75,59 @@ local function IsGarbageSpellName(name)
 end
 
 -- ============================================
+-- Spell Sorting Helpers
+-- ============================================
+
+-- Base type rank (canonical display order when no job context)
+local BASE_TYPE_RANK = {
+    WhiteMagic=1, BlackMagic=2, BardSong=3, Ninjutsu=4,
+    SummonerPact=5, BlueMagic=6, Geomancy=7, Trust=8,
+};
+
+-- Which type to surface first for each job
+local JOB_PRIMARY_TYPE = {
+    [3]  = 'WhiteMagic',    -- WHM
+    [4]  = 'BlackMagic',    -- BLM
+    [5]  = 'WhiteMagic',    -- RDM (has both; white magic is their healing focus)
+    [7]  = 'WhiteMagic',    -- PLD
+    [8]  = 'BlackMagic',    -- DRK
+    [10] = 'BardSong',      -- BRD
+    [13] = 'Ninjutsu',      -- NIN
+    [15] = 'SummonerPact',  -- SMN
+    [16] = 'BlueMagic',     -- BLU
+    [20] = 'WhiteMagic',    -- SCH
+    [21] = 'Geomancy',      -- GEO
+};
+
+--- Build a sort comparator for spells, context-aware by job.
+--- Primary type for the given job sorts to the top.
+--- Within SummonerPact, avatars come before spirits.
+---@param mainJobId number
+--- Spells sort by type group, then level, then name. Status is communicated by colour only.
+---@return function
+local function MakeSpellSortFn(mainJobId)
+    local primaryType = JOB_PRIMARY_TYPE[mainJobId];
+    return function(a, b)
+        local ra = BASE_TYPE_RANK[a.type] or 9;
+        local rb = BASE_TYPE_RANK[b.type] or 9;
+        if primaryType then
+            if a.type == primaryType then ra = 0; end
+            if b.type == primaryType then rb = 0; end
+        end
+        if ra ~= rb then return ra < rb; end
+        -- Within SummonerPact: avatars before spirits
+        if a.type == 'SummonerPact' and b.type == 'SummonerPact' then
+            local aIsSpirit = a.name:find(' Spirit') ~= nil;
+            local bIsSpirit = b.name:find(' Spirit') ~= nil;
+            if aIsSpirit ~= bIsSpirit then return not aIsSpirit; end
+        end
+        -- Sort by level then name; status is communicated by text colour alone
+        if a.level ~= b.level then return a.level < b.level; end
+        return a.name < b.name;
+    end;
+end
+
+-- ============================================
 -- Player Data Retrieval Functions
 -- ============================================
 
@@ -73,61 +143,75 @@ function M.GetPlayerSpells()
     local subJobId = player:GetSubJob();
     local subJobLevel = player:GetSubJobLevel();
     local resMgr = AshitaCore:GetResourceManager();
+    local horizonSpells = require('modules.hotbar.database.horizonspells');
+
+    -- Build id → horizonspells entry and name → type lookups in one pass.
+    -- Using the horizonspells `levels` table for job/level data avoids the
+    -- unreliable LevelRequired indexing in Ashita's resource manager (the
+    -- offset between Ashita's C++ array and Lua indexing is inconsistent).
+    -- This is the same data source used by GetAllSpellsForCurrentJob (Show All
+    -- mode), which is known to work correctly.
+    -- When the same spell name exists as both a castable spell and a SummonerPact
+    -- blood pact, prefer the non-blood-pact type so spells like "Blizzard II"
+    -- sort into the correct section rather than the Rage section.
+    local horizonById = {};
+    local spellTypeByName = {};
+    for _, s in pairs(horizonSpells) do
+        -- Exclude unlearnable entries (NPC/monster-only variants like Sleepga id=363).
+        -- They share names with the learnable versions and would otherwise cause duplicates.
+        if s.id and not s.unlearnable then horizonById[s.id] = s; end
+        if s.en and s.type and not s.unlearnable then
+            local existing = spellTypeByName[s.en];
+            if not existing or (s.type ~= 'SummonerPact' and existing == 'SummonerPact') then
+                spellTypeByName[s.en] = s.type;
+            end
+        end
+    end
 
     local spells = {};
-    local addedSpells = {};  -- Track by spell ID to avoid duplicates
+    local addedSpells = {};
 
-    for spellId = 1, 1024 do
-        -- Skip trust spells (IDs 896+)
-        if spellId >= 896 then
-            break;
-        end
-
+    for spellId = 1, 895 do
         if player:HasSpell(spellId) then
             local spell = resMgr:GetSpellById(spellId);
             if spell and spell.Name and spell.Name[1] and spell.Name[1] ~= '' then
                 local spellName = spell.Name[1];
 
-                -- Skip garbage/test spell names
-                if not IsGarbageSpellName(spellName) then
-                    -- LevelRequired array uses jobId + 1 offset
-                    -- WHM (jobId=3) -> LevelRequired[4], BLM (jobId=4) -> LevelRequired[5]
-                    local mainReqLevel = spell.LevelRequired[mainJobId + 1] or 0;
-                    local subReqLevel = subJobId > 0 and (spell.LevelRequired[subJobId + 1] or 0) or 0;
+                if not IsGarbageSpellName(spellName) and not addedSpells[spellName] then
+                    -- Use horizonspells levels table for job filtering — same indexing
+                    -- ([mainJobId] directly, e.g. [4]=BLM) as the working Show All path.
+                    local hSpell = horizonById[spellId];
+                    local hLevels = hSpell and hSpell.levels;
+                    local mainReqLevel = (hLevels and hLevels[mainJobId]) or 0;
+                    local subReqLevel = (subJobId > 0 and hLevels and hLevels[subJobId]) or 0;
 
-                    -- Filter invalid level values (0 = can't learn, 255 = can't learn)
                     local validMainReq = mainReqLevel > 0 and mainReqLevel < 255;
                     local validSubReq = subReqLevel > 0 and subReqLevel < 255;
 
-                    -- Check if castable by main job
-                    local canCastMain = validMainReq and mainReqLevel <= mainJobLevel;
-                    -- Check if castable by sub job
-                    local canCastSub = validSubReq and subReqLevel <= subJobLevel;
-
-                    if (canCastMain or canCastSub) and not addedSpells[spellId] then
-                        -- Use main job level if castable, otherwise sub job level
-                        local displayLevel = canCastMain and mainReqLevel or subReqLevel;
-                        local source = canCastMain and 'main' or 'sub';
+                    -- Spell must belong to the player's current job or subjob.
+                    -- We don't require canCast (level >= req) because HorizonXI may
+                    -- grant spells at different thresholds than the static DB records;
+                    -- HasSpell() already proves the player can cast it.
+                    local isForCurrentJob = validMainReq or validSubReq;
+                    if isForCurrentJob then
+                        local displayLevel = validMainReq and mainReqLevel or subReqLevel;
+                        local source = validMainReq and 'main' or 'sub';
 
                         table.insert(spells, {
                             id = spellId,
                             name = spellName,
                             level = displayLevel,
                             source = source,
+                            type = (hSpell and hSpell.type) or spellTypeByName[spellName] or 'Unknown',
                         });
-                        addedSpells[spellId] = true;
+                        addedSpells[spellName] = true;
                     end
                 end
             end
         end
     end
 
-    table.sort(spells, function(a, b)
-        if a.level == b.level then
-            return a.name < b.name;
-        end
-        return a.level < b.level;
-    end);
+    table.sort(spells, MakeSpellSortFn(mainJobId));
 
     return spells;
 end
@@ -158,10 +242,13 @@ local ABILITY_TYPE = {
     RuneWard          = 22,
     RuneEffusion      = 23,
 };
+-- Backward-compat alias for Ferris's existing code paths.
+local ABILITY_TYPE_WEAPON_SKILL = ABILITY_TYPE.WeaponSkill;
 
--- Pet commands to filter out from ability list (these belong in Pet Command section)
+-- Pet commands shown under Pet Command in the macro UI — excluded from the Job Ability dropdown only.
+-- Players may still macro these as `/ja "Name"` in-game; IsAbilityInCache() accepts them when HasAbility is true.
+-- Note: 'Assault' (BST pet) intentionally OMITTED — confusable with the Treasures of Aht Urhgan in-game system.
 local PET_COMMAND_NAMES = {
-    ['Assault'] = true,
     ['Retreat'] = true,
     ['Stay'] = true,
     ['Heel'] = true,
@@ -170,20 +257,17 @@ local PET_COMMAND_NAMES = {
     ['Fight'] = true,
     ['Sic'] = true,
     ['Ready'] = true,
-    -- SMN commands
     ['Avatar\'s Favor'] = true,
-    -- DRG commands
     ['Steady Wing'] = true,
-    -- PUP commands
     ['Deploy'] = true,
     ['Retrieve'] = true,
     ['Activate'] = true,
     ['Deactivate'] = true,
 };
 
--- FFXI macro-maker subcategory headers ("Sambas", "Waltzes", etc.) are present
--- as ability entries in the resource manager and HasAbility() returns true for
--- them, but they aren't executable. Filter them out of the JA dropdown.
+-- FFXI macro-maker subcategory headers ("Sambas", "Waltzes", etc.) are present as ability
+-- entries in the resource manager and HasAbility() returns true for them, but they aren't
+-- executable. Filter them out of the JA dropdown and IsAbilityInCache.
 local CATEGORY_PLACEHOLDER_NAMES = {
     ['Sambas']         = true,
     ['Waltzes']        = true,
@@ -194,8 +278,48 @@ local CATEGORY_PLACEHOLDER_NAMES = {
     ['Flourishes III'] = true,
 };
 
+local function sortRankFamiliarFirst(name)
+    return (name == 'Familiar') and 0 or 1;
+end
+
+local function horizonHasBstReadyPetCommand()
+    local ha = require('modules.hotbar.database.horizon_abilities');
+    local row = ha['Ready'];
+    return row ~= nil and row.pet == true;
+end
+
+local function playerHasLearnedNonWsAbilityByName(abilityName)
+    if horizonRetailOnlyJa[abilityName] then
+        return false;
+    end
+    if not abilityName or abilityName == '' then
+        return false;
+    end
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then
+        return false;
+    end
+    local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then
+        return false;
+    end
+    -- Audit win: O(1) name->id via actiondb (session-cached lazy hashmap) replaces the
+    -- O(1024) scan that was here. Same semantics: confirm player has learned it AND it
+    -- is not a weapon-skill type. Falls back to scan if actiondb returns nil (e.g. before
+    -- the lookup table is populated for some edge resource-manager state).
+    local id = actiondb.GetAbilityId(abilityName);
+    if id and id > 0 and player:HasAbility(id) then
+        local ability = resMgr:GetAbilityById(id);
+        if ability and ability.Name and ability.Name[1] == abilityName then
+            local abilityType = ability.Type or 0;
+            return abilityType ~= ABILITY_TYPE_WEAPON_SKILL;
+        end
+    end
+    return false;
+end
+
 --- Get player's available job abilities (includes both main job and subjob abilities)
---- Filters out weapon skills (Type 3) and pet commands
+--- Filters out weapon skills (Type 3) and PET_COMMAND_NAMES (those stay in the Pet Command picker).
 ---@return table Array of {id, name, source} where source is 'main' or 'sub'
 function M.GetPlayerAbilities()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
@@ -206,31 +330,35 @@ function M.GetPlayerAbilities()
     local subJobId = player:GetSubJob();
     local subJobLevel = player:GetSubJobLevel();
     local resMgr = AshitaCore:GetResourceManager();
+    local horizonAbilities = require('modules.hotbar.database.horizon_abilities');
 
     local abilities = {};
-    local addedAbilities = {};  -- Track by ability ID to avoid duplicates
+    local addedAbilities = {};
 
-    -- Scan ability IDs 1-1024 (job abilities can be in higher ranges like 500+)
     for abilityId = 1, 1024 do
         if player:HasAbility(abilityId) then
             local ability = resMgr:GetAbilityById(abilityId);
             if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
                 local abilityType = ability.Type or 0;
-                local abilityName = ability.Name[1];
 
-                -- Exclude: weapon skills (separate dropdown), passive traits (not
-                -- macroable), pet commands (separate section), and subcategory
-                -- header placeholders ("Sambas", "Waltzes", etc.).
-                local isWeaponSkill = abilityType == ABILITY_TYPE.WeaponSkill;
-                local isTrait       = abilityType == ABILITY_TYPE.Trait;
-                if not isWeaponSkill
-                    and not isTrait
+                local abilityName = ability.Name[1];
+                -- Exclude: weapon skills (separate dropdown), passive traits (not macroable),
+                -- pet commands (separate section), Horizon retail-only entries, and FFXI's
+                -- subcategory header placeholders ("Sambas", "Waltzes", etc.).
+                if not horizonRetailOnlyJa[abilityName]
+                    and abilityType ~= ABILITY_TYPE.WeaponSkill
+                    and abilityType ~= ABILITY_TYPE.Trait
                     and not PET_COMMAND_NAMES[abilityName]
-                    and not CATEGORY_PLACEHOLDER_NAMES[abilityName]
-                then
+                    and not CATEGORY_PLACEHOLDER_NAMES[abilityName] then
 
                     if not addedAbilities[abilityId] then
                         local source = 'main';
+                        local displayLevel = nil;
+
+                        local dbEntry = horizonAbilities[abilityName];
+                        if dbEntry and dbEntry.level then
+                            displayLevel = dbEntry.level;
+                        end
 
                         if ability.Level then
                             local mainReqLevel = ability.Level[mainJobId + 1] or 0;
@@ -247,10 +375,14 @@ function M.GetPlayerAbilities()
                             end
                         end
 
+                        local hj = dbEntry and dbEntry.job;
                         table.insert(abilities, {
                             id = abilityId,
                             name = abilityName,
+                            level = displayLevel,
                             source = source,
+                            jobId = hj,
+                            pinkStarTooltip = universalTwoHour.GetTwoHourPinkTooltipIfApplicable(hj, abilityName),
                         });
                         addedAbilities[abilityId] = true;
                     end
@@ -260,6 +392,13 @@ function M.GetPlayerAbilities()
     end
 
     table.sort(abilities, function(a, b)
+        local ta = universalTwoHour.TwoHourSortRank(a.jobId, a.name);
+        local tb = universalTwoHour.TwoHourSortRank(b.jobId, b.name);
+        if ta ~= tb then return ta < tb; end
+        local fa = sortRankFamiliarFirst(a.name);
+        local fb = sortRankFamiliarFirst(b.name);
+        if fa ~= fb then return fa < fb; end
+        if a.level and b.level and a.level ~= b.level then return a.level < b.level; end
         return a.name < b.name;
     end);
 
@@ -274,34 +413,63 @@ function M.GetPlayerWeaponskills()
     if not player then return {}; end
 
     local resMgr = AshitaCore:GetResourceManager();
+    local wsDb = require('modules.hotbar.database.ws_weapon_types');
     local weaponskills = {};
-    local addedWeaponskills = {};  -- Track by name to avoid duplicates
+    local addedWeaponskills = {};
 
-    -- Scan HasAbility and filter by Type == WeaponSkill (3)
-    for abilityId = 1, 1024 do
+    -- Audit win: iterate the static WS-ability-ID list from actiondb instead of scanning
+    -- all 1024 ability slots. The Type==3 filter is moved into the one-time list build,
+    -- so the per-call loop only has to check HasAbility + dedup.
+    local wsIds = actiondb.GetWeaponSkillAbilityIds();
+    for i = 1, #wsIds do
+        local abilityId = wsIds[i];
         if player:HasAbility(abilityId) then
             local ability = resMgr:GetAbilityById(abilityId);
             if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
-                local abilityType = ability.Type or 0;
-                if abilityType == ABILITY_TYPE.WeaponSkill then
-                    local wsName = ability.Name[1];
-                    if not addedWeaponskills[wsName] then
-                        table.insert(weaponskills, {
-                            id = abilityId,
-                            name = wsName,
-                        });
-                        addedWeaponskills[wsName] = true;
+                local wsName = ability.Name[1];
+                if not addedWeaponskills[wsName] then
+                    local info = wsDb[wsName];
+                    local reqStr = nil;
+                    if info then
+                        reqStr = info.relic and 'Relic Weapon' or ('Skill ' .. tostring(info.skill));
                     end
+                    table.insert(weaponskills, {
+                        id = abilityId,
+                        name = wsName,
+                        reqStr = reqStr,
+                        skill = info and info.skill or 0,
+                        relic = info and info.relic or false,
+                    });
+                    addedWeaponskills[wsName] = true;
                 end
             end
         end
     end
 
     table.sort(weaponskills, function(a, b)
+        if a.relic ~= b.relic then return not a.relic; end
+        if a.skill ~= b.skill then return a.skill < b.skill; end
         return a.name < b.name;
     end);
 
     return weaponskills;
+end
+
+--- Count type-3 abilities the player has (cheap drift detector for new WS without job change).
+local function countLearnedWeaponSkillAbilities(player)
+    if not player then return 0; end
+    local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then return 0; end
+    local c = 0;
+    -- Audit win: same actiondb-driven optimization. The WS-id list already filters by Type == 3
+    -- so the per-call body just needs HasAbility check + counter increment.
+    local wsIds = actiondb.GetWeaponSkillAbilityIds();
+    for i = 1, #wsIds do
+        if player:HasAbility(wsIds[i]) then
+            c = c + 1;
+        end
+    end
+    return c;
 end
 
 --- Get items from all player storage containers
@@ -381,18 +549,58 @@ function M.RefreshCachedLists(dataModule)
     local dataJobId = dataModule and dataModule.jobId or currentJobId;
     local dataSubjobId = dataModule and dataModule.subjobId or currentSubJobId;
 
-    -- Refresh if main job, sub job changed, or cache is empty
-    -- Also refresh if data.jobId differs from cache (pending job change)
-    local jobChanged = cacheJobId ~= currentJobId or cacheSubJobId ~= currentSubJobId;
-    local pendingChange = cacheJobId ~= nil and (cacheJobId ~= dataJobId or cacheSubJobId ~= dataSubjobId);
+    local equipSig = equipmentWs.GetPlayerWeaponskillCacheSignature(player);
+    local fullSig = equipSig .. '|' .. tostring(dataJobId) .. '|' .. tostring(dataSubjobId);
 
-    if jobChanged or pendingChange or not cachedSpells then
+    local nowClock = os.clock();
+    local pendingChange = cacheJobId ~= nil and (cacheJobId ~= dataJobId or cacheSubJobId ~= dataSubjobId);
+    local needRefresh = (fullSig ~= cacheFullSignature)
+        or pendingChange
+        or (not cachedSpells);
+
+    if (not needRefresh) and (nowClock - lastWsCountPollClock >= WS_ABILITY_COUNT_POLL_INTERVAL) then
+        lastWsCountPollClock = nowClock;
+        local wsCountNow = countLearnedWeaponSkillAbilities(player);
+        if wsCountNow ~= lastCachedWsAbilityCount then
+            needRefresh = true;
+        end
+    end
+
+    -- Throttled equip/sync signature poll: catches rare drift if memory state updates without a frame-tied signature change
+    if (not needRefresh) and cacheFullSignature and (nowClock - lastEquipSignaturePollClock >= EQUIP_SIGNATURE_POLL_INTERVAL) then
+        lastEquipSignaturePollClock = nowClock;
+        local equipSigPoll = equipmentWs.GetPlayerWeaponskillCacheSignature(player);
+        local fullSigPoll = equipSigPoll .. '|' .. tostring(dataJobId) .. '|' .. tostring(dataSubjobId);
+        if fullSigPoll ~= cacheFullSignature then
+            needRefresh = true;
+        end
+    end
+
+    if needRefresh then
         cachedSpells = M.GetPlayerSpells();
         cachedAbilities = M.GetPlayerAbilities();
+        -- WS list: trust client HasAbility only; gear/job/sync in signature refreshes cache.
         cachedWeaponskills = M.GetPlayerWeaponskills();
         cachedItems = nil;  -- Clear items cache to refresh on next access
         cacheJobId = currentJobId;
         cacheSubJobId = currentSubJobId;
+        cacheFullSignature = fullSig;
+        lastCachedWsAbilityCount = countLearnedWeaponSkillAbilities(player);
+
+        -- Clear expanded caches on job change so they rebuild with fresh data
+        expandedSpellsCache = nil;
+        expandedAbilitiesCache = nil;
+        expandedWsCache = nil;
+
+        -- Discover any newly learned WS and persist to charSettings
+        if M.DiscoverNewWeaponskills() and SaveCharacterSettingsInternal then
+            SaveCharacterSettingsInternal();
+        end
+
+        local okSr, slotrenderer = pcall(require, 'modules.hotbar.slotrenderer');
+        if okSr and slotrenderer and slotrenderer.ClearAvailabilityCache then
+            slotrenderer.ClearAvailabilityCache();
+        end
     end
 
     -- Only refresh items if cache is empty (expensive operation)
@@ -433,6 +641,13 @@ function M.ClearCache()
     cachedItems = nil;
     cacheJobId = nil;
     cacheSubJobId = nil;
+    cacheFullSignature = nil;
+    lastCachedWsAbilityCount = -1;
+    expandedSpellsCache = nil;
+    expandedAbilitiesCache = nil;
+    expandedWsCache = nil;
+    expandedAbilitiesFilterJobId = nil;
+    expandedSpellsFilterType = nil;
 end
 
 --- Get current cache job ID
@@ -448,15 +663,33 @@ function M.GetCacheSubJobId()
 end
 
 --- Check if an ability name is in the cached abilities list
---- This ensures availability check uses same data as dropdown
+--- Used for `/ja` macro availability: matches the Job Ability dropdown when populated, plus PET_COMMAND_NAMES when learned.
 ---@param abilityName string The ability name to check
 ---@return boolean isAvailable True if ability is in cached list
 function M.IsAbilityInCache(abilityName)
-    if not cachedAbilities then return true; end  -- No cache = assume available
-    for _, ability in ipairs(cachedAbilities) do
-        if ability.name == abilityName then
-            return true;
+    if abilityName == universalTwoHour.ACTION_SENTINEL then
+        abilityName = universalTwoHour.ResolveJaActionName(abilityName);
+        if not abilityName then
+            return false;
         end
+    end
+    if horizonRetailOnlyJa[abilityName] then
+        return false;
+    end
+    -- Ready: honor horizon_abilities pet row (HorizonXI defines Ready for jug pets).
+    if abilityName == 'Ready' and not horizonHasBstReadyPetCommand() then
+        return false;
+    end
+    if cachedAbilities and #cachedAbilities > 0 then
+        for _, ability in ipairs(cachedAbilities) do
+            if ability.name == abilityName then
+                return true;
+            end
+        end
+    end
+    -- Omitted from JA dropdown; `/ja` in macros still uses client HasAbility when the name is a known pet command.
+    if PET_COMMAND_NAMES[abilityName] then
+        return playerHasLearnedNonWsAbilityByName(abilityName);
     end
     return false;
 end
@@ -465,7 +698,9 @@ end
 ---@param wsName string The weaponskill name to check
 ---@return boolean isAvailable True if weaponskill is in cached list
 function M.IsWeaponskillInCache(wsName)
-    if not cachedWeaponskills then return true; end
+    if not cachedWeaponskills or #cachedWeaponskills == 0 then
+        return false;
+    end
     for _, ws in ipairs(cachedWeaponskills) do
         if ws.name == wsName then
             return true;
@@ -473,6 +708,476 @@ function M.IsWeaponskillInCache(wsName)
     end
     return false;
 end
+
+-- ============================================
+-- Per-Character WS Knowledge Cache
+-- ============================================
+
+-- Known WS set: {['Savage Blade']=true, ...}. Populated externally from charSettings.
+local knownWeaponskills = {};
+
+--- Set the known WS table (call from XIUI.lua after loading charSettings)
+function M.SetKnownWeaponskills(tbl)
+    knownWeaponskills = tbl or {};
+end
+
+--- Get the known WS table reference
+function M.GetKnownWeaponskills()
+    return knownWeaponskills;
+end
+
+--- Scan player's current abilities for any new WS and add them to the known set.
+--- Returns true if any new WS were discovered (caller should save charSettings).
+function M.DiscoverNewWeaponskills()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return false; end
+
+    local resMgr = AshitaCore:GetResourceManager();
+    local found = false;
+
+    -- Audit win: same actiondb-driven optimization as GetPlayerWeaponskills.
+    local wsIds = actiondb.GetWeaponSkillAbilityIds();
+    for i = 1, #wsIds do
+        local abilityId = wsIds[i];
+        if player:HasAbility(abilityId) then
+            local ability = resMgr:GetAbilityById(abilityId);
+            if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
+                local wsName = ability.Name[1];
+                if not knownWeaponskills[wsName] then
+                    knownWeaponskills[wsName] = true;
+                    found = true;
+                end
+            end
+        end
+    end
+
+    return found;
+end
+
+-- ============================================
+-- "Show All" Expanded List Builders
+-- ============================================
+
+local expandedSpellsCache = nil;
+local expandedAbilitiesCache = nil;
+local expandedWsCache = nil;
+local expandedCacheJobId = nil;
+local expandedCacheSubJobId = nil;
+local expandedAbilitiesFilterJobId = nil;
+local expandedSpellsFilterType = nil;
+
+local STATUS_HAVE = 'have';
+local STATUS_LEARNABLE = 'learnable';
+local STATUS_UNAVAILABLE = 'unavailable';
+
+local STATUS_SORT = { [STATUS_HAVE] = 1, [STATUS_LEARNABLE] = 2, [STATUS_UNAVAILABLE] = 3 };
+
+--- Get expanded spell list from horizonspells DB with availability status.
+--- When filterMagicType is 'All' or nil, only spells for the current main/sub job are shown.
+--- When a specific type is given, ALL spells of that type are shown regardless of job.
+--- Green = have, Yellow = learnable (right job/level but spell not yet on character), Red = unavailable.
+---@param filterMagicType string|nil Magic type filter ('All', 'WhiteMagic', 'BlackMagic', etc.)
+---@return table Array of {id, name, level, source, type, status, icon_id}
+function M.GetAllSpellsForCurrentJob(filterMagicType)
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return {}; end
+
+    local mainJobId = player:GetMainJob();
+    local mainJobLevel = player:GetMainJobLevel();
+    local subJobId = player:GetSubJob();
+    local subJobLevel = player:GetSubJobLevel();
+
+    local effectiveType = (filterMagicType and filterMagicType ~= 'All') and filterMagicType or 'All';
+
+    -- Self-invalidate when job changes
+    if expandedCacheJobId ~= mainJobId or expandedCacheSubJobId ~= subJobId then
+        expandedSpellsCache = nil;
+        expandedAbilitiesCache = nil;
+        expandedWsCache = nil;
+        expandedCacheJobId = mainJobId;
+        expandedCacheSubJobId = subJobId;
+        expandedSpellsFilterType = nil;
+    end
+    if expandedSpellsFilterType ~= effectiveType then
+        expandedSpellsCache = nil;
+        expandedSpellsFilterType = effectiveType;
+    end
+    if expandedSpellsCache then return expandedSpellsCache; end
+
+    local filterByType = (effectiveType ~= 'All');
+
+    local horizonSpells = require('modules.hotbar.database.horizonspells');
+    local omitList = require('modules.hotbar.database.horizon_spell_omissions');
+    local omitSet = {};
+    for _, name in ipairs(omitList) do omitSet[name] = true; end
+    local spells = {};
+
+    for _, spell in pairs(horizonSpells) do
+        if spell.en and spell.en ~= '' and spell.id and not IsGarbageSpellName(spell.en) then
+            if spell.id >= 896 then goto continue; end
+            if spell.unlearnable then goto continue; end
+            if omitSet[spell.en] then goto continue; end
+
+            if filterByType and spell.type ~= effectiveType then goto continue; end
+
+            local levels = spell.levels;
+            if not levels then goto continue; end
+
+            local mainReq = levels[mainJobId];
+            local subReq = (subJobId and subJobId > 0) and levels[subJobId] or nil;
+            local validMain = mainReq and mainReq > 0 and mainReq < 255;
+            local validSub = subReq and subReq > 0 and subReq < 255;
+
+            if not filterByType and not validMain and not validSub then goto continue; end
+
+            local status;
+            local displayLevel;
+            local source;
+
+            local hasSpell = player:HasSpell(spell.id);
+            local canCastMain = validMain and mainReq <= mainJobLevel;
+            local canCastSub = validSub and subReq <= subJobLevel;
+
+            local reason = nil;
+            if hasSpell and (canCastMain or canCastSub) then
+                status = STATUS_HAVE;
+                displayLevel = canCastMain and mainReq or subReq;
+                source = canCastMain and 'main' or 'sub';
+            elseif (validMain and mainReq <= mainJobLevel) or (validSub and subReq <= subJobLevel) then
+                status = STATUS_LEARNABLE;
+                displayLevel = canCastMain and mainReq or (validSub and subReq or mainReq);
+                source = validMain and 'main' or 'sub';
+                reason = 'Not yet learned';
+            else
+                status = STATUS_UNAVAILABLE;
+                local bestLevel = nil;
+                for _, lv in pairs(levels) do
+                    if lv and lv > 0 and lv < 255 then
+                        if not bestLevel or lv < bestLevel then bestLevel = lv; end
+                    end
+                end
+                displayLevel = (validMain and mainReq) or (validSub and subReq) or bestLevel or 99;
+                source = validMain and 'main' or (validSub and 'sub' or 'other');
+                if source == 'other' then
+                    reason = 'Not available to your current job';
+                else
+                    reason = 'Level too low (requires Lv. ' .. tostring(displayLevel) .. ')';
+                end
+            end
+
+            table.insert(spells, {
+                id = spell.id,
+                name = spell.en,
+                level = displayLevel,
+                source = source,
+                type = spell.type or 'Unknown',
+                status = status,
+                reason = reason,
+                icon_id = spell.icon_id,
+            });
+            ::continue::
+        end
+    end
+
+    table.sort(spells, MakeSpellSortFn(mainJobId));
+
+    expandedSpellsCache = spells;
+    return spells;
+end
+
+--- Get expanded ability list with availability status.
+--- Uses the static horizon_abilities database for reliable job-ability mapping,
+--- cross-referenced with player:HasAbility() for ownership status.
+---@param filterJobId number|nil Specific job ID to show abilities for. 0 or nil = main+sub (default).
+---@return table Array of {id, name, level, source, status}
+function M.GetAllAbilitiesForCurrentJob(filterJobId)
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return {}; end
+
+    local mainJobId = player:GetMainJob();
+    local mainJobLevel = player:GetMainJobLevel();
+    local subJobId = player:GetSubJob();
+    local subJobLevel = player:GetSubJobLevel();
+    local resMgr = AshitaCore:GetResourceManager();
+
+    local effectiveFilter = (filterJobId and filterJobId > 0) and filterJobId or 0;
+
+    if expandedCacheJobId ~= mainJobId or expandedCacheSubJobId ~= subJobId then
+        expandedSpellsCache = nil;
+        expandedAbilitiesCache = nil;
+        expandedWsCache = nil;
+        expandedCacheJobId = mainJobId;
+        expandedCacheSubJobId = subJobId;
+        expandedAbilitiesFilterJobId = nil;
+    end
+    if expandedAbilitiesFilterJobId ~= effectiveFilter then
+        expandedAbilitiesCache = nil;
+        expandedAbilitiesFilterJobId = effectiveFilter;
+    end
+    if expandedAbilitiesCache then return expandedAbilitiesCache; end
+
+    local horizonAbilities = require('modules.hotbar.database.horizon_abilities');
+
+    -- Audit win: previously this function did TWO O(1024) resource-manager scans per
+    -- cache miss (one to build name->id, one to populate playerHas). Both are now driven
+    -- by `actiondb` (lazy session-cached name->id hashmap) + iterating the ~80-entry
+    -- horizon_abilities table instead. Net: ~4096 resource calls collapses to ~160 on
+    -- a cache miss (job change / profile load), with actiondb's one-time hashmap build
+    -- amortized across all callers.
+    local playerHas = {};
+    for abilityName, _ in pairs(horizonAbilities) do
+        local id = actiondb.GetAbilityId(abilityName);
+        if id and id > 0 and player:HasAbility(id) then
+            playerHas[abilityName] = true;
+        end
+    end
+
+    local abilities = {};
+
+    for abilityName, info in pairs(horizonAbilities) do
+        if info.pet then goto continue; end
+
+        local matchesMain = info.job == mainJobId;
+        local matchesSub = subJobId and subJobId > 0 and info.job == subJobId;
+
+        if effectiveFilter > 0 then
+            -- Specific job filter: only show abilities for that job
+            if info.job ~= effectiveFilter then goto continue; end
+        else
+            -- Default: show main + sub job abilities
+            if not matchesMain and not matchesSub then goto continue; end
+        end
+
+        local status;
+        local source;
+        local reason = nil;
+
+        if playerHas[abilityName] then
+            status = STATUS_HAVE;
+            source = matchesMain and 'main' or (matchesSub and 'sub' or 'other');
+        elseif matchesMain and mainJobLevel >= info.level then
+            -- Right job and level met but HasAbility returned false (edge case)
+            status = STATUS_LEARNABLE;
+            source = 'main';
+            reason = 'Should be available — try zoning or checking your abilities menu';
+        elseif matchesSub and subJobLevel >= info.level then
+            status = STATUS_LEARNABLE;
+            source = 'sub';
+            reason = 'Should be available — try zoning or checking your abilities menu';
+        else
+            status = STATUS_UNAVAILABLE;
+            source = matchesMain and 'main' or (matchesSub and 'sub' or 'other');
+            reason = 'Level too low (requires Lv. ' .. tostring(info.level) .. ')';
+        end
+
+        local hj = info.job;
+        table.insert(abilities, {
+            id = actiondb.GetAbilityId(abilityName) or 0,
+            name = abilityName,
+            level = info.level,
+            jobId = hj,
+            source = source,
+            status = status,
+            reason = reason,
+            pinkStarTooltip = universalTwoHour.GetTwoHourPinkTooltipIfApplicable(hj, abilityName),
+        });
+        ::continue::
+    end
+
+    table.sort(abilities, function(a, b)
+        local ta = universalTwoHour.TwoHourSortRank(a.jobId, a.name);
+        local tb = universalTwoHour.TwoHourSortRank(b.jobId, b.name);
+        if ta ~= tb then return ta < tb; end
+        local fa = sortRankFamiliarFirst(a.name);
+        local fb = sortRankFamiliarFirst(b.name);
+        if fa ~= fb then return fa < fb; end
+        local sa = STATUS_SORT[a.status] or 9;
+        local sb = STATUS_SORT[b.status] or 9;
+        if sa ~= sb then return sa < sb; end
+        if a.level ~= b.level then return a.level < b.level; end
+        return a.name < b.name;
+    end);
+
+    expandedAbilitiesCache = abilities;
+    return abilities;
+end
+
+--- Get expanded weaponskill list from static WS lookup with known/unknown status.
+---@param knownWsTable table|nil Per-character set of known WS names (defaults to internal set)
+---@return table Array of {name, weapon, skill, relic, status}
+function M.GetAllWeaponskillsExpanded(knownWsTable)
+    if expandedWsCache then return expandedWsCache; end
+
+    knownWsTable = knownWsTable or knownWeaponskills;
+    local wsDb = require('modules.hotbar.database.ws_weapon_types');
+    local weaponskills = {};
+
+    for wsName, info in pairs(wsDb) do
+        local status = knownWsTable[wsName] and STATUS_HAVE or STATUS_UNAVAILABLE;
+        local reqStr;
+        local reason = nil;
+        if info.relic then
+            reqStr = 'Relic Weapon';
+            if status == STATUS_UNAVAILABLE then
+                reason = 'Requires the relic weapon to be equipped';
+            end
+        else
+            reqStr = 'Skill ' .. tostring(info.skill);
+            if status == STATUS_UNAVAILABLE then
+                reason = 'Not yet learned — use a ' .. info.weapon .. ' in battle (skill Lv. ' .. tostring(info.skill) .. ')';
+            end
+        end
+        table.insert(weaponskills, {
+            name = wsName,
+            weapon = info.weapon,
+            skill = info.skill,
+            relic = info.relic or false,
+            status = status,
+            reqStr = reqStr,
+            reason = reason,
+        });
+    end
+
+    -- Show All: group by weapon type A→Z, then skill requirement low→high (relic last per type), then name.
+    -- Availability color stays on rows; order does not shuffle unknown WS out of weapon clusters.
+    table.sort(weaponskills, function(a, b)
+        if a.weapon ~= b.weapon then return a.weapon < b.weapon; end
+        if a.relic ~= b.relic then return not a.relic; end
+        if a.skill ~= b.skill then return a.skill < b.skill; end
+        return a.name < b.name;
+    end);
+
+    expandedWsCache = weaponskills;
+    return weaponskills;
+end
+
+--- Clear expanded list caches (call on job change, etc.)
+function M.ClearExpandedCaches()
+    expandedSpellsCache = nil;
+    expandedAbilitiesCache = nil;
+    expandedWsCache = nil;
+    expandedCacheJobId = nil;
+    expandedCacheSubJobId = nil;
+    expandedAbilitiesFilterJobId = nil;
+    expandedSpellsFilterType = nil;
+end
+
+-- Internal type names used in horizonspells.lua mapped to display labels
+local MAGIC_TYPE_LABELS = {
+    WhiteMagic    = 'White Magic',
+    BlackMagic    = 'Black Magic',
+    BardSong      = 'Songs',
+    Ninjutsu      = 'Ninjutsu',
+    SummonerPact  = 'Summoning',
+    BlueMagic     = 'Blue Magic',
+    Geomancy      = 'Geomancy',
+    Trust         = 'Trust',
+};
+
+local MAGIC_TYPE_ORDER = {
+    'WhiteMagic', 'BlackMagic', 'BardSong', 'Ninjutsu',
+    'SummonerPact', 'BlueMagic', 'Geomancy', 'Trust',
+};
+
+-- Job ID -> which magic types that job can natively use (sorted alphabetically by label)
+local JOB_MAGIC_TYPES = {
+    [1]  = {},                                                       -- WAR
+    [2]  = {},                                                       -- MNK
+    [3]  = { 'WhiteMagic' },                                         -- WHM
+    [4]  = { 'BlackMagic' },                                         -- BLM
+    [5]  = { 'BlackMagic', 'WhiteMagic' },                           -- RDM
+    [6]  = {},                                                       -- THF
+    [7]  = { 'WhiteMagic' },                                         -- PLD
+    [8]  = { 'BlackMagic' },                                         -- DRK
+    [9]  = {},                                                       -- BST
+    [10] = { 'BardSong', 'WhiteMagic' },                             -- BRD
+    [11] = {},                                                       -- RNG
+    [12] = {},                                                       -- SAM
+    [13] = { 'Ninjutsu' },                                           -- NIN
+    [14] = {},                                                       -- DRG
+    [15] = { 'SummonerPact', 'WhiteMagic' },                         -- SMN
+    [16] = { 'BlueMagic' },                                          -- BLU
+    [17] = {},                                                       -- COR
+    [18] = {},                                                       -- PUP
+    [19] = {},                                                       -- DNC
+    [20] = { 'BlackMagic', 'WhiteMagic' },                           -- SCH
+    [21] = { 'Geomancy' },                                           -- GEO
+    [22] = {},                                                       -- RUN
+};
+
+--- Get the ordered list of magic types for a given job (or current main+sub).
+--- Returns entries like {key='WhiteMagic', label='White Magic'}.
+---@param mainJobId number|nil Main job ID (uses current player if nil)
+---@param subJobId number|nil Sub job ID (uses current player if nil)
+---@return table Array of {key, label} sorted by MAGIC_TYPE_ORDER
+function M.GetMagicTypesForJob(mainJobId, subJobId)
+    if not mainJobId then
+        local player = AshitaCore:GetMemoryManager():GetPlayer();
+        if not player then return {}; end
+        mainJobId = player:GetMainJob();
+        subJobId = player:GetSubJob();
+    end
+
+    local seen = {};
+    local mainTypes = JOB_MAGIC_TYPES[mainJobId] or {};
+    local subTypes = (subJobId and subJobId > 0) and (JOB_MAGIC_TYPES[subJobId] or {}) or {};
+    for _, t in ipairs(mainTypes) do seen[t] = true; end
+    for _, t in ipairs(subTypes) do seen[t] = true; end
+
+    local result = {};
+    for _, key in ipairs(MAGIC_TYPE_ORDER) do
+        if seen[key] then
+            table.insert(result, { key = key, label = MAGIC_TYPE_LABELS[key] });
+        end
+    end
+    return result;
+end
+
+--- Get display label for a magic type key.
+---@param key string Internal type key (e.g. 'WhiteMagic')
+---@return string Display label (e.g. 'White Magic')
+function M.GetMagicTypeLabel(key)
+    return MAGIC_TYPE_LABELS[key] or key;
+end
+
+--- Get all magic type options in canonical order.
+---@return table Array of {key, label}
+function M.GetAllMagicTypes()
+    local result = {};
+    for _, key in ipairs(MAGIC_TYPE_ORDER) do
+        table.insert(result, { key = key, label = MAGIC_TYPE_LABELS[key] });
+    end
+    return result;
+end
+
+--- Get all unique weapon types from the WS lookup.
+---@return table Array of weapon type strings, sorted alphabetically
+function M.GetWeaponTypes()
+    local wsDb = require('modules.hotbar.database.ws_weapon_types');
+    local types = {};
+    local seen = {};
+    for _, info in pairs(wsDb) do
+        if not seen[info.weapon] then
+            seen[info.weapon] = true;
+            table.insert(types, info.weapon);
+        end
+    end
+    table.sort(types);
+    return types;
+end
+
+--- Get BST pet commands from the static database with level-gated availability.
+--- Uses horizon_abilities entries flagged with pet = true.
+---@param playerLevel number The BST job level to check against
+---@return table Array of {name, level, status}
+function M.GetBstPetCommandsExpanded(playerLevel)
+    local petregistry = require('modules.hotbar.petregistry');
+    return petregistry.GetBstPetCommandsExpanded(playerLevel, nil);
+end
+
+M.STATUS_HAVE = STATUS_HAVE;
+M.STATUS_LEARNABLE = STATUS_LEARNABLE;
+M.STATUS_UNAVAILABLE = STATUS_UNAVAILABLE;
 
 -- Export helper for external use
 M.IsGarbageSpellName = IsGarbageSpellName;


### PR DESCRIPTION
…ache, Level Sync invalidation

What changed
- playerdata.lua: GetAllSpells, GetAllAbilities, GetAllWeaponskills with status tiers and hover reason strings. ABILITY_TYPE enum (24 entries). Spell sort: level then name within magic type; WS sort: weapon category A->Z, skill req low->high (non-relic before relic). JA two-hour sorts first; pink asterisk + tooltip for Universal 2 Hour hint. Trait + CategoryPlaceholder filters. Horizon filtering throughout using horizon_abilities.lua and horizon_spell_omissions.lua. GetExpandedAbilities via actiondb.GetAbilityId; playerHasLearnedNonWsAbilityByName O(1); WS scans via actiondb.GetWeaponSkillAbilityIds(). RefreshCachedLists called at DrawWindow top for crossbar-only setups (fixes crossbar JA/WS slots showing unavailable without hotbar on).
- actiondb.lua: GetWeaponSkillAbilityIds() lazy session-cached list. Collapses O(1024) ability scans to O(1) or O(~50-100) per cache miss for WS availability and icon resolution paths.
- equipment_ws.lua: New file. WS cache-bust signature: job + levels + level sync + main/sub/range item IDs. Drives WS list refresh on gear swap without full rescan.
- handlers/statushandler.lua: Level Sync buff detection (LEVEL_SYNC_BUFF_ID = 269); transition block clears playerdata cache + slotrenderer availability cache. Encoding import updated to libs.encoding (replaces deprecated gdifonts path from 1.7.5).

Why
- Macro editor and hotbar show consistent availability and readable lists on Horizon without labeling retail-only additions as usable. Crossbar-only setups correctly show JA/WS availability without requiring the keyboard hotbar. Availability caches invalidate on Level Sync toggle so synced-down players see correct spell/ability lists.