### PR TITLE
Shared macro store, dual per-slot bindings, and Universal 2 Hour Glob…

### DIFF
--- a/XIUI/core/shared_macro_store.lua
+++ b/XIUI/core/shared_macro_store.lua
@@ -1,0 +1,359 @@
+--[[
+* Shared vs Profile macro storage: one global SharedMacros.lua vs per-profile gConfig.macroDB.
+* When scope is "shared", gConfig.macroDB is the working copy of SharedMacros.lua only; the profile file
+* stores a frozen macroDB snapshot for when this profile is in shared mode (or last profile mode),
+* so switching back to Profile restores that library. We never copy the profile into the shared library
+* when the shared file is missing or empty — that is a different library; use the file or {}.
+]]--
+
+local profileManager = require('core.profile_manager');
+
+local M = {};
+
+local SHARED_FILENAME = 'SharedMacros.lua';
+
+local function deepCopyTable(tbl)
+    if type(tbl) ~= 'table' then
+        return tbl;
+    end
+    local copy = {};
+    for k, v in pairs(tbl) do
+        copy[k] = deepCopyTable(v);
+    end
+    return copy;
+end
+
+local function lookupInMacroDb(mdb, macroId, paletteKey)
+    if not mdb or not macroId then
+        return nil;
+    end
+    local pk = paletteKey or 1;
+    local function one(bk)
+        if bk == nil then
+            return nil;
+        end
+        local macros = mdb[bk];
+        if type(macros) ~= 'table' then
+            return nil;
+        end
+        for _, m in ipairs(macros) do
+            if m and m.id == macroId then
+                return m;
+            end
+        end
+        return nil;
+    end
+    local m = one(pk);
+    if m then
+        return m;
+    end
+    if type(pk) == 'number' and pk > 0 then
+        m = one(tostring(pk));
+    end
+    if m then
+        return m;
+    end
+    if type(pk) == 'string' and pk:match('^%d+$') then
+        m = one(tonumber(pk));
+    end
+    if m then
+        return m;
+    end
+    if type(pk) == 'string' then
+        local baseJobId = tonumber(pk:match('^(%d+)'));
+        if baseJobId then
+            m = one(baseJobId) or one(tostring(baseJobId));
+        end
+    end
+    return m;
+end
+
+local function pcallEnsureMacroCoherence(gConfig)
+    local ok, mod = pcall(require, 'modules.hotbar.data');
+    if ok and mod and mod.EnsureMacroDatabaseCoherence then
+        mod.EnsureMacroDatabaseCoherence(gConfig);
+    end
+end
+
+-- New / empty Shared library: add only the xiui slash-command bucket (same as fresh profile migration).
+local function pcallMaybeSeedXiuiForEmptySharedLibrary(gConfig)
+    if not M.IsSharedScope(gConfig) or not gConfig then
+        return;
+    end
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    local ok, mxd = pcall(require, 'modules.hotbar.macro_xiui_defaults');
+    if not ok or not mxd or not mxd.IsMacroDatabaseEffectivelyEmpty or not mxd.SeedIfNeeded then
+        return;
+    end
+    if not mxd.IsMacroDatabaseEffectivelyEmpty(gConfig.macroDB) then
+        return;
+    end
+    if mxd.SeedIfNeeded(gConfig, { force = true }) then
+        M.MarkSharedLibraryDirty();
+        local ok2, dat = pcall(require, 'modules.hotbar.data');
+        if ok2 and dat and dat.MarkMacroLookupDirty then
+            dat.MarkMacroLookupDirty();
+        end
+    end
+    local okG, mgd = pcall(require, 'modules.hotbar.macro_global_defaults');
+    if okG and mgd and mgd.SeedUniversalTwoHourIfNeeded then
+        if mgd.SeedUniversalTwoHourIfNeeded(gConfig, { force = true }) then
+            M.MarkSharedLibraryDirty();
+            local ok3, dat = pcall(require, 'modules.hotbar.data');
+            if ok3 and dat and dat.MarkMacroLookupDirty then
+                dat.MarkMacroLookupDirty();
+            end
+        end
+    end
+    pcallEnsureMacroCoherence(gConfig);
+end
+
+-- Frozen profile macroDB (per profile file) used while in shared scope; never replaced by shared edits.
+local frozenProfileMacroDb = nil;
+
+-- Cached on-disk shared file for resolving bar slots with macroSourceStore == "shared" while in profile mode.
+local diskSharedMacroDbCache = nil;
+local diskSharedMacroDbPathIdentity = nil;
+
+-- Only write SharedMacros.lua when the global library actually changed (not on every UI/settings save).
+local sharedLibraryDirty = false;
+
+function M._ProfilesDir()
+    return AshitaCore:GetInstallPath() .. 'config\\addons\\xiui\\profiles\\';
+end
+
+function M.GetSharedFilePath()
+    return M._ProfilesDir() .. SHARED_FILENAME;
+end
+
+local function sharedMacroFileExists()
+    local path = M.GetSharedFilePath();
+    if (ashita and ashita.fs and ashita.fs.exists) and ashita.fs.exists(path) then
+        return true;
+    end
+    local f = io.open(path, 'rb');
+    if f then
+        f:close();
+        return true;
+    end
+    return false;
+end
+
+--- If Shared mode is on but SharedMacros.lua is not on disk yet, write it once (e.g. empty macroDB).
+--- Otherwise the file only appears after MarkSharedLibraryDirty + save, which never ran on a fresh switch.
+function M.EnsureSharedMacroFileOnDisk(gConfig)
+    if not M.IsSharedScope(gConfig) or sharedMacroFileExists() then
+        return;
+    end
+    M.SaveSharedMacroFile(gConfig.macroDB or {});
+end
+
+function M.InvalidateDiskSharedCache()
+    diskSharedMacroDbCache = nil;
+    diskSharedMacroDbPathIdentity = nil;
+end
+
+-- Load { macroDB = ... } from SharedMacros.lua (same wrapper shape as profile files).
+function M.LoadSharedMacroFile()
+    local path = M.GetSharedFilePath();
+    local t = profileManager.LoadTable(path);
+    if not t then
+        return nil;
+    end
+    if t.userSettings and t.userSettings.macroDB then
+        return t.userSettings.macroDB;
+    end
+    if t.macroDB then
+        return t.macroDB;
+    end
+    return nil;
+end
+
+function M.SaveSharedMacroFile(macroDB)
+    if not macroDB then
+        return false;
+    end
+    local path = M.GetSharedFilePath();
+    local wrapper = { userSettings = { macroDB = macroDB } };
+    local ok = profileManager.SaveTable(path, wrapper);
+    if ok then
+        sharedLibraryDirty = false;
+        M.InvalidateDiskSharedCache();
+    end
+    return ok;
+end
+
+--- Call when gConfig.macroDB (the live shared library) is mutated: add/update/delete macro, import macros, custom category add/remove, etc.
+function M.MarkSharedLibraryDirty()
+    sharedLibraryDirty = true;
+end
+
+function M.IsSharedScope(gcfg)
+    if not gcfg then
+        return false;
+    end
+    return (gcfg.macroStorageScope or 'profile') == 'shared';
+end
+
+-- Deep copy (stable for macroDB)
+local function copyMacroDb(mdb)
+    if type(mdb) ~= 'table' then
+        return {};
+    end
+    return deepCopyTable(mdb);
+end
+
+function M.GetDiskSharedMacroDbForExternalLookup()
+    local path = M.GetSharedFilePath();
+    if diskSharedMacroDbCache and diskSharedMacroDbPathIdentity == path then
+        return diskSharedMacroDbCache;
+    end
+    local mdb = M.LoadSharedMacroFile();
+    if not mdb or type(mdb) ~= 'table' then
+        mdb = {};
+    end
+    diskSharedMacroDbCache = mdb;
+    diskSharedMacroDbPathIdentity = path;
+    return mdb;
+end
+
+function M.GetFrozenProfileMacroDb()
+    return frozenProfileMacroDb;
+end
+
+--- Max numeric macro id in one bucket of the frozen profile snapshot (while in Shared scope).
+--- New macros in Shared must use ids above this per bucket so hotbar macroRef values that still
+--- point at the profile library (same palette key) do not resolve to a different row in the shared library.
+function M.GetMaxMacroIdInFrozenProfileBucket(bucketKey)
+    if not frozenProfileMacroDb or bucketKey == nil then
+        return 0;
+    end
+    local list = frozenProfileMacroDb[bucketKey];
+    if not list and type(bucketKey) == 'number' then
+        list = frozenProfileMacroDb[tostring(bucketKey)];
+    end
+    if not list and type(bucketKey) == 'string' and bucketKey:match('^%d+$') then
+        list = frozenProfileMacroDb[tonumber(bucketKey)];
+    end
+    if type(list) ~= 'table' then
+        return 0;
+    end
+    local maxId = 0;
+    for _, m in ipairs(list) do
+        if m and type(m.id) == 'number' and m.id > maxId then
+            maxId = m.id;
+        end
+    end
+    return maxId;
+end
+
+-- Look up a macro when the slot is tagged for the "other" universe.
+function M.LookupInFrozenProfile(macroId, paletteKey)
+    if not frozenProfileMacroDb then
+        return nil;
+    end
+    return lookupInMacroDb(frozenProfileMacroDb, macroId, paletteKey);
+end
+
+function M.LookupInDiskSharedFile(macroId, paletteKey)
+    local mdb = M.GetDiskSharedMacroDbForExternalLookup();
+    if not mdb then
+        return nil;
+    end
+    return lookupInMacroDb(mdb, macroId, paletteKey);
+end
+
+--- After profile load and migrations. Chooses in-memory gConfig.macroDB based on scope.
+function M.ApplyAfterProfileLoad(gConfig)
+    if not gConfig then
+        return;
+    end
+    M.InvalidateDiskSharedCache();
+    sharedLibraryDirty = false;
+
+    local scope = gConfig.macroStorageScope or 'profile';
+    if scope == 'shared' then
+        frozenProfileMacroDb = copyMacroDb(gConfig.macroDB);
+        local fromDisk = M.LoadSharedMacroFile();
+        -- In shared scope, the live list is *only* what is in SharedMacros.lua (including {}).
+        -- Do not seed from the profile: that is a separate store (frozen in the profile file while here).
+        if type(fromDisk) == 'table' then
+            gConfig.macroDB = copyMacroDb(fromDisk);
+        else
+            gConfig.macroDB = {};
+        end
+        pcallEnsureMacroCoherence(gConfig);
+        pcallMaybeSeedXiuiForEmptySharedLibrary(gConfig);
+        M.EnsureSharedMacroFileOnDisk(gConfig);
+    else
+        frozenProfileMacroDb = nil;
+    end
+end
+
+-- Called before writing the active profile to disk. When in shared mode, the profile file's macroDB
+-- must stay the frozen snapshot, not the live global library.
+function M.GetProfileMacroDbForSave(gConfig)
+    if M.IsSharedScope(gConfig) then
+        if frozenProfileMacroDb then
+            return copyMacroDb(frozenProfileMacroDb);
+        end
+        -- Do not write the in-memory global library into the profile file
+        return copyMacroDb({});
+    end
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    return gConfig.macroDB;
+end
+
+-- Persist the global shared file from current gConfig.macroDB (shared scope only, and when dirty; always create the file if missing).
+function M.PersistSharedLibraryIfNeeded(gConfig)
+    if not M.IsSharedScope(gConfig) then
+        return;
+    end
+    M.EnsureSharedMacroFileOnDisk(gConfig);
+    if not sharedLibraryDirty then
+        return;
+    end
+    M.SaveSharedMacroFile(gConfig.macroDB);
+end
+
+-- Switching scope from UI: profile -> shared
+function M.ApplySwitchToShared(gConfig)
+    if not gConfig then
+        return;
+    end
+    frozenProfileMacroDb = copyMacroDb(gConfig.macroDB);
+    gConfig.macroStorageScope = 'shared';
+    local fromDisk = M.LoadSharedMacroFile();
+    if type(fromDisk) == 'table' then
+        gConfig.macroDB = copyMacroDb(fromDisk);
+    else
+        gConfig.macroDB = {};
+    end
+    pcallEnsureMacroCoherence(gConfig);
+    M.InvalidateDiskSharedCache();
+    sharedLibraryDirty = false;
+    pcallMaybeSeedXiuiForEmptySharedLibrary(gConfig);
+    M.EnsureSharedMacroFileOnDisk(gConfig);
+end
+
+-- Switching scope from UI: shared -> profile
+function M.ApplySwitchToProfile(gConfig)
+    if not gConfig then
+        return;
+    end
+    sharedLibraryDirty = false;
+    gConfig.macroStorageScope = 'profile';
+    if frozenProfileMacroDb then
+        gConfig.macroDB = copyMacroDb(frozenProfileMacroDb);
+    else
+        gConfig.macroDB = gConfig.macroDB or {};
+    end
+    frozenProfileMacroDb = nil;
+    pcallEnsureMacroCoherence(gConfig);
+end
+
+return M;

