### PR TITLE
SMN: blood pact action resolution, recast sniffers, and macro primary…

### DIFF
--- a/XIUI/modules/hotbar/actions.lua
+++ b/XIUI/modules/hotbar/actions.lua
@@ -7,9 +7,17 @@ local ffi = require('ffi');
 local d3d8 = require('d3d8');
 local data = require('modules.hotbar.data');
 local horizonSpells = require('modules.hotbar.database.horizonspells');
+local petregistry = require('modules.hotbar.petregistry');
 local textures = require('modules.hotbar.textures');
+local customiconresolve = require('modules.hotbar.customiconresolve');
 local macrosLib = require('libs.ffxi.macros');
 local palette = require('modules.hotbar.palette');
+local macroparse = require('modules.hotbar.macroparse');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
+-- Lazy session-cached name->id hashmaps for spells/abilities/items. Used to replace the
+-- O(65535) item scan in LoadItemIconByName below (#17 in audit table). Both 1.8.0 and
+-- Ferris kept this module but neither propagated it into actions.lua's item lookup.
+local actiondb = require('modules.hotbar.actiondb');
 
 -- Debug logging (controlled via /xiui debug hotbar)
 local DEBUG_ENABLED = false;
@@ -188,8 +196,8 @@ local customIconCache = {};
 local noIconCache = {};
 
 -- Build a key for noIconCache from the fields GetBindIcon branches on.
--- Includes macroRef because the macro lookup at the top of GetBindIcon
--- can change a slot's icon resolution.
+-- Includes macroRef + recastSource* so macro-recast overrides (which can change icon
+-- resolution per Ferris's macro-aware paths) invalidate the negative result.
 local function buildNoIconKey(bind)
     if not bind then return nil; end
     local key = (bind.actionType or '') .. ':' .. (bind.action or '');
@@ -201,7 +209,117 @@ local function buildNoIconKey(bind)
     if bind.macroRef then
         key = key .. ':mr:' .. tostring(bind.macroRef);
     end
+    if bind.recastSourceType or bind.recastSourceAction then
+        key = key .. ':rs:' .. (bind.recastSourceType or '')
+                  .. ':' .. (bind.recastSourceAction or '');
+    end
     return key;
+end
+
+--- After LoadTextureFromPath: use in-memory D3D texture for hotbar (see slotrenderer icon branch).
+--- File-path primitives can re-hit disk every frame; ImGui AddImage uses the loaded texture only.
+local function finalizeCustomIconTextureForHotbar(icon)
+    if not icon or not icon.image then
+        return icon;
+    end
+    local texture_ptr = ffi.cast('IDirect3DTexture8*', icon.image);
+    local _, desc = texture_ptr:GetLevelDesc(0);
+    if desc ~= nil then
+        icon.width = desc.Width;
+        icon.height = desc.Height;
+    else
+        icon.width = icon.width or 40;
+        icon.height = icon.height or 40;
+    end
+    icon.path = nil;
+    return icon;
+end
+
+--- Icons bundled under addons/XIUI/ (not assets/hotbar/custom/). Path uses forward slashes; normalized for Windows load.
+local xiuiBundledAssetIconCache = {};
+
+local function loadXiuiBundledAssetIcon(relUnderXiui)
+    if not relUnderXiui or relUnderXiui == '' then
+        return nil;
+    end
+    local norm = relUnderXiui:gsub('/', '\\');
+    if xiuiBundledAssetIconCache[norm] then
+        return xiuiBundledAssetIconCache[norm];
+    end
+    local base = AshitaCore:GetInstallPath();
+    local full = string.format('%saddons\\XIUI\\%s', base, norm);
+    local icon = textures:LoadTextureFromPath(full);
+    if not icon and relUnderXiui:find('/') then
+        full = string.format('%saddons\\XIUI\\%s', base, relUnderXiui:gsub('/', '\\'));
+        icon = textures:LoadTextureFromPath(full);
+    end
+    if icon then
+        finalizeCustomIconTextureForHotbar(icon);
+        xiuiBundledAssetIconCache[norm] = icon;
+    end
+    return icon;
+end
+
+--- Load a PNG under assets/hotbar/custom/ by relative path. Retries with / → \\ for D3DX on Windows.
+--- Caches by the stored relPath string (as in config / picker).
+local function loadCustomIconByRelativePath(relPath)
+    if not relPath or relPath == '' then
+        return nil;
+    end
+    if customIconCache[relPath] then
+        return customIconCache[relPath];
+    end
+    local customDir = string.format('%saddons\\XIUI\\assets\\hotbar\\custom\\', AshitaCore:GetInstallPath());
+    local full = customDir .. relPath;
+    local icon = textures:LoadTextureFromPath(full);
+    if not icon and relPath:find('/') then
+        full = customDir .. relPath:gsub('/', '\\');
+        icon = textures:LoadTextureFromPath(full);
+    end
+    if icon then
+        finalizeCustomIconTextureForHotbar(icon);
+        customIconCache[relPath] = icon;
+    end
+    return icon;
+end
+
+--- Shared D3D texture for a PNG under assets/hotbar/custom/ (picker + hotbar use one cache).
+function M.GetCustomHotbarIconTexture(relPath)
+    return loadCustomIconByRelativePath(relPath);
+end
+
+--- Load a PNG from assets/hotbar/custom/ using the same name→file rules as the macro icon picker.
+local function TryLoadCustomHotbarIconByActionName(actionName)
+    if not actionName or actionName == '' then
+        return nil;
+    end
+    local rel = customiconresolve.FindRelPathForActionName(actionName, 'all');
+    if not rel or rel == '' then
+        return nil;
+    end
+    return loadCustomIconByRelativePath(rel);
+end
+-- Built-in type defaults under addons/XIUI/assets/icons/ (ma.png, ja.png, macro.png, refresh.png, …)
+local xiuiDefaultIconCache = {};
+
+local function LoadXiuiDefaultIcon(stem)
+    if not stem or stem == '' then
+        stem = 'refresh';
+    end
+    if xiuiDefaultIconCache[stem] then
+        return xiuiDefaultIconCache[stem];
+    end
+    local path = string.format('%saddons\\XIUI\\assets\\icons\\%s.png', AshitaCore:GetInstallPath(), stem);
+    local icon = textures:LoadTextureFromPath(path);
+    if icon then
+        xiuiDefaultIconCache[stem] = icon;
+    end
+    return icon;
+end
+
+--- Load a PNG from addons/XIUI/assets/icons/{stem}.png (same cache as xiui_default icons).
+function M.LoadXiuiAssetIcon(stem)
+    return LoadXiuiDefaultIcon(stem);
 end
 
 -- Mapping from summoning spell names to texture cache keys
@@ -383,25 +501,175 @@ local itemIconCache = {};
 -- Helper Functions
 -- ============================================
 
+--- Case-insensitive compare for spell/ability/item display names from game data or user input.
+local function NameEqualsI(a, b)
+    if a == nil or b == nil then
+        return false;
+    end
+    return string.lower(tostring(a)) == string.lower(tostring(b));
+end
+
+--- Look up in a string-keyed map: exact key first, then case-insensitive match on keys.
+local function LookupStringKeyInsensitive(map, key)
+    if not map or key == nil or key == '' then
+        return nil;
+    end
+    local v = map[key];
+    if v ~= nil then
+        return v;
+    end
+    local needle = string.lower(tostring(key));
+    for mk, val in pairs(map) do
+        if type(mk) == 'string' and string.lower(mk) == needle then
+            return val;
+        end
+    end
+    return nil;
+end
+
+--- Find a spell by English name in horizonspells (exact match; used for MP cost, availability, etc.)
+---@param spellName string The English name of the spell
+---@return table|nil The spell data table with en, icon_id, prefix, and id fields
 -- O(1) lookup from English spell name -> horizonSpells entry. Built lazily on first use.
+-- NOTE: horizonSpells has duplicate entries for the same English name (different prefixes —
+-- e.g. /ma vs /magic vs blood pact). Builders below preserve the FIRST match found; for
+-- prefix/action-type-specific resolution use GetSpellByNameForIcon (case-insensitive) or
+-- GetSpellIndexForMa (Horizon recast index).
 local spellByNameLookup = nil;
 
 local function buildSpellByNameLookup()
     spellByNameLookup = {};
     for _, spell in pairs(horizonSpells) do
-        if spell.en then
+        if spell.en and spellByNameLookup[spell.en] == nil then
             spellByNameLookup[spell.en] = spell;
         end
     end
 end
 
---- Find a spell by English name in horizonspells
----@param spellName string The English name of the spell
----@return table|nil The spell data table with en, icon_id, prefix, and id fields
 local function GetSpellByName(spellName)
-    if not spellName then return nil; end
+    if not spellName or spellName == '' then
+        return nil;
+    end
     if not spellByNameLookup then buildSpellByNameLookup(); end
     return spellByNameLookup[spellName];
+end
+
+--- Horizon spell rows that are "school magic" (/ma) — never use these for /pet command icons (blood pact shares names).
+local function horizonTypeIsSchoolMagicSpellRow(t)
+    t = t or '';
+    return t == 'WhiteMagic' or t == 'BlackMagic' or t == 'BlueMagic';
+end
+
+--- Case-insensitive spell lookup for icons / palette. When several rows share `en`, pick by action context.
+--- For `pet`, rows that are only WM/BM/BLU are ignored so /pet does not show the /ma icon (e.g. Ramuh vs spell "Thunder II").
+---@param actionType string|nil 'ma'|'pet'|nil (nil treated like 'ma' for single-match rows)
+
+-- Case-insensitive multimap: lowercase English name -> list of horizonSpells rows.
+-- Built lazily on first GetSpellByNameForIcon call. Matches the 1.8.0 perf pattern used
+-- for spellByNameLookup (case-sensitive single-match): both replace O(n) scans with O(1)
+-- hashmap probes. Multiple entries per key are preserved because the caller filters by
+-- actionType context (pet vs ma vs blood pact) below.
+local spellsByLowerNameLookup = nil;
+
+local function buildSpellsByLowerNameLookup()
+    spellsByLowerNameLookup = {};
+    for _, spell in pairs(horizonSpells) do
+        if spell.en then
+            local k = string.lower(spell.en);
+            local list = spellsByLowerNameLookup[k];
+            if not list then
+                list = {};
+                spellsByLowerNameLookup[k] = list;
+            end
+            list[#list + 1] = spell;
+        end
+    end
+end
+
+local function GetSpellByNameForIcon(spellName, actionType)
+    if not spellName or spellName == '' then
+        return nil;
+    end
+    if not spellsByLowerNameLookup then buildSpellsByLowerNameLookup(); end
+    local needle = string.lower(spellName);
+    local matches = spellsByLowerNameLookup[needle];
+    if not matches then
+        return nil;
+    end
+    -- Copy into a local working list so we can sort without mutating the cached one.
+    local list = {};
+    for i = 1, #matches do list[i] = matches[i]; end
+    if #list == 0 then
+        return nil;
+    end
+
+    local ctx = actionType or 'ma';
+
+    if #list == 1 then
+        local sp = list[1];
+        if ctx == 'pet' and horizonTypeIsSchoolMagicSpellRow(sp.type) then
+            return nil;
+        end
+        return sp;
+    end
+
+    -- Blood pact / avatar pact names: never bind to Scholar/BLU spell rows when resolving a /pet icon.
+    if ctx == 'pet' and petregistry.GetBloodPactByName(spellName) then
+        for _, sp in ipairs(list) do
+            local t = sp.type or '';
+            if t == 'SummonerPact' or t == 'BloodPact' or t == 'BloodPactRage' or t == 'BloodPactWard' then
+                return sp;
+            end
+        end
+        return nil;
+    end
+
+    table.sort(list, function(a, b)
+        return (a.id or 0) < (b.id or 0);
+    end);
+
+    if ctx == 'ma' then
+        for _, sp in ipairs(list) do
+            local t = sp.type or '';
+            if t == 'WhiteMagic' or t == 'BlackMagic' or t == 'BlueMagic' or t == 'SummonerPact' then
+                return sp;
+            end
+        end
+    end
+
+    if ctx == 'pet' then
+        for _, sp in ipairs(list) do
+            if not horizonTypeIsSchoolMagicSpellRow(sp.type) then
+                return sp;
+            end
+        end
+        return nil;
+    end
+
+    return list[1];
+end
+
+--- Spell id from horizon DB by English name (icon / macro editor only; case-insensitive).
+---@param actionType string|nil optional: 'ma' vs 'pet' when the same `en` exists for different spell kinds
+function M.GetSpellIdByEnglishName(spellName, actionType)
+    if not spellName or spellName == '' then
+        return nil;
+    end
+    local spell = GetSpellByNameForIcon(spellName, actionType);
+    if spell and spell.id then
+        return spell.id;
+    end
+    return nil;
+end
+
+--- Full horizon spell row for icon resolution (same duplicate-name rules as GetSpellIdByEnglishName).
+---@param actionType string|nil 'ma'|'pet'|nil
+---@return table|nil
+function M.GetHorizonSpellForIconResolution(spellName, actionType)
+    if not spellName or spellName == '' then
+        return nil;
+    end
+    return GetSpellByNameForIcon(spellName, actionType);
 end
 
 --- Get MP cost for an action (only applicable to magic spells)
@@ -410,23 +678,260 @@ end
 function M.GetMPCost(bind)
     if not bind then return nil; end
 
-    -- Macros with a magic recast source surface that spell's MP cost so the
-    -- slot shows the underlying spell's mana alongside its cooldown.
-    if bind.actionType == 'macro' and bind.recastSourceType == 'ma' and bind.recastSourceAction then
-        local spell = GetSpellByName(bind.recastSourceAction);
+    -- Helper: safe trimmed string
+    local function trim(s)
+        if not s then return nil; end
+        s = tostring(s);
+        s = s:gsub('^%s+', ''):gsub('%s+$', '');
+        return (s ~= '' and s) or nil;
+    end
+
+    -- Helper: current player main job level (for formula MP costs)
+    local function getPlayerLevel()
+        local player = AshitaCore:GetMemoryManager():GetPlayer();
+        return (player and player:GetMainJobLevel()) or 0;
+    end
+
+    -- Helper: extract a quoted or unquoted name from a macro line after a command token
+    -- e.g. /ma "Fire II" <t>   -> "Fire II"
+    --      /pet Fire II <me>   -> "Fire II"
+    local function extractNameAfterCommand(line, commandToken)
+        if not line or not commandToken then return nil; end
+        -- Quoted form first
+        local quoted = line:match('^' .. commandToken .. '%s+"([^"]+)"');
+        if quoted then return trim(quoted); end
+        -- Unquoted: capture until a target token or end-of-line
+        local unquoted = line:match('^' .. commandToken .. '%s+([^<\r\n]+)');
+        if unquoted then
+            unquoted = unquoted:gsub('%s+<.*$', ''); -- strip trailing target if included
+            return trim(unquoted);
+        end
+        return nil;
+    end
+
+    -- Helper: SMN level used for Blood Pact eligibility (main SMN, else sub SMN)
+    local function getSmnLevelForPacts()
+        local player = AshitaCore:GetMemoryManager():GetPlayer();
+        if not player then return nil; end
+        local JOB_SMN = petregistry.JOB_SMN or 15;
+        if player:GetMainJob() == JOB_SMN then
+            return player:GetMainJobLevel();
+        elseif player:GetSubJob() == JOB_SMN then
+            return player:GetSubJobLevel();
+        end
+        return nil;
+    end
+
+    -- Helper: resolve MP cost from pet registry for a pact name
+    local function getBloodPactMpCost(pactName)
+        pactName = trim(pactName);
+        if not pactName then return nil; end
+
+        local pact = petregistry.GetBloodPactByName and petregistry.GetBloodPactByName(pactName) or nil;
+        if not pact then return nil; end
+
+        -- Do not show MP when SMN level is below pact learn level (UI shows Lvn instead)
+        if pact.level and pact.level > 0 then
+            local smnLv = getSmnLevelForPacts();
+            if not smnLv or smnLv < pact.level then
+                return nil;
+            end
+        end
+
+        local mp = pact.mp;
+        if not mp or mp == 0 then return nil; end
+        if mp == -1 then
+            local lvl = getPlayerLevel();
+            return (lvl > 0) and (lvl * 2) or nil;
+        end
+        return mp;
+    end
+
+    -- Helper: sniff an action from macro text.
+    -- Returns: actionType ('ma'|'pet') and actionName, or nil.
+    -- Rules:
+    -- - If macro line uses /ma or /magic, treat as spell (ma).
+    -- - If macro line uses /pet, treat as pet.
+    -- - If macro line uses /ja, treat as pet ONLY if the name exists in the Blood Pact registry
+    --   (prevents misclassifying normal job abilities).
+    local function sniffActionFromMacroText(macroText)
+        macroText = trim(macroText);
+        if not macroText then return nil; end
+
+        -- Only examine the first few lines (macros are tiny, but keep it bounded)
+        local inspectedLines = 0;
+        for line in macroText:gmatch('[^\r\n]+') do
+            inspectedLines = inspectedLines + 1;
+            if inspectedLines > 6 then break; end
+
+            local l = trim(line);
+            if l then
+                -- Spells first: /ma or /magic
+                local spellName = extractNameAfterCommand(l, '/ma') or extractNameAfterCommand(l, '/magic');
+                if spellName then
+                    return 'ma', spellName;
+                end
+
+                -- Pet commands: /pet
+                local petName = extractNameAfterCommand(l, '/pet');
+                if petName then
+                    return 'pet', petName;
+                end
+
+                -- Pet pacts often appear as /ja "Name" <t> (especially when created via UI dropdowns)
+                local jaName = extractNameAfterCommand(l, '/ja');
+                if jaName then
+                    -- Only treat /ja as a pact if it exists in the pact registry.
+                    if petregistry.GetBloodPactByName and petregistry.GetBloodPactByName(jaName) then
+                        return 'pet', jaName;
+                    end
+                end
+            end
+        end
+
+        return nil;
+    end
+
+    -- Magic spells: use horizon spell DB
+    if bind.actionType == 'ma' then
+        local spell = GetSpellByName(bind.action);
         if spell and spell.mp_cost and spell.mp_cost > 0 then
             return spell.mp_cost;
         end
         return nil;
     end
 
-    if bind.actionType ~= 'ma' then return nil; end
-
-    local spell = GetSpellByName(bind.action);
-    if spell and spell.mp_cost and spell.mp_cost > 0 then
-        return spell.mp_cost;
+    -- Pet commands: Blood Pacts and other pet abilities (only Blood Pacts have MP)
+    if bind.actionType == 'pet' then
+        return getBloodPactMpCost(bind.action);
     end
+
+    -- Macro slots: optionally derive MP cost from recastSourceType, otherwise sniff /pet lines
+    if bind.actionType == 'macro' then
+        -- Prefer explicit recastSourceType if present (matches how cooldowns are overridden)
+        if bind.recastSourceType == 'ma' and bind.recastSourceAction then
+            return M.GetMPCost({ actionType = 'ma', action = bind.recastSourceAction });
+        end
+        if bind.recastSourceType == 'pet' and bind.recastSourceAction then
+            return getBloodPactMpCost(bind.recastSourceAction);
+        end
+
+        -- Sniff macro text (supports /ma, /magic, /pet, and /ja pacts)
+        local sniffType, sniffName = sniffActionFromMacroText(bind.macroText);
+        if sniffType == 'ma' and sniffName then
+            return M.GetMPCost({ actionType = 'ma', action = sniffName });
+        elseif sniffType == 'pet' and sniffName then
+            return getBloodPactMpCost(sniffName);
+        end
+        return nil;
+    end
+
     return nil;
+end
+
+-- Resolve a Blood Pact record (Rage or Ward) for a bind.
+-- Supports:
+-- - actionType='pet' (direct pact name in bind.action)
+-- - actionType='macro' (recastSource pet, /pet, or /ja lines)
+-- Returns: pact table from petregistry (or nil)
+function M.GetResolvedBloodPact(bind)
+    if not bind or not petregistry or not petregistry.GetBloodPactByName then
+        return nil;
+    end
+
+    local function trim(s)
+        if not s then return nil; end
+        s = tostring(s);
+        s = s:gsub('^%s+', ''):gsub('%s+$', '');
+        return (s ~= '' and s) or nil;
+    end
+
+    local function extractNameAfterCommand(line, commandToken)
+        if not line or not commandToken then return nil; end
+        -- Quoted
+        local quoted = line:match('^' .. commandToken .. '%s+"([^"]+)"');
+        if quoted then return trim(quoted); end
+        -- Unquoted
+        local unquoted = line:match('^' .. commandToken .. '%s+([^<\r\n]+)');
+        if unquoted then
+            unquoted = unquoted:gsub('%s+<.*$', '');
+            return trim(unquoted);
+        end
+        return nil;
+    end
+
+    -- Direct pet bind
+    if bind.actionType == 'pet' and bind.action then
+        return petregistry.GetBloodPactByName(bind.action);
+    end
+
+    -- Macro bind: prefer explicit recast source if it's pet
+    if bind.actionType == 'macro' then
+        if bind.recastSourceType == 'pet' and bind.recastSourceAction then
+            return petregistry.GetBloodPactByName(bind.recastSourceAction);
+        end
+
+        local macroText = trim(bind.macroText);
+        if not macroText then return nil; end
+
+        -- Scan up to 8 lines (max macro lines)
+        local inspected = 0;
+        for line in macroText:gmatch('[^\r\n]+') do
+            inspected = inspected + 1;
+            if inspected > 8 then break; end
+
+            local l = trim(line);
+            if l then
+                local petName = extractNameAfterCommand(l, '/pet');
+                if petName then
+                    local pact = petregistry.GetBloodPactByName(petName);
+                    if pact then return pact; end
+                end
+
+                local jaName = extractNameAfterCommand(l, '/ja');
+                if jaName then
+                    local pact = petregistry.GetBloodPactByName(jaName);
+                    if pact then return pact; end
+                end
+            end
+        end
+    end
+
+    return nil;
+end
+
+-- Optional bottom-left "status" badge PNG per blood pact (petregistry.statusCornerIcon), relative to addons/XIUI/
+local bloodPactCornerIconCache = {};
+
+local function loadTextureXiuiAddonRelative(relPath)
+    if not relPath or relPath == '' then
+        return nil;
+    end
+    if bloodPactCornerIconCache[relPath] ~= nil then
+        local c = bloodPactCornerIconCache[relPath];
+        return (c ~= false) and c or nil;
+    end
+    local full = string.format('%saddons\\XIUI\\%s', AshitaCore:GetInstallPath(), relPath:gsub('/', '\\'));
+    local icon = textures:LoadTextureFromPath(full);
+    if icon then
+        finalizeCustomIconTextureForHotbar(icon);
+        bloodPactCornerIconCache[relPath] = icon;
+        return icon;
+    end
+    bloodPactCornerIconCache[relPath] = false;
+    return nil;
+end
+
+--- Texture for bottom-left blood pact badge when petregistry sets statusCornerIcon (else slotrenderer uses theme + pact.status).
+--- @param bind table|nil hotbar bind
+--- @param pactOptional table|nil if already resolved via GetResolvedBloodPact (avoids double lookup)
+--- @return table|nil icon table with .image for ImGui, or nil
+function M.GetBloodPactStatusCornerIcon(bind, pactOptional)
+    local pact = pactOptional or M.GetResolvedBloodPact(bind);
+    if not pact or not pact.statusCornerIcon or pact.statusCornerIcon == '' then
+        return nil;
+    end
+    return loadTextureXiuiAddonRelative(pact.statusCornerIcon);
 end
 
 --- Check if an action is currently available to use
@@ -437,13 +942,29 @@ end
 function M.IsActionAvailable(bind)
     if not bind then return true, nil; end
 
-    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    local memMgr = AshitaCore:GetMemoryManager();
+    local player = memMgr and memMgr:GetPlayer();
     if not player then return true, nil; end
 
     local mainJobId = player:GetMainJob();
-    local mainJobLevel = player:GetMainJobLevel();
     local subJobId = player:GetSubJob();
-    local subJobLevel = player:GetSubJobLevel();
+
+    -- IMPORTANT: Use EFFECTIVE (post-Level Sync) levels for spell/JA/pact gates. Party
+    -- member 0 = the player; `GetMemberMainJobLevel(0)` reflects the synced-down value
+    -- (e.g. 40 while synced) whereas `player:GetMainJobLevel()` returns the raw character
+    -- level (e.g. 75). Without this, a synced player gets told a Lv50 spell is available
+    -- when the game itself will reject the cast. Falls back to raw level if party packet
+    -- hasn't populated yet (zone-in race). Effective levels are also embedded in the
+    -- slotrenderer availability cache key, so transitions invalidate cleanly.
+    local mainJobLevel = player:GetMainJobLevel() or 0;
+    local subJobLevel = player:GetSubJobLevel() or 0;
+    local party = memMgr and memMgr:GetParty();
+    if party then
+        local pMain = party:GetMemberMainJobLevel(0);
+        local pSub = party:GetMemberSubJobLevel(0);
+        if pMain and pMain > 0 then mainJobLevel = pMain; end
+        if pSub and pSub > 0 then subJobLevel = pSub; end
+    end
 
     -- Guard: If job data is invalid (e.g., during zoning), assume available
     -- Don't cache this result - return nil as reason to signal "don't cache"
@@ -451,51 +972,222 @@ function M.IsActionAvailable(bind)
         return true, "pending";  -- "pending" signals not to cache this result
     end
 
+    -- Helper: check if player currently has a given buff id
+    local function HasBuffId(buffId)
+        if not buffId then return false; end
+        local buffs = player:GetBuffs();
+        if not buffs then return false; end
+        for i = 1, 32 do
+            if buffs[i] == buffId then
+                return true;
+            end
+        end
+        return false;
+    end
+
+    -- Helper: extract pact name from /pet or /ja line (quoted or unquoted)
+    local function ExtractNameAfterCommand(line, commandToken)
+        if not line or not commandToken then return nil; end
+        line = tostring(line);
+        -- Quoted
+        local quoted = line:match('^' .. commandToken .. '%s+"([^"]+)"');
+        if quoted and quoted ~= '' then return quoted; end
+        -- Unquoted (until target or EOL)
+        local unquoted = line:match('^' .. commandToken .. '%s+([^<\r\n]+)');
+        if unquoted and unquoted ~= '' then
+            unquoted = unquoted:gsub('%s+<.*$', '');
+            unquoted = unquoted:gsub('^%s+', ''):gsub('%s+$', '');
+            return (unquoted ~= '' and unquoted) or nil;
+        end
+        return nil;
+    end
+
+    -- Helper: resolve a blood pact record by name (if any)
+    local function GetBloodPactByName(name)
+        if not name or name == '' then return nil; end
+        if petregistry and petregistry.GetBloodPactByName then
+            return petregistry.GetBloodPactByName(name);
+        end
+        return nil;
+    end
+
+    local JOB_SMN = petregistry.JOB_SMN or 15;
+
+    -- Effective SMN level: main job SMN uses main level; otherwise sub SMN uses sub level
+    local function GetSmnLevelForBloodPacts()
+        if mainJobId == JOB_SMN then
+            return mainJobLevel;
+        elseif subJobId == JOB_SMN then
+            return subJobLevel;
+        end
+        return nil;
+    end
+
+    -- Blood Pact level gate (Horizon/registry `level` field)
+    local function CheckBloodPactLevelRequirement(pact)
+        if not pact or not pact.level or pact.level <= 0 then
+            return true, nil;
+        end
+        local smnLv = GetSmnLevelForBloodPacts();
+        if smnLv == nil then
+            return false, 'Job';
+        end
+        if smnLv < pact.level then
+            return false, string.format('Lv%d', pact.level);
+        end
+        return true, nil;
+    end
+
+    -- Pet actions: Astral Flow + Blood Pact level
+    if bind.actionType == 'pet' and bind.action then
+        local pact = GetBloodPactByName(bind.action);
+        if pact and pact.requiresFlow then
+            -- Astral Flow buff id is 55 (see bufftable.lua mapping)
+            if not HasBuffId(55) then
+                -- Don't cache this: buff state changes frequently
+                return false, "pending";
+            end
+        end
+        if pact then
+            local ok, lvlReason = CheckBloodPactLevelRequirement(pact);
+            if not ok then
+                return false, lvlReason;
+            end
+        end
+        return true, nil;
+    end
+
+    -- Macro actions: if macro resolves to a blood pact requiring Astral Flow, mark unavailable when Flow is down
+    if bind.actionType == 'macro' then
+        local pactName = nil;
+
+        -- Prefer explicit recast source override when set to pet
+        if bind.recastSourceType == 'pet' and bind.recastSourceAction then
+            pactName = bind.recastSourceAction;
+        end
+
+        -- Otherwise sniff first few lines for /pet or /ja pact names
+        if not pactName and bind.macroText then
+            local inspectedLines = 0;
+            for line in tostring(bind.macroText):gmatch('[^\r\n]+') do
+                inspectedLines = inspectedLines + 1;
+                if inspectedLines > 6 then break; end
+
+                local l = line:gsub('^%s+', ''):gsub('%s+$', '');
+                if l ~= '' then
+                    local petName = ExtractNameAfterCommand(l, '/pet');
+                    if petName then
+                        pactName = petName;
+                        break;
+                    end
+                    local jaName = ExtractNameAfterCommand(l, '/ja');
+                    if jaName and GetBloodPactByName(jaName) then
+                        pactName = jaName;
+                        break;
+                    end
+                end
+            end
+        end
+
+        if pactName then
+            local pact = GetBloodPactByName(pactName);
+            if pact and pact.requiresFlow and not HasBuffId(55) then
+                return false, "pending";
+            end
+            if pact then
+                local ok, lvlReason = CheckBloodPactLevelRequirement(pact);
+                if not ok then
+                    return false, lvlReason;
+                end
+            end
+        end
+        -- Otherwise: fall through to existing checks below (or assume available)
+    end
+
+    -- Macro: validate primary /ws /ma /pet /ja line + optional /ja badge (otherwise macro slots always returned "available")
+    if bind.actionType == 'macro' and bind.macroText and bind.macroText ~= '' then
+        local pType, pName, jaBadge = macroparse.GetMacroPrimaryAndJaBadge(bind.macroText);
+        local function validateActionPair(aType, aName)
+            if not aType or not aName or aName == '' then
+                return true, nil;
+            end
+            if aType == 'item' or aType == 'equip' or aType == 'misc' then
+                return true, nil;
+            end
+            if aType ~= 'ws' and aType ~= 'ma' and aType ~= 'pet' and aType ~= 'ja' then
+                return true, nil;
+            end
+            local syn = { actionType = aType, action = aName };
+            return M.IsActionAvailable(syn);
+        end
+        local okP, rsP = validateActionPair(pType, pName);
+        if not okP then
+            return false, rsP;
+        end
+        if jaBadge and jaBadge ~= '' then
+            local okB, rsB = validateActionPair('ja', jaBadge);
+            if not okB then
+                return false, rsB;
+            end
+        end
+    end
+
     -- Handle magic spells
     if bind.actionType == 'ma' then
         local spell = GetSpellByName(bind.action);
-        if not spell then return true, nil; end  -- Unknown spell, assume available
+        if not spell then return false, 'Unknown'; end
 
         local levels = spell.levels;
-        if not levels then return true, nil; end  -- No level requirements
+        if not levels then return true, nil; end
 
-        -- Check if main job can cast this spell
         local mainReqLevel = levels[mainJobId];
         local subReqLevel = subJobId and levels[subJobId] or nil;
 
-        -- Check main job first
-        if mainReqLevel then
-            if mainJobLevel >= mainReqLevel then
-                return true, nil;  -- Can cast with main job
+        -- Level gate: check if main or sub job meets the requirement
+        local mainCanLevel = mainReqLevel and mainJobLevel >= mainReqLevel;
+        local subCanLevel = subReqLevel and subJobLevel >= subReqLevel;
+
+        if not mainCanLevel and not subCanLevel then
+            if mainReqLevel then
+                return false, string.format("Lv%d", mainReqLevel);
+            elseif subReqLevel then
+                return false, string.format("Lv%d", subReqLevel);
+            else
+                return false, "Job";
             end
         end
 
-        -- Check subjob
-        if subReqLevel then
-            if subJobLevel >= subReqLevel then
-                return true, nil;  -- Can cast with subjob
-            end
+        -- Scroll/quest gate: right job and level but spell not yet learned
+        if spell.id and not player:HasSpell(spell.id) then
+            local reqLv = mainCanLevel and mainReqLevel or subReqLevel;
+            return false, string.format("Lv%d", reqLv);
         end
 
-        -- Spell exists but can't be cast
-        if mainReqLevel then
-            -- Has the job but not the level
-            return false, string.format("Lv%d", mainReqLevel);
-        elseif subReqLevel then
-            -- Subjob has it but not the level
-            return false, string.format("Lv%d", subReqLevel);
-        else
-            -- Job can't cast this spell at all
-            return false, "Job";
-        end
+        return true, nil;
 
     -- Handle job abilities
     elseif bind.actionType == 'ja' then
+        local jaName = universalTwoHour.ResolveJaActionName(bind.action);
+        if not jaName then
+            return false, 'N/A';
+        end
         -- Use playerdata's cached abilities as single source of truth
-        -- This ensures availability matches what's shown in the dropdown
         local playerdata = require('modules.hotbar.playerdata');
         if not playerdata.IsAbilityInCache(bind.action) then
-            return false, "N/A";
+            return false, 'N/A';
+        end
+        -- Blood pacts bound as /ja (e.g. /ja "Judgment Bolt") still follow pact rules: Astral Flow + SMN level
+        local pactJa = GetBloodPactByName(jaName);
+        if pactJa and pactJa.requiresFlow then
+            if not HasBuffId(55) then
+                return false, "pending";
+            end
+        end
+        if pactJa then
+            local okJa, lvlReasonJa = CheckBloodPactLevelRequirement(pactJa);
+            if not okJa then
+                return false, lvlReasonJa;
+            end
         end
 
     -- Handle weapon skills
@@ -572,6 +1264,87 @@ local function LoadItemIconById(itemId)
     return itemIconCache[itemId];
 end
 
+local function GetIconFromMacroStyleCustomFields(customIconType, customIconId, customIconPath)
+    if not customIconType then
+        return nil;
+    end
+    if customIconType == 'spell' and customIconId then
+        return textures:Get('spells' .. string.format('%05d', customIconId));
+    elseif customIconType == 'item' and customIconId then
+        return LoadItemIconById(customIconId);
+    elseif customIconType == 'custom' and customIconPath and customIconPath ~= '' then
+        return loadCustomIconByRelativePath(customIconPath);
+    elseif customIconType == 'xiui_asset' and customIconPath and customIconPath ~= '' then
+        return loadXiuiBundledAssetIcon(customIconPath);
+    elseif customIconType == 'xiui_default' and customIconPath then
+        return LoadXiuiDefaultIcon(customIconPath);
+    end
+    return nil;
+end
+
+--- @param paletteKey number|string|nil macro palette key (job id or global key)
+function M.FindMacroByIdAndPalette(macroId, paletteKey)
+    if not macroId then
+        return nil;
+    end
+    return data.GetMacroById(macroId, paletteKey or data.jobId or 1);
+end
+
+--- Resolve bottom-right /ja badge texture: optional macro.jaBadgeCustom* override, else same as GetBindIcon ja.
+--- ctx: hotbar bind { actionType, macroText, macroRef?, macroPaletteKey? } or palette macro row { id, ... }.
+function M.ResolveMacroJaBadgeIcon(ctx)
+    if not ctx or ctx.actionType ~= 'macro' or not ctx.macroText or ctx.macroText == '' then
+        return nil;
+    end
+    local macroForFlag = ctx;
+    if ctx.macroRef and not ctx.id then
+        local fromDb = M.FindMacroByIdAndPalette(ctx.macroRef, ctx.macroPaletteKey);
+        if fromDb then
+            macroForFlag = fromDb;
+        end
+    end
+    if macroForFlag.showJaBadgeOnMacro == false then
+        return nil;
+    end
+    local jaName = M.GetMacroJaBadgeAbilityName(ctx.macroText);
+    if not jaName or jaName == '' then
+        return nil;
+    end
+    local macro = ctx;
+    if ctx.macroRef and not ctx.id then
+        local fromDb = M.FindMacroByIdAndPalette(ctx.macroRef, ctx.macroPaletteKey);
+        if fromDb then
+            macro = fromDb;
+        end
+    end
+    if macro and macro.jaBadgeCustomIconType then
+        local ic = GetIconFromMacroStyleCustomFields(
+            macro.jaBadgeCustomIconType,
+            macro.jaBadgeCustomIconId,
+            macro.jaBadgeCustomIconPath
+        );
+        if ic and ic.image then
+            return ic;
+        end
+    end
+    return M.GetBindIcon({ actionType = 'ja', action = jaName });
+end
+
+--- Cache-key fragment when a hotbar slot references a macro (invalidates when JA badge icon overrides change).
+function M.GetMacroJaBadgeIconCacheSuffix(bind)
+    if not bind or bind.actionType ~= 'macro' or not bind.macroRef then
+        return '';
+    end
+    local m = M.FindMacroByIdAndPalette(bind.macroRef, bind.macroPaletteKey);
+    if not m then
+        return '';
+    end
+    return ':jb:' .. tostring(m.jaBadgeCustomIconType or '')
+        .. ':' .. tostring(m.jaBadgeCustomIconId or '')
+        .. ':' .. tostring(m.jaBadgeCustomIconPath or '')
+        .. ':' .. tostring(m.showJaBadgeOnMacro ~= false);
+end
+
 -- Cache for item name -> id lookups (populated lazily)
 -- CRITICAL: Must cache BOTH found items AND "not found" results to avoid 65535-iteration search every frame
 local itemNameToIdCache = {};
@@ -585,8 +1358,9 @@ local function LoadItemIconByName(itemName)
         return nil;
     end
 
-    -- Check name->id cache first (includes negative cache for "not found")
-    local cachedId = itemNameToIdCache[itemName];
+    -- Check name->id cache first (includes negative cache for "not found"); key is lowercased
+    local cacheKey = string.lower(tostring(itemName));
+    local cachedId = itemNameToIdCache[cacheKey];
     if cachedId then
         if cachedId == ITEM_NOT_FOUND then
             return nil;  -- Previously searched, item doesn't exist
@@ -594,21 +1368,51 @@ local function LoadItemIconByName(itemName)
         return LoadItemIconById(cachedId);
     end
 
-    -- Search for item by name (slow, but cached after first find)
-    local resMgr = AshitaCore:GetResourceManager();
-    if not resMgr then return nil; end
-
-    for itemId = 1, 65535 do
-        local item = resMgr:GetItemById(itemId);
-        if item and item.Name and item.Name[1] == itemName then
-            itemNameToIdCache[itemName] = itemId;
-            return LoadItemIconById(itemId);
-        end
+    -- Audit win: O(1) name->id via actiondb (session-cached lazy hashmap built once on
+    -- first call). Previously this did a per-call O(65535) scan that only avoided repeats
+    -- via the local itemNameToIdCache. With actiondb the build cost is paid once across
+    -- ALL callers and every subsequent name lookup is constant-time. The local cache is
+    -- still kept so the LoadItemIconById step is also remembered per icon resolution.
+    local itemId = actiondb.GetItemId(itemName);
+    if itemId and itemId > 0 then
+        itemNameToIdCache[cacheKey] = itemId;
+        return LoadItemIconById(itemId);
     end
 
-    -- CRITICAL: Cache negative result to avoid searching 65535 items every frame!
-    itemNameToIdCache[itemName] = ITEM_NOT_FOUND;
+    -- Negative-result cache prevents future actiondb probes for misspelled / nonexistent items.
+    itemNameToIdCache[cacheKey] = ITEM_NOT_FOUND;
     return nil;
+end
+
+--- When a macro row references a custom PNG that failed to load, fall back like an unset icon:
+--- primary /ws /ma /pet /ja /item /equip → that type's default art; otherwise generic macro.png.
+local function GetMacroFallbackIconAfterMissingCustomFile(bind)
+    if not bind or bind.actionType ~= 'macro' then
+        local def = LoadXiuiDefaultIcon('macro');
+        if def then return def, nil; end
+        return nil, nil;
+    end
+    local macroText = bind.macroText;
+    if not macroText or macroText == '' then
+        local def = LoadXiuiDefaultIcon('macro');
+        if def then return def, nil; end
+        return nil, nil;
+    end
+    local mp = require('modules.hotbar.macroparse');
+    local pType, pName = mp.GetMacroPrimaryAndJaBadge(macroText);
+    if pType and pName and pName ~= '' then
+        if pType == 'ma' or pType == 'ja' or pType == 'ws' or pType == 'pet'
+            or pType == 'item' or pType == 'equip' then
+            return M.GetBindIcon({
+                actionType = pType,
+                action = pName,
+                itemId = bind.itemId,
+            });
+        end
+    end
+    local def = LoadXiuiDefaultIcon('macro');
+    if def then return def, nil; end
+    return nil, nil;
 end
 
 --- Get icon for a bind (separate from command building for use in drag preview)
@@ -621,6 +1425,8 @@ function M.GetBindIcon(bind)
     end
 
     -- Negative cache: if we've already determined this bind has no icon, skip the lookups.
+    -- ClearNoIconCache() must be called by upstream paths whenever icon resolution could change
+    -- (macroDB edit, job/pet/palette change, custom icon asset change).
     local noIconKey = buildNoIconKey(bind);
     if noIconKey and noIconCache[noIconKey] then
         return nil, nil;
@@ -629,45 +1435,8 @@ function M.GetBindIcon(bind)
     local icon = nil;
     local iconId = nil;
 
-    -- Check if this slot references a macro - if so, get the macro's current icon
-    -- This enables live updates when macro icons are changed in the palette
-    if bind.macroRef and gConfig and gConfig.macroDB then
-        -- Use stored palette key if available, otherwise fall back to job ID
-        local paletteKey = bind.macroPaletteKey or data.jobId or 1;
-        local macroDB = gConfig.macroDB[paletteKey];
-        if macroDB then
-            for _, macro in ipairs(macroDB) do
-                if macro.id == bind.macroRef then
-                    -- Found the source macro - use its current custom icon if set
-                    if macro.customIconType then
-                        if macro.customIconType == 'spell' and macro.customIconId then
-                            icon = textures:Get('spells' .. string.format('%05d', macro.customIconId));
-                            iconId = macro.customIconId;
-                            if icon then return icon, iconId; end
-                        elseif macro.customIconType == 'item' and macro.customIconId then
-                            icon = LoadItemIconById(macro.customIconId);
-                            iconId = macro.customIconId;
-                            if icon then return icon, iconId; end
-                        elseif macro.customIconType == 'custom' and macro.customIconPath then
-                            -- Check cache first
-                            if customIconCache[macro.customIconPath] then
-                                return customIconCache[macro.customIconPath], nil;
-                            end
-                            local customDir = string.format('%saddons\\XIUI\\assets\\hotbar\\custom\\', AshitaCore:GetInstallPath());
-                            icon = textures:LoadTextureFromPath(customDir .. macro.customIconPath);
-                            if icon then
-                                customIconCache[macro.customIconPath] = icon;
-                                return icon, nil;
-                            end
-                        end
-                    end
-                    break;
-                end
-            end
-        end
-    end
-
-    -- Check for custom icon override on the bind itself
+    -- Inline custom icon on the bind first (merged hotbar slot, macro editor row). Avoids macroDB shadowing
+    -- unsaved editor state when macroRef is present; also matches data.GetKeybindForSlot merge behavior.
     if bind.customIconType then
         if bind.customIconType == 'spell' and bind.customIconId then
             icon = textures:Get('spells' .. string.format('%05d', bind.customIconId));
@@ -677,89 +1446,221 @@ function M.GetBindIcon(bind)
             icon = LoadItemIconById(bind.customIconId);
             iconId = bind.customIconId;
             if icon then return icon, iconId; end
-        elseif bind.customIconType == 'custom' and bind.customIconPath then
-            -- Check cache first
-            if customIconCache[bind.customIconPath] then
-                return customIconCache[bind.customIconPath], nil;
-            end
-            -- Load custom icon from assets/hotbar/custom/ directory
-            local customDir = string.format('%saddons\\XIUI\\assets\\hotbar\\custom\\', AshitaCore:GetInstallPath());
-            icon = textures:LoadTextureFromPath(customDir .. bind.customIconPath);
-            if icon then
-                customIconCache[bind.customIconPath] = icon;
+        elseif bind.customIconType == 'custom' and bind.customIconPath and bind.customIconPath ~= '' then
+            icon = loadCustomIconByRelativePath(bind.customIconPath);
+            if icon and icon.image then
                 return icon, nil;
+            end
+            return GetMacroFallbackIconAfterMissingCustomFile(bind);
+        elseif bind.customIconType == 'xiui_asset' and bind.customIconPath and bind.customIconPath ~= '' then
+            icon = loadXiuiBundledAssetIcon(bind.customIconPath);
+            if icon and icon.image then
+                return icon, nil;
+            end
+            return GetMacroFallbackIconAfterMissingCustomFile(bind);
+        elseif bind.customIconType == 'xiui_default' and bind.customIconPath then
+            icon = LoadXiuiDefaultIcon(bind.customIconPath);
+            if icon then return icon, nil; end
+        end
+    end
+
+    -- Slot references a saved macro row — use palette DB when bind has no inline icon (e.g. stale slot snapshot).
+    if bind.macroRef and gConfig and gConfig.macroDB then
+        local paletteKey = bind.macroPaletteKey or data.jobId or 1;
+        local macro = data.GetMacroById(bind.macroRef, paletteKey);
+        if macro and macro.customIconType then
+            if macro.customIconType == 'spell' and macro.customIconId then
+                icon = textures:Get('spells' .. string.format('%05d', macro.customIconId));
+                iconId = macro.customIconId;
+                if icon then return icon, iconId; end
+            elseif macro.customIconType == 'item' and macro.customIconId then
+                icon = LoadItemIconById(macro.customIconId);
+                iconId = macro.customIconId;
+                if icon then return icon, iconId; end
+            elseif macro.customIconType == 'custom' and macro.customIconPath and macro.customIconPath ~= '' then
+                icon = loadCustomIconByRelativePath(macro.customIconPath);
+                if icon and icon.image then
+                    return icon, nil;
+                end
+                return GetMacroFallbackIconAfterMissingCustomFile(bind);
+            elseif macro.customIconType == 'xiui_asset' and macro.customIconPath and macro.customIconPath ~= '' then
+                icon = loadXiuiBundledAssetIcon(macro.customIconPath);
+                if icon and icon.image then
+                    return icon, nil;
+                end
+                return GetMacroFallbackIconAfterMissingCustomFile(bind);
+            elseif macro.customIconType == 'xiui_default' and macro.customIconPath then
+                icon = LoadXiuiDefaultIcon(macro.customIconPath);
+                if icon then return icon, nil; end
             end
         end
     end
 
+    -- Macro (palette preview / hotbar): icon follows the same primary line as macroparse (no custom icon set).
+    if bind.actionType == 'macro' then
+        local macroText = bind.macroText;
+        if macroText and macroText ~= '' then
+            local mp = require('modules.hotbar.macroparse');
+            local pType, pName = mp.GetMacroPrimaryAndJaBadge(macroText);
+            if pType and pName and pName ~= '' then
+                if pType == 'ma' or pType == 'ja' or pType == 'ws' or pType == 'pet'
+                    or pType == 'item' or pType == 'equip' then
+                    return M.GetBindIcon({
+                        actionType = pType,
+                        action = pName,
+                        itemId = bind.itemId,
+                    });
+                end
+            end
+        end
+        local def = LoadXiuiDefaultIcon('macro');
+        if def then return def, nil; end
+        return nil, nil;
+    end
+
     if bind.actionType == 'ma' then
         -- Check for summoning magic first (custom icons)
-        local summonIconKey = summonSpellToIconKey[bind.action];
+        local summonIconKey = LookupStringKeyInsensitive(summonSpellToIconKey, bind.action);
         if summonIconKey then
             icon = textures:Get(summonIconKey);
             if icon then
-                local spell = GetSpellByName(bind.action);
+                local spell = GetSpellByNameForIcon(bind.action, 'ma');
                 if spell then iconId = spell.id; end
                 return icon, iconId;
             end
         end
         -- Check for Trust icons
-        local trustIconKey = trustToIconKey[bind.action];
+        local trustIconKey = LookupStringKeyInsensitive(trustToIconKey, bind.action);
         if trustIconKey then
             icon = textures:Get(trustIconKey);
             if icon then
-                local spell = GetSpellByName(bind.action);
+                local spell = GetSpellByNameForIcon(bind.action, 'ma');
                 if spell then iconId = spell.id; end
                 return icon, iconId;
             end
         end
         -- Check for Blue Magic icons
-        local blueIconKey = blueMagicToIconKey[bind.action];
+        local blueIconKey = LookupStringKeyInsensitive(blueMagicToIconKey, bind.action);
         if blueIconKey then
             icon = textures:Get(blueIconKey);
             if icon then
-                local spell = GetSpellByName(bind.action);
+                local spell = GetSpellByNameForIcon(bind.action, 'ma');
                 if spell then iconId = spell.id; end
                 return icon, iconId;
             end
         end
+        -- Any PNG indexed by normalized spell name (SMN/Summons/Summoning, etc.) — matches "Fire Spirit" / fire spirit / file FireSpirit.png
+        icon = textures:GetIconBySpellName(bind.action);
+        if icon and icon.image then
+            local spell = GetSpellByNameForIcon(bind.action, 'ma');
+            if spell then iconId = spell.id; end
+            return icon, iconId;
+        end
+        icon = TryLoadCustomHotbarIconByActionName(bind.action);
+        if icon and icon.image then
+            local spell = GetSpellByNameForIcon(bind.action, 'ma');
+            if spell then iconId = spell.id; end
+            return icon, iconId;
+        end
         -- Magic spell - look up in horizonspells database
-        local spell = GetSpellByName(bind.action);
+        local spell = GetSpellByNameForIcon(bind.action, 'ma');
         if spell then
             iconId = spell.id;
             icon = textures:Get('spells' .. string.format('%05d', spell.id));
         end
     elseif bind.actionType == 'ja' then
+        local jaBindName = universalTwoHour.ResolveJaActionName(bind.action);
+        if jaBindName then
         -- Check for SMN ability icons first
-        local smnIconKey = smnAbilityToIconKey[bind.action];
+        local smnIconKey = LookupStringKeyInsensitive(smnAbilityToIconKey, jaBindName);
         if smnIconKey then
             icon = textures:Get(smnIconKey);
             if icon then return icon, iconId; end
         end
         -- Check for RUN ability icons
-        local runIconKey = runAbilityToIconKey[bind.action];
+        local runIconKey = LookupStringKeyInsensitive(runAbilityToIconKey, jaBindName);
         if runIconKey then
             icon = textures:Get(runIconKey);
             if icon then return icon, iconId; end
         end
         -- Check for other job ability icons
-        local otherIconKey = otherAbilityToIconKey[bind.action];
+        local otherIconKey = LookupStringKeyInsensitive(otherAbilityToIconKey, jaBindName);
         if otherIconKey then
             icon = textures:Get(otherIconKey);
             if icon then return icon, iconId; end
         end
-        -- No further icon source for generic job abilities; abbreviation fallback handles display.
+        -- Indexed / Summoning / Summons PNGs before vanilla ability id (macro icons: custom first)
+        icon = textures:GetIconBySpellName(jaBindName);
+        if icon and icon.image then
+            return icon, iconId;
+        end
+        icon = TryLoadCustomHotbarIconByActionName(jaBindName);
+        if icon and icon.image then
+            return icon, iconId;
+        end
+        -- Job ability - resolve id for overlays; texture may still come from default ja.png below
+        local resMgr = AshitaCore:GetResourceManager();
+        if resMgr then
+            for abilityId = 1, 1024 do
+                local ability = resMgr:GetAbilityById(abilityId);
+                if ability and ability.Name and NameEqualsI(ability.Name[1], jaBindName) then
+                    iconId = abilityId;
+                    break;
+                end
+            end
+        end
+        end
     elseif bind.actionType == 'pet' then
         -- Check for pet command icons first
-        local petIconKey = petCommandToIconKey[bind.action];
+        local petIconKey = LookupStringKeyInsensitive(petCommandToIconKey, bind.action);
         if petIconKey then
             icon = textures:Get(petIconKey);
             if icon then
                 return icon, iconId;
             end
         end
+        -- Blood pacts / Ready: prefer indexed PNGs and horizon row only when it is a pact row (not Scholar/BLU dupes)
+        icon = textures:GetIconBySpellName(bind.action);
+        if icon and icon.image then
+            local sp = GetSpellByNameForIcon(bind.action, 'pet');
+            if sp and not horizonTypeIsSchoolMagicSpellRow(sp.type) then
+                iconId = sp.id;
+            end
+            return icon, iconId;
+        end
+        icon = TryLoadCustomHotbarIconByActionName(bind.action);
+        if icon and icon.image then
+            local sp = GetSpellByNameForIcon(bind.action, 'pet');
+            if sp and not horizonTypeIsSchoolMagicSpellRow(sp.type) then
+                iconId = sp.id;
+            end
+            return icon, iconId;
+        end
+        local sp = GetSpellByNameForIcon(bind.action, 'pet');
+        if sp and not horizonTypeIsSchoolMagicSpellRow(sp.type) then
+            iconId = sp.id;
+            icon = textures:Get('spells' .. string.format('%05d', sp.id));
+        end
     elseif bind.actionType == 'ws' then
-        -- No icon source for weaponskills; abbreviation fallback handles display.
+        -- Weaponskill - try to get from game resources
+        local resMgr = AshitaCore:GetResourceManager();
+        if resMgr then
+            for wsId = 1, 255 do
+                local ability = resMgr:GetAbilityById(wsId + 256);
+                if ability and ability.Name and NameEqualsI(ability.Name[1], bind.action) then
+                    iconId = wsId;
+                    break;
+                end
+            end
+        end
+        icon = textures:GetIconBySpellName(bind.action);
+        if icon and icon.image then
+            return icon, iconId;
+        end
+        icon = TryLoadCustomHotbarIconByActionName(bind.action);
+        if icon and icon.image then
+            return icon, iconId;
+        end
     elseif bind.actionType == 'item' or bind.actionType == 'equip' then
         -- Item or Equipment - load icon from game resources
         -- Use itemId if available (faster), otherwise fall back to name lookup
@@ -770,6 +1671,26 @@ function M.GetBindIcon(bind)
         end
     end
 
+    -- XIUI defaults (assets/icons/{ma,ja,ws,pet,item}.png) when no game/custom texture loaded.
+    -- Spell rows can resolve in horizonspells while spells#####.png is still missing on disk; SMN
+    -- summon PNGs can fail similarly — user still sees the type icon instead of a blank/abbreviation.
+    if (not icon or not icon.image) and bind.actionType then
+        local stem = ({
+            ma = 'ma',
+            ja = 'ja',
+            ws = 'ws',
+            pet = 'pet',
+            item = 'item',
+            equip = 'item',
+        })[bind.actionType];
+        if stem then
+            local def = LoadXiuiDefaultIcon(stem);
+            if def and def.image then
+                icon = def;
+            end
+        end
+    end
+
     -- Memoize negative results so future cache misses (after display.iconCache wipes)
     -- skip the lookup work for binds that have no resolvable icon.
     if not icon and noIconKey then
@@ -777,6 +1698,18 @@ function M.GetBindIcon(bind)
     end
 
     return icon, iconId;
+end
+
+--- Last /ja ability name in a macro when the prioritized command is /ws, /ma, or /pet (for bottom-right badge).
+---@param macroText string|nil
+---@return string|nil
+function M.GetMacroJaBadgeAbilityName(macroText)
+    if not macroText or macroText == '' then
+        return nil;
+    end
+    local mp = require('modules.hotbar.macroparse');
+    local _, _, jaBadge = mp.GetMacroPrimaryAndJaBadge(macroText);
+    return jaBadge;
 end
 
 --- Build command and icon from keybind data
@@ -791,47 +1724,52 @@ local function FormatTargetForCommand(target)
     return '<' .. cleaned .. '>';
 end
 
+--- Command string only (no GetBindIcon). Use from per-frame draw paths; icons are resolved separately and cached.
+---@param bind table The keybind data with actionType, action, and target fields
+---@return string|nil command The command to execute
+function M.BuildCommandString(bind)
+    if not bind then
+        return nil;
+    end
+
+    local target = FormatTargetForCommand(bind.target);
+
+    if bind.actionType == 'ma' then
+        return '/ma "' .. bind.action .. '" ' .. target;
+    elseif bind.actionType == 'ja' then
+        local jaName = universalTwoHour.ResolveJaActionName(bind.action);
+        if not jaName then
+            return nil;
+        end
+        local rawTarget = universalTwoHour.ResolveJaBindTarget(bind) or bind.target;
+        target = FormatTargetForCommand(rawTarget);
+        return '/ja "' .. jaName .. '" ' .. target;
+    elseif bind.actionType == 'ws' then
+        return '/ws "' .. bind.action .. '" ' .. target;
+    elseif bind.actionType == 'item' then
+        return '/item "' .. bind.action .. '" ' .. target;
+    elseif bind.actionType == 'equip' then
+        local slot = bind.equipSlot or 'main';
+        return '/equip ' .. slot .. ' "' .. bind.action .. '"';
+    elseif bind.actionType == 'pet' then
+        return '/pet "' .. bind.action .. '" ' .. target;
+    elseif bind.actionType == 'macro' then
+        return bind.macroText or bind.action;
+    end
+
+    return nil;
+end
+
 ---@param bind table The keybind data with actionType, action, and target fields
 ---@return string|nil command The command to execute
 ---@return any|nil icon The icon texture (if applicable)
 function M.BuildCommand(bind)
-    local command = nil;
-
     if not bind then
         return nil, nil;
     end
 
-    -- Get icon using the helper function
     local icon = M.GetBindIcon(bind);
-
-    -- Format target consistently (handles both "me" and "<me>" formats)
-    local target = FormatTargetForCommand(bind.target);
-
-    -- Build command based on action type
-    if bind.actionType == 'ma' then
-        -- Magic spell
-        command = '/ma "' .. bind.action .. '" ' .. target;
-    elseif bind.actionType == 'ja' then
-        -- Job ability
-        command = '/ja "' .. bind.action .. '" ' .. target;
-    elseif bind.actionType == 'ws' then
-        -- Weapon skill
-        command = '/ws "' .. bind.action .. '" ' .. target;
-    elseif bind.actionType == 'item' then
-        -- Use item
-        command = '/item "' .. bind.action .. '" ' .. target;
-    elseif bind.actionType == 'equip' then
-        -- Equip item to slot
-        local slot = bind.equipSlot or 'main';
-        command = '/equip ' .. slot .. ' "' .. bind.action .. '"';
-    elseif bind.actionType == 'pet' then
-        -- Pet command
-        command = '/pet "' .. bind.action .. '" ' .. target;
-    elseif bind.actionType == 'macro' then
-        -- Macro command (raw command or use macroText)
-        command = bind.macroText or bind.action;
-    end
-
+    local command = M.BuildCommandString(bind);
     return command, icon;
 end
 
@@ -1007,8 +1945,11 @@ function M.HandleKeybind(hotbar, slot)
         return false;
     end
 
-    -- Build and execute command
-    local command, _ = M.BuildCommand(bind);
+    local command = M.BuildCommandString(bind);
+    if not command or command == '' then
+        return false;
+    end
+    M.NotifySlotExecutionEffects(bind);
     return M.ExecuteCommandString(command, bind.actionType == 'macro');
 end
 
@@ -1237,6 +2178,20 @@ function M.GetPressedSlot()
     return currentPressedSlot;
 end
 
+--- Called immediately before QueueCommand for a hotbar/crossbar bind (click, key, controller).
+function M.NotifySlotExecutionEffects(bind)
+    if bind and bind.actionType == 'ja' and bind.action == universalTwoHour.ACTION_SENTINEL then
+        local okR, recastMod = pcall(require, 'modules.hotbar.recast');
+        if okR and recastMod and recastMod.GetCooldownInfo then
+            local cd = recastMod.GetCooldownInfo(bind);
+            if cd and cd.isOnCooldown then
+                return;
+            end
+        end
+        universalTwoHour.NotifyUniversalTwoHourExecuted();
+    end
+end
+
 --- Execute an action directly from slot data
 --- Used by crossbar for controller input
 ---@param slotAction table The slot action with actionType, action, target, etc.
@@ -1245,19 +2200,23 @@ function M.ExecuteAction(slotAction)
     if not slotAction then return false; end
     if not slotAction.actionType or not slotAction.action then return false; end
 
-    -- Build and execute command (handles multi-line macros)
-    local command, _ = M.BuildCommand(slotAction);
+    local command = M.BuildCommandString(slotAction);
+    if not command or command == '' then
+        return false;
+    end
+    M.NotifySlotExecutionEffects(slotAction);
     return M.ExecuteCommandString(command, slotAction.actionType == 'macro');
 end
 
 -- Clear the custom icon cache (call when icons may have changed)
 function M.ClearCustomIconCache()
     customIconCache = {};
+    xiuiDefaultIconCache = {};
 end
 
--- Clear the negative-result cache. Must be called whenever something upstream
--- could change icon resolution: macroDB edits, job/pet/palette changes, custom
--- icon asset changes. Failing to clear it pins stale "no icon" decisions.
+--- Clear the negative-result cache. Must be called whenever something upstream
+--- could change icon resolution: macroDB edits, job/pet/palette changes, custom
+--- icon asset changes. Failing to clear it pins stale "no icon" decisions.
 function M.ClearNoIconCache()
     noIconCache = {};
 end

--- a/XIUI/modules/hotbar/macroparse.lua
+++ b/XIUI/modules/hotbar/macroparse.lua
@@ -1,0 +1,155 @@
+--[[
+ * Parse multi-line FFXI macros for icon/badge logic.
+ * Primary icon priority (first matching line in macro, first 8 lines only):
+ *   (1) /ws /ma /pet  — first among these, document order
+ *   (2) /ja
+ *   (3) /item /equip
+ *   (4) any other /command with a payload (e.g. /wait 1) — "misc"
+ * When primary is ws/ma/pet and any /ja line exists, the last /ja name is the corner badge (job ability).
+]]
+
+local M = {};
+
+local function trim(s)
+    if not s then return nil; end
+    s = tostring(s):gsub('^%s+', ''):gsub('%s+$', '');
+    return (s ~= '' and s) or nil;
+end
+
+--- Extract spell/ability name after leading /command (case-insensitive on the command).
+local function extractNameAfterCommand(line, rawCmd)
+    if not line or not rawCmd then return nil; end
+    line = trim(line);
+    if not line then return nil; end
+    local cmd = line:match('^(/%S+)');
+    if not cmd or cmd:lower() ~= rawCmd:lower() then return nil; end
+    local tail = trim(line:sub(#cmd + 1));
+    if not tail or tail == '' then return nil; end
+    local quoted = tail:match('^"([^"]+)"');
+    if quoted then return trim(quoted); end
+    local unquoted = tail:match('^([^<\r\n]+)');
+    if unquoted then
+        return trim(unquoted:gsub('%s+$', ''));
+    end
+    return nil;
+end
+
+local function normalizeCmd(raw)
+    if not raw then return nil; end
+    local c = raw:lower();
+    if c == '/weaponskill' then return '/ws'; end
+    if c == '/magic' then return '/ma'; end
+    return c;
+end
+
+-- Known action types; unknown /commands become 'misc' when a name/tail exists.
+local function actionTypeForCmd(cmdLower)
+    if not cmdLower then return nil; end
+    if cmdLower == '/ws' then return 'ws'; end
+    if cmdLower == '/ma' then return 'ma'; end
+    if cmdLower == '/pet' then return 'pet'; end
+    if cmdLower == '/ja' then return 'ja'; end
+    if cmdLower == '/item' then return 'item'; end
+    if cmdLower == '/equip' then return 'equip'; end
+    return nil;
+end
+
+--- @return string|nil primaryType  ws ma pet ja item equip misc
+--- @return string|nil primaryName
+--- @return string|nil jaBadgeName  last /ja in macro when primary is ws, ma, or pet
+function M.GetMacroPrimaryAndJaBadge(macroText)
+    macroText = trim(macroText);
+    if not macroText then
+        return nil, nil, nil;
+    end
+
+    local entries = {};
+    local jaNames = {};
+    local lineIdx = 0;
+
+    for line in macroText:gmatch('[^\r\n]+') do
+        lineIdx = lineIdx + 1;
+        if lineIdx > 8 then break; end
+
+        local l = trim(line);
+        if l and l:sub(1, 1) == '/' then
+            local rawCmd = l:match('^(/%S+)');
+            if rawCmd then
+                local ncmd = normalizeCmd(rawCmd);
+                local name = extractNameAfterCommand(l, rawCmd);
+                if name and name ~= '' then
+                    local atype = actionTypeForCmd(ncmd);
+                    if not atype then
+                        atype = 'misc';
+                    end
+                    table.insert(entries, {
+                        line = lineIdx,
+                        atype = atype,
+                        name = name,
+                    });
+                    if atype == 'ja' then
+                        table.insert(jaNames, name);
+                    end
+                end
+            end
+        end
+    end
+
+    if #entries == 0 then
+        return nil, nil, nil;
+    end
+
+    -- Primary: /ws /ma /pet > /ja > /item /equip > misc (first line in each group wins).
+    local function firstWhere(pred)
+        for i = 1, #entries do
+            local e = entries[i];
+            if pred(e) then return e; end
+        end
+        return nil;
+    end
+
+    local best = firstWhere(function(e)
+        return e.atype == 'ws' or e.atype == 'ma' or e.atype == 'pet';
+    end);
+    if not best then
+        best = firstWhere(function(e) return e.atype == 'ja'; end);
+    end
+    if not best then
+        best = firstWhere(function(e)
+            return e.atype == 'item' or e.atype == 'equip';
+        end);
+    end
+    if not best then
+        best = firstWhere(function(e) return e.atype == 'misc'; end);
+    end
+    if not best then
+        best = entries[1];
+    end
+
+    local jaBadge = nil;
+    if best.atype == 'ws' or best.atype == 'ma' or best.atype == 'pet' then
+        if #jaNames > 0 then
+            jaBadge = jaNames[#jaNames];
+            if jaBadge == best.name then
+                -- Rare duplicate name; use previous /ja if any
+                jaBadge = #jaNames > 1 and jaNames[#jaNames - 1] or nil;
+            end
+        end
+    end
+
+    return best.atype, best.name, jaBadge;
+end
+
+--- True when the macro has a bottom-right /ja badge (primary is /ws, /ma, or /pet and a /ja line exists).
+function M.MacroHasJaBadgePair(macroText)
+    local pType, _, jaBadge = M.GetMacroPrimaryAndJaBadge(macroText);
+    if not jaBadge or jaBadge == '' then
+        return false;
+    end
+    if pType == 'ws' or pType == 'ma' or pType == 'pet' then
+        return true;
+    end
+    return false;
+end
+
+return M;

--- a/XIUI/modules/hotbar/recast.lua
+++ b/XIUI/modules/hotbar/recast.lua
@@ -8,8 +8,25 @@ local abilityRecast = require('libs.abilityrecast');
 local itemRecast = require('libs.itemrecast');
 local actiondb = require('modules.hotbar.actiondb');
 local petregistry = require('modules.hotbar.petregistry');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
 
 local M = {};
+
+-- Lazy require: actions.lua requires recast.lua (circular). Resolved at first call.
+local actionsModule = nil;
+local function getActionsModule()
+    if not actionsModule then
+        actionsModule = require('modules.hotbar.actions');
+    end
+    return actionsModule;
+end
+
+local function normalizeCommandName(name)
+    if not name then return nil; end
+    local s = tostring(name):gsub('^%s+', ''):gsub('%s+$', '');
+    if s == '' then return nil; end
+    return s:lower();
+end
 
 -- Module-level setting for Hh:MM format (set once per frame, used by all functions)
 local useHHMMFormat = false;
@@ -23,26 +40,112 @@ end
 local BP_RAGE_TIMER_ID = 173;
 local BP_WARD_TIMER_ID = 174;
 
--- Get Blood Pact timer ID by command name
--- Returns timer ID (173 for Rage, 174 for Ward) or nil if not a blood pact
+-- Get Blood Pact timer ID by command name.
+-- Case-insensitive: slot labels / macro text can differ in casing from registry entries; otherwise
+-- we fall through to ability-id lookup and miss the shared BP timer (173/174) entirely.
 local function GetBloodPactTimerId(commandName)
-    if not commandName then return nil; end
+    local want = normalizeCommandName(commandName);
+    if not want then return nil; end
 
-    -- Check if it's a Rage pact
     for _, pact in ipairs(petregistry.bloodPactsRage or {}) do
-        if pact.name == commandName then
+        if pact.name and normalizeCommandName(pact.name) == want then
             return BP_RAGE_TIMER_ID;
         end
     end
 
-    -- Check if it's a Ward pact
     for _, pact in ipairs(petregistry.bloodPactsWard or {}) do
-        if pact.name == commandName then
+        if pact.name and normalizeCommandName(pact.name) == want then
             return BP_WARD_TIMER_ID;
         end
     end
 
     return nil;
+end
+
+-- Use Horizon spell list / recast index for /ma. Same resolution as castcost/icons —
+-- otherwise duplicate English names (e.g. SummonerPact) can return the wrong spell ID.
+local function resolveSpellIndexForMa(spellName)
+    if not spellName then return nil; end
+    local am = getActionsModule();
+    if am and am.GetHorizonSpellForIconResolution then
+        local row = am.GetHorizonSpellForIconResolution(spellName, 'ma');
+        if row then
+            local idx = row.recast_id or row.id;
+            if idx then return idx; end
+        end
+    end
+    return actiondb.GetSpellId(spellName);
+end
+
+-- Fixed ability recast component IDs (Windower recast_id / memory compId) for /pet-style commands.
+-- FindAbilityRecast(abilityId) often fails when no pet is active because slots are cleared/rebound,
+-- but GetAbilityRecastSeconds(timerId) still reads the correct timer (e.g. Release 172).
+-- Source: Windower Resources job_abilities (PetCommand); aligns with castcost abilityLookup where present.
+local PET_COMMAND_TIMER_ID_BY_NAME = {
+    ['fight'] = 100,
+    ['heel'] = 101,
+    ['stay'] = 101,
+    ['leave'] = 101,
+    ['sic'] = 102,
+    ['ready'] = 102,
+    ['snarl'] = 107,
+    ['dismiss'] = 161,
+    ['assault'] = 170,
+    ['retreat'] = 171,
+    ['release'] = 172,
+    ['deploy'] = 207,
+    ['deactivate'] = 208,
+    ['retrieve'] = 209,
+    ["avatar's favor"] = 176,
+    ['steady wing'] = 70,
+    ['smiting breath'] = 238,
+    ['restoring breath'] = 239,
+};
+
+local function getPetCommandTimerIdByName(commandName)
+    local n = normalizeCommandName(commandName);
+    if not n then return nil; end
+    local tid = PET_COMMAND_TIMER_ID_BY_NAME[n];
+    if tid then return tid; end
+    if n:match('maneuver$') then
+        return 210;
+    end
+    return nil;
+end
+
+-- Fallback: read timer component id from Ashita ability resource when available
+-- (covers gaps / Horizon-specific rows the static table doesn't list).
+local function getRecastTimerIdFromAbilityResource(commandName)
+    local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then return nil; end
+    local aid = actiondb.GetAbilityId(commandName);
+    if not aid then return nil; end
+    local ab = resMgr:GetAbilityById(aid);
+    if not ab then return nil; end
+    local tid = ab.TimerId or ab.RecastTimerId or ab.timer_id or ab.RecastId;
+    if type(tid) == 'number' and tid > 0 then
+        return tid;
+    end
+    return nil;
+end
+
+-- Resolve recast using shared BP timer, static pet-command timer id, or resource timer id
+-- BEFORE falling back to ability-id scan. Returns (remaining, formattedText) or (nil, nil).
+local function getRemainingForPetLikeAbilityName(commandName)
+    local bp = GetBloodPactTimerId(commandName);
+    if bp then
+        local r = M.GetPetCommandRecast(bp);
+        return r, M.FormatRecast(r);
+    end
+    local tid = getPetCommandTimerIdByName(commandName);
+    if not tid then
+        tid = getRecastTimerIdFromAbilityResource(commandName);
+    end
+    if tid then
+        local r = M.GetPetCommandRecast(tid);
+        return r, M.FormatRecast(r);
+    end
+    return nil, nil;
 end
 
 -- Get pet command recast by timer ID
@@ -171,6 +274,154 @@ function M.GetActionRecast(actionType, spellId, abilityId, itemId)
     return remaining, M.FormatRecast(remaining);
 end
 
+-- ============================================
+-- Macro Recast Source Sniffing
+-- ============================================
+--
+-- Macros and palette rows can fire /ma, /pet, or /ja lines. To display a meaningful cooldown
+-- timer on the slot we need to figure out WHICH action's recast applies. There are two paths:
+--   1. Explicit override: actionData.recastSourceType set by the macro editor.
+--   2. Implicit sniff: scan the first few lines of macroText for /ma, /pet, /ja and use that
+--      as the recast source.
+--
+-- For palette rows whose actionType is ma / pet / ja (not the literal "macro" type), we sniff
+-- in TYPE-SPECIFIC mode so a leading /ma line in a Pet Command row doesn't replace the shared
+-- BP Ward/Rage timer with a spell recast, and a leading /pet line in a Spell row doesn't steal
+-- Carbuncle's spell timer.
+
+local function trimRecastStr(s)
+    if not s then return nil; end
+    s = tostring(s):gsub('^%s+', ''):gsub('%s+$', '');
+    return (s ~= '' and s) or nil;
+end
+
+local function extractNameAfterMacroCommand(line, commandToken)
+    if not line or not commandToken then return nil; end
+    local quoted = line:match('^' .. commandToken .. '%s+"([^"]+)"');
+    if quoted then return trimRecastStr(quoted); end
+    local unquoted = line:match('^' .. commandToken .. '%s+([^<\r\n]+)');
+    if unquoted then
+        unquoted = unquoted:gsub('%s+<.*$', '');
+        return trimRecastStr(unquoted);
+    end
+    return nil;
+end
+
+-- Generic macro: first /ma, /pet, or /ja per line (order within each line: ma → pet → ja).
+local function sniffRecastTargetFromMacroText(macroText)
+    macroText = trimRecastStr(macroText);
+    if not macroText then return nil, nil; end
+
+    local inspectedLines = 0;
+    for line in macroText:gmatch('[^\r\n]+') do
+        inspectedLines = inspectedLines + 1;
+        if inspectedLines > 6 then break; end
+
+        local l = trimRecastStr(line);
+        if l then
+            local spellName = extractNameAfterMacroCommand(l, '/ma') or extractNameAfterMacroCommand(l, '/magic');
+            if spellName then
+                return 'ma', spellName;
+            end
+
+            local petName = extractNameAfterMacroCommand(l, '/pet');
+            if petName then
+                return 'pet', petName;
+            end
+
+            local jaName = extractNameAfterMacroCommand(l, '/ja');
+            if jaName then
+                if petregistry.GetBloodPactByName and petregistry.GetBloodPactByName(jaName) then
+                    return 'pet', jaName;
+                end
+                return 'ja', jaName;
+            end
+        end
+    end
+    return nil, nil;
+end
+
+-- Spell (ma) palette rows: only /ma and /magic — ignores leading /pet so summon/buff lines
+-- do not steal Carbuncle's spell timer.
+local function sniffRecastTargetFromMaMacroText(macroText)
+    macroText = trimRecastStr(macroText);
+    if not macroText then return nil, nil; end
+
+    local inspectedLines = 0;
+    for line in macroText:gmatch('[^\r\n]+') do
+        inspectedLines = inspectedLines + 1;
+        if inspectedLines > 8 then break; end
+
+        local l = trimRecastStr(line);
+        if l then
+            local spellName = extractNameAfterMacroCommand(l, '/ma') or extractNameAfterMacroCommand(l, '/magic');
+            if spellName then
+                return 'ma', spellName;
+            end
+        end
+    end
+    return nil, nil;
+end
+
+-- Pet Command palette rows: only /pet and blood-pact /ja — ignores leading /ma so BP Ward/Rage
+-- shared timers (173/174) are not replaced by a spell recast.
+local function sniffRecastTargetFromPetMacroText(macroText)
+    macroText = trimRecastStr(macroText);
+    if not macroText then return nil, nil; end
+
+    local inspectedLines = 0;
+    for line in macroText:gmatch('[^\r\n]+') do
+        inspectedLines = inspectedLines + 1;
+        if inspectedLines > 8 then break; end
+
+        local l = trimRecastStr(line);
+        if l then
+            local petName = extractNameAfterMacroCommand(l, '/pet');
+            if petName then
+                return 'pet', petName;
+            end
+
+            local jaName = extractNameAfterMacroCommand(l, '/ja');
+            if jaName and petregistry.GetBloodPactByName and petregistry.GetBloodPactByName(jaName) then
+                return 'pet', jaName;
+            end
+        end
+    end
+    return nil, nil;
+end
+
+-- Job ability (ja) rows: /ja only — blood pacts map to pet timers, else ability recast.
+local function sniffRecastTargetFromJaMacroText(macroText)
+    macroText = trimRecastStr(macroText);
+    if not macroText then return nil, nil; end
+
+    local inspectedLines = 0;
+    for line in macroText:gmatch('[^\r\n]+') do
+        inspectedLines = inspectedLines + 1;
+        if inspectedLines > 8 then break; end
+
+        local l = trimRecastStr(line);
+        if l then
+            local jaName = extractNameAfterMacroCommand(l, '/ja');
+            if jaName then
+                if petregistry.GetBloodPactByName and petregistry.GetBloodPactByName(jaName) then
+                    return 'pet', jaName;
+                end
+                return 'ja', jaName;
+            end
+        end
+    end
+    return nil, nil;
+end
+
+local function macroHasRecastSourceOverride(actionData)
+    local t = actionData.recastSourceType;
+    if not t or t == '' or t == 'none' then
+        return false;
+    end
+    return true;
+end
+
 -- Get complete cooldown info for an action
 -- This is the main entry point for hotbar/crossbar cooldown display
 -- @param actionData: Table with actionType and action fields (bind or slotData)
@@ -187,16 +438,56 @@ function M.GetCooldownInfo(actionData)
         return cooldownResult;
     end
 
-    -- Check for macro recast source override
-    -- Allows macros to display cooldown from a different action type
-    if actionData.actionType == 'macro' and actionData.recastSourceType then
+    -- Macro: optional explicit recast source (editor override)
+    if actionData.actionType == 'macro' and macroHasRecastSourceOverride(actionData) then
         local recastData = {
             actionType = actionData.recastSourceType,
             action = actionData.recastSourceAction,
             itemId = actionData.recastSourceItemId,
         };
-        -- Safe: recastSourceType can't be 'macro', so no infinite recursion
         return M.GetCooldownInfo(recastData);
+    end
+
+    -- Macro: no override — infer from /ma, /pet, /ja (including job abilities like Divine Seal)
+    if actionData.actionType == 'macro' then
+        local st, name = sniffRecastTargetFromMacroText(actionData.macroText);
+        if st and name then
+            return M.GetCooldownInfo({
+                actionType = st,
+                action = name,
+                itemId = nil,
+            });
+        end
+        cooldownResult.isOnCooldown = false;
+        cooldownResult.recastText = nil;
+        cooldownResult.remaining = 0;
+        cooldownResult.spellId = nil;
+        cooldownResult.abilityId = nil;
+        cooldownResult.itemId = nil;
+        return cooldownResult;
+    end
+
+    -- Pet Command / Magic / Job Ability palette rows (not actionType "macro"):
+    -- Use type-specific sniffing so shared BP Rage/Ward timers are not replaced by a leading /ma line,
+    -- and Carbuncle (ma row) is not replaced by a leading /pet line.
+    local mt = actionData.macroText;
+    if mt and mt ~= '' then
+        if actionData.actionType == 'pet' then
+            local st, name = sniffRecastTargetFromPetMacroText(mt);
+            if st and name then
+                return M.GetCooldownInfo({ actionType = st, action = name, itemId = nil });
+            end
+        elseif actionData.actionType == 'ma' then
+            local st, name = sniffRecastTargetFromMaMacroText(mt);
+            if st and name then
+                return M.GetCooldownInfo({ actionType = st, action = name, itemId = nil });
+            end
+        elseif actionData.actionType == 'ja' then
+            local st, name = sniffRecastTargetFromJaMacroText(mt);
+            if st and name then
+                return M.GetCooldownInfo({ actionType = st, action = name, itemId = nil });
+            end
+        end
     end
 
     -- Look up action IDs based on action type
@@ -207,23 +498,29 @@ function M.GetCooldownInfo(actionData)
     local recastText = nil;
 
     if actionData.actionType == 'ma' then
-        spellId = actiondb.GetSpellId(actionData.action);
+        spellId = resolveSpellIndexForMa(actionData.action);
         remaining, recastText = M.GetActionRecast(actionData.actionType, spellId, nil, nil);
     elseif actionData.actionType == 'pet' then
-        -- Pet commands (Blood Pacts, Ready, etc.) - check for known timer IDs
-        local bpTimerId = GetBloodPactTimerId(actionData.action);
-        if bpTimerId then
-            -- Blood Pact - use timer ID directly
-            remaining = M.GetPetCommandRecast(bpTimerId);
-            recastText = M.FormatRecast(remaining);
+        -- Pet commands (Blood Pacts, pet-command IDs, resource-derived timer IDs) before ability scan.
+        local rPet, rtPet = getRemainingForPetLikeAbilityName(actionData.action);
+        if rPet ~= nil then
+            remaining = rPet;
+            recastText = rtPet;
         else
-            -- Other pet commands - try ability lookup
             abilityId = actiondb.GetAbilityId(actionData.action);
             remaining, recastText = M.GetActionRecast(actionData.actionType, nil, abilityId, nil);
         end
     elseif actionData.actionType == 'ja' then
-        abilityId = actiondb.GetAbilityId(actionData.action);
-        remaining, recastText = M.GetActionRecast(actionData.actionType, nil, abilityId, nil);
+        -- Universal 2hr: route to the player's current job-specific 2hr ability when applicable.
+        local jaActionName = universalTwoHour.ResolveJaActionName(actionData.action) or actionData.action;
+        local rJa, rtJa = getRemainingForPetLikeAbilityName(jaActionName);
+        if rJa ~= nil then
+            remaining = rJa;
+            recastText = rtJa;
+        else
+            abilityId = actiondb.GetAbilityId(jaActionName);
+            remaining, recastText = M.GetActionRecast(actionData.actionType, nil, abilityId, nil);
+        end
     elseif actionData.actionType == 'item' or actionData.actionType == 'equip' then
         -- itemId should already be stored in the action data
         itemId = actionData.itemId;


### PR DESCRIPTION
… parser

What changed
- actions.lua: BloodPactRage/BloodPactWard handling. GetBloodPactByName integration for icon resolution. Horizon-aware resolveSpellIndexForMa. spellsByLowerNameLookup lazy multimap for O(1) name lookups. noIconCache extended key for blood pact slots. LoadItemIconByName via actiondb.GetItemId. Effective level reads party:GetMemberMainJobLevel(0) / GetMemberSubJobLevel(0) (post-Level-Sync) instead of raw player:GetMainJobLevel() so synced-down players see correct availability. NotifySlotExecutionEffects skips Universal 2 Hour arming shimmer while the bind is on cooldown.
- recast.lua: Blood pact shared timer (173/174) name-based lookup. Macro text sniffers: sniffRecastTargetFromMaMacroText, sniffRecastTargetFromPetMacroText, sniffRecastTargetFromJaMacroText. BuildCommandString uses resolved ability names and per-job target tokens. Lazy recast architecture preserved (no periodic M.Update() reintroduced).
- macroparse.lua: New file. Multi-line macro parser. Priority order: /ws,/ma,/pet -> /ja ->
  /item,/equip -> other. (Originally these icons were used to replace text, but now that GDIFonts aren't used might not be necessary) Returns primary action type + JA badge for corner rendering. Drives skillchain/MB routing for macros, recast sniffing, and crossbar SMN blood pact dispatch.

Why
- Hotbar and macro layers resolve correct icons, names, and cooldowns for blood pact abilities. Macro parser enables skillchain prediction and Magic Burst highlight routing for /pet and /ma primary macros on the crossbar, matching the keyboard hotbar's existing behavior.