### PR TITLE
Foundational: entry point, settings, DeferRelease, independent hotbar…

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -55,6 +55,31 @@ local settingsUpdater = require('core.settings.updater');
 local gameState = require('core.gamestate');
 local uiModules = require('core.moduleregistry');
 local profileManager = require('core.profile_manager');
+local sharedMacroStore = require('core.shared_macro_store');
+
+-- When gConfig is replaced, hotbar data caches must be invalidated (macroIdLookup points into macroDB)
+local function xiuiInvalidateHotbarDataCaches()
+    local ok, d = pcall(require, 'modules.hotbar.data');
+    if (ok and d and d.InvalidateConfigDerivedCaches) then
+        d.InvalidateConfigDerivedCaches();
+    end
+end
+
+-- Apply Crossbar "Default Palette Type" from the loaded profile only (not on zone/level/job packets).
+local function xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad()
+    local okD, dataMod = pcall(require, 'modules.hotbar.data');
+    local okP, paletteMod = pcall(require, 'modules.hotbar.palette');
+    if not (okD and okP and dataMod and paletteMod) then
+        return;
+    end
+    if dataMod.SetPlayerJob and dataMod.SetPlayerJob() and dataMod.jobId then
+        pcall(function()
+            paletteMod.ValidatePalettesForJob(dataMod.jobId, dataMod.subjobId or 0, { applyDefaultCrossbarScope = true });
+        end);
+    else
+        paletteMod.NotifyProfileSettingsLoaded();
+    end
+end
 
 -- UI modules
 local uiMods = require('modules.init');
@@ -82,6 +107,7 @@ local palette = require('modules.hotbar.palette');
 local skillchainModule = require('modules.hotbar.skillchain');
 local slotrenderer = require('modules.hotbar.slotrenderer');
 local configMenu = require('config');
+local paletteManager = require('config.palettemanager');
 local debuffHandler = require('handlers.debuffhandler');
 local petBuffHandler = require('handlers.petbuffhandler');
 local actionTracker = require('handlers.actiontracker');