--- a/XIUI/libs/target.lua
+++ b/XIUI/libs/target.lua
@@ -50,11 +50,11 @@ function M.GetSubTargetActive()
         return true;
     end
 
-    -- Fallback: Check if there's a valid entity in sub-target slot (index 1)
-    -- that differs from main target - indicates sub-targeting even if API doesn't report it
+    -- Fallback: sub-target slot (1) differs from main slot (0). Includes main==0 with a pending
+    -- <stpc>/<stnpc> pick (no prior target) — previous logic required main~=0 and missed that case.
     local mainTarget = playerTarget:GetTargetIndex(0);
     local subTarget = playerTarget:GetTargetIndex(1);
-    if mainTarget ~= 0 and subTarget ~= 0 and subTarget ~= mainTarget then
+    if subTarget ~= 0 and subTarget ~= mainTarget then
         return true;
     end
 

--- a/XIUI/modules/hotbar/macro_global_defaults.lua
+++ b/XIUI/modules/hotbar/macro_global_defaults.lua
@@ -1,0 +1,173 @@
+--[[
+  Seed default Global macros (same spirit as macro_xiui_defaults.lua for XIUI Commands).
+]]--
+
+local buckets = require('modules.hotbar.macro_palette_buckets');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
+local data = require('modules.hotbar.data');
+
+local M = {};
+
+--- Relative to addons/XIUI/ on disk (icons bundled with the addon).
+M.UNIVERSAL_TWO_HOUR_ICON_PATH = 'assets/status/HD/228.png';
+
+function M.IsUniversalTwoHourMacro(macro)
+    return macro and macro.actionType == 'ja' and macro.action == universalTwoHour.ACTION_SENTINEL;
+end
+
+local function maxMacroIdInBucket(db)
+    local maxId = 0;
+    if type(db) ~= 'table' then
+        return maxId;
+    end
+    for _, macro in ipairs(db) do
+        if macro.id and macro.id > maxId then
+            maxId = macro.id;
+        end
+    end
+    return maxId;
+end
+
+local function maxMacroIdAll(mdb)
+    local maxId = 0;
+    if not mdb or type(mdb) ~= 'table' then
+        return maxId;
+    end
+    for _, list in pairs(mdb) do
+        if type(list) == 'table' then
+            for _, macro in ipairs(list) do
+                if macro.id and macro.id > maxId then
+                    maxId = macro.id;
+                end
+            end
+        end
+    end
+    return maxId;
+end
+
+local function findUniversalTwoHourIndex(db)
+    if type(db) ~= 'table' then
+        return nil;
+    end
+    for i, macro in ipairs(db) do
+        if M.IsUniversalTwoHourMacro(macro) then
+            return i;
+        end
+    end
+    return nil;
+end
+
+--- opts.persist: when false, skip SaveSettingsToDisk (caller batches save).
+--- Returns true if macroDB was mutated.
+function M.SyncUniversalTwoHourGlobalRow(gConfig, opts)
+    if not gConfig then
+        return false;
+    end
+    opts = (type(opts) == 'table') and opts or {};
+    local persist = opts.persist ~= false;
+    if not gConfig.macroDB then
+        return false;
+    end
+    local db = gConfig.macroDB[buckets.GLOBAL];
+    if type(db) ~= 'table' then
+        return false;
+    end
+    local idx = findUniversalTwoHourIndex(db);
+    if not idx then
+        return false;
+    end
+
+    local macro = db[idx];
+    local abilityName = universalTwoHour.GetTwoHourAbilityNameForMainJob() or 'Two Hour';
+    local tgt = universalTwoHour.GetTwoHourTargetTokenForMainJob();
+    local changed = false;
+
+    if (macro.displayName or '') ~= abilityName then
+        macro.displayName = abilityName;
+        changed = true;
+    end
+    if (macro.target or '') ~= tgt then
+        macro.target = tgt;
+        changed = true;
+    end
+    if macro.customIconType ~= 'xiui_asset' or (macro.customIconPath or '') ~= M.UNIVERSAL_TWO_HOUR_ICON_PATH then
+        macro.customIconType = 'xiui_asset';
+        macro.customIconPath = M.UNIVERSAL_TWO_HOUR_ICON_PATH;
+        changed = true;
+    end
+
+    if idx ~= 1 then
+        table.remove(db, idx);
+        table.insert(db, 1, macro);
+        changed = true;
+    end
+
+    if changed then
+        data.MarkMacroLookupDirty();
+        if persist and SaveSettingsToDisk then
+            SaveSettingsToDisk();
+        end
+    end
+
+    return changed;
+end
+
+local function globalBucketHasUniversalTwoHour(db)
+    return findUniversalTwoHourIndex(db) ~= nil;
+end
+
+--- opts.force: seed even if macroGlobalUniversalTwoHourSeeded is true (empty shared library path).
+--- Returns true if a macro row was added.
+function M.SeedUniversalTwoHourIfNeeded(gConfig, opts)
+    if not gConfig then
+        return false;
+    end
+    opts = (type(opts) == 'table') and opts or {};
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    local db = gConfig.macroDB[buckets.GLOBAL];
+    if type(db) ~= 'table' then
+        db = {};
+        gConfig.macroDB[buckets.GLOBAL] = db;
+    end
+    if globalBucketHasUniversalTwoHour(db) then
+        gConfig.macroGlobalUniversalTwoHourSeeded = true;
+        M.SyncUniversalTwoHourGlobalRow(gConfig, { persist = opts.persist ~= false });
+        return false;
+    end
+    if (not opts.force) and gConfig.macroGlobalUniversalTwoHourSeeded then
+        return false;
+    end
+
+    local nextId = math.max(maxMacroIdAll(gConfig.macroDB), maxMacroIdInBucket(db));
+    if (gConfig.macroStorageScope or 'profile') == 'shared' then
+        local ok, sms = pcall(require, 'core.shared_macro_store');
+        if ok and sms and sms.GetMaxMacroIdInFrozenProfileBucket then
+            local fmax = sms.GetMaxMacroIdInFrozenProfileBucket(buckets.GLOBAL);
+            if fmax > nextId then
+                nextId = fmax;
+            end
+        end
+    end
+
+    nextId = nextId + 1;
+    table.insert(db, 1, {
+        id = nextId,
+        actionType = 'ja',
+        action = universalTwoHour.ACTION_SENTINEL,
+        target = universalTwoHour.GetTwoHourTargetTokenForMainJob(),
+        displayName = universalTwoHour.GetTwoHourAbilityNameForMainJob() or 'Two Hour',
+        customIconType = 'xiui_asset',
+        customIconPath = M.UNIVERSAL_TWO_HOUR_ICON_PATH,
+    });
+    gConfig.macroGlobalUniversalTwoHourSeeded = true;
+    M.SyncUniversalTwoHourGlobalRow(gConfig, { persist = false });
+    data.MarkMacroLookupDirty();
+    if opts.persist ~= false and SaveSettingsToDisk then
+        SaveSettingsToDisk();
+    end
+    return true;
+end
+
+return M;

--- a/XIUI/modules/hotbar/macro_xiui_defaults.lua
+++ b/XIUI/modules/hotbar/macro_xiui_defaults.lua
@@ -1,0 +1,92 @@
+--[[
+* One-time seed of default /xiui slash macros into the "xiui" macro bucket.
+]]--
+
+local buckets = require('modules.hotbar.macro_palette_buckets');
+
+local DEFAULT_ROWS = {
+    { displayName = 'Toggle XIUI Menu', macroText = '/xiui', action = '/xiui' },
+    { displayName = 'Open Macros', macroText = '/xiui macro', action = '/xiui macro' },
+    { displayName = 'Hotbar Palette Manager', macroText = '/xiui pal', action = '/xiui pal' },
+    { displayName = 'Crossbar Palette Manager', macroText = '/xiui cpal', action = '/xiui cpal' },
+    { displayName = 'Edit Current Palette', macroText = '/xiui cpaledit', action = '/xiui cpaledit' },
+    { displayName = 'Toggle Party List', macroText = '/xiui partylist', action = '/xiui partylist' },
+    { displayName = 'Pass All Treasure', macroText = '/xiui pass', action = '/xiui pass' },
+    { displayName = 'Toggle Treasure Pool', macroText = '/xiui tp', action = '/xiui tp' },
+    { displayName = 'Reset Gil Tracking', macroText = '/xiui gil reset', action = '/xiui gil reset' },
+};
+
+local function maxMacroId(db)
+    local maxId = 0;
+    for _, macro in ipairs(db) do
+        if macro.id and macro.id > maxId then
+            maxId = macro.id;
+        end
+    end
+    return maxId;
+end
+
+local M = {};
+
+--- True when there are no macro rows in any bucket (or macroDB is missing/empty).
+function M.IsMacroDatabaseEffectivelyEmpty(mdb)
+    if not mdb or type(mdb) ~= 'table' or next(mdb) == nil then
+        return true;
+    end
+    for _, list in pairs(mdb) do
+        if type(list) == 'table' and #list > 0 then
+            return false;
+        end
+    end
+    return true;
+end
+
+--- opts.force: seed the xiui bucket even if macroXiuiDefaultsSeeded is true (e.g. new empty Shared library).
+--- Returns true if new default rows were added.
+function M.SeedIfNeeded(gConfig, opts)
+    if not gConfig then
+        return false;
+    end
+    opts = (type(opts) == 'table') and opts or {};
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    local db = gConfig.macroDB[buckets.XIUI];
+    if type(db) ~= 'table' then
+        db = {};
+        gConfig.macroDB[buckets.XIUI] = db;
+    end
+    if #db > 0 then
+        gConfig.macroXiuiDefaultsSeeded = true;
+        return false;
+    end
+    if (not opts.force) and gConfig.macroXiuiDefaultsSeeded then
+        return false;
+    end
+
+    local nextId = maxMacroId(db);
+    if (gConfig.macroStorageScope or 'profile') == 'shared' then
+        local ok, sms = pcall(require, 'core.shared_macro_store');
+        if ok and sms and sms.GetMaxMacroIdInFrozenProfileBucket then
+            local fmax = sms.GetMaxMacroIdInFrozenProfileBucket(buckets.XIUI);
+            if fmax > nextId then
+                nextId = fmax;
+            end
+        end
+    end
+    for _, row in ipairs(DEFAULT_ROWS) do
+        nextId = nextId + 1;
+        table.insert(db, {
+            id = nextId,
+            actionType = 'macro',
+            action = row.action,
+            target = row.target,
+            displayName = row.displayName,
+            macroText = row.macroText,
+        });
+    end
+    gConfig.macroXiuiDefaultsSeeded = true;
+    return true;
+end
+
+return M;