@@ -283,7 +309,6 @@ uiModules.Register('hotbar', {
     settingsKey = 'hotbarSettings',
     configKey = 'showhotbar',
     hideOnEventKey = 'hotbarHideDuringEvents',
-    hideOnMenuFocusKey = 'hotbarHideOnMenuFocus',
     hasSetHidden = true,
 });
 uiModules.Register('readyCheck', {
@@ -307,7 +332,7 @@ local migrationResult = settingsMigration.MigrateFromHXUI();
 -- Load raw settings to detect legacy data (without default filtering)
 -- Use pcall to handle first-load case where no settings exist
 local rawSettingsSuccess, rawSettings = pcall(function()
-    return settings.load({});
+    return settings.load(T{});
 end);
 if not rawSettingsSuccess then
     rawSettings = {}; -- No existing settings, nothing to migrate
@@ -460,8 +485,19 @@ end
 -- ==========================================================
 
 -- Load character settings (tracks which profile is active)
-local charSettings = settings.load({ currentProfile = 'Default' });
+local charSettings = settings.load(T{ currentProfile = 'Default' });
 config = charSettings; -- Keep reference to character config
+
+-- Initialize per-character known weaponskills cache
+do
+    if not charSettings.knownWeaponskills then
+        charSettings.knownWeaponskills = {};
+    end
+    local okPd, pd = pcall(require, 'modules.hotbar.playerdata');
+    if okPd and pd and pd.SetKnownWeaponskills then
+        pd.SetKnownWeaponskills(charSettings.knownWeaponskills);
+    end
+end
 
 -- Global profiles list
 local globalProfiles = profileManager.GetGlobalProfiles();
@@ -539,6 +575,9 @@ end
 
 gConfigVersion = 0;
 settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+xiuiInvalidateHotbarDataCaches();
+xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
 
 -- Show migration message
 
@@ -595,7 +634,12 @@ function CreateProfile(name)
     return true;
 end
 
-function DuplicateProfile(name)
+-- options.includeMacroLibrary: default true (full file clone). When false, macroDB is reset and
+-- palette-macro bar slots are cleared; use for a new character that should keep layout but not
+-- the source macro library. Use Profile -> Export/Import JSON to move a chosen macro set.
+function DuplicateProfile(name, options)
+    options = options or {};
+    local includeMacroLibrary = (options.includeMacroLibrary ~= false);
     local baseName = name;
     -- If duplicating Default, we might want to name it "Profile (1)" or just "Default (1)"
 
@@ -611,6 +655,17 @@ function DuplicateProfile(name)
     if (currentSettings == nil) then return false; end
 
     local newSettings = deep_copy_table(currentSettings);
+    if (not includeMacroLibrary) then
+        newSettings.macroDB = {};
+        newSettings.macroCustomCategories = deep_copy_table(defaultUserSettings.macroCustomCategories or T{});
+        newSettings.macroCustomNextSeq = defaultUserSettings.macroCustomNextSeq or 1;
+        newSettings.macroXiuiDefaultsSeeded = false;
+        newSettings.macroGlobalUniversalTwoHourSeeded = false;
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if (ok and hotbarData and hotbarData.StripPaletteMacroBindsFromSettings) then
+            hotbarData.StripPaletteMacroBindsFromSettings(newSettings);
+        end
+    end
     profileManager.SaveProfileSettings(newName, newSettings);
 
     local globalProfiles = profileManager.GetGlobalProfiles();
@@ -622,13 +677,27 @@ function DuplicateProfile(name)
     return true;
 end
 
+-- Writes profiles/<name>.lua. When macroStorageScope is shared, the profile file keeps the frozen
+-- macroDB snapshot; the live global library is saved to SharedMacros.lua.
+function SaveCurrentProfileFileToDisk()
+    if sharedMacroStore.IsSharedScope(gConfig) then
+        local oldM = gConfig.macroDB;
+        gConfig.macroDB = sharedMacroStore.GetProfileMacroDbForSave(gConfig);
+        profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+        gConfig.macroDB = oldM;
+        sharedMacroStore.PersistSharedLibraryIfNeeded(gConfig);
+    else
+        profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    end
+end
+
 
 
 function ChangeProfile(name)
     if (not profileManager.ProfileExists(name)) then return false; end
 
     -- Always save current profile before switching (positions, etc.)
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
 
     config.currentProfile = name;
     bInternalSave = true;
@@ -650,6 +719,9 @@ function ChangeProfile(name)
     end
 
     settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+    sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+    xiuiInvalidateHotbarDataCaches();
+    xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
     UpdateSettings();
     return true;
 end
@@ -678,7 +750,11 @@ function ResetSettings()
     gConfig = deep_copy_table(defaultUserSettings);
     gConfig.windowPositions = GetDefaultWindowPositions();
     gConfig.appliedPositions = {};
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+    sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+    xiuiInvalidateHotbarDataCaches();
+    xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
+    SaveCurrentProfileFileToDisk();
 
     -- Reset all module positions to defaults BEFORE deferring visuals so the
     -- next-frame UpdateVisualsAll picks up the corrected positions.
@@ -722,7 +798,7 @@ function RecoverAllPositions()
     gConfig.partyListState = {};
 
     -- Save
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
     bInternalSave = true;
     settings.save();
     if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
@@ -747,7 +823,7 @@ function SaveSettingsToDisk()
         gConfig.colorCustomization = deep_copy_table(defaultUserSettings.colorCustomization);
     end
     gConfigVersion = gConfigVersion + 1; -- Notify caches of settings change
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
     bInternalSave = true;
     settings.save();
     if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
@@ -758,7 +834,7 @@ function SaveSettingsOnly()
         gConfig.colorCustomization = deep_copy_table(defaultUserSettings.colorCustomization);
     end
     gConfigVersion = gConfigVersion + 1; -- Notify caches of settings change
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
     bInternalSave = true;
     settings.save();
     if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
@@ -942,6 +1018,9 @@ settings.register('settings', 'settings_update', function (s)
 
         -- Run migrations
         settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+        sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+        xiuiInvalidateHotbarDataCaches();
+        xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
 
         -- Update visuals
         UpdateSettings();
@@ -962,6 +1041,14 @@ ashita.events.register('d3d_present', 'present_cb', function ()
     if not bInitialized then return; end
 
     local ok, err = pcall(function()
+        -- Reset ImGui cursor to Arrow at the start of every frame.
+        -- FFXI uses a DirectX hardware cursor that can get lost on alt+tab;
+        -- resetting here ensures we never leave a stale Hand/None cursor
+        -- state that survives into the first frame after the game regains focus.
+        if imgui and imgui.SetMouseCursor then
+            imgui.SetMouseCursor(0); -- 0 = ImGuiMouseCursor_Arrow
+        end
+
         -- Drop references to textures evicted/cleared during the PREVIOUS
         -- frame so Lua GC is free to run d3d8.gc_safe_release on them.
         -- Must run before anything else this frame queues new draws or
@@ -1018,6 +1105,13 @@ ashita.events.register('d3d_present', 'present_cb', function ()
             end
 
             configMenu.DrawWindow();
+            -- Floating Palette Manager + shared modals (must run outside config hotbar/crossbar tabs or /xiui pal never draws)
+            paletteManager.Draw();
+
+            -- Finalize drag-drop after all drop zones (including palette editor) have been processed
+            if hotbar.FinalizeFrame then
+                hotbar.FinalizeFrame();
+            end
 
             -- Render deferred hotbar tooltip after all modules (correct z-order)
             slotrenderer.FlushTooltip();
@@ -1118,6 +1212,26 @@ ashita.events.register('command', 'command_cb', function (e)
             return;
         end
 
+        -- Debug: print the current FFXI menu name to chat: /xiui menuname
+        if (#command_args == 2 and command_args[2]:any('menuname', 'menu')) then
+            local gamestate = require('core.gamestate');
+            local raw  = gamestate.GetMenuName();
+            local isContainer = gamestate.IsContainerNavigationMenu();
+            AshitaCore:GetChatManager():QueueCommand(1, string.format(
+                '/echo [XIUI] Menu: "%s" | container-nav: %s', raw, tostring(isContainer)));
+            return;
+        end
+
+        -- /xiui pal - toggle floating Palette Manager (hotbar); /xiui pal <...> still cycles/selects palettes below
+        if #command_args == 2 and command_args[2] == 'pal' then
+            if paletteManager.ToggleHotbarPaletteManager() then
+                print('[XIUI] Palette Manager opened (Hotbar).');
+            else
+                print('[XIUI] Palette Manager closed.');
+            end
+            return;
+        end
+
         -- Open keybind editor: /xiui keybinds or /xiui binds [bar]
         if (#command_args >= 2 and command_args[2]:any('keybinds', 'keybind', 'binds', 'bind')) then
             local hotbarConfig = require('config.hotbar');
@@ -1197,7 +1311,7 @@ ashita.events.register('command', 'command_cb', function (e)
         -- Switch between named palettes. Hotbar palettes (bars 1-6) and the crossbar
         -- have separate palette pools; "all" applies across both, "crossbar"/"cb"/"xb"
         -- targets the crossbar only, a bar number targets a single hotbar.
-        if (command_args[2] == 'palette' or command_args[2] == 'pal') then
+        if (command_args[2] == 'palette' or (command_args[2] == 'pal' and #command_args >= 3)) then
             local paletteModule = require('modules.hotbar.palette');
             local hotbarData = require('modules.hotbar.data');
             local jobId = hotbarData.jobId or 1;
@@ -1380,6 +1494,353 @@ ashita.events.register('command', 'command_cb', function (e)
                     end
                 end
             end
+            return;
+        end
+
+        -- Toggle Edit Full Palette for the currently active crossbar palette (silent): /xiui cpaledit
+        if (command_args[2] == 'cpaledit') then
+            paletteManager.ToggleEditFullPaletteForCurrent();
+            return;
+        end
+
+        -- Crossbar palettes: /xiui cpalette toggles config; Global [G] vs Job storage are separate CLI paths (no Global-Sets gate). Aliases: cpal, xcpalette, xcpal.
+        if (command_args[2] == 'cpalette' or command_args[2] == 'cpal' or command_args[2] == 'xcpalette' or command_args[2] == 'xcpal') then
+            if #command_args == 2 then
+                configMenu.ToggleCrossbarManagePalettes();
+                return;
+            end
+
+            local sub = command_args[3];
+            local originalArgs = e.command:args();
+
+            if sub == 'help' or sub == '?' then
+                print('[XIUI] Crossbar palette:');
+                print('  /xiui cpalette          Toggle Crossbar -> Manage Palettes in config');
+                print('  /xiui cpaledit          Toggle Edit Full Palette for current active palette');
+                print('  /xiui cpalette list     List Global [G] crossbar palettes');
+                print('  /xiui cpalette scope job|universal');
+                print('  /xiui cpalette toggle   (same as controller: hold L1, tap R1)');
+                print('  /xiui cpalette g <name>   Global [G] only (also: global, gname)');
+                print('  /xiui cpalette <JOB> <name|#>   Job [J]-tier (# = order in list)');
+                print('  /xiui cpalette WHMSMN <name|#>   SJ-tier: # = (SJ) rows in Manage, e.g. WHMBLM 1');
+                print('  /xiui cpalette job <JOB> <...>   optional keyword (J-tier)');
+                print('  Other job than yours = temporary preview; RB+D-pad still cycles live job');
+                print('  /xiui cpalette cycle on|off <name>   Global [G] RB+D-pad cycle include');
+                print('  Optional legacy prefix: active ...');
+                return;
+            end
+
+            local cross = gConfig and gConfig.hotbarCrossbar;
+
+            local function cpalXbLogVerbose()
+                local hg = gConfig and gConfig.hotbarGlobal;
+                local v = hg and hg.logPaletteNameCrossbar;
+                if v == nil then return true; end
+                return v == true;
+            end
+            local function cpalXbLogRbHint()
+                if not cpalXbLogVerbose() then return false; end
+                local hg = gConfig and gConfig.hotbarGlobal;
+                local v = hg and hg.logPaletteNameCrossbarCycleHint;
+                if v == nil then return true; end
+                return v == true;
+            end
+            local function cpalNotice(msg)
+                print('[XIUI Notice] ' .. msg);
+            end
+            local function cpalLogJobSuccess(mainAbbr, storageSubjob, sjAbbr, paletteName)
+                if not cpalXbLogVerbose() then return; end
+                local loc;
+                if storageSubjob == 0 then
+                    loc = mainAbbr .. '[J]';
+                else
+                    loc = mainAbbr .. '[SJ:' .. (sjAbbr or '?') .. ']';
+                end
+                print('[XIUI] Crossbar Palette: ' .. loc .. ' "' .. paletteName .. '".');
+            end
+            local function cpalLogGlobalSuccess(paletteName)
+                if not cpalXbLogVerbose() then return; end
+                print('[XIUI] Crossbar Palette: Global[G] "' .. paletteName .. '".');
+            end
+            local function cpalLogPreviewHint()
+                if not cpalXbLogRbHint() then return; end
+                print('[XIUI] RB(R1)+Up/Down to return to Job Palettes.');
+            end
+
+            if sub == 'list' then
+                local names = palette.GetUniversalCrossbarPaletteNamesOrdered();
+                local active = palette.GetActiveUniversalCrossbarPalette();
+                local scope = palette.GetCrossbarPaletteScope();
+                print('[XIUI] Global [G] crossbar palettes (scope: ' .. scope .. '):');
+                for _, name in ipairs(names) do
+                    local inc = palette.GetUniversalPaletteIncludeInCycle(name);
+                    local m = (name == active) and ' *' or '';
+                    local c = inc and '' or ' [cycle off]';
+                    print('  - ' .. name .. m .. c);
+                end
+                return;
+            end
+
+            if sub == 'toggle' then
+                if palette.ToggleCrossbarPaletteScope() then
+                    if cpalXbLogVerbose() then
+                        print('[XIUI] Crossbar palette scope: ' .. palette.GetCrossbarPaletteScope());
+                    end
+                else
+                    if cpalXbLogVerbose() then
+                        print('[XIUI] Scope unchanged (debounced or already toggling).');
+                    end
+                end
+                return;
+            end
+
+            if sub == 'scope' then
+                if not command_args[4] then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+                local s = command_args[4]:lower();
+                if s == 'job' or s == 'universal' then
+                    if palette.SetCrossbarPaletteScope(s) then
+                        if cpalXbLogVerbose() then
+                            print('[XIUI] Crossbar palette scope: ' .. s);
+                        end
+                    else
+                        if cpalXbLogVerbose() then
+                            print('[XIUI] Scope unchanged (already ' .. s .. ').');
+                        end
+                    end
+                else
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                end
+                return;
+            end
+
+            if sub == 'cycle' then
+                if not command_args[4] or #originalArgs < 5 then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+                local onoff = command_args[4]:lower();
+                if onoff ~= 'on' and onoff ~= 'off' then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+                local nameParts = {};
+                for i = 5, #originalArgs do
+                    table.insert(nameParts, originalArgs[i]);
+                end
+                local paletteName = table.concat(nameParts, ' ');
+                local key = palette.BuildUniversalCrossbarStorageKey(paletteName);
+                if not cross or not cross.slotActions or not cross.slotActions[key] then
+                    cpalNotice('Cannot find the requested Palette.');
+                    return;
+                end
+                palette.SetUniversalPaletteIncludeInCycle(paletteName, onoff == 'on');
+                if cpalXbLogVerbose() then
+                    print('[XIUI] ' .. paletteName .. ' include in RB+D-pad cycle: ' .. onoff);
+                end
+                return;
+            end
+
+            -- Select crossbar palette: first token at [ps], or after optional "active" at [3].
+            local ps = 3;
+            if sub == 'active' then
+                ps = 4;
+                if #command_args < ps then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+            end
+
+            if #command_args >= ps then
+                local tbarMigration = require('handlers.tbar_migration');
+                local hotbarData = require('modules.hotbar.data');
+
+                local function joinOriginalName(fromIdx)
+                    local nameParts = {};
+                    for i = fromIdx, #originalArgs do
+                        table.insert(nameParts, originalArgs[i]);
+                    end
+                    return table.concat(nameParts, ' ');
+                end
+
+                -- Compact MAIN(3)+SUB(3) only (e.g. WHMSMN).
+                local function splitCompactMainSub(compactTok)
+                    local s = compactTok:upper();
+                    if #s ~= 6 then
+                        return nil, nil;
+                    end
+                    local a = s:sub(1, 3);
+                    local b = s:sub(4, 6);
+                    local j1 = tbarMigration.GetJobId(a);
+                    local j2 = tbarMigration.GetJobId(b);
+                    if not j1 or not j2 then
+                        return nil, nil;
+                    end
+                    return j1, j2;
+                end
+
+                local function paletteNameFromTierIndex(mainJobId, storageTier, idx)
+                    local names = palette.GetCrossbarPaletteNamesForOrderTier(mainJobId, storageTier);
+                    if #names == 0 or idx < 1 or idx > #names or idx ~= math.floor(idx) then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return nil;
+                    end
+                    return names[idx];
+                end
+
+                -- WHMSMN # numbering matches (SJ) rows only in Manage (not full SJ bucket list).
+                local function paletteNameFromSjExtrasIndex(mainJobId, sjId, idx)
+                    local names = palette.GetCrossbarSjOnlyPaletteNamesOrdered(mainJobId, sjId);
+                    if #names == 0 or idx < 1 or idx > #names or idx ~= math.floor(idx) then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return nil;
+                    end
+                    return names[idx];
+                end
+
+                local function applyJobPaletteCli(mainJobId, storageSubjob, paletteName)
+                    if not cross then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    if not cross.slotActions then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    local key = palette.BuildPaletteStorageKey(mainJobId, storageSubjob, paletteName);
+                    if not cross.slotActions[key] then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    local crossCfg = cross;
+                    if crossCfg.enableUniversalCrossbarPalettes and palette.GetCrossbarPaletteScope() == 'universal' then
+                        cpalNotice('Cannot apply Job Palettes to Global.');
+                        return;
+                    end
+                    local liveJob = hotbarData.jobId;
+                    local liveSub = hotbarData.subjobId or 0;
+                    local commit = liveJob
+                        and mainJobId == liveJob
+                        and (storageSubjob == 0 or storageSubjob == liveSub);
+                    local jobs = require('libs.jobs');
+                    local jn = jobs[mainJobId] or ('JOB' .. tostring(mainJobId));
+                    local sjAbbr = (storageSubjob ~= 0) and (jobs[storageSubjob] or nil) or nil;
+                    if commit then
+                        palette.SetCpalJobAnchorIfUnset(
+                            palette.GetActivePaletteForCombo(nil),
+                            palette.GetCrossbarActiveStorageSubjob(),
+                            hotbarData.jobId
+                        );
+                        palette.SetActivePaletteForCombo(nil, paletteName, storageSubjob);
+                        cpalLogJobSuccess(jn, storageSubjob, sjAbbr, paletteName);
+                    else
+                        palette.SetCrossbarCliPreview(mainJobId, storageSubjob, paletteName);
+                        cpalLogJobSuccess(jn, storageSubjob, sjAbbr, paletteName);
+                        cpalLogPreviewHint();
+                    end
+                end
+
+                local function parseJobAndApply(firstIdx)
+                    if #command_args < firstIdx + 1 then
+                        cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                        return true;
+                    end
+                    local mainId = tbarMigration.GetJobId(command_args[firstIdx]:upper());
+                    if not mainId then
+                        return false;
+                    end
+                    local tok = command_args[firstIdx + 1];
+                    local idx = tonumber(tok);
+                    if idx and idx >= 1 and idx == math.floor(idx) then
+                        if #command_args > firstIdx + 1 then
+                            cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                            return true;
+                        end
+                        local jobs = require('libs.jobs');
+                        local jn = jobs[mainId] or ('JOB' .. tostring(mainId));
+                        local name = paletteNameFromTierIndex(mainId, 0, idx);
+                        if not name then
+                            return true;
+                        end
+                        applyJobPaletteCli(mainId, 0, name);
+                        return true;
+                    end
+                    local paletteName = joinOriginalName(firstIdx + 1);
+                    if paletteName == '' then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return true;
+                    end
+                    applyJobPaletteCli(mainId, 0, paletteName);
+                    return true;
+                end
+
+                local caFirst = command_args[ps];
+
+                if caFirst == 'global' or caFirst == 'g' or caFirst == 'gname' then
+                    local paletteName = joinOriginalName(ps + 1);
+                    if paletteName == '' then
+                        cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                        return;
+                    end
+                    local key = palette.BuildUniversalCrossbarStorageKey(paletteName);
+                    if cross and cross.slotActions and cross.slotActions[key] then
+                        palette.SetCpalUniversalAnchorIfUnset(palette.GetActiveUniversalCrossbarPalette());
+                        palette.SetActiveUniversalCrossbarPalette(paletteName);
+                        cpalLogGlobalSuccess(paletteName);
+                    else
+                        cpalNotice('Cannot find the requested Palette.');
+                    end
+                    return;
+                end
+
+                local cMain, cSub = splitCompactMainSub(caFirst);
+                if cMain and cSub and #command_args >= ps + 1 then
+                    local tok = command_args[ps + 1];
+                    local idx = tonumber(tok);
+                    if idx and idx >= 1 and idx == math.floor(idx) then
+                        if #command_args > ps + 1 then
+                            cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                            return;
+                        end
+                        local name = paletteNameFromSjExtrasIndex(cMain, cSub, idx);
+                        if not name then
+                            return;
+                        end
+                        applyJobPaletteCli(cMain, cSub, name);
+                        return;
+                    end
+                    local paletteName = joinOriginalName(ps + 1);
+                    if paletteName == '' then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    applyJobPaletteCli(cMain, cSub, paletteName);
+                    return;
+                end
+
+                if caFirst == 'job' then
+                    if #command_args < ps + 2 then
+                        cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                        return;
+                    end
+                    if parseJobAndApply(ps + 1) then
+                        return;
+                    end
+                    cpalNotice('Cannot find the requested Palette.');
+                    return;
+                end
+
+                if parseJobAndApply(ps) then
+                    return;
+                end
+
+                cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                return;
+            end
+
+            cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
             return;
         end
 
@@ -1616,8 +2077,8 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         petBar.HandlePacket(e);
     end
 
-    -- Hotbar pet palette sync (0x0068 Pet Sync)
-    if e.id == 0x0068 and gConfig.hotbarEnabled then
+    -- Hotbar pet palette sync (0x0068 Pet Sync) - also updates crossbar pet palettes
+    if e.id == 0x0068 and (gConfig.hotbarEnabled or gConfig.crossbarEnabled) then
         hotbar.HandlePetSyncPacket();
     end
 
@@ -1635,7 +2096,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
             actionTracker.HandleActionPacket(actionPacket);
             if gConfig.showNotifications then notifications.HandleActionPacket(actionPacket); end
             -- Skillchain tracking for hotbar/crossbar WS highlighting
-            if gConfig.hotbarEnabled then
+            if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
                 skillchainModule.HandleActionPacket(actionPacket);
             end
         end
@@ -1660,8 +2121,8 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         ClearEntityCache();
         ResetD3D8Device();
         bLoggedIn = true;
-        -- Initialize hotbar job on zone-in (handles initial login and job change during zone)
-        if gConfig.hotbarEnabled then
+        -- Initialize hotbar/crossbar job on zone-in (handles initial login and job change during zone)
+        if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
             hotbar.HandleJobChangePacket(e);
         end
     elseif (e.id == 0x0029) then
@@ -1708,14 +2169,14 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         TextureManager.clearOnZone();
         ResetD3D8Device();
         bLoggedIn = false;
-        -- Also notify hotbar of zone (clears state)
-        if gConfig.hotbarEnabled then
+        -- Also notify hotbar/crossbar of zone (clears state)
+        if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
             hotbar.HandleZonePacket();
             skillchainModule.ClearState();  -- Clear skillchain tracking on zone
         end
     elseif (e.id == 0x001B) then
-        -- Job change packet - update hotbar to show new job's actions
-        if gConfig.hotbarEnabled then
+        -- Job change packet - update hotbar/crossbar to show new job's actions
+        if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
             hotbar.HandleJobChangePacket(e);
         end
     elseif (e.id == 0x076) then

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 * XIUI Config Menu - Main Window
 * Entry point for the config menu, handles window rendering and dispatches to module files
 ]]--
@@ -24,16 +24,27 @@ local petbarModule = require('config.petbar');
 local notificationsModule = require('config.notifications');
 local treasurepoolModule = require('config.treasurepool');
 local hotbarModule = require('config.hotbar');
+local crossbarModule = require('config.crossbar');
 local readycheckModule = require('config.readycheck');
 
 local treasurePool = require('modules.treasurepool.init');
 local macropalette = require('modules.hotbar.macropalette');
 local palette = require('modules.hotbar.palette');
+local paletteJson = require('modules.hotbar.palette_json');
 
 local config = {};
 
 -- Track previous config state to detect when config closes
 local wasConfigOpen = false;
+
+-- Lazy: defer closing XIUI Config when Edit Full Palette is open (see config.palettemanager).
+local paletteManagerForCloseDefer = nil;
+local function getPaletteManagerForCloseDefer()
+    if not paletteManagerForCloseDefer then
+        paletteManagerForCloseDefer = require('config.palettemanager');
+    end
+    return paletteManagerForCloseDefer;
+end
 
 -- Track last known config window geometry for smart reposition on open
 local lastConfigPosX, lastConfigPosY = 20, 20;
@@ -114,6 +125,23 @@ local showNewProfilePopup = false;
 local triggerNewProfilePopup = false;
 local triggerDeleteProfilePopup = false;
 local triggerRenameProfilePopup = false;
+local triggerCopyProfilePopup = false;
+-- [1] = include full macroDB when using Copy (DuplicateProfile)
+local copyProfileIncludeMacros = { true };
+
+-- Profile JSON export/import (whole-profile: all palettes + all macros)
+local profileJsonWinOpen = { false };
+local profileJsonMode = 'export'; -- 'export' | 'import'
+local profileJsonBuf = { '' };
+local profileJsonErr = nil;
+local profileJsonInfo = nil;
+local profileJsonExportPart = { 'all' }; -- paletteJson.EXPORT_PART_*
+local profileJsonImportPalettes = { true };
+local profileJsonImportMacros = { true };
+local profileJsonImportMode = { paletteJson.IMPORT_MODE_MERGE }; -- merge | replace (see palette_json)
+local profileJsonImportFiles = {};
+local profileJsonImportSelectedIdx = { -1 };
+local profileJsonImportSelectedName = nil;
 
 -- XIUI Theme Colors (dark + gold accent)
 local gold = {0.957, 0.855, 0.592, 1.0};           -- #F4DA97 - Primary gold accent
@@ -192,12 +220,275 @@ local function PopThemeStyles()
     imgui.PopStyleColor(34);
 end
 
+local function OpenProfileJsonExport()
+    profileJsonMode = 'export';
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+    profileJsonBuf[1] = '';
+    profileJsonExportPart[1] = paletteJson.EXPORT_PART_ALL;
+    profileJsonWinOpen[1] = true;
+end
+
+local function RefreshProfileJsonImportFiles()
+    local files = paletteJson.ListExportFiles();
+    profileJsonImportFiles = files or {};
+    if profileJsonImportSelectedName then
+        profileJsonImportSelectedIdx[1] = -1;
+        for i, n in ipairs(profileJsonImportFiles) do
+            if n == profileJsonImportSelectedName then
+                profileJsonImportSelectedIdx[1] = i - 1;
+                break;
+            end
+        end
+    else
+        profileJsonImportSelectedIdx[1] = -1;
+    end
+end
+
+local function LoadSelectedProfileJsonImportFile()
+    local idx = profileJsonImportSelectedIdx[1];
+    if not idx or idx < 0 then
+        profileJsonErr = 'Pick a file from the list first (or paste JSON below).';
+        return;
+    end
+    local name = profileJsonImportFiles[idx + 1];
+    if not name then
+        profileJsonErr = 'Selected file is no longer present.';
+        return;
+    end
+    local text, err = paletteJson.ReadExportFile(name);
+    if not text then
+        profileJsonErr = err or ('Could not read ' .. name);
+        return;
+    end
+    profileJsonBuf[1] = text;
+    profileJsonErr = nil;
+    profileJsonInfo = 'Loaded ' .. name;
+    profileJsonImportSelectedName = name;
+end
+
+local function OpenProfileJsonImport()
+    profileJsonMode = 'import';
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+    profileJsonBuf[1] = '';
+    profileJsonImportPalettes[1] = true;
+    profileJsonImportMacros[1] = true;
+    profileJsonImportMode[1] = paletteJson.IMPORT_MODE_MERGE;
+    profileJsonImportSelectedName = nil;
+    profileJsonWinOpen[1] = true;
+    RefreshProfileJsonImportFiles();
+end
+
+local function RunProfileJsonExport()
+    local text, err = paletteJson.ExportProfile(profileJsonExportPart[1] or paletteJson.EXPORT_PART_ALL);
+    if not text then
+        profileJsonErr = err or 'Export failed';
+        return;
+    end
+    profileJsonBuf[1] = text;
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+end
+
+local function RunProfileJsonSaveToFile()
+    local baseName = (GetCurrentProfileName and GetCurrentProfileName()) or 'profile';
+    local part = profileJsonExportPart[1] or paletteJson.EXPORT_PART_ALL;
+    baseName = tostring(baseName) .. '_' .. part;
+    local ok, path = paletteJson.SaveTextFile(baseName, profileJsonBuf[1] or '');
+    if ok then
+        profileJsonInfo = path;
+        profileJsonErr = nil;
+    else
+        profileJsonErr = tostring(path);
+    end
+end
+
+local function RunProfileJsonImport()
+    local okImp, errImp = paletteJson.ImportProfile(profileJsonBuf[1] or '', {
+        importPalettes = profileJsonImportPalettes[1],
+        importMacros = profileJsonImportMacros[1],
+        importMode = profileJsonImportMode[1] or paletteJson.IMPORT_MODE_MERGE,
+    });
+    if okImp then
+        profileJsonErr = nil;
+        profileJsonInfo = 'Import applied.';
+        profileJsonWinOpen[1] = false;
+    else
+        profileJsonErr = errImp or 'Import failed';
+    end
+end
+
+local function DrawProfileJsonWindow()
+    if not profileJsonWinOpen[1] then return; end
+
+    PushThemeStyles();
+    imgui.SetNextWindowSize({ 680, 560 }, ImGuiCond_FirstUseEver);
+    local title = (profileJsonMode == 'export') and 'Profile Export (JSON)##xiuiProfJson' or 'Profile Import (JSON)##xiuiProfJson';
+    if imgui.Begin(title, profileJsonWinOpen, ImGuiWindowFlags_NoCollapse) then
+        if profileJsonMode == 'export' then
+            imgui.TextWrapped(
+                'Export this profile\'s palettes and/or macros to a single JSON file. Use it to back up this profile or transfer it to a new character. Entries are pretty-printed with human-readable "_label" tags (job / subjob / palette name), so you can open the file in a text editor, delete the blocks you do not want, save, and then import only the rest.'
+            );
+        else
+            imgui.TextWrapped(
+                'Pick a file from the exports folder, or paste JSON below. Choose Add to existing to merge with this profile, or Replace with file to clear the matching data first so the result matches the export.'
+            );
+        end
+        imgui.Spacing();
+
+        if profileJsonErr then
+            imgui.TextColored({ 1.0, 0.3, 0.3, 1.0 }, profileJsonErr);
+        end
+        if profileJsonInfo then
+            imgui.TextColored({ 0.65, 0.8, 0.65, 1.0 }, profileJsonInfo);
+        end
+        imgui.Separator();
+
+        if profileJsonMode == 'export' then
+            imgui.Text('Include in file:');
+            if imgui.RadioButton('All palettes + macros##pjExAll', profileJsonExportPart[1] == paletteJson.EXPORT_PART_ALL) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_ALL;
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('All palettes only##pjExPal', profileJsonExportPart[1] == paletteJson.EXPORT_PART_PALETTES_ONLY) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_PALETTES_ONLY;
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('All macros only##pjExMac', profileJsonExportPart[1] == paletteJson.EXPORT_PART_MACROS_ONLY) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_MACROS_ONLY;
+            end
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'All palettes + macros: complete profile backup (every keyboard hotbar palette, every crossbar palette, and all macro text).\nAll palettes only: every palette for this profile without macro definitions. Import into a profile that already has the macros.\nAll macros only: the entire macro library without changing any palette layouts.'
+                );
+            end
+
+            imgui.Spacing();
+            if imgui.Button('Generate JSON##pjGen') then
+                RunProfileJsonExport();
+            end
+            imgui.SameLine();
+            if imgui.Button('Save to file##pjSave') then
+                if profileJsonBuf[1] == nil or profileJsonBuf[1] == '' then
+                    RunProfileJsonExport();
+                end
+                if profileJsonBuf[1] ~= nil and profileJsonBuf[1] ~= '' then
+                    RunProfileJsonSaveToFile();
+                end
+            end
+            imgui.SameLine();
+            if imgui.Button('Open exports folder##pjExOpenDir') then
+                paletteJson.OpenExportsDir();
+            end
+            imgui.SameLine();
+            imgui.TextColored({ 0.6, 0.6, 0.65, 1.0 }, 'Files save to config/addons/xiui/exports/.');
+
+            imgui.Spacing();
+            imgui.InputTextMultiline('##profJsonBuf', profileJsonBuf, 200000, { -1, -1 });
+        else
+            if imgui.Checkbox('Import palettes##pjImpPal', profileJsonImportPalettes) then end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Apply keyboard hotbar and crossbar layouts from the file. Add to existing: overlay slot data and merge palette name lists. Replace with file: clear those layouts first, then apply; palette order lists come only from the file.'
+                );
+            end
+            if imgui.Checkbox('Import macros##pjImpMac', profileJsonImportMacros) then end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Add to existing: append macro rows with new IDs and remap palette references. Replace with file: macro library becomes exactly what is in the file (same macro IDs as the export). If you import palettes only and uncheck macros, the file must reference macros that already exist here.'
+                );
+            end
+
+            imgui.Spacing();
+            imgui.Text('Apply mode:');
+            if imgui.RadioButton('Add to existing (merge)##pjModeMerge', profileJsonImportMode[1] == paletteJson.IMPORT_MODE_MERGE) then
+                profileJsonImportMode[1] = paletteJson.IMPORT_MODE_MERGE;
+            end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Overlay the file onto this profile: palette slot data and name lists merge with what you already have; new macro rows get new IDs.'
+                );
+            end
+            if imgui.RadioButton('Replace with file (overwrite)##pjModeReplace', profileJsonImportMode[1] == paletteJson.IMPORT_MODE_REPLACE) then
+                profileJsonImportMode[1] = paletteJson.IMPORT_MODE_REPLACE;
+            end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Before applying: clears hotbar/crossbar layouts for sides present in the file, replaces palette order lists from the file, and replaces the macro library with the file when Import macros is checked. Use this when you want the profile to match the export instead of mixing with old data.'
+                );
+            end
+            if profileJsonImportMode[1] == paletteJson.IMPORT_MODE_REPLACE then
+                imgui.PushStyleColor(ImGuiCol_Text, { 1.0, 0.55, 0.35, 1.0 });
+                if imgui.TextWrapped then
+                    imgui.TextWrapped(
+                        'Replace mode can remove existing bars, combos, palette lists, and macros (for the options you checked) so only the file remains.'
+                    );
+                end
+                imgui.PopStyleColor();
+            end
+
+            imgui.Spacing();
+            imgui.Text('Pick a file from config/addons/xiui/exports/:');
+            imgui.SetNextItemWidth(-220);
+            local fileCount = #profileJsonImportFiles;
+            if fileCount == 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, { 0.7, 0.7, 0.75, 1.0 });
+                -- BeginListBox is not available on all Ashita ImGui builds; use a bordered child instead.
+                imgui.BeginChild('##profJsonFilesEmpty', { -220, 90 }, true);
+                imgui.Text('(No .json files found in the exports folder.)');
+                imgui.EndChild();
+                imgui.PopStyleColor();
+            else
+                if imgui.ListBox and imgui.ListBox('##profJsonFiles', profileJsonImportSelectedIdx, profileJsonImportFiles, fileCount, 5) then
+                    local idx = profileJsonImportSelectedIdx[1];
+                    if idx and idx >= 0 then
+                        profileJsonImportSelectedName = profileJsonImportFiles[idx + 1];
+                    end
+                end
+            end
+            imgui.SameLine();
+            imgui.BeginGroup();
+            if imgui.Button('Load selected##pjLoadFile', { 200, 0 }) then
+                LoadSelectedProfileJsonImportFile();
+            end
+            if imgui.Button('Refresh list##pjRefreshFiles', { 200, 0 }) then
+                RefreshProfileJsonImportFiles();
+                profileJsonInfo = 'Refreshed (' .. #profileJsonImportFiles .. ' file(s)).';
+            end
+            if imgui.Button('Open exports folder##pjOpenDir', { 200, 0 }) then
+                paletteJson.OpenExportsDir();
+            end
+            imgui.EndGroup();
+
+            imgui.Spacing();
+            if imgui.Button('Apply import##pjApply', { 140, 0 }) then
+                RunProfileJsonImport();
+            end
+            imgui.SameLine();
+            imgui.TextColored({ 0.6, 0.6, 0.65, 1.0 }, 'Or paste JSON directly below and Apply.');
+
+            imgui.Spacing();
+            imgui.InputTextMultiline('##profJsonBuf', profileJsonBuf, 200000, { -1, -1 });
+        end
+    end
+    imgui.End();
+    PopThemeStyles();
+end
+
 local function DrawProfilesWindow()
-    if (not showProfilesWindow[1]) then return; end
+    if (not showProfilesWindow[1]) then
+        DrawProfileJsonWindow();
+        return;
+    end
 
     PushThemeStyles();
 
-    imgui.SetNextWindowSize({ 350, 145 }, ImGuiCond_Always);
+    imgui.SetNextWindowSize({ 380, 300 }, ImGuiCond_Always);
     -- Using + for flags as they are typically integers
     if (imgui.Begin("Profiles", showProfilesWindow, ImGuiWindowFlags_NoCollapse + ImGuiWindowFlags_NoResize)) then
 
@@ -221,6 +512,17 @@ local function DrawProfilesWindow()
             imgui.EndCombo();
         end
 
+        if imgui.TextWrapped then
+            imgui.Spacing();
+            imgui.PushStyleColor(ImGuiCol_Text, { 0.55, 0.55, 0.62, 1.0 });
+            imgui.TextWrapped(
+                'Every character that uses this profile name shares the same XIUI data (palettes, macros, layout). '
+                .. 'Use Copy to duplicate the active profile: you can include the full macro library or only layout/appearance. '
+                .. 'To move specific macros, use Export/Import JSON. Empty palette buckets (e.g. Items) are not stored on disk until you add something there.'
+            );
+            imgui.PopStyleColor();
+        end
+
         imgui.Spacing();
         imgui.Spacing();
 
@@ -234,7 +536,8 @@ local function DrawProfilesWindow()
         imgui.SameLine();
 
         if (imgui.Button("Copy")) then
-            DuplicateProfile(currentProfile);
+            copyProfileIncludeMacros[1] = true;
+            triggerCopyProfilePopup = true;
         end
 
         imgui.SameLine();
@@ -282,12 +585,30 @@ local function DrawProfilesWindow()
             imgui.PopStyleColor(3);
         end
 
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
 
+        imgui.Text('Backup / Transfer:');
+        if imgui.ShowHelp then
+            imgui.SameLine();
+            imgui.ShowHelp(
+                'Export or import this entire profile as one JSON file: all keyboard hotbar palettes, all crossbar palettes, and the full macro library for this profile. Use it to back up this profile or move everything onto a new character. You can choose to include palettes, macros, or both on both sides.'
+            );
+        end
+        if imgui.Button('Export JSON##profJsonOpenEx') then
+            OpenProfileJsonExport();
+        end
+        imgui.SameLine();
+        if imgui.Button('Import JSON##profJsonOpenIm') then
+            OpenProfileJsonImport();
+        end
 
         imgui.End();
     end
 
     PopThemeStyles();
+    DrawProfileJsonWindow();
 end
 
 -- Navigation state
@@ -304,8 +625,7 @@ local selectedPetTypeTab = 1;  -- 1 = Avatar, 2 = Charm, 3 = Jug, 4 = Automaton,
 local selectedPetTypeColorTab = 1;  -- Pet type color sub-tab
 local selectedPetBarColorTab = 1;  -- 1 = Pet Bar, 2 = Pet Target (for color settings)
 local selectedHotbarTab = 1;  -- 1 = Bar 1, 2 = Bar 2, etc. (for hotbar settings)
-local selectedModeTab = 'hotbar';  -- 'hotbar' or 'crossbar' (for hotbar/crossbar toggle in 'both' mode)
-local selectedCrossbarTab = 1;  -- 1=L2, 2=R2, 3=L2R2, 4=R2L2, 5=L2x2, 6=R2x2
+local selectedCrossbarTab = 1;  -- 1=Global, 2=L2, â€¦ (for Crossbar category panel)
 
 -- Category definitions
 local categories = {
@@ -323,13 +643,26 @@ local categories = {
     { name = 'notifications', label = 'Notifications' },
     { name = 'treasurePool', label = 'Treasure Pool' },
     { name = 'hotbar', label = 'Hotbar' },
+    { name = 'crossbar', label = 'Crossbar' },
     { name = 'readyCheck', label = 'Ready Check' },
 };
 
 
+-- Index of the Crossbar sidebar category (for palette edit context sync)
+local function GetCrossbarCategoryIndex()
+    for i, c in ipairs(categories) do
+        if c.name == 'crossbar' then
+            return i;
+        end
+    end
+    return nil;
+end
+
 -- Build state object for modules that need tab state
 local function buildState()
     return {
+        selectedCategory = selectedCategory,
+        crossbarCategoryIndex = GetCrossbarCategoryIndex(),
         selectedPartyTab = selectedPartyTab,
         selectedPartyColorTab = selectedPartyColorTab,
         selectedInventoryTab = selectedInventoryTab,
@@ -341,7 +674,6 @@ local function buildState()
         selectedPetTypeTab = selectedPetTypeTab,
         selectedPetTypeColorTab = selectedPetTypeColorTab,
         selectedHotbarTab = selectedHotbarTab,
-        selectedModeTab = selectedModeTab,
         selectedCrossbarTab = selectedCrossbarTab,
         githubTexture = githubTexture,
     };
@@ -356,7 +688,6 @@ local function applySettingsState(newState)
         if newState.selectedPetBarTab then selectedPetBarTab = newState.selectedPetBarTab; end
         if newState.selectedPetTypeTab then selectedPetTypeTab = newState.selectedPetTypeTab; end
         if newState.selectedHotbarTab then selectedHotbarTab = newState.selectedHotbarTab; end
-        if newState.selectedModeTab then selectedModeTab = newState.selectedModeTab; end
         if newState.selectedCrossbarTab then selectedCrossbarTab = newState.selectedCrossbarTab; end
     end
 end
@@ -369,7 +700,6 @@ local function applyColorState(newState)
         if newState.selectedPetBarColorTab then selectedPetBarColorTab = newState.selectedPetBarColorTab; end
         if newState.selectedPetTypeColorTab then selectedPetTypeColorTab = newState.selectedPetTypeColorTab; end
         if newState.selectedHotbarTab then selectedHotbarTab = newState.selectedHotbarTab; end
-        if newState.selectedModeTab then selectedModeTab = newState.selectedModeTab; end
         if newState.selectedCrossbarTab then selectedCrossbarTab = newState.selectedCrossbarTab; end
     end
 end
@@ -433,6 +763,11 @@ end
 
 local function DrawHotbarSettings()
     local newState = hotbarModule.DrawSettings(buildState());
+    applySettingsState(newState);
+end
+
+local function DrawCrossbarSettingsPanel()
+    local newState = crossbarModule.DrawSettings(buildState());
     applySettingsState(newState);
 end
 
@@ -502,6 +837,11 @@ local function DrawHotbarColorSettings()
     applyColorState(newState);
 end
 
+local function DrawCrossbarColorSettingsPanel()
+    local newState = crossbarModule.DrawColorSettings(buildState());
+    applyColorState(newState);
+end
+
 local function DrawReadyCheckColorSettings()
     readycheckModule.DrawColorSettings();
 end
@@ -522,6 +862,7 @@ local settingsDrawFunctions = {
     DrawNotificationsSettings,
     DrawTreasurePoolSettings,
     DrawHotbarSettings,
+    DrawCrossbarSettingsPanel,
     DrawReadyCheckSettings,
 };
 
@@ -540,6 +881,7 @@ local colorSettingsDrawFunctions = {
     DrawNotificationsColorSettings,
     DrawTreasurePoolColorSettings,
     DrawHotbarColorSettings,
+    DrawCrossbarColorSettingsPanel,
     DrawReadyCheckColorSettings,
 };
 
@@ -559,9 +901,13 @@ local function DrawProfilePopups()
         imgui.OpenPopup("Delete Profile");
         triggerDeleteProfilePopup = false;
     end
+    if (triggerCopyProfilePopup) then
+        imgui.OpenPopup("Copy Profile");
+        triggerCopyProfilePopup = false;
+    end
 
     -- New Profile Popup
-    if (imgui.BeginPopupModal("New Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("New Profile")) then
         isModalOpen = true;
         imgui.Text("Create New Profile:");
         imgui.InputText("##NewProfileName", newProfileName, 32);
@@ -584,7 +930,7 @@ local function DrawProfilePopups()
     end
 
     -- Rename Popup
-    if (imgui.BeginPopupModal("Rename Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("Rename Profile")) then
         isModalOpen = true;
         imgui.Text("Rename '" .. GetCurrentProfileName() .. "' to:");
         imgui.InputText("##RenameInput", renameProfileName, 32);
@@ -606,7 +952,7 @@ local function DrawProfilePopups()
     end
 
     -- Delete Confirmation Popup
-    if (imgui.BeginPopupModal("Delete Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("Delete Profile")) then
         isModalOpen = true;
         imgui.Text("Are you sure you want to delete profile:");
         imgui.TextColored({1.0, 0.3, 0.3, 1.0}, profileToDelete);
@@ -624,7 +970,41 @@ local function DrawProfilePopups()
         end
         imgui.EndPopup();
     end
-    
+
+    -- Copy Profile: optional macro library (full clone vs layout-only for another character)
+    if (imgui.BeginPopup("Copy Profile")) then
+        isModalOpen = true;
+        local src = (GetCurrentProfileName and GetCurrentProfileName()) or '';
+        imgui.Text("Create a new profile from:");
+        imgui.TextColored(gold, src);
+        imgui.Spacing();
+        imgui.TextWrapped(
+            'Copy is a full snapshot of the selected profile on disk, except you can start without a macro library. '
+            .. 'Buckets that were never used (e.g. Items / Equipment) are not in the file â€” that is why a clone can show Global/job rows but no separate items bucket until you add some.'
+        );
+        imgui.Spacing();
+        imgui.Checkbox("Include full macro library##copyInclMacros", copyProfileIncludeMacros);
+        if (imgui.ShowHelp) then
+            imgui.SameLine();
+            imgui.ShowHelp(
+                "When checked: all macro palette buckets in this profile (same as a full file copy). When unchecked: empty macro list and custom categories reset; keyboard/crossbar slots that used palette macros are cleared. Spells, abilities, and items on bars are kept. Use Profile â†’ Export/Import JSON to move chosen macros between profiles."
+            );
+        end
+        imgui.Spacing();
+        if (imgui.Button("Create copy##CopyProfileGo", { 120, 0 })) then
+            if (DuplicateProfile and GetCurrentProfileName) then
+                if (DuplicateProfile(GetCurrentProfileName(), { includeMacroLibrary = (copyProfileIncludeMacros[1] == true) })) then
+                    imgui.CloseCurrentPopup();
+                end
+            end
+        end
+        imgui.SameLine();
+        if (imgui.Button("Cancel##CopyProfile", { 120, 0 })) then
+            imgui.CloseCurrentPopup();
+        end
+        imgui.EndPopup();
+    end
+
     return isModalOpen;
 end
 
@@ -634,23 +1014,32 @@ config.DrawWindow = function(us)
     -- Detect when config closes and clear treasure pool preview
     local isConfigOpen = showConfig[1];
     if wasConfigOpen and not isConfigOpen then
-        -- Config just closed - always save profile to persist window positions
-        SaveSettingsToDisk();
-        
-        -- Clear dirty flags if they were set
-        if macropalette.IsHotbarDirty() then
-            macropalette.ClearHotbarDirty();
+        local deferClose = getPaletteManagerForCloseDefer().DeferConfigCloseIfEditFullPaletteOpen();
+        if deferClose then
+            -- Keep XIUI Config open; palette manager shows a confirm popup on the next draw.
+            showConfig[1] = true;
+        else
+            -- Config just closed - always save profile to persist window positions
+            SaveSettingsToDisk();
+
+            -- Clear dirty flags if they were set
+            if macropalette.IsHotbarDirty() then
+                macropalette.ClearHotbarDirty();
+            end
+            if palette.IsPaletteStateDirty() then
+                palette.ClearPaletteStateDirty();
+            end
+            -- Clear preview state and reset settings
+            treasurePool.ClearPreview();
+            gConfig.treasurePoolMiniPreview = false;
+            gConfig.treasurePoolFullPreview = false;
         end
-        if palette.IsPaletteStateDirty() then
-            palette.ClearPaletteStateDirty();
-        end
-        -- Clear preview state and reset settings
-        treasurePool.ClearPreview();
-        gConfig.treasurePoolMiniPreview = false;
-        gConfig.treasurePoolFullPreview = false;
     end
     local configJustOpened = isConfigOpen and not wasConfigOpen;
     wasConfigOpen = isConfigOpen;
+    if configJustOpened then
+        crossbarModule.OnConfigWindowOpened();
+    end
 
     -- Early exit if config window isn't shown (atom0s recommendation)
     -- This prevents unnecessary style pushes and imgui.End() calls when window is hidden
@@ -658,9 +1047,9 @@ config.DrawWindow = function(us)
 
     -- Constrain config window to never exceed the game's render resolution.
     -- Prevents the window from being larger than the screen or lost off-screen on small resolutions.
-    local ioData = imgui.GetIO();
-    local sw = ioData.DisplaySize.x;
-    local sh = ioData.DisplaySize.y;
+    local io = imgui.GetIO();
+    local sw = io.DisplaySize.x;
+    local sh = io.DisplaySize.y;
     if not sw or sw < 1 then return; end
     if not sh or sh < 1 then return; end
 
@@ -690,8 +1079,7 @@ config.DrawWindow = function(us)
             imgui.SetNextWindowPos({ 20, 20 }, ImGuiCond_Always);
         end
     end
-    local configVisible = imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking));
-    if configVisible then
+    if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
         local windowWidth = imgui.GetContentRegionAvail();
         local sidebarWidth = 180;
         local contentWidth = windowWidth - sidebarWidth - 20;
@@ -819,7 +1207,7 @@ config.DrawWindow = function(us)
             showRestoreDefaultsConfirm = false;
         end
 
-        if (imgui.BeginPopupModal("Confirm Reset Settings", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+        if (imgui.BeginPopup("Confirm Reset Settings")) then
             anyModalOpen = true;
             imgui.Text("Are you sure you want to reset all settings to defaults?");
             imgui.Text("This will reset all your customizations including:");
@@ -985,10 +1373,12 @@ config.DrawWindow = function(us)
     end
 
     -- Capture config window geometry while open for smart reposition on next open.
-    -- Two local assignments per frame — negligible cost, but ensures we always have
+    -- Two local assignments per frame â€” negligible cost, but ensures we always have
     -- current values even on addon unload or profile change without an extra frame.
     lastConfigPosX, lastConfigPosY = imgui.GetWindowPos();
     lastConfigSizeW, lastConfigSizeH = imgui.GetWindowSize();
+    -- For other UI (e.g. Crossbar full palette window) to stagger offset from this window without a require() cycle
+    _G._XIUI_CONFIG_LAST_GEOM = { lastConfigPosX, lastConfigPosY, lastConfigSizeW, lastConfigSizeH };
 
     imgui.End();
 
@@ -1023,4 +1413,42 @@ function config.OpenResetSettingsPopup()
     showRestoreDefaultsConfirm = true;
 end
 
+-- Open XIUI config on Crossbar category, Manage Palettes & Crossbar tab (/xiui cpalette)
+-- Used by palette manager modal to close XIUI Config after forcing Edit Full Palette shut.
+function config.SetWindowOpen(isOpen)
+    showConfig[1] = isOpen and true or false;
+end
+
+function config.OpenCrossbarManagePalettes()
+    local idx = GetCrossbarCategoryIndex();
+    if not idx then
+        return false;
+    end
+    selectedCategory = idx;
+    selectedTab = 1;
+    showConfig[1] = true;
+    crossbarModule.OpenCrossbarManagePalettesTab();
+    return true;
+end
+
+-- Toggle: close config if already on Crossbar â†’ Manage Palettes; otherwise open there (/xiui cpalette with no subcommand)
+function config.ToggleCrossbarManagePalettes()
+    local idx = GetCrossbarCategoryIndex();
+    if not idx then
+        return nil;
+    end
+    if showConfig[1] and selectedCategory == idx and selectedTab == 1 then
+        local cross = gConfig and gConfig.hotbarCrossbar;
+        if cross and cross.configUiTab == 2 then
+            showConfig[1] = false;
+            return 'closed';
+        end
+    end
+    if not config.OpenCrossbarManagePalettes() then
+        return nil;
+    end
+    return 'opened';
+end
+
 return config;
+

--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -274,7 +274,7 @@ end
 function M.createHotbarGlobalDefaults()
     return T{
         -- Game UI patches
-        disableMacroBars = false,  -- Disable native XI macros (macro bar display + controller macro blocking)
+        disableMacroBars = false,  -- Keyboard: hide native macro bar UI + block Ctrl/Alt+number macro keys (controller blocking is Crossbar → Disable XI Macros)
         controllerHoldToShow = true,  -- Controller triggers use hold-to-show (like macrofix addon) instead of tap-to-toggle
 
         -- Blocked game keys - array of key definitions that should be blocked from reaching the game
@@ -292,6 +292,10 @@ function M.createHotbarGlobalDefaults()
         -- Palette cycling controller (RB + Dpad)
         paletteCycleControllerEnabled = true,  -- Enable controller palette cycling
         hotbarPaletteCycleButton = 'R1',       -- 'R1' or 'L1' for hotbar cycling
+
+        logPaletteName = true,                 -- Log palette name when cycling keyboard hotbars
+        logPaletteNameCrossbar = true,         -- Log palette name when cycling via controller (crossbar)
+        logPaletteNameCrossbarCycleHint = true, -- Second CLI line: RB+D-pad return hint after job preview
 
         -- Visual settings
         slotSize = 48,          -- Slot size in pixels
@@ -333,7 +337,7 @@ function M.createHotbarGlobalDefaults()
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -350,7 +354,16 @@ function M.createHotbarGlobalDefaults()
         skillchainIconScale = 1.0,              -- Scale multiplier for icon (0.5-2.0)
         skillchainIconOffsetX = 0,              -- X offset in pixels
         skillchainIconOffsetY = 0,              -- Y offset in pixels
-    
+
+        -- Magic Burst highlight settings. Window opens IMMEDIATELY when a SC closes and runs
+        -- for 7.0s (matches retail's MB cutoff at the back end while front-loading the visual
+        -- cue). Highlights spell / magical pact rage / /ma-or-/pet macro slots whose element
+        -- matches one of the SC's burstable elements. Uses the same corner icon as the
+        -- skillchain highlight (the SC's name asset) but in the bottom-left corner with a
+        -- cyan-blue border to keep the two highlights visually distinct.
+        magicBurstHighlightEnabled = true,      -- Show MB highlight on element-matching spell slots
+        magicBurstHighlightColor = 0xFF44D4FF,  -- Cyan-blue (ARGB) — distinct from gold SC border
+
         -- Cooldown timer settings
         recastTimerFontSize = 11,               -- Font size for cooldown timer display
         recastTimerFontColor = 0xFFFFFFFF,      -- Color for cooldown timer text
@@ -372,6 +385,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Pet-aware toggle (when true, hotbar can have different palettes per pet for SMN/BST/DRG/PUP)
         petAware = false,
         showPetIndicator = true,  -- Show indicator dot when petAware is enabled
+        -- When set: array of type tokens 'avatars'|'elementals'|'beasts'|'wyvern'|'puppet' (legacy 'summons' = avatars+elementals). nil = all.
+        petPalettePetKeys = nil,
 
         -- Layout settings (always per-bar)
         enabled = true,
@@ -420,7 +435,7 @@ function M.createHotbarBarDefaults(overrides)
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -443,6 +458,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Structure: paletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Palettes are displayed in this order; missing palettes are appended alphabetically
         paletteOrder = {},
+        -- paletteExcludeFromCycle[orderKey][paletteName] = true skips palette for RB / keyboard cycling only
+        paletteExcludeFromCycle = {},
     };
     if overrides then
         for k, v in pairs(overrides) do
@@ -460,22 +477,51 @@ end
 -- The crossbar provides 4 combo modes: L2, R2, L2+R2, R2+L2 (32 total slots)
 function M.createCrossbarDefaults()
     return T{
-        -- Layout mode: 'hotbar', 'crossbar', or 'both'
-        mode = 'hotbar',
+        -- Show controller crossbar UI (mirrors gConfig.crossbarEnabled; kept for migration)
+        showCrossbar = true,
+
+        -- Hide crossbar when game menu open (independent from Hotbar → Hide When Menu Open)
+        crossbarHideOnMenuFocus = false,
+
+        -- Disable crossbar input while a game menu is open (keeps it visible but blocks trigger macros)
+        crossbarDisableInMenu = true,
+
+        -- Config UI: which main section is active (1=Controller, 2=Manage palettes, 3=Global visuals)
+        configUiTab = 1,
+        -- 'universal' = editing [G] all-jobs sets; 'job' = editing palettes for configEditJobId
+        configFocus = 'job',
+        configEditJobId = nil,   -- nil = use live main job from data when in job focus
+        configEditSubjobId = nil,
 
         -- Job-specific toggle (when true, actions are stored per-job; when false, actions are shared across all jobs)
         jobSpecific = true,
 
-        -- Per-combo-mode settings (pet-aware is per-combo, palettes are GLOBAL)
-        -- NOTE: activePalette was removed - crossbar palettes are now global (see palette.lua state.crossbarActivePalette)
+        -- All-jobs universal crossbar palettes (storage: global:palette:{name} in slotActions)
+        enableUniversalCrossbarPalettes = false,
+        -- 'job' = job/subjob named palettes; 'universal' = all-jobs sets (toggle L1+R1 when enabled)
+        defaultCrossbarPaletteScope = 'job',
+        -- Per-palette: includeInCycle = false hides palette from RB+D-pad when scope is universal
+        crossbarUniversalPaletteMeta = {},
+        universalCrossbarPaletteOrder = {},
+
+        -- Per-segment: petAware, optional per-segment petPalettePetKeys, universalOverridePalette = all-jobs palette name. Default pet types: petPalettePetKeys on parent.
         comboModeSettings = {
-            L2 = { petAware = false },
-            R2 = { petAware = false },
-            L2R2 = { petAware = false },
-            R2L2 = { petAware = false },
-            L2x2 = { petAware = false },
-            R2x2 = { petAware = false },
+            L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
         },
+        -- Optional per named [J] palette: comboMode -> { petAware?, universalOverridePalette? } (nil field = inherit Crossbar defaults)
+        namedPaletteComboModeSettings = {},
+
+        -- Crossbar [J] only: which pet families (avatars/elementals/beasts/wyvern/puppet) use pet hotbar storage; nil = all. Not per named palette.
+        petPalettePetKeys = nil,
+
+        -- Per main job id (string key): effective combo mode -> { scope = 'jobShared' | 'global', globalPalette = name? }
+        -- Primary L2/R2 are not used. Resolves slot data to jobsegment:{jobId}:{mode} or global:palette:{name}.
+        segmentOverrides = {},
 
         -- Layout
         slotSize = 40,              -- Slot size in pixels
@@ -495,7 +541,8 @@ function M.createCrossbarDefaults()
         slotBackgroundColor = 0x55000000,
         slotOpacity = 1.0,                  -- Opacity multiplier for slot.png (0.0-1.0)
         activeSlotHighlight = 0x44FFFFFF,   -- Highlight color when trigger held
-        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side
+        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side (expanded / non-trigger dim)
+        inactiveSideWhileTriggerDim = 0.15, -- Dim for the non-active half while L2 or R2 is held
 
         -- Display mode
         displayMode = 'normal',             -- 'normal' or 'activeOnly'
@@ -511,6 +558,8 @@ function M.createCrossbarDefaults()
         buttonIconGapH = 8,                 -- Horizontal spacing between center icons
         buttonIconGapV = 2,                 -- Vertical spacing between center icons
         buttonIconPosition = 'corner',      -- 'corner' or 'replace_keybind'
+        -- Job icon set for palette UI (Manage Palettes strip + in-game palette scope icon when Job [J])
+        paletteJobIconTheme = 'Classic',     -- 'Classic', 'FFXI', 'FFXIV-1' (under assets/jobs/)
         controllerTheme = 'Xbox',           -- 'PlayStation', 'Xbox', or 'Nintendo' button icons
         controllerScheme = 'xbox',          -- Controller profile: 'xbox', 'dualsense', 'switchpro', 'dinput'
         triggerIconScale = 0.8,             -- Scale for L2/R2 trigger icons (base 49x28)
@@ -545,10 +594,14 @@ function M.createCrossbarDefaults()
         comboTextOffsetY = 0,               -- Y offset for combo text position
 
         -- Palette name display (shows current palette and index, e.g., "Stuns (2/5)")
-        showPaletteName = false,            -- Toggle to show palette name
+        showPaletteName = false,            -- Toggle to show palette name text below crossbar
+        showPaletteScopeIcon = true,        -- Job / Global scope icon above divider; nil in saved config = legacy (follow showPaletteName)
         paletteNameFontSize = 10,           -- Font size for palette name
         paletteNameOffsetX = 0,             -- X offset for position
         paletteNameOffsetY = 0,             -- Y offset for position
+        -- Job / Global palette scope icon above center divider
+        paletteScopeIconOffsetY = 12,       -- Vertical lift (px); higher = icon moves up
+        paletteScopeIconSize = 22,          -- Icon width/height (px); legacy profiles fall back to font-based size if unset
 
         -- Expanded crossbar (L2+R2 combos)
         enableExpandedCrossbar = true,      -- Enable L2+R2 and R2+L2 combos
@@ -557,6 +610,12 @@ function M.createCrossbarDefaults()
         -- Double-tap crossbar (tap trigger twice quickly)
         enableDoubleTap = false,            -- Enable L2x2 and R2x2 double-tap modes
         doubleTapWindow = 0.3,              -- Time window for double-tap detection (seconds)
+
+        -- Double-tap preview windows (always-visible overlays showing L2x2 / R2x2 bars)
+        showDoubleTapPreview    = false,     -- Show floating preview windows for double-tap bars
+        doubleTapPreviewScale   = 0.60,     -- Preview scale relative to main crossbar (0.3–1.0)
+        doubleTapPreviewOpacity = 1.0,      -- Preview opacity multiplier (0.2–1.0; dims with trigger)
+        doubleTapPreviewLocked  = false,    -- Lock preview positions independently of the main crossbar
 
         -- Analog trigger thresholds (0-255 normalized range)
         -- Used by Xbox (XInput) and PlayStation (DirectInput with signed->unsigned conversion)
@@ -587,6 +646,8 @@ function M.createCrossbarDefaults()
         -- Structure: crossbarPaletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Note: Crossbar palettes are independent from hotbar palettes
         crossbarPaletteOrder = {},
+        -- Same shape as paletteExcludeFromCycle on hotbar; per job:storage-tier key
+        crossbarPaletteExcludeFromCycle = {},
     };
 end
 

--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -5,6 +5,8 @@
 
 local M = {};
 local profileManager = require('core.profile_manager');
+local macroXiuiDefaults = require('modules.hotbar.macro_xiui_defaults');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
 
 -- Migrate settings from HXUI to XIUI (one-time migration for users upgrading from HXUI)
 -- IMPORTANT: This must be called BEFORE settings.load() so that copied files are picked up
@@ -607,6 +609,20 @@ function M.MigrateIndividualSettings(gConfig, defaults)
             if petType.tpFontSize == nil then petType.tpFontSize = oldVitalsFontSize; end
         end
     end
+
+    if gConfig.petBarResizeAnchor == nil then
+        local wantsBottom = false;
+        for _, pt in ipairs(petTypeTables) do
+            if pt and pt.alignBottom then
+                wantsBottom = true;
+                break;
+            end
+        end
+        gConfig.petBarResizeAnchor = wantsBottom and 'bottom' or 'top';
+    end
+    if gConfig.petTargetSnapAnchor == 'top' and type(gConfig.petTargetSnapOffsetX) == 'number' and gConfig.petTargetSnapOffsetX >= 100 then
+        gConfig.petTargetSnapOffsetX = 0;
+    end
 end
 
 -- Migrate flat castCost* settings to nested castCost table
@@ -1053,7 +1069,116 @@ end
 
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
+-- Split legacy hotbarCrossbar.mode ('hotbar'|'crossbar'|'both') into separate visibility flags
+function M.MigrateCrossbarModuleFlags(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.crossbarEnabled == nil then
+        if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.showCrossbar ~= nil then
+            gConfig.crossbarEnabled = gConfig.hotbarCrossbar.showCrossbar;
+        else
+            gConfig.crossbarEnabled = true;
+        end
+    end
+    local hg = gConfig.hotbarGlobal;
+    if hg and hg.logPaletteNameCrossbar == nil then
+        hg.logPaletteNameCrossbar = hg.logPaletteName;
+    end
+    if hg and hg.logPaletteNameCrossbarCycleHint == nil then
+        hg.logPaletteNameCrossbarCycleHint = true;
+    end
+end
+
+function M.MigrateHotbarCrossbarLayoutFlags(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local m = gConfig.hotbarCrossbar.mode;
+    if m ~= nil then
+        if m == 'hotbar' then
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = false;
+        elseif m == 'crossbar' then
+            gConfig.hotbarShowKeyboardBars = false;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        else
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        end
+        gConfig.hotbarCrossbar.mode = nil;
+    end
+    if gConfig.hotbarShowKeyboardBars == nil then
+        gConfig.hotbarShowKeyboardBars = true;
+    end
+    if gConfig.hotbarCrossbar.showCrossbar == nil then
+        gConfig.hotbarCrossbar.showCrossbar = true;
+    end
+end
+
+-- Fold legacy hotbarShowKeyboardBars into hotbarEnabled (same intent as Hotbar → Enabled today).
+function M.MigrateHotbarShowKeyboardBarsRemoval(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.hotbarShowKeyboardBars == false and gConfig.hotbarEnabled ~= false then
+        gConfig.hotbarEnabled = false;
+    end
+    gConfig.hotbarShowKeyboardBars = nil;
+end
+
+-- Drop deprecated keys from profiles saved during older builds (macros/skillchain are hotbarGlobal only now).
+function M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local xb = gConfig.hotbarCrossbar;
+    xb.crossbarDisableXiMacros = nil;
+    xb.skillchainHighlightEnabled = nil;
+    xb.skillchainHighlightColor = nil;
+    xb.skillchainIconScale = nil;
+    xb.skillchainIconOffsetX = nil;
+    xb.skillchainIconOffsetY = nil;
+end
+
+function M.MigrateMacroGlobalUniversalTwoHour(gConfig)
+    if not gConfig then
+        return;
+    end
+    macroGlobalDefaults.SeedUniversalTwoHourIfNeeded(gConfig);
+end
+
+function M.MigrateMacroXiuiDefaults(gConfig)
+    if not gConfig then
+        return;
+    end
+    local inserted = macroXiuiDefaults.SeedIfNeeded(gConfig);
+    if inserted then
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if ok and hotbarData and hotbarData.MarkMacroLookupDirty then
+            hotbarData.MarkMacroLookupDirty();
+        end
+    end
+end
+
 function M.RunStructureMigrations(gConfig, defaults)
+    -- Run before anything touches macroDB: coalesce "4" vs 4 and dedupe macro ids (fixes wrong macro on hotbar / drag)
+    if gConfig then
+        local ok, data = pcall(require, 'modules.hotbar.data');
+        if ok and data and data.EnsureMacroDatabaseCoherence then
+            data.EnsureMacroDatabaseCoherence(gConfig);
+        end
+    end
+    M.MigrateCrossbarModuleFlags(gConfig);
+    M.MigrateHotbarCrossbarLayoutFlags(gConfig);
+    M.MigrateHotbarShowKeyboardBarsRemoval(gConfig);
+    M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig);
+    if gConfig then
+        local ok, hbData = pcall(require, 'modules.hotbar.data');
+        if ok and hbData and hbData.MigrateSlotDualMacroBindings then
+            hbData.MigrateSlotDualMacroBindings(gConfig);
+        end
+    end
     M.MigratePartyListLayoutSettings(gConfig, defaults);
     M.MigratePerPartySettings(gConfig, defaults);
     M.MigratePerPetTypeSettings(gConfig, defaults);
@@ -1067,6 +1192,8 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
     M.MigrateSlotMacroRefs(gConfig);
+    M.MigrateMacroXiuiDefaults(gConfig);
+    M.MigrateMacroGlobalUniversalTwoHour(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -63,10 +63,31 @@ function M.createUserSettingsDefaults()
         treasurePoolExpanded = false,         -- Expanded view (false = collapsed)
 
         -- Hotbar settings (global)
-        hotbarEnabled = true,                 -- Show hotbar module
-        -- Lock movement: when true, disables drag/drop and slot swapping for hotbar bars
+        hotbarEnabled = true,                 -- Show hotbar module (keyboard strips when enabled; use Crossbar category for controller UI)
+
+        crossbarEnabled = true,               -- Load controller crossbar (L2/R2 UI); independent from keyboard hotbars
+        -- Lock movement: when true, disables drag/drop and slot swapping for keyboard hotbars only
         hotbarLockMovement = false,
+        -- Lock crossbar: when true, disables drag/drop/slot moves and window drag for controller crossbar
+        crossbarLockMovement = false,
         hotbarPreview = false,                -- Show preview with test data
+
+        -- Macro palette editor: icon auto-source + custom/ subfolder (persists per profile)
+        macroEditorIconPrefs = {
+            iconAutoSource = 'all',   -- 'all' | 'spells' | 'items' | 'custom'
+            customIconFolder = 'all', -- 'all' or a top-level folder name under assets/hotbar/custom/
+        },
+
+        -- Macro palette: custom dropdown categories (keys "custom:N" under macroDB)
+        macroCustomCategories = T{},
+        macroCustomNextSeq = 1,
+        -- When false, empty "xiui" macro bucket gets default /xiui slash shortcuts once (see macro_xiui_defaults.lua)
+        macroXiuiDefaultsSeeded = false,
+        -- When false, Global bucket may receive default "Universal 2 Hour" macro once (see macro_global_defaults.lua)
+        macroGlobalUniversalTwoHourSeeded = false,
+
+        -- "profile" = macros in this profile's lua only; "shared" = one global library (SharedMacros.lua) for all characters using Shared.
+        macroStorageScope = 'profile',
 
         -- Global hotbar visual settings (used when bar's useGlobalSettings = true)
         hotbarGlobal = factories.createHotbarGlobalDefaults(),
@@ -665,6 +686,7 @@ function M.createUserSettingsDefaults()
         petBarScaleY = 1.0,
         petBarHideDuringEvents = true,
         petBarPreview = true,
+        petBarResizeAnchor = 'top',              -- Pet bar resize: 'top' or 'bottom' fixed edge when height changes
         petBarPreviewType = 2, -- Avatar (SMN)
         petBarShowDistance = true,
         petBarShowTarget = true,
@@ -792,10 +814,14 @@ function M.createUserSettingsDefaults()
         petTargetDistanceOffsetY = 44,
 
         -- Pet Target snap to petbar (positions pet target directly below petbar)
-        petTargetSnapToPetBar = true,        -- When enabled, pet target snaps below petbar
-        petTargetSnapAnchor = 'bottom',      -- 'bottom' = offset from bottom of pet bar, 'top' = offset from top (static when buffs change height)
+        petTargetSnapToPetBar = true,        -- When enabled, pet target snaps relative to pet bar geometry
+        petTargetSnapAnchor = 'bottom',      -- bottom: pet target window below pet bar; top: above pet bar
         petTargetSnapOffsetX = 0,            -- Horizontal offset from petbar position
         petTargetSnapOffsetY = 16,           -- Vertical offset below petbar (accounts for background border)
+        -- Extra pixels between Pet Target bottom and pet bar top when snap anchor is Top (0 = use offset Y only)
+        petTargetSnapTopGap = 5,
+        -- Last measured PetBarTarget window height (top snap only); avoids first-frame placement jump after load
+        petTargetSnapCachedHeight = nil,
 
         -- Per-pet-type settings (Avatar, Charm, Jug, Automaton, Wyvern each have independent visual settings)
         petBarAvatar = factories.createPetBarTypeDefaults(),

--- a/XIUI/handlers/imgui_compat.lua
+++ b/XIUI/handlers/imgui_compat.lua
@@ -129,6 +129,18 @@ else
 
 end
 
+-- ImGuiWindowFlags_NoInputs: skip missing on some Ashita builds (PetBarTarget mouse pass-through during drag-drop)
+if ImGuiWindowFlags_NoInputs == nil then
+    if ImGuiWindowFlags_NoMouseInputs ~= nil and ImGuiWindowFlags_NoNavInputs ~= nil then
+        ImGuiWindowFlags_NoInputs = bit.bor(ImGuiWindowFlags_NoMouseInputs, ImGuiWindowFlags_NoNavInputs);
+    elseif ImGuiWindowFlags_NoMouseInputs ~= nil then
+        ImGuiWindowFlags_NoInputs = ImGuiWindowFlags_NoMouseInputs;
+    else
+        -- Dear ImGui 1.83-style composite (NoMouseInputs|NoNavInputs); used when Ashita exposes neither constant
+        ImGuiWindowFlags_NoInputs = 1536;
+    end
+end
+
 -- Return module info for debugging
 return {
     version = '1.0.0',

--- a/XIUI/libs/texturemanager.lua
+++ b/XIUI/libs/texturemanager.lua
@@ -42,8 +42,9 @@ local CATEGORY_CONFIG = {
         clearOnZone = false,
     },
     custom_icons = {
-        maxSize = 250,  -- ~2 pages of icons cached
-        evictionCount = 50,
+        -- No eviction: hotbar/macro picker revisit the same PNG paths; LRU evict+reload caused heavy stutter.
+        maxSize = 0,
+        evictionCount = 0,
         clearOnZone = false,
     },
     assets = {
@@ -73,6 +74,19 @@ local function deferRelease(entry)
     if entry ~= nil then
         pendingReleases[#pendingReleases + 1] = entry;
     end
+end
+
+-- Public: hold any Lua value (table, texture entry, cache-row) alive until the
+-- start of the next d3d_present, then drop the reference so GC can finalize it.
+-- Use this whenever caller code wipes a cache that holds the last Lua reference
+-- to a texture (so its FFI pointer may still be queued in this frame's ImGui
+-- draw list). Same race the per-category clears already guard against — see
+-- the comment on `pendingReleases` above. Without this, palette-deletion paths
+-- (slotrenderer / display / crossbar icon caches) crash with
+-- EXCEPTION_ACCESS_VIOLATION when the renderer reaches an already-released
+-- D3D texture pointer.
+function M.DeferRelease(value)
+    deferRelease(value);
 end
 
 -- Per-category arrays for LRU eviction tracking

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -35,6 +35,7 @@
 
 require('common');
 require('handlers.helpers');
+local gameState = require('core.gamestate');
 local dragdrop = require('libs.dragdrop');
 local imtext = require('libs.imtext');
 
@@ -75,6 +76,17 @@ M.visible = true;
 -- Track hotbar enable/disable state for transitions
 local wasHotbarEnabled = nil;
 
+-- Crossbar controller "Disable XI Macros" is shared with Hotbar -> Disable XI Macros (hotbarGlobal.disableMacroBars).
+-- Wrapper exists so the call sites read as crossbar-specific intent.
+local function GetCrossbarDisableXiMacrosEffective()
+    local hg = gConfig and gConfig.hotbarGlobal;
+    return hg and hg.disableMacroBars == true;
+end
+
+-- Palette change dedup: SetActivePalette / SetActivePaletteForCombo fire one callback per bar (1-6)
+-- or per combo mode (6x). Without deduping, display/slot cache clears run 6x per logical palette change.
+local lastPaletteVisualRefreshSig = nil;
+
 -- True if any hotbar bar or crossbar combo-mode has petAware enabled.
 -- Used to short-circuit the pet-change callback's cache wipes when no
 -- bar would actually rebind its slots in response.
@@ -113,6 +125,11 @@ function M.Initialize(settings)
 
     -- Initialize data module (sets player job)
     data.Initialize();
+    -- Migrate any legacy non-pet-aware storage keys + invalidate cache after migration.
+    if data.MigratePetAwareSlotStorageKeys then
+        data.MigratePetAwareSlotStorageKeys();
+    end
+    data.InvalidateStorageKeyCache();
 
     -- Validate palettes on reload (not just on job change packets)
     -- Helper function to validate palettes once job is ready
@@ -121,7 +138,14 @@ function M.Initialize(settings)
         local maxAttempts = 20;
 
         if data.SetPlayerJob() then
-            palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+            -- Honor pending "profile loaded before job was readable" (char select / logout)
+            -- so the default crossbar palette scope applies on first job-ready frame.
+            local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+                and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+                or nil;
+            palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+                applyDefaultCrossbarScope = pending,
+            });
             macropalette.SyncToCurrentJob();
             display.ClearIconCache();
             slotrenderer.ClearAllCache();
@@ -138,7 +162,12 @@ function M.Initialize(settings)
     end
 
     if data.jobId then
-        palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+        local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+            and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+            or nil;
+        palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+            applyDefaultCrossbarScope = pending,
+        });
     else
         -- Job not ready yet, start retry loop
         ashita.tasks.once(0.3, function()
@@ -177,16 +206,28 @@ function M.Initialize(settings)
         macropalette.ClearPetCommandsCache();
     end);
 
-    -- Register palette change callback to clear caches
+    -- Register palette change callback to clear caches.
+    -- Dedupe identical logical palette switches: SetActivePalette / SetActivePaletteForCombo
+    -- fire one callback per bar (1-6) or per combo mode (6x), so a single user palette change
+    -- triggers 6+ identical cache flushes if unguarded.
+    -- For no-op refreshes (same name -> same name, e.g. JSON import) include barIdentifier so
+    -- every bar/combo still runs; otherwise only the first callback fires and the UI stays blank.
     palette.OnPaletteChanged(function(barIdentifier, oldPaletteName, newPaletteName)
-        -- Invalidate storage key cache (palette change affects storage keys)
+        local sig;
+        if oldPaletteName == newPaletteName then
+            sig = tostring(barIdentifier) .. '\0' .. tostring(oldPaletteName) .. '\0' .. tostring(newPaletteName);
+        else
+            sig = tostring(oldPaletteName) .. '\0' .. tostring(newPaletteName);
+        end
+        if sig == lastPaletteVisualRefreshSig then
+            return;
+        end
+        lastPaletteVisualRefreshSig = sig;
         data.InvalidateStorageKeyCache();
-        -- Clear crossbar icon cache when any palette changes (hotbar or crossbar)
+        display.ClearIconCache();
         if crossbarInitialized then
             crossbar.ClearIconCache();
         end
-        -- Clear ONLY slot rendering cache (not availability/MP/item caches)
-        -- OPTIMIZED: Selective invalidation avoids unnecessary recalculation cascade
         slotrenderer.ClearSlotRenderingCache();
     end);
 
@@ -204,11 +245,10 @@ function M.Initialize(settings)
     end
     -- If checkbox is OFF, macrofix is already applied by initialize_patches()
 
-    -- Initialize crossbar if mode includes crossbar
-    -- Defensive: validate gConfig.hotbarCrossbar is a table before accessing
+    -- Initialize crossbar when enabled (independent flag, not mode-based).
+    -- Defensive: validate gConfig.hotbarCrossbar is a table before accessing.
     local crossbarConfig = gConfig and type(gConfig.hotbarCrossbar) == 'table' and gConfig.hotbarCrossbar or nil;
-    local crossbarMode = crossbarConfig and crossbarConfig.mode or 'hotbar';
-    local crossbarNeeded = crossbarMode == 'crossbar' or crossbarMode == 'both';
+    local crossbarNeeded = gConfig and gConfig.crossbarEnabled ~= false;
     if crossbarNeeded and crossbarConfig then
         crossbar.Initialize(crossbarConfig, gAdjustedSettings.crossbarSettings);
         
@@ -231,8 +271,8 @@ function M.Initialize(settings)
         controller.SetSlotActivateCallback(function(comboMode, slotIndex)
             crossbar.ActivateSlot(comboMode, slotIndex);
         end);
-        -- Set controller blocking enabled state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Set controller blocking enabled state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
         crossbarInitialized = true;
     end
 
@@ -271,9 +311,8 @@ function M.UpdateVisuals(settings)
         macrosLib.set_controller_hold_to_show(holdToShow);
     end
 
-    -- Handle crossbar enable/disable based on mode
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    local crossbarNeeded = crossbarMode == 'crossbar' or crossbarMode == 'both';
+    -- Handle crossbar enable/disable (independent flag, not mode-based)
+    local crossbarNeeded = gConfig and gConfig.crossbarEnabled ~= false;
 
     if crossbarNeeded and not crossbarInitialized then
         -- Initialize crossbar when newly needed
@@ -290,8 +329,8 @@ function M.UpdateVisuals(settings)
         controller.SetSlotActivateCallback(function(comboMode, slotIndex)
             crossbar.ActivateSlot(comboMode, slotIndex);
         end);
-        -- Set controller blocking enabled state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Set controller blocking enabled state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
         crossbarInitialized = true;
     elseif not crossbarNeeded and crossbarInitialized then
         -- Cleanup crossbar when no longer needed
@@ -312,8 +351,8 @@ function M.UpdateVisuals(settings)
             customMapping = gConfig.hotbarCrossbar.customControllerMappings.dinput;
         end
         controller.SetControllerScheme(gConfig.hotbarCrossbar.controllerScheme, customMapping);
-        -- Update controller blocking state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Update controller blocking state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
     end
 
     -- Update state tracking for hotbar enable/disable
@@ -339,38 +378,50 @@ function M.DrawWindow(settings)
         texturesInitialized = true;
     end
 
-    if gConfig and gConfig.hotbarEnabled == false then
-        display.HideWindow();
-        if crossbarInitialized then
-            crossbar.SetHidden(true);
-        end
-        return;
-    end
+    -- Hotbar and crossbar are independent; either, both, or neither can be on. Menu-hide
+    -- is evaluated here per-system so keyboard hotbars and the crossbar can have different
+    -- hideOnMenuFocus behaviors (they previously shared `hotbarHideOnMenuFocus`).
+    local menuOpen = gameState.IsMenuOpen();
+    local hideKbOnMenu = gConfig.hotbarHideOnMenuFocus == true;
+    local hideXbOnMenu = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.crossbarHideOnMenuFocus == true;
+    local showHotbar = gConfig
+        and gConfig.hotbarEnabled ~= false
+        and not (menuOpen and hideKbOnMenu);
+    local showCrossbar = gConfig
+        and gConfig.crossbarEnabled ~= false
+        and not (menuOpen and hideXbOnMenu);
 
-    -- Determine what to draw based on mode
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    local showHotbar = crossbarMode == 'hotbar' or crossbarMode == 'both';
-    local showCrossbar = crossbarMode == 'crossbar' or crossbarMode == 'both';
-
-    -- Draw hotbar if mode includes it
+    -- Draw keyboard hotbars when enabled
     if showHotbar then
         display.DrawWindow(settings);
     else
         display.HideWindow();
     end
 
-    -- Draw crossbar if mode includes it
+    -- Draw crossbar when enabled
     if showCrossbar and crossbarInitialized then
         crossbar.DrawWindow(gConfig.hotbarCrossbar, gAdjustedSettings.crossbarSettings);
     elseif crossbarInitialized then
         crossbar.SetHidden(true);
     end
 
-    -- Always draw macro palette and keybind modal (regardless of mode)
+    -- Always draw macro palette and keybind modal (regardless of enabled state)
     macropalette.DrawPalette();
     hotbarConfig.DrawKeybindModal();
 
-    -- Render drag preview (must be called at end of frame, after all drop zones)
+    -- Drop previews / deferred overlaps happen in M.FinalizeFrame() — XIUI.lua calls it
+    -- after palettemanager.Draw so the floating palette can win when its DropZone overlaps
+    -- the HUD crossbar / Edit Full Palette preview.
+end
+
+-- Called by XIUI.lua at the very end of d3d_present, after palettemanager.Draw().
+-- Resolves overlapping DropZone hits via FlushDeferredDrops (highest dropPriority wins)
+-- and then renders the drag preview overlay.
+function M.FinalizeFrame()
+    if not M.initialized then return; end
+
+    -- Resolve overlapping DropZones (HUD crossbar vs. Edit Full Palette preview, etc.)
+    dragdrop.FlushDeferredDrops();
     dragdrop.Render();
 
     -- Handle slot dragged outside (remove the action)
@@ -381,9 +432,13 @@ function M.DrawWindow(settings)
                 -- Standard hotbar slot was dragged outside - clear it
                 macropalette.ClearSlot(lastPayload.barIndex, lastPayload.slotIndex);
             elseif lastPayload.type == 'crossbar_slot' then
-                -- Crossbar slot was dragged outside - clear it
-                data.ClearCrossbarSlotData(lastPayload.comboMode, lastPayload.slotIndex);
-                -- Clear icon cache for this slot (targeted - fast)
+                -- Crossbar slot dragged outside: distinguish a draft slot (Edit Full Palette
+                -- editing buffer) from a live HUD slot so we don't blow away the wrong store.
+                if lastPayload.paletteEditStorageKey and data.ClearDraftSlotData then
+                    data.ClearDraftSlotData(lastPayload.comboMode, lastPayload.slotIndex);
+                else
+                    data.ClearCrossbarSlotData(lastPayload.comboMode, lastPayload.slotIndex);
+                end
                 if crossbarInitialized then
                     crossbar.ClearIconCacheForSlot(lastPayload.comboMode, lastPayload.slotIndex);
                 end
@@ -437,6 +492,12 @@ function M.HandleZonePacket()
     petpalette.ClearPetState();
     -- Clear availability cache since player state is invalid during zone
     slotrenderer.ClearAvailabilityCache();
+    -- Universal 2hr glow state can hold a stale subtarget arm across zones.
+    -- Defensive require: module may not be merged yet in intermediate states.
+    local okU, uth = pcall(require, 'modules.hotbar.universal_two_hour');
+    if okU and uth and uth.ResetUniversalTwoHourSubtargetGlowArm then
+        uth.ResetUniversalTwoHourSubtargetGlowArm();
+    end
 end
 
 function M.HandleJobChangePacket(e)
@@ -445,9 +506,26 @@ function M.HandleJobChangePacket(e)
         local maxAttempts = 20;
 
         if data.SetPlayerJob() then
-            -- Job successfully read - proceed with refresh
+            -- Job successfully read - proceed with refresh.
+            -- Reset universal 2hr subtarget glow arm; it can carry stale state across job change.
+            local okU, uth = pcall(require, 'modules.hotbar.universal_two_hour');
+            if okU and uth and uth.ResetUniversalTwoHourSubtargetGlowArm then
+                uth.ResetUniversalTwoHourSubtargetGlowArm();
+            end
             macropalette.SyncToCurrentJob();
-            palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+            -- Universal 2hr global row mirrors the current job's 2hr ability; resync after job change.
+            local okMg, macroGlobalDefaults = pcall(require, 'modules.hotbar.macro_global_defaults');
+            if okMg and macroGlobalDefaults and macroGlobalDefaults.SyncUniversalTwoHourGlobalRow and gConfig then
+                macroGlobalDefaults.SyncUniversalTwoHourGlobalRow(gConfig);
+            end
+            -- Honor pending "profile loaded before job was readable" (char select / logout) so
+            -- Default Palette Type on Profile Load applies on first job-ready frame.
+            local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+                and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+                or nil;
+            palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+                applyDefaultCrossbarScope = pending,
+            });
             display.ClearIconCache();
             actions.ClearNoIconCache();
             if crossbarInitialized then
@@ -524,10 +602,8 @@ function M.HandleKey(event)
 end
 
 function M.HandleXInputState(e)
+    -- Controller events go through crossbar regardless of keyboard hotbar enable state.
     if not crossbarInitialized then return; end
-    if gConfig and gConfig.hotbarEnabled == false then return; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return; end
     controller.HandleXInputState(e);
 end
 
@@ -535,9 +611,6 @@ end
 -- Returns true if the button should be blocked
 function M.HandleXInputButton(e)
     if not crossbarInitialized then return false; end
-    if gConfig and gConfig.hotbarEnabled == false then return false; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return false; end
     return controller.HandleXInputButton(e);
 end
 
@@ -545,18 +618,12 @@ end
 -- Returns true if the button should be blocked
 function M.HandleDInputButton(e)
     if not crossbarInitialized then return false; end
-    if gConfig and gConfig.hotbarEnabled == false then return false; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return false; end
     return controller.HandleDInputButton(e);
 end
 
 -- Handle DirectInput state event (for D-pad POV)
 function M.HandleDInputState(e)
     if not crossbarInitialized then return; end
-    if gConfig and gConfig.hotbarEnabled == false then return; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return; end
     controller.HandleDInputState(e);
 end
 


### PR DESCRIPTION
…/crossbar enable

What changed
- XIUI.lua: Independent crossbarEnabled toggle alongside hotbarEnabled. Packet handlers (0x0068 pet sync, 0x0028 skillchain, 0x00A zone-in, 0x00B zone-out, 0x001B job change) fire when either bar is enabled â€” not hotbar-only â€” so crossbar-only setups still get palette/pet/skillchain updates. SaveCurrentProfileFileToDisk() swaps frozen macroDB snapshot, saves profile, persists SharedMacros. Post-load hook trio: ApplyAfterProfileLoad / xiuiInvalidateHotbarDataCaches / xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad after every settings load or reset.
  Palette Manager + FinalizeFrame draw order: configMenu -> paletteManager -> FlushTooltip ->
  hotbar.FinalizeFrame(). WS cache init: SetKnownWeaponskills() with pcall guard after charSettings load so Show All WS colors are correct on login. imgui.SetMouseCursor(0) in d3d_present for alt-tab hardware cursor recovery. TextureManager.FlushPendingReleases() at top of d3d_present. hideOnMenuFocusKey intentionally absent from hotbar Register block (separate per-bar-type toggle).
- config.lua: Crossbar tab registration, Palette Manager routing, smart window sizing, non-blocking profile create/rename/delete modals (BeginPopup instead of BeginPopupModal); hardware cursor stays visible over FFXI while profile prompts are open.
- core/settings/user.lua: crossbarEnabled, crossbarLockMovement, 6 macro storage scope keys, petBarResizeAnchor, petTargetSnapTopGap, petTargetSnapCachedHeight. Retains all 1.8.0 additions.
- core/settings/migration.lua: 6 Ferris migrations + EnsureMacroDatabaseCoherence + MigrateSlotDualMacroBindings. Runs after 1.8.0's MigrateSlotMacroRefs; idempotent.
- core/settings/factories.lua: createCrossbarDefaults() rewrite: universal palettes, segmentOverrides, double-tap preview, paletteJobIconTheme, magicBurst defaults. Re-injected 1.8.0's showStackQuantity lines. mpCostAnchor defaults to topLeft.
- handlers/actiontracker.lua, debuffhandler.lua, petbuffhandler.lua: Ferris-only overlays carried forward unchanged (1.8.0 did not touch these files).
- handlers/imgui_compat.lua: Ashita 4.3/4.16 compatibility shim; focus-regain hardware cursor recovery; hover detection helpers used by pet target cluster drag.
- libs/texturemanager.lua: TextureManager.DeferRelease(value) public API holds a Lua reference to a D3D texture for one extra d3d_present frame before releasing, preventing EXCEPTION_ACCESS_VIOLATION when palette deletion triggers a cache clear mid-frame. Extends 1.8.0's existing pendingReleases / FlushPendingReleases pattern. Also: custom_icons.maxSize = 0 no-eviction tweak prevents macro picker stutter from LRU evict+reload cycles.
- modules/hotbar/init.lua: M.FinalizeFrame() for deferred drag/drop resolution. Separated hotbar vs crossbar menu-hide logic. GetCrossbarDisableXiMacrosEffective(). lastPaletteVisualRefreshSig dedup. ValidatePalettesForJob with applyDefaultCrossbarScope. Universal 2hr reset/sync on zone/job change. 1.8.0's AnyBarIsPetAware() optimization preserved.

Why
- Foundation layer that must land before all feature slices. Establishes independent hotbar/crossbar enable so crossbar-only setups receive all state updates. DeferRelease prevents reproducible CTD on palette deletion (EXCEPTION_ACCESS_VIOLATION when D3D texture freed while still queued for AddImage). Post-load hook trio ensures macro scope, caches, and crossbar palette scope are coherent after any settings mutation. Non-blocking profile modals keep cursor visible throughout.