--- a/XIUI/modules/hotbar/universal_two_hour.lua
+++ b/XIUI/modules/hotbar/universal_two_hour.lua
@@ -1,0 +1,205 @@
+--[[
+  HorizonXI main-job two-hour ability names (job ID → English name).
+  Used for: JA list pink marker + sort + Global "Universal 2 Hour" macro resolution.
+]]--
+
+local M = {};
+
+-- Stored on macro rows as action name; resolved at command/icon/recast time.
+M.ACTION_SENTINEL = '__XIUI_UNIVERSAL_TWO_HOUR__';
+
+M.PINK_STAR_TWO_HOUR_TOOLTIP =
+    '2Hour - Main Job Only - Universal Macro available under "Global"';
+
+M.PINK_STAR_ASTRAL_FLOW_TOOLTIP = 'This Ability is only available during Astral Flow';
+
+-- Horizon roster (no GEO/RUN in this list — extend when those jobs exist in data).
+local JOB_TWO_HOUR = {
+    [1]  = 'Mighty Strikes',
+    [2]  = 'Hundred Fists',
+    [3]  = 'Benediction',
+    [4]  = 'Manafont',
+    [5]  = 'Chainspell',
+    [6]  = 'Perfect Dodge',
+    [7]  = 'Invincible',
+    [8]  = 'Blood Weapon',
+    [9]  = 'Familiar',
+    [10] = 'Soul Voice',
+    [11] = 'Eagle Eye Shot',
+    [12] = 'Meikyo Shisui',
+    [13] = 'Mikage',
+    [14] = 'Spirit Surge',
+    [15] = 'Astral Flow',
+    [16] = 'Azure Lore',
+    [17] = 'Wild Card',
+    [18] = 'Overdrive',
+    [19] = 'Trance',
+    [20] = 'Tabula Rasa',
+};
+
+--- Macro /ja target token (no <me> / <t>): stpc = confirm player (self two-hours); stnpc = confirm NPC (Eagle Eye Shot).
+local JOB_TWO_HOUR_TARGET = {
+    [1]  = 'stpc',
+    [2]  = 'stpc',
+    [3]  = 'stpc',
+    [4]  = 'stpc',
+    [5]  = 'stpc',
+    [6]  = 'stpc',
+    [7]  = 'stpc',
+    [8]  = 'stpc',
+    [9]  = 'stpc',
+    [10] = 'stpc',
+    [11] = 'stnpc',
+    [12] = 'stpc',
+    [13] = 'stpc',
+    [14] = 'stpc',
+    [15] = 'stpc',
+    [16] = 'stpc',
+    [17] = 'stpc',
+    [18] = 'stpc',
+    [19] = 'stpc',
+    [20] = 'stpc',
+};
+
+-- After firing /ja "<two-hour>" <stpc|stnpc>, glow this slot while subtarget is open; disarm when subtarget closes.
+local subtargetGlowArmUntil = 0;
+local sawSubtargetWhileArmed = false;
+local SUBTARGET_GLOW_ARM_SECONDS = 45;
+--- After /ja queues, subtarget may open a frame later (especially with no prior target).
+local lastUniversalTwoHourNotifyClock = 0;
+local ARMING_SHIMMER_SECONDS = 7.5;
+--- During pre-subtarget arming only: full opacity until this elapsed second, then linear fade to 0 at ARMING_SHIMMER_SECONDS.
+local ARMING_OPACITY_FADE_START = 6.5;
+
+function M.GetTwoHourNameForJobId(jobId)
+    if not jobId or jobId <= 0 then
+        return nil;
+    end
+    return JOB_TWO_HOUR[jobId];
+end
+
+function M.GetTwoHourAbilityNameForMainJob()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then
+        return nil;
+    end
+    return M.GetTwoHourNameForJobId(player:GetMainJob());
+end
+
+function M.GetTwoHourTargetTokenForJobId(jobId)
+    if not jobId or jobId < 1 then
+        return nil;
+    end
+    return JOB_TWO_HOUR_TARGET[jobId];
+end
+
+function M.GetTwoHourTargetTokenForMainJob()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then
+        return 'stpc';
+    end
+    local jid = player:GetMainJob();
+    return M.GetTwoHourTargetTokenForJobId(jid) or 'stpc';
+end
+
+function M.ResolveJaActionName(action)
+    if action == M.ACTION_SENTINEL then
+        return M.GetTwoHourAbilityNameForMainJob();
+    end
+    return action;
+end
+
+--- Resolved palette/hotbar target for JA rows (forces stpc/stnpc for the Universal 2 Hour sentinel).
+function M.ResolveJaBindTarget(bind)
+    if not bind or bind.actionType ~= 'ja' then
+        return bind and bind.target;
+    end
+    if bind.action == M.ACTION_SENTINEL then
+        return M.GetTwoHourTargetTokenForMainJob();
+    end
+    return bind.target;
+end
+
+function M.NotifyUniversalTwoHourExecuted()
+    subtargetGlowArmUntil = os.clock() + SUBTARGET_GLOW_ARM_SECONDS;
+    sawSubtargetWhileArmed = false;
+    lastUniversalTwoHourNotifyClock = os.clock();
+end
+
+function M.ResetUniversalTwoHourSubtargetGlowArm()
+    subtargetGlowArmUntil = 0;
+    sawSubtargetWhileArmed = false;
+    lastUniversalTwoHourNotifyClock = 0;
+end
+
+--- 1 while subtarget is active or before fade window; during pre-subtarget arming after ARMING_OPACITY_FADE_START, ramps to 0 at ARMING_SHIMMER_SECONDS.
+function M.GetArmingShimmerOpacityScale()
+    if sawSubtargetWhileArmed then
+        return 1.0;
+    end
+    local elapsed = os.clock() - lastUniversalTwoHourNotifyClock;
+    if elapsed < ARMING_OPACITY_FADE_START then
+        return 1.0;
+    end
+    if elapsed >= ARMING_SHIMMER_SECONDS then
+        return 0.0;
+    end
+    local dur = ARMING_SHIMMER_SECONDS - ARMING_OPACITY_FADE_START;
+    if dur <= 0 then
+        return 1.0;
+    end
+    return 1.0 - ((elapsed - ARMING_OPACITY_FADE_START) / dur);
+end
+
+--- Hotbar/crossbar slot glow: armed after executing this bind, while game subtarget UI is active.
+function M.ShouldGlowUniversalTwoHourSlot(bind)
+    if not bind or bind.actionType ~= 'ja' or bind.action ~= M.ACTION_SENTINEL then
+        return false;
+    end
+    local now = os.clock();
+    if subtargetGlowArmUntil <= 0 or now > subtargetGlowArmUntil then
+        subtargetGlowArmUntil = 0;
+        sawSubtargetWhileArmed = false;
+        return false;
+    end
+    local ok, targetLib = pcall(require, 'libs.target');
+    local active = false;
+    if ok and targetLib and targetLib.GetSubTargetActive then
+        active = targetLib.GetSubTargetActive();
+    end
+    if active then
+        sawSubtargetWhileArmed = true;
+        return true;
+    end
+    -- Arm shimmer: game may open subtarget shortly after QueueCommand (visible when main target was empty).
+    if not sawSubtargetWhileArmed and (now - lastUniversalTwoHourNotifyClock) < ARMING_SHIMMER_SECONDS then
+        return true;
+    end
+    -- Subtarget closed after we saw it: confirm or cancel — stop glowing and disarm.
+    if sawSubtargetWhileArmed then
+        subtargetGlowArmUntil = 0;
+        sawSubtargetWhileArmed = false;
+    end
+    return false;
+end
+
+function M.IsHorizonTwoHourAbility(jobId, abilityName)
+    if not abilityName or not jobId then
+        return false;
+    end
+    return JOB_TWO_HOUR[jobId] == abilityName;
+end
+
+function M.GetTwoHourPinkTooltipIfApplicable(jobId, abilityName)
+    if M.IsHorizonTwoHourAbility(jobId, abilityName) then
+        return M.PINK_STAR_TWO_HOUR_TOOLTIP;
+    end
+    return nil;
+end
+
+--- Sort rank: 0 = main-job two-hour for this row's job, 1 = normal.
+function M.TwoHourSortRank(jobId, abilityName)
+    return M.IsHorizonTwoHourAbility(jobId, abilityName) and 0 or 1;
+end
+
+return M;


### PR DESCRIPTION
…al macro

What changed
- core/shared_macro_store.lua: Two-mode macro storage shared (global SharedMacros.lua across all profiles) vs profile (per-profile gConfig.macroDB). Frozen snapshot in shared mode for profile switch. Separate id namespace from profile macros. ApplyAfterProfileLoad integration.
- libs/target.lua: subtarget-active detection treats a standalone subtarget as active even without a primary target, so Universal 2 Hour /ja targeting (stpc/stnpc) matches in-game behavior.
- modules/hotbar/universal_two_hour.lua: Maps job ID -> 2-hour ability name. Arming window (~7.5s) after execute with late-window opacity ramp for shimmer. Subtarget-glow eligibility cleared on zone/job change. ShouldGlowUniversalTwoHourSlot() for slot renderer gating.
- modules/hotbar/macro_global_defaults.lua: Sentinel resolution for Universal 2 Hour Global macro. /ja bind targets: stpc for most jobs, stnpc for RNG. One-time seed migration gated by flag. Locked Global-row macro cannot be deleted or moved through normal palette paths.
- modules/hotbar/macro_xiui_defaults.lua: Default /xiui slash macros (Toggle XIUI Menu, Open Macros, Palette Manager, etc.). One-time seed gated by macroXiuiDefaultsSeeded.

Why
- One global shared macro library vs per-profile gConfig.macroDB; each physical hotbar/crossbar slot holds independent macroBindProfile and macroBindShared arms (active arm follows scope). Deletes, DnD, JSON import, and Edit Full Palette use the same data paths. Players get one pinned Global macro that always reflects the current main job 2-hour name, icon, and correct /ja targeting without hand-maintaining per-job copies. Default /xiui macros seed discoverability.