### PR TITLE
Magic Burst highlight: MB window state, slot border, crossbar wiring,…

### DIFF
--- a/XIUI/config/hotbar.lua
+++ b/XIUI/config/hotbar.lua
@@ -1,10 +1,13 @@
---[[
-* XIUI Config Menu - Hotbar Settings
-* Contains settings and color settings for Hotbar with per-bar customization
+﻿--[[
+* XIUI Config Menu - Hotbar (keyboard bars) settings
+* Controller crossbar UI lives in config/crossbar_settings.lua (sibling module).
+* Contains settings and color settings for Hotbar with per-bar customization.
 ]]--
 
 require('common');
 require('handlers.helpers');
+local ffi = require('ffi');
+local TextureManager = require('libs.texturemanager');
 local components = require('config.components');
 local statusHandler = require('handlers.statushandler');
 local imgui = require('imgui');
@@ -14,13 +17,14 @@ local actions = require('modules.hotbar.actions');
 local jobs = require('libs.jobs');
 local macropalette = require('modules.hotbar.macropalette');
 local playerdata = require('modules.hotbar.playerdata');
-local controller = require('modules.hotbar.controller');
 local macrosLib = require('libs.ffxi.macros');
 local palette = require('modules.hotbar.palette');
 local migrationWizard = require('config.migration');
 local paletteManager = require('config.palettemanager');
+local petAllowlist = require('modules.hotbar.pet_palette_allowlist');
 
 local M = {};
+
 
 -- Expose migration wizard for external access (used by config.lua to draw the popup)
 M.migrationWizard = migrationWizard;
@@ -38,16 +42,37 @@ local jobSpecificConfirmState = {
     isCrossbar = false,
 };
 
--- Button detection wizard state
-local buttonDetectionState = {
-    active = false,
-    progress = 0,
-};
 
 -- ============================================
 -- Unified Palette Modal System
 -- Shared between hotbar and crossbar palettes
 -- ============================================
+
+-- Persists the last-selected crossbar create job/storageSubjob across popup opens.
+-- Resets to live job/sj only when the character's job or subjob changes.
+local xbCreatePersisted = {
+    jobId = nil,
+    storageSubjob = nil,
+    lastSeenJobId = nil,
+    lastSeenSubjobId = nil,
+};
+
+local function GetOrResetXbCreateDefaults()
+    local liveJob = data.jobId or 1;
+    local liveSj  = data.subjobId or 0;
+    if xbCreatePersisted.lastSeenJobId ~= liveJob or xbCreatePersisted.lastSeenSubjobId ~= liveSj then
+        xbCreatePersisted.jobId          = liveJob;
+        xbCreatePersisted.storageSubjob  = liveSj;
+        xbCreatePersisted.lastSeenJobId  = liveJob;
+        xbCreatePersisted.lastSeenSubjobId = liveSj;
+    end
+    return xbCreatePersisted.jobId, xbCreatePersisted.storageSubjob;
+end
+
+-- One-shot open flags (see palettemanager.lua for rationale)
+local xbHotbarCreatePopupPending = false;
+local palettePopupPendingId      = nil;
+local jobSpecificPopupPending    = false;
 
 -- Single modal state for all palette operations
 local paletteModal = {
@@ -57,6 +82,9 @@ local paletteModal = {
     paletteName = nil,    -- For rename: current name
     inputBuffer = { '' },
     errorMessage = nil,
+    -- Job crossbar create (non-modal popup): storage tier 0 = Shared [J], else Subjob [SJ] id
+    crossbarCreateJobId = nil,
+    crossbarCreateStorageSubjob = nil,
 };
 
 -- Helper: Open palette create modal
@@ -67,6 +95,14 @@ local function OpenPaletteCreateModal(paletteType)
     paletteModal.paletteName = nil;
     paletteModal.inputBuffer[1] = '';
     paletteModal.errorMessage = nil;
+    if paletteType == 'crossbar' then
+        local j, s = GetOrResetXbCreateDefaults();
+        paletteModal.crossbarCreateJobId = j;
+        paletteModal.crossbarCreateStorageSubjob = s;
+    else
+        paletteModal.crossbarCreateJobId = nil;
+        paletteModal.crossbarCreateStorageSubjob = nil;
+    end
 end
 
 -- Helper: Open palette rename modal
@@ -87,15 +123,21 @@ local function ClosePaletteModal()
     paletteModal.paletteName = nil;
     paletteModal.inputBuffer[1] = '';
     paletteModal.errorMessage = nil;
+    paletteModal.crossbarCreateJobId = nil;
+    paletteModal.crossbarCreateStorageSubjob = nil;
+    xbHotbarCreatePopupPending = false;
+    palettePopupPendingId      = nil;
 end
 
 -- Helper function to draw the job-specific confirmation popup
 local function DrawJobSpecificConfirmPopup()
-    if jobSpecificConfirmState.showPopup then
+    if jobSpecificConfirmState.showPopup and not jobSpecificPopupPending then
         imgui.OpenPopup('Confirm Action Storage Change##jobSpecificConfirm');
+        jobSpecificConfirmState.showPopup = false;
+        jobSpecificPopupPending = true;
     end
 
-    if imgui.BeginPopupModal('Confirm Action Storage Change##jobSpecificConfirm', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if imgui.BeginPopup('Confirm Action Storage Change##jobSpecificConfirm', ImGuiWindowFlags_AlwaysAutoResize) then
         local targetName;
         if jobSpecificConfirmState.isCrossbar then
             targetName = jobSpecificConfirmState.targetBarIndex and ('Crossbar ' .. jobSpecificConfirmState.targetBarIndex) or 'Crossbar';
@@ -159,28 +201,172 @@ local function DrawJobSpecificConfirmPopup()
         end
 
         imgui.EndPopup();
+    else
+        -- Dismissed by clicking outside
+        jobSpecificPopupPending = false;
+        jobSpecificConfirmState.showPopup = false;
     end
 end
 
 -- Unified palette modal - handles create/rename for both hotbar and crossbar
 local function DrawPaletteModal()
     if not paletteModal.isOpen then
+        xbHotbarCreatePopupPending = false;
+        palettePopupPendingId      = nil;
+        return;
+    end
+
+    -- Job crossbar create: non-modal popup (same idea as Palette Manager Copy To â€” no fullscreen dim).
+    if paletteModal.mode == 'create' and paletteModal.paletteType == 'crossbar' then
+        if paletteModal.crossbarCreateJobId == nil then
+            paletteModal.crossbarCreateJobId = data.jobId or 1;
+        end
+        if paletteModal.crossbarCreateStorageSubjob == nil then
+            paletteModal.crossbarCreateStorageSubjob = data.subjobId or 0;
+        end
+        local cj = paletteModal.crossbarCreateJobId;
+        if cj < 1 then cj = 1; end
+        if cj > 22 then cj = 22; end
+        paletteModal.crossbarCreateJobId = cj;
+
+        if not xbHotbarCreatePopupPending then
+            imgui.SetNextWindowSize({ 560, 0 }, ImGuiCond_Always);
+            imgui.OpenPopup('Crossbar Create Palette##paletteModalXbJobNm');
+            xbHotbarCreatePopupPending = true;
+        end
+        if imgui.BeginPopup('Crossbar Create Palette##paletteModalXbJobNm', ImGuiWindowFlags_AlwaysAutoResize) then
+            imgui.TextWrapped('Create a new palette for Job [J] / Subjob [SJ] crossbar storage.');
+            imgui.Spacing();
+
+            local storSj = paletteModal.crossbarCreateStorageSubjob or 0;
+            if storSj ~= 0 then
+                local usingFallback = palette.IsUsingFallback(cj, storSj, 'crossbar');
+                if usingFallback then
+                    local jobName = jobs[cj] or ('Job ' .. cj);
+                    local subjobName = jobs[storSj] or ('Job ' .. storSj);
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'Warning: Creating this palette will stop');
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'using shared palettes for ' .. jobName .. '/' .. subjobName .. '.');
+                    imgui.Spacing();
+                end
+            end
+
+            imgui.Text('Job:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            if imgui.BeginCombo('##xbCreateJobCfg', jobs[cj] or ('Job ' .. cj)) then
+                for jobId = 1, 22 do
+                    local isSelected = (jobId == cj);
+                    if imgui.Selectable((jobs[jobId] or ('Job ' .. jobId)) .. '##xbCj' .. jobId, isSelected) then
+                        paletteModal.crossbarCreateJobId = jobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.SameLine();
+            imgui.Text('Subjob storage:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            local subLabel = storSj == 0 and 'Shared' or (jobs[storSj] or ('Job ' .. storSj));
+            if imgui.BeginCombo('##xbCreateSubCfg', subLabel) then
+                local sharedSel = (storSj == 0);
+                if imgui.Selectable('Shared##xbCs0', sharedSel) then
+                    paletteModal.crossbarCreateStorageSubjob = 0;
+                end
+                if sharedSel then
+                    imgui.SetItemDefaultFocus();
+                end
+                for subjobId = 1, 22 do
+                    local isSelected = (subjobId == storSj);
+                    if imgui.Selectable((jobs[subjobId] or ('Job ' .. subjobId)) .. '##xbCs' .. subjobId, isSelected) then
+                        paletteModal.crossbarCreateStorageSubjob = subjobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.Spacing();
+            imgui.Text('Palette name:');
+            imgui.PushItemWidth(220);
+            local enterPressed = imgui.InputText('##paletteModalXbCreateInput', paletteModal.inputBuffer, 32, ImGuiInputTextFlags_EnterReturnsTrue);
+            imgui.PopItemWidth();
+
+            if paletteModal.errorMessage then
+                imgui.Spacing();
+                imgui.TextColored({ 1.0, 0.4, 0.4, 1.0 }, paletteModal.errorMessage);
+            end
+
+            imgui.Spacing();
+            local newName = paletteModal.inputBuffer[1];
+            local canCreate = newName and newName ~= '';
+            if not canCreate then
+                imgui.BeginDisabled();
+            end
+            if imgui.Button('Create##paletteModalXbCreateOk', { 88, 0 }) or (enterPressed and canCreate) then
+                if canCreate then
+                    storSj = paletteModal.crossbarCreateStorageSubjob or 0;
+                    local createJob = paletteModal.crossbarCreateJobId;
+                    local success, err = palette.CreateCrossbarPalette(newName, createJob, storSj);
+                    if success then
+                        xbCreatePersisted.jobId         = createJob;
+                        xbCreatePersisted.storageSubjob = storSj;
+                        ClosePaletteModal();
+                        imgui.CloseCurrentPopup();
+                    else
+                        paletteModal.errorMessage = err or 'Failed to create palette';
+                    end
+                else
+                    paletteModal.errorMessage = 'Name cannot be empty';
+                end
+            end
+            if not canCreate then
+                imgui.EndDisabled();
+            end
+
+            imgui.SameLine();
+            if imgui.Button('Cancel##paletteModalXbCreateCancel', { 88, 0 }) then
+                ClosePaletteModal();
+                imgui.CloseCurrentPopup();
+            end
+
+            imgui.EndPopup();
+        else
+            xbHotbarCreatePopupPending = false;
+            ClosePaletteModal();
+        end
         return;
     end
 
     -- Determine popup title based on mode and type
-    local typeLabel = paletteModal.paletteType == 'crossbar' and 'Crossbar ' or '';
+    local typeLabel = '';
+    if paletteModal.paletteType == 'crossbar_universal' then
+        typeLabel = 'Global Crossbar ';
+    elseif paletteModal.paletteType == 'crossbar' then
+        typeLabel = 'Crossbar ';
+    end
     local popupId = paletteModal.mode == 'create'
         and (typeLabel .. 'Create Palette##paletteModal')
         or (typeLabel .. 'Rename Palette##paletteModal');
 
-    imgui.OpenPopup(popupId);
+    if palettePopupPendingId ~= popupId then
+        imgui.SetNextWindowSize({ 320, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup(popupId);
+        palettePopupPendingId = popupId;
+    end
 
-    if imgui.BeginPopupModal(popupId, nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
         -- Warning when creating will break away from shared palettes
         local jobId = data.jobId or 1;
         local subjobId = data.subjobId or 0;
-        if paletteModal.mode == 'create' and subjobId ~= 0 then
+        if paletteModal.mode == 'create' and subjobId ~= 0 and paletteModal.paletteType == 'hotbar' then
             local usingFallback = palette.IsUsingFallback(jobId, subjobId, paletteModal.paletteType);
             if usingFallback then
                 local jobName = jobs[jobId] or ('Job ' .. jobId);
@@ -234,19 +420,19 @@ local function DrawPaletteModal()
 
                 if isCreateMode then
                     -- Create palette
-                    if paletteModal.paletteType == 'crossbar' then
-                        success, err = palette.CreateCrossbarPalette(newName, jobId, subjobId);
-                    else
+                    if paletteModal.paletteType == 'crossbar_universal' then
+                        success, err = palette.CreateUniversalCrossbarPalette(newName);
+                    elseif paletteModal.paletteType == 'hotbar' then
                         success, err = palette.CreatePalette(1, newName, jobId, subjobId);
-                        if success then
-                            palette.SetActivePalette(1, newName);
-                        end
                     end
                 else
                     -- Rename palette
                     local oldName = paletteModal.paletteName;
-                    if paletteModal.paletteType == 'crossbar' then
-                        success, err = palette.RenameCrossbarPalette(oldName, newName, jobId, subjobId);
+                    if paletteModal.paletteType == 'crossbar_universal' then
+                        success, err = palette.RenameUniversalCrossbarPalette(oldName, newName);
+                    elseif paletteModal.paletteType == 'crossbar' then
+                        local renameTier = palette.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, subjobId);
+                        success, err = palette.RenameCrossbarPalette(oldName, newName, jobId, renameTier);
                     else
                         success, err = palette.RenamePalette(1, oldName, newName, jobId, subjobId);
                     end
@@ -275,6 +461,9 @@ local function DrawPaletteModal()
         end
 
         imgui.EndPopup();
+    else
+        -- Dismissed by clicking outside
+        ClosePaletteModal();
     end
 end
 
@@ -382,34 +571,42 @@ local function DrawGlobalPalettesSection()
     -- Ensure at least one palette exists for this job
     palette.EnsureDefaultPaletteExists(jobId, subjobId);
     local availablePalettes = palette.GetAvailablePalettes(1, jobId, subjobId);
+    local cyclePalettes = palette.GetHotbarPaletteNamesInRbCycle(1, jobId, subjobId);
     local currentPalette = palette.GetActivePalette(1);  -- Same for all bars
 
-    -- OPTIMIZED: Cache palette count and index for reuse within this frame
-    local paletteCount = #availablePalettes;
-    local currentPaletteIndex = nil;
-    if currentPalette then
-        for i, name in ipairs(availablePalettes) do
-            if name == currentPalette then
-                currentPaletteIndex = i;
-                break;
-            end
+    -- Index/total for "Active" (RB-cycle) palettes only â€” inactive palettes are omitted from numbering
+    local paletteCount = #cyclePalettes;
+    local cycleIndexByName = {};
+    for i, name in ipairs(cyclePalettes) do
+        cycleIndexByName[name] = i;
+    end
+    local currentPaletteIndex = currentPalette and cycleIndexByName[currentPalette] or nil;
+    local fullPaletteIndex = nil;
+    for i, name in ipairs(availablePalettes) do
+        if name == currentPalette then
+            fullPaletteIndex = i;
+            break;
         end
     end
+    local totalPaletteCount = #availablePalettes;
 
     -- Check if using fallback (shared library) palettes
     local usingFallback = palette.IsUsingFallback(jobId, subjobId, 'hotbar');
 
     -- Ensure active palette is set if we have palettes but none active
-    if paletteCount > 0 and not currentPalette then
-        currentPalette = availablePalettes[1];
-        currentPaletteIndex = 1;
+    if #availablePalettes > 0 and not currentPalette then
+        local pick = cyclePalettes[1] or availablePalettes[1];
+        currentPalette = pick;
+        currentPaletteIndex = cycleIndexByName[pick];
         palette.SetActivePalette(1, currentPalette);
     end
 
     imgui.TextColored(components.TAB_STYLE.gold, 'Palettes');
+    components.PushPaletteManagerButtonStyle();
     if imgui.SmallButton('Palette Manager##hotbar') then
         paletteManager.Open();
     end
+    components.PopPaletteManagerButtonStyle();
     if usingFallback then
         imgui.SameLine();
         imgui.TextColored({0.4, 0.8, 1.0, 1.0}, '(Shared Library)');
@@ -420,22 +617,24 @@ local function DrawGlobalPalettesSection()
     -- Header with count
     imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Palettes:');
     imgui.SameLine();
-    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' palette(s)');
-    imgui.ShowHelp('Create named palettes to quickly switch between different hotbar configurations.\nPalettes are GLOBAL - switching changes all 6 hotbars at once.\nUse keybind cycling or /xiui palette <name> to switch.');
+    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' in cycle');
+    imgui.ShowHelp('Create named palettes to quickly switch between different hotbar configurations.\nPalettes are GLOBAL - switching changes all 6 hotbars at once.\n"Inactive" in Palette Manager is excluded from RB/key cycling and from this count.\nUse keybind cycling or /xiui palette <name> to switch.');
 
     -- Current palette selector with inline buttons
     -- Get display name with number prefix for the closed dropdown
     local currentDisplayName = currentPalette or 'Select palette';
     if currentPalette and currentPaletteIndex then
         currentDisplayName = currentPaletteIndex .. '. ' .. currentPalette;
+    elseif currentPalette then
+        currentDisplayName = currentPalette .. ' (inactive)';
     end
 
     imgui.SetNextItemWidth(150);
     if imgui.BeginCombo('##globalPalette', currentDisplayName) then
         for i, paletteName in ipairs(availablePalettes) do
             local isSelected = (paletteName == currentPalette);
-            -- Show number prefix for all palettes
-            local displayName = i .. '. ' .. paletteName;
+            local cycIdx = cycleIndexByName[paletteName];
+            local displayName = (cycIdx and (cycIdx .. '. ') or 'â€“ ') .. paletteName;
             if imgui.Selectable(displayName .. '##globalPal', isSelected) then
                 palette.SetActivePalette(1, paletteName);  -- Sets global palette
             end
@@ -464,8 +663,7 @@ local function DrawGlobalPalettesSection()
     imgui.PopStyleColor(2);
 
     -- Delete button (only if more than 1 palette exists - can't delete the last one)
-    -- OPTIMIZED: Using cached paletteCount instead of calling GetPaletteCount again
-    if currentPalette and paletteCount > 1 then
+    if currentPalette and totalPaletteCount > 1 then
         imgui.SameLine();
         imgui.PushStyleColor(ImGuiCol_Button, {0.6, 0.2, 0.2, 1.0});
         imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.8, 0.3, 0.3, 1.0});
@@ -480,16 +678,15 @@ local function DrawGlobalPalettesSection()
         imgui.PopStyleColor(2);
     end
 
-    -- Arrow key reordering (for palettes with multiple items)
-    if currentPalette and paletteCount > 1 then
+    -- Arrow key reordering (full palette list order â€” not cycle-only)
+    if currentPalette and totalPaletteCount > 1 then
         imgui.SameLine();
         imgui.TextColored({0.5, 0.5, 0.5, 1.0}, '|');
         imgui.SameLine();
 
         -- Up arrow button
-        -- OPTIMIZED: Using cached currentPaletteIndex instead of calling GetPaletteIndex again
-        local canMoveUp = currentPaletteIndex and currentPaletteIndex > 1;
-        local canMoveDown = currentPaletteIndex and currentPaletteIndex < paletteCount;
+        local canMoveUp = fullPaletteIndex and fullPaletteIndex > 1;
+        local canMoveDown = fullPaletteIndex and fullPaletteIndex < totalPaletteCount;
 
         if not canMoveUp then
             imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
@@ -540,169 +737,6 @@ local function DrawGeneralPalettesSection(configKey, barSettings, barIndex)
     imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'Manage palettes in Global tab.');
 end
 
--- ============================================
--- Crossbar Global Palettes UI Section
--- ============================================
-
--- Global crossbar palette error state
-local crossbarGlobalPaletteErrorMessage = nil;
-
--- Draw the global crossbar palettes management section
--- Crossbar palettes are GLOBAL - one palette switch changes all combo modes
-local function DrawCrossbarGlobalPalettesSection()
-    local crossbarSettings = gConfig.hotbarCrossbar;
-    if not crossbarSettings then
-        return;
-    end
-
-    local jobId = data.jobId or 1;
-    local subjobId = data.subjobId or 0;
-
-    -- Ensure at least one palette exists for this job
-    palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
-    local availablePalettes = palette.GetCrossbarAvailablePalettes(jobId, subjobId);
-    local currentPalette = palette.GetActivePaletteForCombo('L2');  -- Global for all combos
-
-    -- OPTIMIZED: Cache palette count and index for reuse within this frame
-    local paletteCount = #availablePalettes;
-    local currentPaletteIndex = nil;
-    if currentPalette then
-        for i, name in ipairs(availablePalettes) do
-            if name == currentPalette then
-                currentPaletteIndex = i;
-                break;
-            end
-        end
-    end
-
-    -- Check if using fallback (shared library) palettes
-    local usingFallback = palette.IsUsingFallback(jobId, subjobId, 'crossbar');
-
-    -- Ensure active palette is set if we have palettes but none active
-    if paletteCount > 0 and not currentPalette then
-        currentPalette = availablePalettes[1];
-        currentPaletteIndex = 1;
-        palette.SetActivePaletteForCombo('L2', currentPalette);
-    end
-
-    imgui.TextColored(components.TAB_STYLE.gold, 'Crossbar Palettes');
-    if imgui.SmallButton('Palette Manager##crossbar') then
-        paletteManager.Open();
-    end
-    if usingFallback then
-        imgui.SameLine();
-        imgui.TextColored({0.4, 0.8, 1.0, 1.0}, '(Shared Library)');
-        imgui.ShowHelp('These palettes are from your Shared Library.\nOpen Palette Manager to create subjob-specific palettes.');
-    end
-    imgui.Spacing();
-
-    -- Header with count
-    imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Palettes:');
-    imgui.SameLine();
-    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' palette(s)');
-    imgui.ShowHelp('Create named palettes to quickly switch between crossbar configurations.\nPalettes are GLOBAL - switching changes all combo modes (L2, R2, L2+R2, etc.) at once.');
-
-    -- Current palette selector with inline buttons
-    -- Get display name with number prefix for the closed dropdown
-    local currentDisplayName = currentPalette or 'Select palette';
-    if currentPalette and currentPaletteIndex then
-        currentDisplayName = currentPaletteIndex .. '. ' .. currentPalette;
-    end
-
-    imgui.SetNextItemWidth(150);
-    if imgui.BeginCombo('##crossbarGlobalPalette', currentDisplayName) then
-        for i, paletteName in ipairs(availablePalettes) do
-            local isSelected = (paletteName == currentPalette);
-            -- Show number prefix for all palettes
-            local displayName = i .. '. ' .. paletteName;
-            if imgui.Selectable(displayName .. '##cbGlobalPal' .. i, isSelected) then
-                palette.SetActivePaletteForCombo('L2', paletteName);
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-
-    -- Rename button (for any palette)
-    if currentPalette then
-        imgui.SameLine();
-        if imgui.Button('Rename##cbGlobalPalette', {55, 0}) then
-            OpenPaletteRenameModal('crossbar', currentPalette);
-        end
-    end
-
-    -- New button (always visible, green)
-    imgui.SameLine();
-    imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.5, 0.2, 1.0});
-    imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.3, 0.6, 0.3, 1.0});
-    if imgui.Button('New##cbGlobalPalette', {40, 0}) then
-        OpenPaletteCreateModal('crossbar');
-    end
-    imgui.PopStyleColor(2);
-
-    -- Delete button (only if more than 1 palette exists - can't delete the last one)
-    -- OPTIMIZED: Using cached paletteCount instead of calling GetCrossbarPaletteCount again
-    if currentPalette and paletteCount > 1 then
-        imgui.SameLine();
-        imgui.PushStyleColor(ImGuiCol_Button, {0.6, 0.2, 0.2, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.8, 0.3, 0.3, 1.0});
-        if imgui.Button('Delete##cbGlobalPalette', {50, 0}) then
-            local success, err = palette.DeleteCrossbarPalette(currentPalette, jobId, subjobId);
-            if not success then
-                crossbarGlobalPaletteErrorMessage = err or 'Failed to delete palette';
-            else
-                crossbarGlobalPaletteErrorMessage = nil;
-            end
-        end
-        imgui.PopStyleColor(2);
-    end
-
-    -- Arrow key reordering (for palettes with multiple items)
-    if currentPalette and paletteCount > 1 then
-        imgui.SameLine();
-        imgui.TextColored({0.5, 0.5, 0.5, 1.0}, '|');
-        imgui.SameLine();
-
-        -- OPTIMIZED: Using cached currentPaletteIndex instead of recalculating
-        local canMoveUp = currentPaletteIndex and currentPaletteIndex > 1;
-        local canMoveDown = currentPaletteIndex and currentPaletteIndex < paletteCount;
-
-        if not canMoveUp then
-            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
-        end
-        if imgui.Button('^##cbGlobalPaletteUp', {20, 0}) and canMoveUp then
-            palette.MoveCrossbarPalette(currentPalette, -1, jobId, subjobId);
-        end
-        if not canMoveUp then
-            imgui.PopStyleColor(3);
-        end
-
-        imgui.SameLine();
-
-        if not canMoveDown then
-            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
-        end
-        if imgui.Button('v##cbGlobalPaletteDown', {20, 0}) and canMoveDown then
-            palette.MoveCrossbarPalette(currentPalette, 1, jobId, subjobId);
-        end
-        if not canMoveDown then
-            imgui.PopStyleColor(3);
-        end
-    end
-
-    -- Show error message (for delete failures)
-    if crossbarGlobalPaletteErrorMessage then
-        imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
-    end
-
-    imgui.Spacing();
-end
 
 -- Keybind editor modal state
 local keybindModal = {
@@ -1528,11 +1562,8 @@ local function DrawVisualSettingsContent(settings, configKey)
         components.DrawPartySliderInt(settings, 'Slot X Padding##' .. configKey, 'slotXPadding', 0, 32, '%d', nil, 8);
         imgui.ShowHelp('Horizontal gap between slots.');
 
-        -- Slot Y Padding slider removed: each hotbar is now positioned
-        -- independently, so bar-to-bar spacing is handled by drag-positioning.
-        -- The setting still exists on the data side and controls the row gap
-        -- inside multi-row bars; we keep the saved value but hide the slider
-        -- to avoid misleading users.
+        components.DrawPartySliderInt(settings, 'Slot Y Padding##' .. configKey, 'slotYPadding', 0, 32, '%d', nil, 6);
+        imgui.ShowHelp('Vertical gap between rows.');
 
         -- Show Hotbar Number with inline offsets
         components.DrawPartyCheckbox(settings, 'Show Hotbar Number##' .. configKey, 'showHotbarNumber');
@@ -1572,7 +1603,7 @@ local function DrawVisualSettingsContent(settings, configKey)
         end
         imgui.ShowHelp('Display item quantity on item slots. Choose anchor position and fine-tune with X/Y offsets.');
 
-        -- Show full-stack count above the item quantity (only counts complete stacks)
+        -- 1.8.0 addition: full-stack count above the item quantity (only counts complete stacks)
         components.DrawPartyCheckbox(settings, 'Show Stack Quantity##' .. configKey, 'showStackQuantity');
         imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
 
@@ -1758,21 +1789,34 @@ local function DrawBarVisualSettings(configKey, barLabel)
         end
         if imgui.Button(petAware and 'Enabled##pet' .. configKey or 'Disabled##pet' .. configKey, {100, 0}) then
             barSettings.petAware = not petAware;
+            if not barSettings.petAware then
+                barSettings.petPalettePetKeys = nil;
+            end
             SaveSettingsOnly();
         end
         imgui.PopStyleColor(3);
-        imgui.ShowHelp('Pet Palettes: Each summoned pet can have its own hotbar configuration.\nSMN: Per-avatar palettes (Ifrit, Shiva, etc.)\nDRG: Wyvern palette\nBST: Jug pet / Charm palettes\nPUP: Automaton palette\n\nClick to toggle.');
+        imgui.ShowHelp('Pet Palettes: Each pet can have its own hotbar configuration.\nSMN: Per-avatar and per-elemental (spirit) palettes (Ifrit, Fire Spirit, etc.)\nDRG: Wyvern palette\nBST: Jug pet / Charm palettes\nPUP: Automaton palette\n\nClick to toggle.');
 
-        -- Show indicator checkbox (only visible when petAware is enabled)
+        -- Show indicator + pet allowlist (only when petAware is enabled)
         if petAware then
-            imgui.SameLine();
-            imgui.SetCursorPosX(imgui.GetCursorPosX() + 10);
+            imgui.Dummy({ 0, 4 });
             local showIndicator = { barSettings.showPetIndicator ~= false };
             if imgui.Checkbox('Show Indicator##' .. configKey, showIndicator) then
                 barSettings.showPetIndicator = showIndicator[1];
                 SaveSettingsOnly();
             end
             imgui.ShowHelp('Show a small dot indicator next to the bar number when pet palettes are active.');
+            local popupId = 'petallow_hb_' .. configKey;
+            if imgui.SmallButton('Petsâ€¦##' .. popupId) then
+                imgui.OpenPopup(popupId);
+            end
+            imgui.ShowHelp('Optional: limit which pet types use a separate layout (Avatars, Elementals, Beasts, Wyvern, Puppet). Others use your normal job bar.');
+            if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
+                petAllowlist.DrawEditorInPopup(barSettings, data.jobId or 1, SaveSettingsOnly, function()
+                    data.InvalidateStorageKeyCache();
+                end);
+                imgui.EndPopup();
+            end
         end
     end
 
@@ -1824,736 +1868,29 @@ local function DrawBarVisualSettings(configKey, barLabel)
     end
 end
 
--- ============================================
--- Crossbar Settings Functions
--- ============================================
 
--- Helper: Get or initialize per-crossbar settings
--- Helper: Get per-combo-mode settings (from comboModeSettings)
--- NOTE: Only petAware is per-combo-mode; palettes are GLOBAL (see palette.lua)
-local function GetCrossbarComboModeSettings(crossbarSettings, comboMode)
-    if not crossbarSettings.comboModeSettings then
-        crossbarSettings.comboModeSettings = {};
-    end
-    if not crossbarSettings.comboModeSettings[comboMode] then
-        crossbarSettings.comboModeSettings[comboMode] = {
-            petAware = false,
-        };
-    end
-    return crossbarSettings.comboModeSettings[comboMode];
-end
-
--- Helper: Draw per-crossbar bar settings (simplified for global palette model)
-local function DrawCrossbarBarSettings(crossbarSettings, barType, comboMode)
-    local modeSettings = GetCrossbarComboModeSettings(crossbarSettings, comboMode);
-
-    imgui.TextColored(components.TAB_STYLE.gold, 'Settings for ' .. (barType.label or comboMode));
-    imgui.Spacing();
-
-    -- Pet-Aware Palettes toggle (per-combo-mode)
-    local petAware = modeSettings.petAware == true;
-    imgui.AlignTextToFramePadding();
-    imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Pet Palettes:');
-    imgui.SameLine();
-    -- Color button based on state: cyan for enabled, grey for disabled
-    if petAware then
-        imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.5, 0.5, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.3, 0.6, 0.6, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.4, 0.7, 0.7, 1.0});
-    else
-        imgui.PushStyleColor(ImGuiCol_Button, {0.35, 0.35, 0.35, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.45, 0.45, 0.45, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.55, 0.55, 0.55, 1.0});
-    end
-    if imgui.Button(petAware and 'Enabled##petcb' .. comboMode or 'Disabled##petcb' .. comboMode, {100, 0}) then
-        modeSettings.petAware = not petAware;
-        SaveSettingsOnly();
-    end
-    imgui.PopStyleColor(3);
-    imgui.ShowHelp('Pet Palettes: Each summoned pet can have its own crossbar configuration.\nSMN: Per-avatar palettes\nDRG: Wyvern palette\nBST: Jug pet / Charm palettes\nPUP: Automaton palette\n\nClick to toggle.');
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Crossbar Palettes - redirect to Global tab (mirrors hotbar pattern)
-    local currentPalette = palette.GetActivePaletteForCombo(comboMode);
-    if currentPalette then
-        imgui.TextColored({0.4, 0.8, 1.0, 1.0}, 'Palette: ' .. currentPalette);
-    else
-        imgui.TextColored({0.6, 0.6, 0.6, 1.0}, 'Palette: (none)');
-    end
-    imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'Manage palettes in Global tab.');
-end
-
-local function DrawCrossbarSettings(selectedCrossbarTab)
-    local crossbarSettings = gConfig.hotbarCrossbar;
-    if not crossbarSettings then
-        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
-        return selectedCrossbarTab;
-    end
-
-    selectedCrossbarTab = selectedCrossbarTab or 1;
-
-    -- Controller Settings section
-    imgui.TextColored(components.TAB_STYLE.gold, 'Controller Settings');
-    imgui.Spacing();
-
-    -- Controller Profile selection
-    local devices = require('modules.hotbar.devices');
-    local currentScheme = controller.GetControllerScheme();
-    local deviceSchemes = devices.GetSchemeNames();
-    local deviceDisplayNames = devices.GetSchemeDisplayNames();
-
-    -- Find current selection index
-    local currentIndex = 1;
-    for i, scheme in ipairs(deviceSchemes) do
-        if scheme == currentScheme then
-            currentIndex = i;
-            break;
-        end
-    end
-
-    -- Map profile to matching theme
-    local profileToTheme = {
-        xbox = 'Xbox',
-        dualsense = 'PlayStation',
-        switchpro = 'Nintendo',
-        dinput = 'Xbox',
-    };
-
-    imgui.AlignTextToFramePadding();
-    imgui.Text('Controller Profile:');
-    imgui.SameLine();
-    imgui.SetNextItemWidth(150);
-    if imgui.BeginCombo('##controllerSelect', deviceDisplayNames[currentScheme] or currentScheme, ImGuiComboFlags_None) then
-        for i, scheme in ipairs(deviceSchemes) do
-            local isSelected = (scheme == currentScheme);
-            if imgui.Selectable(deviceDisplayNames[scheme], isSelected) then
-                crossbarSettings.controllerScheme = scheme;
-                -- If switching to dinput, apply custom mapping if it exists
-                local customMapping = nil;
-                if scheme == 'dinput' and crossbarSettings.customControllerMappings and crossbarSettings.customControllerMappings.dinput then
-                    customMapping = crossbarSettings.customControllerMappings.dinput;
-                end
-                controller.SetControllerScheme(scheme, customMapping);
-                -- Auto-adjust theme to match profile
-                local matchingTheme = profileToTheme[scheme];
-                if matchingTheme then
-                    crossbarSettings.controllerTheme = matchingTheme;
-                end
-                SaveSettingsOnly();
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-    imgui.ShowHelp('Select which button mapping profile to use.\n\n- Xbox: For XInput controllers (Xbox, 8BitDo in X-mode)\n- PlayStation: For DualSense/DualShock via DirectInput\n- Switch Pro: For Nintendo Switch Pro controller\n- Generic DirectInput: For other DirectInput controllers\n\nChanging this will also update the button icon theme.');
-
-    -- Analog Trigger Threshold Settings (Xbox and PlayStation only)
-    local hasAnalogTriggers = (currentScheme == 'xbox' or currentScheme == 'dualsense');
-    if hasAnalogTriggers then
-        imgui.Spacing();
-        imgui.Text('Analog Trigger Settings');
-        imgui.Separator();
-
-        components.DrawPartySliderInt(crossbarSettings, 'Press Threshold##crossbar', 'triggerPressThreshold', 5, 250, '%d', function()
-            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
-        end, 30);
-        imgui.ShowHelp('Analog trigger value (0-255) required to register as pressed. Higher values require a deeper press. Default: 30');
-
-        components.DrawPartySliderInt(crossbarSettings, 'Release Threshold##crossbar', 'triggerReleaseThreshold', 5, 250, '%d', function()
-            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
-        end, 15);
-        imgui.ShowHelp('Analog trigger value (0-255) below which the trigger is considered released. Provides hysteresis to prevent jitter. Default: 15');
-    end
-
-    imgui.Spacing();
-
-    -- Custom DirectInput button mapping section (only for dinput scheme)
-    if currentScheme == 'dinput' then
-        imgui.Indent(20);
-
-        local hasCustomMapping = crossbarSettings.customControllerMappings and 
-                                  crossbarSettings.customControllerMappings.dinput;
-
-        -- Configure button
-        if imgui.Button('Configure Button Mapping##dinput', {0, 0}) then
-            local buttondetect = require('modules.hotbar.buttondetect');
-            buttonDetectionState.active = true;
-            buttonDetectionState.progress = 0;
-            buttondetect.StartDetection(function(results)
-                if not crossbarSettings.customControllerMappings then
-                    crossbarSettings.customControllerMappings = {};
-                end
-                crossbarSettings.customControllerMappings.dinput = results;
-                buttonDetectionState.active = false;
-                SaveSettingsOnly();
-                -- Re-initialize controller with new mapping
-                controller.SetControllerScheme('dinput', results);
-            end);
-        end
-        imgui.SameLine();
-        imgui.ShowHelp('Launch wizard to configure button layout for your controller. Custom mappings allow you to define your own button layout for DirectInput controllers.');
-
-        -- Status indicator
-        imgui.SameLine();
-        if hasCustomMapping then
-            imgui.TextColored({0, 1, 0, 1}, '(Using custom mapping)');
-        else
-            imgui.TextColored({0.7, 0.7, 0.7, 1}, '(Using default mapping)');
-        end
-
-        -- Clear custom mapping button (only show if custom mapping exists)
-        if hasCustomMapping then
-            imgui.SameLine();
-            if imgui.Button('Clear Custom Mapping##dinput', {150, 0}) then
-                crossbarSettings.customControllerMappings.dinput = nil;
-                SaveSettingsOnly();
-                -- Re-initialize controller without custom mapping
-                controller.SetControllerScheme('dinput');
-            end
-            imgui.SameLine();
-            imgui.ShowHelp('Remove custom mapping and revert to defaults.');
-        end
-
-        -- Show progress bar during detection
-        if buttonDetectionState.active then
-            local buttondetect = require('modules.hotbar.buttondetect');
-            local progress, maxProgress = buttondetect.GetProgress();
-            imgui.ProgressBar(progress / maxProgress, {-1, 20}, string.format('Button %d of %d', progress, maxProgress));
-            imgui.TextWrapped('Detecting buttons... ' .. (buttondetect.GetCurrentPrompt() or ''));
-            if imgui.Button('Cancel##buttondetect', {0, 0}) then
-                buttondetect.Cancel();
-                buttonDetectionState.active = false;
-            end
-        end
-
-        imgui.Unindent(20);
-    end
-
-    imgui.Spacing();
-    imgui.Spacing();
-
-    -- Controller Input settings (combo modes, double-tap) - directly under controller
-    components.DrawPartyCheckbox(crossbarSettings, 'Enable L2+R2 / R2+L2##crossbar', 'enableExpandedCrossbar');
-    imgui.ShowHelp('Enable L2+R2 and R2+L2 combo modes. Hold one trigger, then press the other to access expanded bars.');
-
-    -- Nested option: Use shared expanded bar (only visible when L2+R2/R2+L2 is enabled)
-    if crossbarSettings.enableExpandedCrossbar then
-        imgui.Indent(20);
-        components.DrawPartyCheckbox(crossbarSettings, 'Use Shared Expanded Bar##crossbar', 'useSharedExpandedBar', DeferredUpdateVisuals);
-        imgui.ShowHelp('When enabled, L2+R2 and R2+L2 will access the same shared expanded bar instead of separate bars.\nThis shared bar is completely independent from the separate L2+R2 and R2+L2 bars.');
-        imgui.Unindent(20);
-    end
-
-    components.DrawPartyCheckbox(crossbarSettings, 'Enable Double-Tap##crossbar', 'enableDoubleTap', DeferredUpdateVisuals);
-    imgui.ShowHelp('Enable L2x2 and R2x2 double-tap modes. Tap a trigger twice quickly (hold on second tap) to access double-tap bars.');
-
-    if crossbarSettings.enableDoubleTap then
-        components.DrawPartySlider(crossbarSettings, 'Double-Tap Window##crossbar', 'doubleTapWindow', 0.1, 0.6, '%.2f sec', function()
-            controller.SetDoubleTapWindow(crossbarSettings.doubleTapWindow);
-        end, 0.3);
-        imgui.ShowHelp('Time window to register a double-tap (in seconds).');
-
-        -- Minimum Trigger Hold (only for analog controllers with double-tap enabled)
-        if hasAnalogTriggers then
-            components.DrawPartySlider(crossbarSettings, 'Minimum Trigger Hold##crossbar', 'minTriggerHold', 0.01, 0.15, '%.3f sec', function()
-                controller.SetMinTriggerHold(crossbarSettings.minTriggerHold);
-            end, 0.05);
-            imgui.ShowHelp('Minimum time the trigger must be held before releasing for the release to count toward double-tap detection. Prevents false double-taps from analog jitter or accidental taps. Default: 0.050 sec (50ms)');
-        end
-    end
-
-    imgui.Spacing();
-
-    -- Display Mode dropdown
-    local displayModes = { 'normal', 'activeOnly' };
-    local displayModeLabels = { 'Normal', 'Active Only' };
-    local currentDisplayMode = crossbarSettings.displayMode or 'normal';
-    local currentDisplayIndex = 1;
-    for i, mode in ipairs(displayModes) do
-        if mode == currentDisplayMode then
-            currentDisplayIndex = i;
-            break;
-        end
-    end
-
-    imgui.AlignTextToFramePadding();
-    imgui.Text('Display Mode:');
-    imgui.SameLine();
-    imgui.SetNextItemWidth(150);
-    if imgui.BeginCombo('##displayModeCrossbar', displayModeLabels[currentDisplayIndex]) then
-        for i, label in ipairs(displayModeLabels) do
-            local isSelected = (i == currentDisplayIndex);
-            if imgui.Selectable(label, isSelected) then
-                crossbarSettings.displayMode = displayModes[i];
-                SaveSettingsOnly();
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-    imgui.ShowHelp('Normal: Always show both sides (inactive side dimmed).\nActive Only: Show only when trigger is held, displaying only the active side.');
-
-    imgui.Spacing();
-
-    -- Edit Mode for setting up crossbars without holding triggers
-    local editModeEnabled = { crossbarSettings.editMode == true };
-    if imgui.Checkbox('Edit Mode##crossbar', editModeEnabled) then
-        crossbarSettings.editMode = editModeEnabled[1];
-        SaveSettingsOnly();
-    end
-    imgui.ShowHelp('Enable Edit Mode to preview and set up crossbars without holding triggers.');
-
-    if crossbarSettings.editMode then
-        -- Preview bar dropdown on same line as checkbox
-        imgui.SameLine();
-
-        -- Build preview bar options dynamically based on settings
-        local previewBarOptions = { 'L2', 'R2' };
-        local previewBarKeys = { 'L2', 'R2' };
-
-        -- Add expanded bar options
-        if crossbarSettings.enableExpandedCrossbar then
-            if crossbarSettings.useSharedExpandedBar then
-                -- Shared mode: show single "L2+R2 (Shared)" option
-                table.insert(previewBarOptions, 'L2+R2 (Shared)');
-                table.insert(previewBarKeys, 'Shared');
-            else
-                -- Separate mode: show both L2+R2 and R2+L2
-                table.insert(previewBarOptions, 'L2+R2');
-                table.insert(previewBarKeys, 'L2R2');
-                table.insert(previewBarOptions, 'R2+L2');
-                table.insert(previewBarKeys, 'R2L2');
-            end
-        end
-
-        -- Add double-tap options if enabled
-        if crossbarSettings.enableDoubleTap then
-            table.insert(previewBarOptions, 'L2x2');
-            table.insert(previewBarKeys, 'L2x2');
-            table.insert(previewBarOptions, 'R2x2');
-            table.insert(previewBarKeys, 'R2x2');
-        end
-
-        local currentPreviewBar = crossbarSettings.editModeBar or 'L2';
-        -- Handle migration: if current bar is L2R2 or R2L2 but shared mode is now enabled, switch to Shared
-        if crossbarSettings.useSharedExpandedBar and (currentPreviewBar == 'L2R2' or currentPreviewBar == 'R2L2') then
-            currentPreviewBar = 'Shared';
-            crossbarSettings.editModeBar = 'Shared';
-        end
-        -- Handle migration: if current bar is Shared but shared mode is now disabled, switch to L2R2
-        if not crossbarSettings.useSharedExpandedBar and currentPreviewBar == 'Shared' then
-            currentPreviewBar = 'L2R2';
-            crossbarSettings.editModeBar = 'L2R2';
-        end
-
-        local currentPreviewLabel = currentPreviewBar;
-        -- Convert key to label
-        for i, key in ipairs(previewBarKeys) do
-            if key == currentPreviewBar then
-                currentPreviewLabel = previewBarOptions[i];
-                break;
-            end
-        end
-
-        imgui.SetNextItemWidth(110);
-        if imgui.BeginCombo('##editModeBar', currentPreviewLabel) then
-            for i, label in ipairs(previewBarOptions) do
-                local isSelected = (previewBarKeys[i] == currentPreviewBar);
-                if imgui.Selectable(label, isSelected) then
-                    crossbarSettings.editModeBar = previewBarKeys[i];
-                    SaveSettingsOnly();
-                end
-                if isSelected then
-                    imgui.SetItemDefaultFocus();
-                end
-            end
-            imgui.EndCombo();
-        end
-        imgui.ShowHelp('Select which crossbar to preview in Edit Mode.');
-
-        -- Warning text on next line
-        imgui.TextColored({1.0, 1.0, 0.0, 1.0}, '(!) Disable before playing');
-    end
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Per-Crossbar tabs
-    imgui.TextColored(components.TAB_STYLE.gold, 'Per-Crossbar Settings');
-    imgui.Spacing();
-
-    for i, crossbarType in ipairs(CROSSBAR_TYPES) do
-        local clicked, _ = components.DrawStyledTab(
-            crossbarType.label,
-            'crossbarTab' .. crossbarType.key,
-            selectedCrossbarTab == i,
-            nil,
-            components.TAB_STYLE.smallHeight,
-            components.TAB_STYLE.smallPadding
-        );
-        if clicked then
-            selectedCrossbarTab = i;
-        end
-        if i < #CROSSBAR_TYPES then
-            imgui.SameLine();
-        end
-    end
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Draw settings based on selected tab
-    local currentCrossbar = CROSSBAR_TYPES[selectedCrossbarTab];
-    if currentCrossbar then
-        if currentCrossbar.isGlobal then
-            -- Global Crossbar Palettes section first (most commonly used)
-            DrawCrossbarGlobalPalettesSection();
-            imgui.Separator();
-
-            -- Global Visual Settings
-            imgui.TextColored(components.TAB_STYLE.gold, 'Global Visual Settings');
-            imgui.Spacing();
-
-            if components.CollapsingSection('Slot Settings##crossbar', false) then
-                components.DrawPartySliderInt(crossbarSettings, 'Slot Size (px)##crossbar', 'slotSize', 32, 64, '%d', nil, 48);
-                imgui.ShowHelp('Size of each slot in pixels.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Vertical)##crossbar', 'slotGapV', 0, 128, '%d', nil, 4);
-                imgui.ShowHelp('Vertical gap between top and bottom slots in each diamond.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Horizontal)##crossbar', 'slotGapH', 0, 128, '%d', nil, 4);
-                imgui.ShowHelp('Horizontal gap between left and right slots in each diamond.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Diamond Spacing##crossbar', 'diamondSpacing', 0, 128, '%d', nil, 20);
-                imgui.ShowHelp('Horizontal space between D-pad and face button diamonds.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Group Spacing##crossbar', 'groupSpacing', 0, 128, '%d', nil, 40);
-                imgui.ShowHelp('Space between L2 and R2 groups.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Divider##crossbar', 'showDivider');
-                imgui.ShowHelp('Show a divider line between L2 and R2 groups.');
-
-                -- Show MP Cost with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show MP Cost##crossbar', 'showMpCost');
-                if crossbarSettings.showMpCost then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarmp', 'mpCostOffsetX', 'mpCostOffsetY', 35);
-                end
-                imgui.ShowHelp('Display MP cost on spell slots. X/Y offsets adjust position.');
-
-                -- Show Item Quantity with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Item Quantity##crossbar', 'showQuantity');
-                if crossbarSettings.showQuantity then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarqty', 'quantityOffsetX', 'quantityOffsetY', 35);
-                end
-                imgui.ShowHelp('Display item quantity on item slots. X/Y offsets adjust position.');
-
-                -- Show full-stack count above the item quantity (only counts complete stacks)
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Stack Quantity##crossbar', 'showStackQuantity');
-                imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
-
-                -- Show Combo Text with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Combo Text##crossbar', 'showComboText');
-                if crossbarSettings.showComboText then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarcombo', 'comboTextOffsetX', 'comboTextOffsetY', 35);
-                end
-                imgui.ShowHelp('Show current combo mode text in center (L2+R2, R2+L2, L2x2, R2x2). X/Y offsets adjust position.');
-
-                -- Show Palette Name with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Palette Name##crossbar', 'showPaletteName');
-                if crossbarSettings.showPaletteName then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarpalette', 'paletteNameOffsetX', 'paletteNameOffsetY', 35);
-                end
-                imgui.ShowHelp('Display current palette name and index (e.g., "Stuns (2/5)"). X/Y offsets adjust position.');
-
-                -- Show Action Labels with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Action Labels##crossbar', 'showActionLabels');
-                if crossbarSettings.showActionLabels then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarlbl', 'actionLabelOffsetX', 'actionLabelOffsetY', 35);
-                end
-                imgui.ShowHelp('Show spell/ability names below slots. X/Y offsets adjust position.');
-            end
-
-            -- Background section
-            if components.CollapsingSection('Background##crossbar', false) then
-                local bgThemes = {'-None-', 'Plain', 'Window1', 'Window2', 'Window3', 'Window4', 'Window5', 'Window6', 'Window7', 'Window8'};
-                components.DrawPartyComboBox(crossbarSettings, 'Theme##bgcrossbar', 'backgroundTheme', bgThemes, DeferredUpdateVisuals);
-                imgui.ShowHelp('Select the background window theme.');
-
-                components.DrawPartySlider(crossbarSettings, 'Background Scale##crossbar', 'bgScale', 0.1, 3.0, '%.2f', nil, 1.0);
-                imgui.ShowHelp('Scale of the background texture.');
-
-                components.DrawPartySlider(crossbarSettings, 'Border Scale##crossbar', 'borderScale', 0.1, 3.0, '%.2f', nil, 1.0);
-                imgui.ShowHelp('Scale of the window borders.');
-
-                components.DrawPartySlider(crossbarSettings, 'Background Opacity##crossbar', 'backgroundOpacity', 0.0, 1.0, '%.2f');
-                imgui.ShowHelp('Opacity of the background.');
-
-                components.DrawPartySlider(crossbarSettings, 'Border Opacity##crossbar', 'borderOpacity', 0.0, 1.0, '%.2f');
-                imgui.ShowHelp('Opacity of the window borders.');
-            end
-
-            -- Controller Icons section
-            if components.CollapsingSection('Controller Icons##crossbar', false) then
-                local controllerThemes = { 'PlayStation', 'Xbox', 'Nintendo' };
-                components.DrawPartyComboBox(crossbarSettings, 'Controller Theme##crossbar', 'controllerTheme', controllerThemes);
-                imgui.ShowHelp('Select controller button icon style. Nintendo layout: X top, A right, B bottom, Y left.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Button Icons##crossbar', 'showButtonIcons');
-                imgui.ShowHelp('Show d-pad and face button icons on slots.');
-
-                if crossbarSettings.showButtonIcons then
-                    components.DrawPartySliderInt(crossbarSettings, 'Button Icon Size##crossbar', 'buttonIconSize', 8, 32, '%d', nil, 16);
-                    imgui.ShowHelp('Size of controller button icons.');
-
-                    components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (H)##crossbar', 'buttonIconGapH', 0, 24, '%d', nil, 2);
-                    imgui.ShowHelp('Horizontal spacing between center controller icons.');
-
-                    components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (V)##crossbar', 'buttonIconGapV', 0, 24, '%d', nil, 2);
-                    imgui.ShowHelp('Vertical spacing between center controller icons.');
-                end
-
-                imgui.Separator();
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Trigger Icons##crossbar', 'showTriggerLabels');
-                imgui.ShowHelp('Show L2/R2 trigger icons above the crossbar groups.');
-
-                if crossbarSettings.showTriggerLabels then
-                    components.DrawPartySlider(crossbarSettings, 'Trigger Icon Scale##crossbar', 'triggerIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
-                    imgui.ShowHelp('Scale for L2/R2 trigger icons above groups (base size 49x28).');
-                end
-            end
-
-            -- Text section
-            if components.CollapsingSection('Text Settings##crossbar', false) then
-                components.DrawPartySliderInt(crossbarSettings, 'Keybind Text Size##crossbar', 'keybindFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for keybind labels.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Label Text Size##crossbar', 'labelFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for action labels.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Cooldown Text Size##crossbar', 'recastTimerFontSize', 6, 24, '%d', DeferredUpdateVisuals, 11);
-                imgui.ShowHelp('Text size for cooldown timer display.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Flash Under 5 Seconds##crossbar', 'flashCooldownUnder5');
-                imgui.ShowHelp('Flash the cooldown timer text when remaining time is under 5 seconds.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Use Hh:MM Cooldown Format##crossbar', 'useHHMMCooldownFormat');
-                imgui.ShowHelp('Display cooldown timers as Hh:MM (e.g., "1h:49") instead of "1h 49m" for shorter text.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Trigger Label Text Size##crossbar', 'triggerLabelFontSize', 6, 24, '%d', nil, 14);
-                imgui.ShowHelp('Text size for combo mode labels (L2, R2, etc.).');
-
-                components.DrawPartySliderInt(crossbarSettings, 'MP Cost Text Size##crossbar', 'mpCostFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for MP cost display.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Quantity Text Size##crossbar', 'quantityFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for item quantity display.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Combo Text Size##crossbar', 'comboTextFontSize', 8, 24, '%d', nil, 12);
-                imgui.ShowHelp('Font size for combo mode text (L2+R2, R2+L2, etc.).');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Palette Name Text Size##crossbar', 'paletteNameFontSize', 8, 24, '%d', nil, 10);
-                imgui.ShowHelp('Font size for palette name display.');
-            end
-
-            -- Visual Feedback section
-            if components.CollapsingSection('Visual Feedback##crossbar', false) then
-                components.DrawPartySlider(crossbarSettings, 'Inactive Dim##crossbar', 'inactiveSlotDim', 0.0, 1.0, '%.2f', nil, 0.5);
-                imgui.ShowHelp('Dim factor for inactive trigger side (0 = black, 1 = full brightness).');
-
-                -- Default to true if not set
-                if crossbarSettings.enableTransitionAnimations == nil then
-                    crossbarSettings.enableTransitionAnimations = true;
-                end
-                local transAnimEnabled = { crossbarSettings.enableTransitionAnimations };
-                if imgui.Checkbox('Enable Transition Animations##crossbar', transAnimEnabled) then
-                    crossbarSettings.enableTransitionAnimations = transAnimEnabled[1];
-                    SaveSettingsOnly();
-                end
-                imgui.ShowHelp('Enable smooth animations when switching between crossbar modes (L2, R2, combos). Disable for instant transitions.');
-
-                -- Default to true if not set
-                if crossbarSettings.enablePressScale == nil then
-                    crossbarSettings.enablePressScale = true;
-                end
-                local pressScaleEnabled = { crossbarSettings.enablePressScale };
-                if imgui.Checkbox('Enable Press Scale##crossbar', pressScaleEnabled) then
-                    crossbarSettings.enablePressScale = pressScaleEnabled[1];
-                    SaveSettingsOnly();
-                end
-                imgui.ShowHelp('Enable icon scaling animation when pressing an action slot. Disable for no visual feedback on press.');
-            end
-        else
-            -- Per-crossbar settings (L2, R2, etc.)
-            DrawCrossbarBarSettings(crossbarSettings, currentCrossbar, currentCrossbar.settingsKey);
-        end
-    end
-
-    -- Draw confirmation popup for job-specific toggle
-    DrawJobSpecificConfirmPopup();
-
-    -- Draw palette modal (unified for both hotbar and crossbar)
-    DrawPaletteModal();
-
-    -- Draw palette manager window (separate window for advanced management)
-    paletteManager.Draw();
-
-    return selectedCrossbarTab;
-end
-
-local function DrawCrossbarColorSettings()
-    local crossbarSettings = gConfig.hotbarCrossbar;
-    if not crossbarSettings then
-        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+-- Disable XI Macros row + diagnostics + Controller Hold-to-Show (hotbarGlobal.disableMacroBars).
+-- Shared between Hotbar and Crossbar; idSuffix keeps ImGui IDs distinct when both UIs exist.
+function M.DrawSharedDisableXiMacrosControls(idSuffix)
+    idSuffix = idSuffix or 'hb';
+    local hg = gConfig.hotbarGlobal;
+    if not hg then
         return;
     end
 
-    local colorFlags = bit.bor(ImGuiColorEditFlags_NoInputs, ImGuiColorEditFlags_AlphaPreviewHalf, ImGuiColorEditFlags_AlphaBar);
-
-    imgui.TextColored(components.TAB_STYLE.gold, 'Crossbar Color Settings');
-    imgui.Spacing();
-
-    if components.CollapsingSection('Window Colors##crossbarcolor', true) then
-        local bgColor = crossbarSettings.bgColor or 0xFFFFFFFF;
-        local bgColorTable = ARGBToImGui(bgColor);
-        if imgui.ColorEdit4('Background Color##crossbar', bgColorTable, colorFlags) then
-            crossbarSettings.bgColor = ImGuiToARGB(bgColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color tint for the window background.');
-
-        local borderColor = crossbarSettings.borderColor or 0xFFFFFFFF;
-        local borderColorTable = ARGBToImGui(borderColor);
-        if imgui.ColorEdit4('Border Color##crossbar', borderColorTable, colorFlags) then
-            crossbarSettings.borderColor = ImGuiToARGB(borderColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color tint for the window borders.');
-    end
-
-    if components.CollapsingSection('Slot Colors##crossbarcolor', true) then
-        local slotBgColor = crossbarSettings.slotBackgroundColor or 0x55000000;
-        local slotBgColorTable = ARGBToImGui(slotBgColor);
-        if imgui.ColorEdit4('Slot Background##crossbar', slotBgColorTable, colorFlags) then
-            crossbarSettings.slotBackgroundColor = ImGuiToARGB(slotBgColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color and transparency of slot backgrounds.');
-
-        components.DrawPartySlider(crossbarSettings, 'Slot Opacity##crossbar', 'slotOpacity', 0.0, 1.0, '%.2f', nil, 1.0);
-        imgui.ShowHelp('Opacity of the slot background texture.');
-
-        local highlightColor = crossbarSettings.activeSlotHighlight or 0x44FFFFFF;
-        local highlightColorTable = ARGBToImGui(highlightColor);
-        if imgui.ColorEdit4('Active Highlight##crossbar', highlightColorTable, colorFlags) then
-            crossbarSettings.activeSlotHighlight = ImGuiToARGB(highlightColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Highlight color for slots when trigger is held.');
-    end
-
-    if components.CollapsingSection('Text Colors##crossbarcolor', true) then
-        local keybindColor = crossbarSettings.keybindFontColor or 0xFFFFFFFF;
-        local keybindColorTable = ARGBToImGui(keybindColor);
-        if imgui.ColorEdit4('Keybind Color##crossbar', keybindColorTable, colorFlags) then
-            crossbarSettings.keybindFontColor = ImGuiToARGB(keybindColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for keybind labels.');
-
-        local triggerLabelColor = crossbarSettings.triggerLabelColor or 0xFFFFCC00;
-        local triggerLabelColorTable = ARGBToImGui(triggerLabelColor);
-        if imgui.ColorEdit4('Trigger Label Color##crossbar', triggerLabelColorTable, colorFlags) then
-            crossbarSettings.triggerLabelColor = ImGuiToARGB(triggerLabelColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for combo mode labels (L2, R2, etc.).');
-
-        local mpCostColor = crossbarSettings.mpCostFontColor or 0xFFD4FF97;
-        local mpCostColorTable = ARGBToImGui(mpCostColor);
-        if imgui.ColorEdit4('MP Cost Color##crossbar', mpCostColorTable, colorFlags) then
-            crossbarSettings.mpCostFontColor = ImGuiToARGB(mpCostColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for MP cost display on spell slots.');
-
-        local quantityColor = crossbarSettings.quantityFontColor or 0xFFFFFFFF;
-        local quantityColorTable = ARGBToImGui(quantityColor);
-        if imgui.ColorEdit4('Quantity Color##crossbar', quantityColorTable, colorFlags) then
-            crossbarSettings.quantityFontColor = ImGuiToARGB(quantityColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for item quantity display. Note: Shows red when quantity is 0.');
-
-        local labelColor = crossbarSettings.labelFontColor or 0xFFFFFFFF;
-        local labelColorTable = ARGBToImGui(labelColor);
-        if imgui.ColorEdit4('Label Color##crossbar', labelColorTable, colorFlags) then
-            crossbarSettings.labelFontColor = ImGuiToARGB(labelColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for action labels below slots.');
-
-        local timerColor = crossbarSettings.recastTimerFontColor or 0xFFFFFFFF;
-        local timerColorTable = ARGBToImGui(timerColor);
-        if imgui.ColorEdit4('Cooldown Timer Color##crossbar', timerColorTable, colorFlags) then
-            crossbarSettings.recastTimerFontColor = ImGuiToARGB(timerColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for cooldown timer text displayed on slots.');
-    end
-end
-
--- Section: Hotbar Settings
-function M.DrawSettings(state)
-    local selectedBarTab = state and state.selectedHotbarTab or 1;
-    local selectedModeTab = state and state.selectedModeTab or 'hotbar';  -- 'hotbar' or 'crossbar' when mode is 'both'
-    local selectedCrossbarTab = state and state.selectedCrossbarTab or 1;  -- 1=L2, 2=R2, 3=L2R2, etc.
-
-    -- Basic toggles at top
-    components.DrawCheckbox('Enabled', 'hotbarEnabled');
-    -- Lock Movement disables drag/drop and slot swapping for hotbar bars
-    components.DrawCheckbox('Lock Movement', 'hotbarLockMovement', function()
-        -- Only reset anchors when lock is being ENABLED
-        if gConfig.hotbarLockMovement then
-            for i = 1, 6 do
-                drawing.ResetAnchorState('Hotbar' .. tostring(i));
-            end
-            drawing.ResetAnchorState('Crossbar');
-        end
-        DeferredUpdateVisuals();
-    end);
-    imgui.ShowHelp('When enabled, prevents dragging/dropping and swapping of hotbar and crossbar slots.');
-    components.DrawCheckbox('Hide When Menu Open', 'hotbarHideOnMenuFocus');
-    imgui.ShowHelp('Hide hotbars when a game menu is open (equipment, map, etc.).');
-
-    -- Disable XI macros checkbox (stored in hotbarGlobal)
-    local disableMacroBars = { gConfig.hotbarGlobal.disableMacroBars or false };
-    if imgui.Checkbox('Disable XI Macros', disableMacroBars) then
-        gConfig.hotbarGlobal.disableMacroBars = disableMacroBars[1];
+    local disableMacroBars = { hg.disableMacroBars or false };
+    if imgui.Checkbox('Disable XI Macros##disableXi_' .. idSuffix, disableMacroBars) then
+        hg.disableMacroBars = disableMacroBars[1];
         SaveSettingsOnly();
         DeferredUpdateVisuals();
     end
+    imgui.ShowHelp('Toggle macro bar behavior:\n- OFF: Built-in macros work with speed fix (macrofix)\n- ON: Macro bar hidden, XIUI hotbar/crossbar only\n\nNote: When ON, also blocks native macro commands.');
 
-    -- Controller Hold-to-Show checkbox (only shown when Disable XI Macros is OFF)
-    if not gConfig.hotbarGlobal.disableMacroBars then
+    if not hg.disableMacroBars then
         imgui.Indent(20);
-        local holdToShow = { gConfig.hotbarGlobal.controllerHoldToShow ~= false };  -- default true
-        if imgui.Checkbox('Controller Hold-to-Show', holdToShow) then
-            gConfig.hotbarGlobal.controllerHoldToShow = holdToShow[1];
+        local holdToShow = { hg.controllerHoldToShow ~= false };
+        if imgui.Checkbox('Controller Hold-to-Show##holdXi_' .. idSuffix, holdToShow) then
+            hg.controllerHoldToShow = holdToShow[1];
             SaveSettingsOnly();
             DeferredUpdateVisuals();
         end
@@ -2562,10 +1899,9 @@ function M.DrawSettings(state)
     end
 
     imgui.SameLine();
-    -- Get diagnostic info for tooltip
+    imgui.PushID('diagXi_' .. idSuffix);
     local diag = macrosLib.get_diagnostics();
 
-    -- Show warning icon if macrofix addon conflict detected
     if diag.macrofixConflict then
         imgui.TextColored({1.0, 0.4, 0.0, 1.0}, '(!)');
         if imgui.IsItemHovered() then
@@ -2584,15 +1920,13 @@ function M.DrawSettings(state)
         end
         imgui.SameLine();
     end
-    -- Show status indicator with color based on mode
     if diag.mode == 'hide' then
-        imgui.TextColored({0.5, 1.0, 0.5, 1.0}, '(hidden)');  -- Green when hidden
+        imgui.TextColored({0.5, 1.0, 0.5, 1.0}, '(hidden)');
     elseif diag.mode == 'macrofix' then
-        -- Show hold-to-show status when in macrofix mode
         local statusText = diag.controllerHoldToShow and '(macrofix, hold-to-show)' or '(macrofix)';
-        imgui.TextColored({0.5, 0.8, 1.0, 1.0}, statusText);  -- Cyan for macrofix mode
+        imgui.TextColored({0.5, 0.8, 1.0, 1.0}, statusText);
     else
-        imgui.TextColored({1.0, 0.7, 0.3, 1.0}, '(init...)');  -- Orange if still initializing
+        imgui.TextColored({1.0, 0.7, 0.3, 1.0}, '(init...)');
     end
     if imgui.IsItemHovered() then
         imgui.BeginTooltip();
@@ -2606,13 +1940,11 @@ function M.DrawSettings(state)
         end
         imgui.Text('Mode: ' .. modeStr);
 
-        -- Show controller hold-to-show status when in macrofix mode
         if diag.mode == 'macrofix' then
             local holdStatus = diag.controllerHoldToShow and 'enabled' or 'disabled';
             imgui.Text('Controller Hold-to-Show: ' .. holdStatus);
         end
 
-        -- Check if macrofix addon is loaded (safely - GetAddonManager may not exist)
         local macrofixLoaded = false;
         local ok, addonManager = pcall(function() return AshitaCore:GetAddonManager(); end);
         if ok and addonManager then
@@ -2659,42 +1991,116 @@ function M.DrawSettings(state)
         imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'active = applied, ready = available');
         imgui.EndTooltip();
     end
-    imgui.ShowHelp('Toggle macro bar behavior:\n- OFF: Built-in macros work with speed fix (macrofix)\n- ON: Macro bar hidden, XIUI hotbar/crossbar only\n\nNote: When ON, also blocks native macro commands.');
+    imgui.PopID();
+end
 
-    -- Skillchain highlight checkbox (stored in hotbarGlobal)
-    local skillchainHighlight = { gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false };
-    if imgui.Checkbox('Skillchain Highlight', skillchainHighlight) then
-        gConfig.hotbarGlobal.skillchainHighlightEnabled = skillchainHighlight[1];
+-- Helper: draw a compact inline ARGB color swatch (no label, no input fields — just the
+-- swatch + click-to-open picker). Used inline with checkboxes so each toggle gets its color
+-- chip on the same row, e.g. `[x] Skillchain Highlight  [██]  (?)`. Saves on edit-finish
+-- the same way DrawTextColorPicker does, so behavior matches the rest of the config UI.
+local function DrawInlineArgbColorSwatch(parentTable, key, defaultArgb, imguiId)
+    local rgba = ARGBToImGui(parentTable[key] or defaultArgb);
+    local flags = bit.bor(ImGuiColorEditFlags_NoInputs, ImGuiColorEditFlags_NoLabel, ImGuiColorEditFlags_AlphaBar);
+    if imgui.ColorEdit4('##' .. imguiId, rgba, flags) then
+        parentTable[key] = ImGuiToARGB(rgba);
+    end
+    if imgui.IsItemDeactivatedAfterEdit() then
         SaveSettingsOnly();
     end
-    imgui.ShowHelp('Show animated border and skillchain icon on weapon skill slots when a skillchain window is open.');
+end
 
-    if gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false then
-        components.DrawPartySlider(gConfig.hotbarGlobal, 'Icon Scale##skillchain', 'skillchainIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
-        imgui.ShowHelp('Scale of the skillchain icon (default 1.0).');
-        components.DrawPartySliderInt(gConfig.hotbarGlobal, 'Icon Offset X##skillchain', 'skillchainIconOffsetX', -50, 50, '%d', nil, 0);
-        imgui.ShowHelp('Horizontal offset for skillchain icon position.');
-        components.DrawPartySliderInt(gConfig.hotbarGlobal, 'Icon Offset Y##skillchain', 'skillchainIconOffsetY', -50, 50, '%d', nil, 0);
-        imgui.ShowHelp('Vertical offset for skillchain icon position.');
+-- Skillchain & Magic Burst highlight options (hotbarGlobal); shared between Hotbar and Crossbar.
+-- Layout: each toggle gets its color swatch inline on the same row (only when enabled), with
+-- the (?) help marker trailing. Shared icon Scale/OffsetX/OffsetY sliders sit below and only
+-- render when at least one of the two highlights is enabled (they have no effect otherwise).
+function M.DrawSharedSkillchainHighlightControls(idSuffix)
+    idSuffix = idSuffix or 'hb';
+    local hg = gConfig.hotbarGlobal;
+    if not hg then
+        return;
     end
+
+    -- Skillchain highlight: checkbox + inline color swatch (when enabled) + help marker.
+    local skillchainHighlight = { hg.skillchainHighlightEnabled ~= false };
+    if imgui.Checkbox('Skillchain Highlight##skillchainHl_' .. idSuffix, skillchainHighlight) then
+        hg.skillchainHighlightEnabled = skillchainHighlight[1];
+        SaveSettingsOnly();
+    end
+    if hg.skillchainHighlightEnabled ~= false then
+        imgui.SameLine();
+        DrawInlineArgbColorSwatch(hg, 'skillchainHighlightColor', 0xFFD4AA44, 'skillchainColor_' .. idSuffix);
+    end
+    imgui.ShowHelp('Show animated border and skillchain icon (top-right corner) on weapon skill / Blood Pact / /ws|/pet-macro slots when a skillchain window is open on your target. Applies to keyboard hotbars and controller crossbar.');
+
+    -- Magic Burst highlight: checkbox + inline color swatch (when enabled) + help marker.
+    -- Sits directly under the skillchain row since the two are sibling features sharing the
+    -- icon scale/offset sliders below.
+    local magicBurst = { hg.magicBurstHighlightEnabled ~= false };
+    if imgui.Checkbox('Magic Burst Highlight##magicBurstHl_' .. idSuffix, magicBurst) then
+        hg.magicBurstHighlightEnabled = magicBurst[1];
+        SaveSettingsOnly();
+    end
+    if hg.magicBurstHighlightEnabled ~= false then
+        imgui.SameLine();
+        DrawInlineArgbColorSwatch(hg, 'magicBurstHighlightColor', 0xFF44D4FF, 'magicBurstColor_' .. idSuffix);
+    end
+    imgui.ShowHelp('When a skillchain closes on your target, highlight for 7 seconds any spell slots whose element matches the burstable elements (Fire/Ice/Wind/Earth/Lightning/Water/Light/Dark). Covers White / Black / Blue Magic, Ninjutsu, and the spell-named SMN Magic Blood Pact Rages (Fire II/IV, Blizzard II/IV, etc.). Border draws cyan-blue by default with the SC name in the bottom-left corner so it stays distinct from the skillchain highlight.');
+
+    -- Shared icon scale + offsets. Render only when at least one highlight is enabled — they
+    -- govern both, so showing the sliders with both highlights off would be confusing dead UI.
+    if hg.skillchainHighlightEnabled ~= false or hg.magicBurstHighlightEnabled ~= false then
+        components.DrawPartySlider(hg, 'Icon Scale##skillchainScale_' .. idSuffix, 'skillchainIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
+        imgui.ShowHelp('Scale of the highlight icon (default 1.0). Shared between skillchain (top-right) and Magic Burst (bottom-left).');
+        components.DrawPartySliderInt(hg, 'Icon Offset X##skillchainOx_' .. idSuffix, 'skillchainIconOffsetX', -50, 50, '%d', nil, 0);
+        imgui.ShowHelp('Horizontal offset for the highlight icon (shared by both highlights).');
+        components.DrawPartySliderInt(hg, 'Icon Offset Y##skillchainOy_' .. idSuffix, 'skillchainIconOffsetY', -50, 50, '%d', nil, 0);
+        imgui.ShowHelp('Vertical offset for the highlight icon (shared by both highlights).');
+    end
+end
+
+
+-- Section: Hotbar Settings
+function M.DrawSettings(state)
+    local selectedBarTab = state and state.selectedHotbarTab or 1;
+
+    -- Basic toggles at top
+    components.DrawCheckbox('Enabled', 'hotbarEnabled');
+    -- Lock Movement disables drag/drop and slot swapping for keyboard hotbars only
+    components.DrawCheckbox('Lock Movement', 'hotbarLockMovement', function()
+        if gConfig.hotbarLockMovement then
+            for i = 1, 6 do
+                drawing.ResetAnchorState('Hotbar' .. tostring(i));
+            end
+        end
+        DeferredUpdateVisuals();
+    end);
+    imgui.ShowHelp('When enabled, prevents dragging, dropping, and swapping slots on keyboard hotbars (bars 1â€“6). Crossbar uses Lock Crossbar under the Crossbar category.');
+    components.DrawCheckbox('Hide When Menu Open', 'hotbarHideOnMenuFocus');
+    imgui.ShowHelp('Hide keyboard hotbars (bars 1â€“6) when a game menu is open (equipment, map, etc.). Crossbar has its own Hide When Menu Open next to Lock Crossbar.');
+
+    M.DrawSharedDisableXiMacrosControls('hb');
+    M.DrawSharedSkillchainHighlightControls('hb');
 
     imgui.Spacing();
     imgui.Separator();
     imgui.Spacing();
 
-    -- Action buttons
-    imgui.PushStyleColor(ImGuiCol_Button, components.TAB_STYLE.bgLight);
-    imgui.PushStyleColor(ImGuiCol_ButtonHovered, components.TAB_STYLE.bgLighter);
-    imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.22, 0.20, 0.17, 1.0});
-
+    -- Action buttons (Macro Manager = gold, Palette Manager = gold-accent, rest = default strip)
+    components.PushMacroManagerButtonStyle();
     if imgui.Button('Macro Manager', {120, 0}) then
-        macropalette.OpenPalette();
+        macropalette.TogglePalette();
     end
+    components.PopMacroManagerButtonStyle();
     imgui.SameLine();
+    components.PushPaletteManagerButtonStyle();
     if imgui.Button('Palette Manager', {120, 0}) then
         paletteManager.Open();
     end
+    components.PopPaletteManagerButtonStyle();
     imgui.SameLine();
+    imgui.PushStyleColor(ImGuiCol_Button, components.TAB_STYLE.bgLight);
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, components.TAB_STYLE.bgLighter);
+    imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.22, 0.20, 0.17, 1.0});
     -- selectedBarTab is index into BAR_TYPES where 1=Global, 2=Bar1, 3=Bar2, etc.
     -- So actual bar index is selectedBarTab - 1 (default to 1 if Global is selected)
     local editBarIndex = math.max(1, (selectedBarTab or 1) - 1);
@@ -2714,47 +2120,10 @@ function M.DrawSettings(state)
     imgui.Separator();
     imgui.Spacing();
 
-    -- Layout Mode dropdown
-    local modeOptions = { 'Hotbar', 'Crossbar', 'Both' };
-    local modeValues = { 'hotbar', 'crossbar', 'both' };
-    local currentMode = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-
-    -- Find current mode index
-    local currentModeIndex = 1;
-    for i, v in ipairs(modeValues) do
-        if v == currentMode then
-            currentModeIndex = i;
-            break;
-        end
-    end
-
-    imgui.AlignTextToFramePadding();
-    imgui.Text('Layout Mode:');
-    imgui.SameLine();
-    imgui.SetNextItemWidth(120);
-    if imgui.BeginCombo('##layoutMode', modeOptions[currentModeIndex]) then
-        for i, label in ipairs(modeOptions) do
-            local isSelected = currentModeIndex == i;
-            if imgui.Selectable(label, isSelected) then
-                if gConfig.hotbarCrossbar then
-                    gConfig.hotbarCrossbar.mode = modeValues[i];
-                    SaveSettingsOnly();
-                    DeferredUpdateVisuals();
-                end
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-    imgui.ShowHelp('Hotbar: Standard keyboard hotbars (Bars 1-6)\nCrossbar: Controller layout with L2/R2 triggers\nBoth: Show both hotbar and crossbar');
-
-    -- Conditional: KB Palette Cycle (show if mode is hotbar or both)
-    if currentMode == 'hotbar' or currentMode == 'both' then
+    if gConfig.hotbarEnabled ~= false then
         local kbOptions = { 'Disabled', 'Ctrl + Up/Down', 'Alt + Up/Down', 'Shift + Up/Down', 'Up/Down' };
         local kbModifierValues = { nil, 'ctrl', 'alt', 'shift', 'none' };
-        local currentKbIndex = 1;  -- Default to Disabled
+        local currentKbIndex = 1;
         if gConfig.hotbarGlobal.paletteCycleEnabled ~= false then
             local currentMod = gConfig.hotbarGlobal.paletteCycleModifier or 'ctrl';
             for i = 1, #kbModifierValues do
@@ -2786,72 +2155,53 @@ function M.DrawSettings(state)
             end
             imgui.EndCombo();
         end
-        imgui.ShowHelp('Keyboard shortcut to cycle through palettes.');
-    end
+        imgui.ShowHelp('Keyboard shortcut to cycle through hotbar palettes.');
 
-    -- Conditional: Controller Palette Cycle (show if mode is crossbar or both)
-    if currentMode == 'crossbar' or currentMode == 'both' then
-        local ctrlOptions = { 'Disabled', 'Enabled' };
-        local currentCtrlIndex = (gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false) and 2 or 1;
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
 
-        imgui.AlignTextToFramePadding();
-        imgui.Text('Palette Cycle:');
-        imgui.SameLine();
-        imgui.SetNextItemWidth(90);
-        if imgui.BeginCombo('##ctrlPaletteCycle', ctrlOptions[currentCtrlIndex]) then
-            for i, label in ipairs(ctrlOptions) do
-                local isSelected = currentCtrlIndex == i;
-                if imgui.Selectable(label, isSelected) then
-                    gConfig.hotbarGlobal.paletteCycleControllerEnabled = (i == 2);
-                    SaveSettingsOnly();
-                end
-                if isSelected then imgui.SetItemDefaultFocus(); end
+        -- Per-Bar Visual Settings header
+        imgui.TextColored(components.TAB_STYLE.gold, 'Per-Bar Visual Settings');
+        imgui.ShowHelp('Configure each hotbar independently. Each bar can have its own layout, theme, and button settings.');
+        imgui.Spacing();
+
+        -- Draw Bar 1-6 tabs
+        for i, barType in ipairs(BAR_TYPES) do
+            local clicked, tabWidth = components.DrawStyledTab(
+                barType.label,
+                'hotbarBarTab' .. i,
+                selectedBarTab == i,
+                nil,
+                components.TAB_STYLE.smallHeight,
+                components.TAB_STYLE.smallPadding
+            );
+            if clicked then
+                selectedBarTab = i;
             end
-            imgui.EndCombo();
-        end
-
-        -- Hotbar cycle button selection (only if enabled)
-        if gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false then
-            imgui.SameLine();
-            imgui.Text('Button:');
-            imgui.SameLine();
-
-            local buttonOptions = { 'R1', 'L1' };
-            local currentButton = gConfig.hotbarGlobal.hotbarPaletteCycleButton or 'R1';
-            local currentButtonIndex = 1;
-            for i, btn in ipairs(buttonOptions) do
-                if btn == currentButton then
-                    currentButtonIndex = i;
-                    break;
-                end
-            end
-
-            imgui.SetNextItemWidth(60);
-            if imgui.BeginCombo('##hotbarCycleBtn', currentButton) then
-                for i, btn in ipairs(buttonOptions) do
-                    local isSelected = (i == currentButtonIndex);
-                    if imgui.Selectable(btn .. '##hbCycleBtn' .. i, isSelected) then
-                        gConfig.hotbarGlobal.hotbarPaletteCycleButton = btn;
-                        SaveSettingsOnly();
-                    end
-                    if isSelected then imgui.SetItemDefaultFocus(); end
-                end
-                imgui.EndCombo();
+            if i < #BAR_TYPES then
+                imgui.SameLine();
             end
         end
-        imgui.ShowHelp('Controller shortcut to cycle palettes.\nPress the selected button + DPad Up/Down to cycle palettes for all hotbars and the active crossbar.');
+
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
+
+        -- Draw settings for selected bar (Global tab vs per-bar tabs)
+        local currentBar = BAR_TYPES[selectedBarTab];
+        if currentBar then
+            if currentBar.isGlobal then
+                DrawGlobalVisualSettings();
+            else
+                DrawBarVisualSettings(currentBar.configKey, currentBar.label);
+            end
+        end
+    else
+        imgui.TextColored({0.55, 0.52, 0.48, 1.0}, 'Keyboard hotbars are turned off (Hotbar â†’ Enabled). Turn Hotbar on to configure bars 1â€“6, or use the Crossbar category for controller layout.');
     end
 
-    -- Log Palette Name checkbox (show if any palette cycling is potentially enabled)
-    if currentMode == 'hotbar' or currentMode == 'crossbar' or currentMode == 'both' then
-        local logPaletteName = gConfig.hotbarGlobal.logPaletteName;
-        if logPaletteName == nil then logPaletteName = true; end  -- Default to true
-        if imgui.Checkbox('Log Palette Name', {logPaletteName}) then
-            gConfig.hotbarGlobal.logPaletteName = not logPaletteName;
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Show palette name in chat log when cycling palettes.');
-    end
+    M.DrawLogPaletteNameCheckbox('##hbLogPal');
 
     -- Conflicting Game Keys section
     local blockedKeys = gConfig.hotbarGlobal.blockedGameKeys or {};
@@ -2928,105 +2278,13 @@ function M.DrawSettings(state)
         imgui.EndPopup();
     end
 
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- When mode is 'both', show tabs to switch between hotbar and crossbar settings
-    if currentMode == 'both' then
-        -- Draw Hotbar/Crossbar tabs
-        local hotbarClicked = components.DrawStyledTab(
-            'Hotbar',
-            'modeTabHotbar',
-            selectedModeTab == 'hotbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if hotbarClicked then
-            selectedModeTab = 'hotbar';
-        end
-
-        imgui.SameLine();
-
-        local crossbarClicked = components.DrawStyledTab(
-            'Crossbar',
-            'modeTabCrossbar',
-            selectedModeTab == 'crossbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if crossbarClicked then
-            selectedModeTab = 'crossbar';
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Show content based on selected tab
-        if selectedModeTab == 'crossbar' then
-            selectedCrossbarTab = DrawCrossbarSettings(selectedCrossbarTab);
-            return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
-        end
-        -- Fall through to hotbar settings below
-    elseif currentMode == 'crossbar' then
-        -- Show crossbar settings only
-        selectedCrossbarTab = DrawCrossbarSettings(selectedCrossbarTab);
-        return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
-    end
-
-    -- Show hotbar settings (mode is 'hotbar' or 'both' with hotbar tab selected)
-    imgui.Spacing();
-
-    -- Per-Bar Visual Settings header
-    imgui.TextColored(components.TAB_STYLE.gold, 'Per-Bar Visual Settings');
-    imgui.ShowHelp('Configure each hotbar independently. Each bar can have its own layout, theme, and button settings.');
-    imgui.Spacing();
-
-    -- Draw Bar 1-6 tabs
-    for i, barType in ipairs(BAR_TYPES) do
-        local clicked, tabWidth = components.DrawStyledTab(
-            barType.label,
-            'hotbarBarTab' .. i,
-            selectedBarTab == i,
-            nil,
-            components.TAB_STYLE.smallHeight,
-            components.TAB_STYLE.smallPadding
-        );
-        if clicked then
-            selectedBarTab = i;
-        end
-        if i < #BAR_TYPES then
-            imgui.SameLine();
-        end
-    end
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Draw settings for selected bar (Global tab vs per-bar tabs)
-    local currentBar = BAR_TYPES[selectedBarTab];
-    if currentBar then
-        if currentBar.isGlobal then
-            DrawGlobalVisualSettings();
-        else
-            DrawBarVisualSettings(currentBar.configKey, currentBar.label);
-        end
-    end
-
     -- Draw confirmation popup for job-specific toggle
     DrawJobSpecificConfirmPopup();
 
     -- Draw palette modal (unified for both hotbar and crossbar)
     DrawPaletteModal();
 
-    -- Draw palette manager window (separate window for advanced management)
-    paletteManager.Draw();
-
-    return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
+    return { selectedHotbarTab = selectedBarTab };
 end
 
 -- Helper: Draw color settings content (shared between global and per-bar)
@@ -3169,63 +2427,15 @@ end
 -- Section: Hotbar Color Settings
 function M.DrawColorSettings(state)
     local selectedBarTab = state and state.selectedHotbarTab or 1;
-    local selectedModeTab = state and state.selectedModeTab or 'hotbar';  -- 'hotbar' or 'crossbar' when mode is 'both'
-    local selectedCrossbarTab = state and state.selectedCrossbarTab or 1;  -- 1=L2, 2=R2, 3=L2R2, etc.
 
-    -- Determine what to show based on mode
-    local currentMode = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-
-    -- When mode is 'both', show tabs to switch between hotbar and crossbar color settings
-    if currentMode == 'both' then
-        -- Draw Hotbar/Crossbar tabs
-        local hotbarClicked = components.DrawStyledTab(
-            'Hotbar',
-            'colorModeTabHotbar',
-            selectedModeTab == 'hotbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if hotbarClicked then
-            selectedModeTab = 'hotbar';
-        end
-
-        imgui.SameLine();
-
-        local crossbarClicked = components.DrawStyledTab(
-            'Crossbar',
-            'colorModeTabCrossbar',
-            selectedModeTab == 'crossbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if crossbarClicked then
-            selectedModeTab = 'crossbar';
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Show content based on selected tab
-        if selectedModeTab == 'crossbar' then
-            DrawCrossbarColorSettings();
-            return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
-        end
-        -- Fall through to hotbar color settings below
-    elseif currentMode == 'crossbar' then
-        -- Show crossbar color settings only
-        DrawCrossbarColorSettings();
-        return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
+    if gConfig.hotbarEnabled == false then
+        imgui.TextColored({0.55, 0.52, 0.48, 1.0}, 'Keyboard hotbars are turned off. Crossbar colors are under the Crossbar category â†’ Color settings.');
+        return { selectedHotbarTab = selectedBarTab };
     end
 
-    -- Show hotbar color settings (mode is 'hotbar' or 'both' with hotbar tab selected)
-    -- Per-Bar Color Settings header
     imgui.TextColored(components.TAB_STYLE.gold, 'Per-Bar Color Settings');
     imgui.Spacing();
 
-    -- Draw Bar 1-6 tabs (same as visual settings)
     for i, barType in ipairs(BAR_TYPES) do
         local clicked, tabWidth = components.DrawStyledTab(
             barType.label,
@@ -3247,7 +2457,6 @@ function M.DrawColorSettings(state)
     imgui.Separator();
     imgui.Spacing();
 
-    -- Draw color settings for selected bar (Global tab vs per-bar tabs)
     local currentBar = BAR_TYPES[selectedBarTab];
     if currentBar then
         if currentBar.isGlobal then
@@ -3257,7 +2466,26 @@ function M.DrawColorSettings(state)
         end
     end
 
-    return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
+    return { selectedHotbarTab = selectedBarTab };
 end
 
+function M.DrawLogPaletteNameCheckbox(idSuffix)
+    idSuffix = idSuffix or '##logPalName';
+    local logPaletteName = gConfig.hotbarGlobal.logPaletteName;
+    if logPaletteName == nil then logPaletteName = true; end
+    local logVal = { logPaletteName };
+    if imgui.Checkbox('Log Palette Name' .. idSuffix, logVal) then
+        gConfig.hotbarGlobal.logPaletteName = logVal[1];
+        SaveSettingsOnly();
+    end
+    imgui.ShowHelp('Show palette name in chat log when cycling palettes.');
+end
+
+-- Shared palette modal API (used by config/crossbar_settings.lua for crossbar category)
+M.OpenPaletteCreateModal = OpenPaletteCreateModal;
+M.OpenPaletteRenameModal = OpenPaletteRenameModal;
+M.DrawJobSpecificConfirmPopup = DrawJobSpecificConfirmPopup;
+M.DrawPaletteModal = DrawPaletteModal;
+
 return M;
+

--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -274,7 +274,7 @@ end
 function M.createHotbarGlobalDefaults()
     return T{
         -- Game UI patches
-        disableMacroBars = false,  -- Disable native XI macros (macro bar display + controller macro blocking)
+        disableMacroBars = false,  -- Keyboard: hide native macro bar UI + block Ctrl/Alt+number macro keys (controller blocking is Crossbar → Disable XI Macros)
         controllerHoldToShow = true,  -- Controller triggers use hold-to-show (like macrofix addon) instead of tap-to-toggle
 
         -- Blocked game keys - array of key definitions that should be blocked from reaching the game
@@ -292,6 +292,10 @@ function M.createHotbarGlobalDefaults()
         -- Palette cycling controller (RB + Dpad)
         paletteCycleControllerEnabled = true,  -- Enable controller palette cycling
         hotbarPaletteCycleButton = 'R1',       -- 'R1' or 'L1' for hotbar cycling
+
+        logPaletteName = true,                 -- Log palette name when cycling keyboard hotbars
+        logPaletteNameCrossbar = true,         -- Log palette name when cycling via controller (crossbar)
+        logPaletteNameCrossbarCycleHint = true, -- Second CLI line: RB+D-pad return hint after job preview
 
         -- Visual settings
         slotSize = 48,          -- Slot size in pixels
@@ -333,7 +337,7 @@ function M.createHotbarGlobalDefaults()
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -350,7 +354,16 @@ function M.createHotbarGlobalDefaults()
         skillchainIconScale = 1.0,              -- Scale multiplier for icon (0.5-2.0)
         skillchainIconOffsetX = 0,              -- X offset in pixels
         skillchainIconOffsetY = 0,              -- Y offset in pixels
-    
+
+        -- Magic Burst highlight settings. Window opens IMMEDIATELY when a SC closes and runs
+        -- for 7.0s (matches retail's MB cutoff at the back end while front-loading the visual
+        -- cue). Highlights spell / magical pact rage / /ma-or-/pet macro slots whose element
+        -- matches one of the SC's burstable elements. Uses the same corner icon as the
+        -- skillchain highlight (the SC's name asset) but in the bottom-left corner with a
+        -- cyan-blue border to keep the two highlights visually distinct.
+        magicBurstHighlightEnabled = true,      -- Show MB highlight on element-matching spell slots
+        magicBurstHighlightColor = 0xFF44D4FF,  -- Cyan-blue (ARGB) — distinct from gold SC border
+
         -- Cooldown timer settings
         recastTimerFontSize = 11,               -- Font size for cooldown timer display
         recastTimerFontColor = 0xFFFFFFFF,      -- Color for cooldown timer text
@@ -372,6 +385,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Pet-aware toggle (when true, hotbar can have different palettes per pet for SMN/BST/DRG/PUP)
         petAware = false,
         showPetIndicator = true,  -- Show indicator dot when petAware is enabled
+        -- When set: array of type tokens 'avatars'|'elementals'|'beasts'|'wyvern'|'puppet' (legacy 'summons' = avatars+elementals). nil = all.
+        petPalettePetKeys = nil,
 
         -- Layout settings (always per-bar)
         enabled = true,
@@ -420,7 +435,7 @@ function M.createHotbarBarDefaults(overrides)
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -443,6 +458,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Structure: paletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Palettes are displayed in this order; missing palettes are appended alphabetically
         paletteOrder = {},
+        -- paletteExcludeFromCycle[orderKey][paletteName] = true skips palette for RB / keyboard cycling only
+        paletteExcludeFromCycle = {},
     };
     if overrides then
         for k, v in pairs(overrides) do
@@ -460,22 +477,51 @@ end
 -- The crossbar provides 4 combo modes: L2, R2, L2+R2, R2+L2 (32 total slots)
 function M.createCrossbarDefaults()
     return T{
-        -- Layout mode: 'hotbar', 'crossbar', or 'both'
-        mode = 'hotbar',
+        -- Show controller crossbar UI (mirrors gConfig.crossbarEnabled; kept for migration)
+        showCrossbar = true,
+
+        -- Hide crossbar when game menu open (independent from Hotbar → Hide When Menu Open)
+        crossbarHideOnMenuFocus = false,
+
+        -- Disable crossbar input while a game menu is open (keeps it visible but blocks trigger macros)
+        crossbarDisableInMenu = true,
+
+        -- Config UI: which main section is active (1=Controller, 2=Manage palettes, 3=Global visuals)
+        configUiTab = 1,
+        -- 'universal' = editing [G] all-jobs sets; 'job' = editing palettes for configEditJobId
+        configFocus = 'job',
+        configEditJobId = nil,   -- nil = use live main job from data when in job focus
+        configEditSubjobId = nil,
 
         -- Job-specific toggle (when true, actions are stored per-job; when false, actions are shared across all jobs)
         jobSpecific = true,
 
-        -- Per-combo-mode settings (pet-aware is per-combo, palettes are GLOBAL)
-        -- NOTE: activePalette was removed - crossbar palettes are now global (see palette.lua state.crossbarActivePalette)
+        -- All-jobs universal crossbar palettes (storage: global:palette:{name} in slotActions)
+        enableUniversalCrossbarPalettes = false,
+        -- 'job' = job/subjob named palettes; 'universal' = all-jobs sets (toggle L1+R1 when enabled)
+        defaultCrossbarPaletteScope = 'job',
+        -- Per-palette: includeInCycle = false hides palette from RB+D-pad when scope is universal
+        crossbarUniversalPaletteMeta = {},
+        universalCrossbarPaletteOrder = {},
+
+        -- Per-segment: petAware, optional per-segment petPalettePetKeys, universalOverridePalette = all-jobs palette name. Default pet types: petPalettePetKeys on parent.
         comboModeSettings = {
-            L2 = { petAware = false },
-            R2 = { petAware = false },
-            L2R2 = { petAware = false },
-            R2L2 = { petAware = false },
-            L2x2 = { petAware = false },
-            R2x2 = { petAware = false },
+            L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
         },
+        -- Optional per named [J] palette: comboMode -> { petAware?, universalOverridePalette? } (nil field = inherit Crossbar defaults)
+        namedPaletteComboModeSettings = {},
+
+        -- Crossbar [J] only: which pet families (avatars/elementals/beasts/wyvern/puppet) use pet hotbar storage; nil = all. Not per named palette.
+        petPalettePetKeys = nil,
+
+        -- Per main job id (string key): effective combo mode -> { scope = 'jobShared' | 'global', globalPalette = name? }
+        -- Primary L2/R2 are not used. Resolves slot data to jobsegment:{jobId}:{mode} or global:palette:{name}.
+        segmentOverrides = {},
 
         -- Layout
         slotSize = 40,              -- Slot size in pixels
@@ -495,7 +541,8 @@ function M.createCrossbarDefaults()
         slotBackgroundColor = 0x55000000,
         slotOpacity = 1.0,                  -- Opacity multiplier for slot.png (0.0-1.0)
         activeSlotHighlight = 0x44FFFFFF,   -- Highlight color when trigger held
-        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side
+        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side (expanded / non-trigger dim)
+        inactiveSideWhileTriggerDim = 0.15, -- Dim for the non-active half while L2 or R2 is held
 
         -- Display mode
         displayMode = 'normal',             -- 'normal' or 'activeOnly'
@@ -511,6 +558,8 @@ function M.createCrossbarDefaults()
         buttonIconGapH = 8,                 -- Horizontal spacing between center icons
         buttonIconGapV = 2,                 -- Vertical spacing between center icons
         buttonIconPosition = 'corner',      -- 'corner' or 'replace_keybind'
+        -- Job icon set for palette UI (Manage Palettes strip + in-game palette scope icon when Job [J])
+        paletteJobIconTheme = 'Classic',     -- 'Classic', 'FFXI', 'FFXIV-1' (under assets/jobs/)
         controllerTheme = 'Xbox',           -- 'PlayStation', 'Xbox', or 'Nintendo' button icons
         controllerScheme = 'xbox',          -- Controller profile: 'xbox', 'dualsense', 'switchpro', 'dinput'
         triggerIconScale = 0.8,             -- Scale for L2/R2 trigger icons (base 49x28)
@@ -545,10 +594,14 @@ function M.createCrossbarDefaults()
         comboTextOffsetY = 0,               -- Y offset for combo text position
 
         -- Palette name display (shows current palette and index, e.g., "Stuns (2/5)")
-        showPaletteName = false,            -- Toggle to show palette name
+        showPaletteName = false,            -- Toggle to show palette name text below crossbar
+        showPaletteScopeIcon = true,        -- Job / Global scope icon above divider; nil in saved config = legacy (follow showPaletteName)
         paletteNameFontSize = 10,           -- Font size for palette name
         paletteNameOffsetX = 0,             -- X offset for position
         paletteNameOffsetY = 0,             -- Y offset for position
+        -- Job / Global palette scope icon above center divider
+        paletteScopeIconOffsetY = 12,       -- Vertical lift (px); higher = icon moves up
+        paletteScopeIconSize = 22,          -- Icon width/height (px); legacy profiles fall back to font-based size if unset
 
         -- Expanded crossbar (L2+R2 combos)
         enableExpandedCrossbar = true,      -- Enable L2+R2 and R2+L2 combos
@@ -557,6 +610,12 @@ function M.createCrossbarDefaults()
         -- Double-tap crossbar (tap trigger twice quickly)
         enableDoubleTap = false,            -- Enable L2x2 and R2x2 double-tap modes
         doubleTapWindow = 0.3,              -- Time window for double-tap detection (seconds)
+
+        -- Double-tap preview windows (always-visible overlays showing L2x2 / R2x2 bars)
+        showDoubleTapPreview    = false,     -- Show floating preview windows for double-tap bars
+        doubleTapPreviewScale   = 0.60,     -- Preview scale relative to main crossbar (0.3–1.0)
+        doubleTapPreviewOpacity = 1.0,      -- Preview opacity multiplier (0.2–1.0; dims with trigger)
+        doubleTapPreviewLocked  = false,    -- Lock preview positions independently of the main crossbar
 
         -- Analog trigger thresholds (0-255 normalized range)
         -- Used by Xbox (XInput) and PlayStation (DirectInput with signed->unsigned conversion)
@@ -587,6 +646,8 @@ function M.createCrossbarDefaults()
         -- Structure: crossbarPaletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Note: Crossbar palettes are independent from hotbar palettes
         crossbarPaletteOrder = {},
+        -- Same shape as paletteExcludeFromCycle on hotbar; per job:storage-tier key
+        crossbarPaletteExcludeFromCycle = {},
     };
 end
 

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -17,13 +17,35 @@ local dragdrop = require('libs.dragdrop');
 local data = require('modules.hotbar.data');
 local actions = require('modules.hotbar.actions');
 local textures = require('modules.hotbar.textures');
+-- TextureManager is used for the palette scope icon overlay (job icon / infinity for universal palettes).
+local TextureManager = require('libs.texturemanager');
 local controller = require('modules.hotbar.controller');
 local recast = require('modules.hotbar.recast');
 local slotrenderer = require('modules.hotbar.slotrenderer');
+-- playerdata caches the player's known abilities + weaponskills; `IsActionAvailable` falls
+-- back to "unavailable" when the caches are empty. Keyboard hotbars warm these from their
+-- own DrawWindow, but crossbar-only setups (`hotbarEnabled=false, crossbarEnabled=true`)
+-- never touched playerdata before — every JA/WS slot then read as unavailable (grayed +
+-- "X") even on jobs that knew the abilities. We now refresh once per frame from crossbar
+-- DrawWindow as well; the refresh is signature-gated internally (job/level/equip diff) so
+-- the steady-state cost is a few cache reads, not a full re-scan.
+local playerdata = require('modules.hotbar.playerdata');
 local animation = require('libs.animation');
 local skillchain = require('modules.hotbar.skillchain');
+-- macroparse extracts the primary line + JA badge type from a /ws or /pet macro body, so we can
+-- predict skillchain icons on macro slots whose first line is a weapon skill or blood pact.
+-- Display.lua does the same thing for keyboard hotbars; without it, crossbar macro slots whose
+-- primary line is /ws or /pet would never light up even though firing the macro IS the WS/pact.
+local macroparse = require('modules.hotbar.macroparse');
 local targetLib = require('libs.target');
 local palette = require('modules.hotbar.palette');
+-- Used to dim the crossbar when a blocking game menu is open AND `crossbarDisableInMenu`
+-- is enabled, so the player can see at a glance that controller input is paused.
+local gamestate = require('core.gamestate');
+-- macropalette is required only for the palette-editor drop handlers (effective palette key
+-- + macro source store). Required at module scope here (mirrors Ferris); if a future
+-- circular dependency creeps in this can be flipped to a lazy `require` inside the closures.
+local macropalette = require('modules.hotbar.macropalette');
 
 local M = {};
 
@@ -75,6 +97,13 @@ end
 
 local SLOTS_PER_SIDE = 8;
 local COMBO_MODES = controller.COMBO_MODES;
+-- Full enumeration of combo-mode storage keys (used by the Edit Full Palette editor and the
+-- pet-tab filter). 'Shared' is the chord-fallback for sharedExpanded layouts where both
+-- L2+R2 and R2+L2 collapse to one set.
+local ALL_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', 'Shared' };
+-- Naming prefix on resource maps + IDs used by the Edit Full Palette draft layer so its
+-- ImGui drop zones / animation keys never collide with the live HUD's 'crossbar_*' set.
+local PAL_ED_PREFIX = 'PalEd_';
 
 -- ============================================
 -- Layout Calculation Functions
@@ -277,7 +306,14 @@ local function GetCachedCrossbarIcon(comboMode, slotIndex, slotData)
 end
 
 -- Clear crossbar icon cache
+-- iconCache rows hold the only Lua ref to D3D textures returned by actions.GetBindIcon
+-- (LoadTextureFromPath wires a gc_safe_release finalizer). Wiping mid-frame — e.g. palette
+-- deletion fires InvalidateAllVisualCachesAfterPaletteListMutation while the crossbar
+-- DrawWindow is still building this frame's ImGui draw list — lets Lua GC finalize the COM
+-- texture while AddImage still references it (CTD on Ashita 4.16). DeferRelease holds the
+-- old table alive until FlushPendingReleases runs at the top of the next d3d_present.
 local function ClearCrossbarIconCache()
+    TextureManager.DeferRelease(iconCache);
     iconCache = {};
 end
 
@@ -286,6 +322,10 @@ local function ClearCrossbarIconCacheForSlot(comboMode, slotIndex)
     -- Use effective combo mode for cache key (Shared when shared expanded bar is enabled)
     comboMode = data.GetEffectiveComboModeForStorage and data.GetEffectiveComboModeForStorage(comboMode) or comboMode;
     if iconCache[comboMode] then
+        local oldRow = iconCache[comboMode][slotIndex];
+        if oldRow ~= nil then
+            TextureManager.DeferRelease(oldRow);
+        end
         iconCache[comboMode][slotIndex] = nil;
     end
 end
@@ -328,6 +368,16 @@ local state = {
         progress = 1.0,
         wasHidden = false,
     },
+
+    -- useSharedExpandedBar bookkeeping. The shared-center layout collapses the bar to one
+    -- diamond width and forces the X anchor to screen-center every frame; without these the
+    -- normal X anchor would either get persisted as the centered narrow value (chord persists
+    -- across a save) or snap back to the leftmost saved position on chord exit. The two-step
+    -- handoff is: while in chord we stash the last "wide" window X here, then on the first
+    -- frame that exits chord we re-anchor to that stashed X so the bar returns where the
+    -- user actually placed it (rather than wherever the centered narrow bar happened to land).
+    lastWideCrossbarWindowX = nil,
+    wasSharedCenterChordLayout = false,
 };
 
 -- ============================================
@@ -376,12 +426,24 @@ end
 -- ============================================
 
 -- Determine which combo modes to display on left/right based on active combo
--- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'both', or nil)
-local function GetDisplayModes(activeCombo)
+-- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'center', 'both', or nil)
+-- When useSharedExpandedBar is enabled and the user holds a chord (L2+R2 / R2+L2), expandedSide
+-- becomes 'center': only the left column is drawn (using the 'Shared' storage key), the window
+-- shrinks to one diamond width, and DrawWindow re-centers it to screen X (a single 8-slot strip
+-- centered like the FFXIV controller bar) rather than the two-diamond wide layout.
+local function GetDisplayModes(activeCombo, settings)
+    settings = settings or (gConfig and gConfig.hotbarCrossbar);
+    local useSharedExp = settings and settings.useSharedExpandedBar == true;
     if activeCombo == COMBO_MODES.L2_THEN_R2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: L2 first, then R2 -> show L2R2 on left side only, right side dimmed (shows R2)
         return 'L2R2', 'R2', true, 'left';
     elseif activeCombo == COMBO_MODES.R2_THEN_L2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: R2 first, then L2 -> show R2L2 on right side only, left side dimmed (shows L2)
         return 'L2', 'R2L2', true, 'right';
     elseif activeCombo == 'Shared' then
@@ -585,6 +647,69 @@ local function GetSlotPositionInWindow(side, slotIndex, windowX, windowY, settin
 end
 
 -- ============================================
+-- Window-decor padding (slot-top vs window-top accounting)
+-- ============================================
+-- ImGui clips anything we draw OUTSIDE the window's content rect. The crossbar paints a
+-- lot of decoration above the slot grid (L2/R2 trigger icons, combo text, R1 cpal-anchor
+-- pulse, palette-modifier refresh glyph) and below it (palette name, action labels). To
+-- keep all of that inside the window's draw region we open the ImGui window taller than
+-- the slot grid by CROSSBAR_WINDOW_TOP_DECOR_PAD on top and `GetCrossbarWindowBottomPad`
+-- on the bottom, then offset the window-top so the SLOT GRID still lands at the user's
+-- saved (or default) Y. `state.windowY` continues to mean "slot grid top" everywhere
+-- else in this module, which lets the rest of the layout code stay unchanged.
+local CROSSBAR_WINDOW_TOP_DECOR_PAD = 80;
+
+local function GetCrossbarWindowBottomPad(settings)
+    settings = settings or {};
+    local pad = 10;
+    if settings.showActionLabels then
+        pad = pad + (settings.labelFontSize or 10) + 6 + math.max(0, tonumber(settings.actionLabelOffsetY) or 0);
+    end
+    pad = pad + math.floor(((settings.mpCostFontSize or 10) + (settings.quantityFontSize or 10)) * 0.15 + 0.5);
+    return math.min(72, math.max(10, pad));
+end
+
+-- Profile stores SLOT TOP Y (`gConfig.windowPositions.Crossbar.y`), not window-top. When
+-- we apply a saved position we subtract the decor pad so the slot grid lands where the
+-- user originally placed it. The `appliedPositions` flag keeps ImGui's drag from being
+-- overridden every frame (ImGuiCond_Always otherwise).
+local function ApplyCrossbarWindowPositionOnce()
+    if not gConfig or not gConfig.windowPositions or not gConfig.windowPositions['Crossbar'] then
+        return false;
+    end
+    if not gConfig.appliedPositions then
+        gConfig.appliedPositions = {};
+    end
+    if gConfig.appliedPositions['Crossbar'] then
+        return false;
+    end
+    local pos = gConfig.windowPositions['Crossbar'];
+    imgui.SetNextWindowPos({ pos.x, pos.y - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    gConfig.appliedPositions['Crossbar'] = true;
+    return true;
+end
+
+-- Save SLOT TOP Y, not window-top, so the saved coordinate stays meaningful even if the
+-- decor pad changes between releases (or a future patch adds more decoration above the
+-- slot grid). Skips writes when nothing changed to avoid table churn / unnecessary disk
+-- saves on every frame.
+local function SaveCrossbarWindowSlotTopPosition()
+    if not gConfig then return; end
+    local wx, wy = imgui.GetWindowPos();
+    if not gConfig.windowPositions then
+        gConfig.windowPositions = {};
+    end
+    local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+    local saved = gConfig.windowPositions['Crossbar'];
+    if not saved then
+        gConfig.windowPositions['Crossbar'] = { x = wx, y = slotTopY };
+    elseif saved.x ~= wx or saved.y ~= slotTopY then
+        saved.x = wx;
+        saved.y = slotTopY;
+    end
+end
+
+-- ============================================
 -- Initialization
 -- ============================================
 
@@ -671,12 +796,147 @@ end
 -- animOpacity: 0-1 for animation fade (default 1.0)
 -- yOffset: Y offset in pixels for animation (default 0)
 -- skillchainName: (optional) Skillchain name for WS slots
-local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName)
+-- Reusable cbInteraction sub-tables built lazily for palette-editor slots so the editor and
+-- the live crossbar each get their own slotInteraction set (different idPrefix/buttonId/
+-- dropZoneId — palette editor uses 'paled_*'; live crossbar uses 'crossbar_*'). Keeping
+-- them separate also lets the slotrenderer drop-zone-lock semantics treat them differently
+-- (paled_* are never locked; crossbar_* respect crossbarLockMovement).
+local cbInteractionPalEd = {};
+
+local function GetCbInteractionPaletteEditor(comboMode, slotIndex)
+    if not cbInteractionPalEd[comboMode] then cbInteractionPalEd[comboMode] = {}; end
+    local cached = cbInteractionPalEd[comboMode][slotIndex];
+    if cached then return cached; end
+
+    local entry = {
+        buttonId = string.format('##paled_%s_%d', comboMode, slotIndex),
+        dropZoneId = string.format('paled_%s_%d', comboMode, slotIndex),
+        pressKey = 'paled_' .. comboMode .. '_' .. slotIndex,
+        onDrop = function(payload)
+            -- Palette-editor drops go through the draft layer; Apply Draft promotes them to live.
+            -- All branches normalize through the overlay (draft falls back to live) and finalize
+            -- before writing so dual-arm macros swap correctly and empty results clear properly.
+            if payload.type == 'macro' then
+                if payload.data and payload.data.macroPaletteKey == nil then
+                    if macropalette.GetEffectivePaletteType then
+                        payload.data.macroPaletteKey = macropalette.GetEffectivePaletteType();
+                    else
+                        payload.data.macroPaletteKey = data.jobId or 1;
+                    end
+                end
+                if payload.data and macropalette.GetMacroSourceTagForDrops
+                    and payload.data.macroSourceStore == nil then
+                    payload.data.macroSourceStore = macropalette.GetMacroSourceTagForDrops();
+                end
+                local arm = {};
+                for k, v in pairs(payload.data) do arm[k] = v; end
+                if arm.macroRef == nil and payload.data.id then
+                    arm.macroRef = payload.data.id;
+                end
+                local existingRaw = data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex);
+                local existing = data.NormalizeCrossbarSlotRawForSwap(existingRaw);
+                local store = arm.macroSourceStore
+                    or (macropalette.GetMacroSourceTagForDrops and macropalette.GetMacroSourceTagForDrops())
+                    or 'profile';
+                local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                data.SetDraftSlotData(comboMode, slotIndex, built);
+            elseif payload.type == 'crossbar_slot' then
+                -- Always read source/target from overlay at drop time; payload.data was captured
+                -- at drag start and can alias stale tables after earlier moves in the same session.
+                local srcCombo = payload.comboMode;
+                local srcSlot = payload.slotIndex;
+                if srcCombo == comboMode and srcSlot == slotIndex then return; end
+                if data.BeginDraftUndoGroup then data.BeginDraftUndoGroup(); end
+                local srcRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(srcCombo, srcSlot));
+                local tgtRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+                local newTgt, newSrc = data.SwapActiveMacroArmsInPlace(srcRaw, tgtRaw);
+                local fT = data.FinalizeCrossbarRawSlotForStorage(newTgt);
+                local fS = data.FinalizeCrossbarRawSlotForStorage(newSrc);
+                if fT == nil then
+                    data.ClearDraftSlotData(comboMode, slotIndex);
+                else
+                    data.SetDraftSlotData(comboMode, slotIndex, fT);
+                end
+                if fS == nil then
+                    data.ClearDraftSlotData(srcCombo, srcSlot);
+                else
+                    data.SetDraftSlotData(srcCombo, srcSlot, fS);
+                end
+                if data.EndDraftUndoGroup then data.EndDraftUndoGroup(); end
+                -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+                -- the icon cache clear above is the only refresh needed for the source slot.
+                ClearCrossbarIconCacheForSlot(srcCombo, srcSlot);
+            elseif payload.type == 'slot' then
+                if payload.data then
+                    local c = data.FinalizeCrossbarRawSlotForStorage(data.CopyTable(payload.data));
+                    if c == nil then
+                        data.ClearDraftSlotData(comboMode, slotIndex);
+                    else
+                        data.SetDraftSlotData(comboMode, slotIndex, c);
+                    end
+                end
+            end
+            -- Visual refresh for the target slot (matches live-HUD drop behaviour).
+            -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+            -- the icon cache clear is the only refresh needed (the bind hash on next frame
+            -- naturally re-derives slot draw state — see ClearSlotIconCache notes in macropalette).
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        getDragData = function()
+            -- Use overlay (draft falling back to live) so dragging a slot that hasn't been
+            -- touched in this edit session still carries its persisted data. Reading draft-only
+            -- here would drag nil and the drop handler would clear the target slot.
+            local raw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+            return {
+                type = 'crossbar_slot',
+                comboMode = comboMode,
+                slotIndex = slotIndex,
+                data = raw,
+            };
+        end,
+        onRightClick = function()
+            data.ClearDraftSlotData(comboMode, slotIndex);
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        -- Double-click in Edit Full Palette opens the macro editor for the slot's draft
+        -- content. For empty slots that resolves to nil and macropalette.OpenEditorForSlotData
+        -- starts a fresh "creating new" session seeded with the active palette type's defaults.
+        -- The (comboMode, slotIndex) carried in the pending edit lets palettemanager auto-bind
+        -- the new macro to this slot after Save (see config/palettemanager.lua consume site).
+        -- We funnel through data.SetPendingPaletteSlotEdit so the editor opens on the NEXT
+        -- frame (consumed by config/palettemanager.lua after slots draw); opening it directly
+        -- inside this click handler would put a modal inside the hotbar's draw pass and skip
+        -- the macropalette draw-order assumptions.
+        onDoubleClick = function()
+            local slotData = data.GetDraftSlotData
+                and data.GetDraftSlotData(comboMode, slotIndex)
+                or nil;
+            data.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex);
+        end,
+    };
+    cbInteractionPalEd[comboMode][slotIndex] = entry;
+    return entry;
+end
+
+-- Palette-editor empty-slot panel tint (matches the Edit Full Palette row fill in palettemanager.lua).
+-- Lighter than the live crossbar's 0x55000000 so slot outlines read clearly against the editor row.
+local PAL_ED_EMPTY_SLOT_BG = 0xFF8E96AC;
+
+local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName, activeCombo, editorClipRect, magicBurstName)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
-    -- Get pre-created interaction closures and IDs
-    local interaction = GetCbInteraction(comboMode, slotIndex);
+    -- Edit Full Palette state: when active, this slot belongs to the editor's draft layer
+    -- rather than the live crossbar. palSk is the storage-key the editor is targeting; the
+    -- draft layer is separate per-key (so editing one palette doesn't touch the live binding).
+    local palSk = data.GetCrossbarPaletteEditSessionKey and data.GetCrossbarPaletteEditSessionKey();
+    local isEditor = palSk ~= nil;
+
+    -- Get pre-created interaction closures and IDs. Editor and live get different prefixes so
+    -- the slotrenderer drop-zone-lock policy can distinguish them (paled_* are never locked).
+    local interaction = isEditor
+        and GetCbInteractionPaletteEditor(comboMode, slotIndex)
+        or GetCbInteraction(comboMode, slotIndex);
 
     -- Apply Y offset for animation
     local drawY = y + yOffset;
@@ -687,8 +947,14 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
         iconPressScale = animation.getPressScale(interaction.pressKey, isPressed and isActive);
     end
 
-    -- Get slot data
-    local slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    -- Slot data source: editor reads from the draft layer (synced from live at session start
+    -- via data.SyncDraftSlotFromLive); live crossbar always reads the persisted binding.
+    local slotData;
+    if isEditor then
+        slotData = data.GetDraftSlotData and data.GetDraftSlotData(comboMode, slotIndex) or nil;
+    else
+        slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    end
 
     -- Get icon + cached abbreviation for this action (cached - only rebuilds when bind changes)
     local icon, cachedAbbr, cachedAbbrW = GetCachedCrossbarIcon(comboMode, slotIndex, slotData);
@@ -696,6 +962,33 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     -- Global UI scale (slotSize/x/y come in already scaled; we apply gs here to
     -- font sizes and pixel offsets that come straight from settings).
     local gs = (gConfig and gConfig.globalScale) or 1.0;
+
+    -- Diamond position: 1=Top, 2=Right, 3=Bottom, 4=Left (slots 5-8 map via -4 for face buttons).
+    -- Top-slot labels placed below would overlap the bottom slot's MP/quantity text, so the
+    -- editor (and any caller that asks for labels) flips them above for the top position.
+    local posIndex = (slotIndex <= 4) and slotIndex or (slotIndex - 4);
+    local labelAboveSlot = (posIndex == 1);
+
+    -- Dim policy. Live crossbar: inactive sides get a softer dim; when a trigger is held the
+    -- non-active half dims much harder so the active set pops. Editor: nothing is "inactive".
+    local dimFactor = 1.0;
+    if not isEditor and not isActive then
+        if activeCombo and activeCombo ~= COMBO_MODES.NONE then
+            dimFactor = settings.inactiveSideWhileTriggerDim;
+            if dimFactor == nil then dimFactor = 0.15; end
+        else
+            dimFactor = settings.inactiveSlotDim or 0.5;
+        end
+    end
+
+    -- Editor background: lighter tint behind empty editor slots so slot borders pop on the
+    -- panel row; filled editor slots use the user's normal background.
+    local slotBgColor = settings.slotBackgroundColor or 0x55000000;
+    local slotOpacity = settings.slotOpacity or 1.0;
+    if isEditor and not slotData then
+        slotBgColor = PAL_ED_EMPTY_SLOT_BG;
+        slotOpacity = 1.0;
+    end
 
     -- Update reusable params table in-place
     local p = cbParams;
@@ -707,28 +1000,30 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.cachedAbbrW = cachedAbbrW;
     p.bind = slotData;
     p.icon = icon;
-    p.slotBgColor = settings.slotBackgroundColor or 0x55000000;
-    p.slotOpacity = settings.slotOpacity or 1.0;
-    p.dimFactor = isActive and 1.0 or (settings.inactiveSlotDim or 0.5);
+    p.slotBgColor = slotBgColor;
+    p.slotOpacity = slotOpacity;
+    p.dimFactor = dimFactor;
     p.animOpacity = animOpacity;
     p.isPressed = isPressed and isActive;
     p.iconPressScale = iconPressScale;
-    p.showMpCost = settings.showMpCost ~= false;
+    p.showMpCost = isEditor and false or (settings.showMpCost ~= false);
     p.mpCostFontSize = (settings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = settings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = settings.mpCostNoMpColor or 0xFFFF4444;
     p.mpCostOffsetX = (settings.mpCostOffsetX or 0) * gs;
     p.mpCostOffsetY = (settings.mpCostOffsetY or 0) * gs;
-    p.showQuantity = settings.showQuantity ~= false;
+    p.showQuantity = isEditor and false or (settings.showQuantity ~= false);
     p.showStackQuantity = settings.showStackQuantity == true;
     p.quantityFontSize = (settings.quantityFontSize or 10) * gs;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
     p.quantityOffsetX = (settings.quantityOffsetX or 0) * gs;
     p.quantityOffsetY = (settings.quantityOffsetY or 0) * gs;
-    p.showLabel = settings.showActionLabels or false;
+    -- Editor: always show labels (on-slot abbrev with hover popup); live crossbar respects the user setting.
+    p.showLabel = isEditor and true or (settings.showActionLabels or false);
     p.labelText = slotData and (slotData.displayName or slotData.action or '') or '';
-    p.labelOffsetX = (settings.actionLabelOffsetX or 0) * gs;
-    p.labelOffsetY = ((settings.actionLabelOffsetY or 0) + 2) * gs;
+    p.labelOffsetX = isEditor and 0 or ((settings.actionLabelOffsetX or 0) * gs);
+    p.labelOffsetY = isEditor and 0 or (((settings.actionLabelOffsetY or 0) + 2) * gs);
+    p.labelAboveSlot = labelAboveSlot;
     p.labelFontSize = (settings.labelFontSize or 10) * gs;
     p.recastTimerFontSize = (settings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = settings.recastTimerFontColor or 0xFFFFFFFF;
@@ -744,10 +1039,29 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.dragType = 'crossbar_slot';
     p.getDragData = interaction.getDragData;
     p.onRightClick = interaction.onRightClick;
+    -- Editor slots: double-click opens the macro editor (empty slot = new macro seeded
+    -- with palette defaults, filled slot = edit existing). Live crossbar slots leave
+    -- onDoubleClick nil so single-click executes the action immediately.
+    p.onDoubleClick = isEditor and interaction.onDoubleClick or nil;
+    -- Editor slots don't have a "live" action to execute; suppressing the single-click
+    -- action is what enables the click-tracking pipeline in slotrenderer to detect a
+    -- second click and dispatch onDoubleClick. Live HUD keeps the default behavior.
+    p.suppressActionOnClick = isEditor and true or false;
     p.showTooltip = true;
-    -- Skillchain highlight
-    p.skillchainName = skillchainName;
+    -- Editor-only params consumed by slotrenderer Pass 2 (clip culling + on-slot multi-line label).
+    p.editorClipRect = editorClipRect;
+    p.editorMinimalView = isEditor;
+    p.labelForeground = isEditor;
+    -- Editor drops should win against the live crossbar zone underneath when the editor preview
+    -- overlaps the HUD (FlushDeferredDrops resolves overlaps by highest priority).
+    p.dropPriority = isEditor and 10 or nil;
+    -- Skillchain highlight (only on live crossbar; editor preview suppresses it).
+    p.skillchainName = (not isEditor) and skillchainName or nil;
     p.skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44;
+    -- Magic Burst highlight — same suppression rules as skillchain (editor preview has no
+    -- live target so the prediction would be meaningless / misleading there).
+    p.magicBurstName = (not isEditor) and magicBurstName or nil;
+    p.magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF;
 
     -- Render slot using shared renderer (handles ALL rendering and interactions)
     slotrenderer.DrawSlot(p);
@@ -879,8 +1193,125 @@ local function DrawTriggerIcons(activeCombo, l2GroupX, r2GroupX, groupY, groupWi
                 {0, 0}, {1, 1},
                 tintColor
             );
+
+            -- R1 return indicator: rendered above R2 when the user has set a "cpal" anchor
+            -- (via `/xiui cpal <Job>`). Pulses to draw the eye toward the return-to-anchor
+            -- shortcut. Per-scope so anchors don't leak across universal vs job-scoped views.
+            local scope = palette.GetCrossbarPaletteScope();
+            local anchor = palette.GetCpalAnchor and palette.GetCpalAnchor(scope);
+            if anchor then
+                local r1Texture = textures:GetControllerIcon('R1');
+                if r1Texture and r1Texture.image then
+                    local r1Ptr = tonumber(ffi.cast('uint32_t', r1Texture.image));
+                    if r1Ptr then
+                        local r1Width = baseIconWidth;
+                        local r1Height = baseIconHeight;
+                        local r1IconX = r2GroupX + (groupWidth / 2) - (r1Width / 2);
+                        local r1IconY = r2IconY - r1Height - 4;
+
+                        -- ~2.5 Hz size pulse (peak +30%) keeps the indicator visible without
+                        -- being distracting. Sin → abs so the icon "breathes" symmetrically.
+                        local pulse = math.abs(math.sin(os.clock() * 2.5));
+                        local sizeScale = 1.0 + 0.30 * pulse;
+                        local sw = r1Width * sizeScale;
+                        local sh = r1Height * sizeScale;
+                        local sx = r1IconX + r1Width * 0.5 - sw * 0.5;
+                        local sy = r1IconY + r1Height * 0.5 - sh * 0.5;
+
+                        -- Pill-shaped dark backdrop spans the icon + "x2" text so they read
+                        -- as a single legend regardless of the underlying scene.
+                        local textGap, textEstW, pad = 3, 14, 4;
+                        drawList:AddRectFilled(
+                            { r1IconX - pad, r1IconY - pad },
+                            { r1IconX + r1Width + textGap + textEstW + pad, r1IconY + r1Height + pad },
+                            0x99000000, 5
+                        );
+
+                        drawList:AddImage(r1Ptr, { sx, sy }, { sx + sw, sy + sh }, { 0, 0 }, { 1, 1 }, 0xFFFFFFFF);
+                        -- Gold ARGB: A=FF R=FF G=C8 B=32 → ImGui's GetColorU32 byte order is 0xAABBGGRR
+                        drawList:AddText(
+                            { r1IconX + r1Width + textGap, r1IconY + r1Height * 0.5 - 6 },
+                            0xFF32C8FF,
+                            'x2'
+                        );
+                    end
+                end
+            end
         end
     end
+end
+
+-- Shared expanded bar (useSharedExpandedBar): the L2+R2 / R2+L2 chord collapses both diamonds
+-- into a single centered 8-slot strip, so DrawTriggerIcons can't position L2 over the left group
+-- and R2 over the (now-absent) right group. This variant renders an "L2 + R2" chord glyph centred
+-- on the single visible diamond: both icons inline with a small "+" between them, tinted brighter
+-- when their trigger is part of the active combo. Same draw list as DrawTriggerIcons so the chord
+-- glyph layers with the same z-order as the regular trigger labels.
+local function DrawTriggerIconsSharedExpandedCenter(activeCombo, groupLeftX, groupY, groupWidth, settings, drawList)
+    if not settings.showTriggerLabels then return; end
+    if not drawList then return; end
+
+    local baseScale = settings.triggerIconScale or 1.0;
+    local iw = 49 * baseScale;
+    local ih = 28 * baseScale;
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    -- chordTight: pull the +/glyphs closer together as the icons shrink so the legend stays compact
+    -- (matches the spacing the editor's shared-chord glyph uses in DrawPaletteEditorL2R2TriggerGlyphs).
+    local chordTight = math.max(0.5, 0.65 * baseScale);
+    local cx = groupLeftX + groupWidth * 0.5;
+    local cy = groupY - ih * 0.5;
+
+    -- Both triggers participate in any chord / double-tap involving them, so animate accordingly.
+    local l2Active = activeCombo == COMBO_MODES.L2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.L2_DOUBLE;
+    local r2Active = activeCombo == COMBO_MODES.R2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.R2_DOUBLE;
+    if activeCombo == COMBO_MODES.NONE then
+        l2Active = false;
+        r2Active = false;
+    end
+
+    local l2PressScale = 1.0;
+    local r2PressScale = 1.0;
+    if settings.enablePressScale ~= false then
+        l2PressScale = animation.getPressScale('trigger_L2', l2Active);
+        r2PressScale = animation.getPressScale('trigger_R2', r2Active);
+    end
+
+    -- Measure the "+" once so the chord can be centered as a single unit (icon + plus + icon).
+    -- Fallback dims 10x14 keep layout sensible on builds where imgui.CalcTextSize isn't bound.
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImageScaled(texName, ix, iy, w, h, tintColor)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        drawList:AddImage(p, { ix, iy }, { ix + w, iy + h }, { 0, 0 }, { 1, 1 }, tintColor);
+    end
+
+    local ptw, pth = plusSize();
+    local lw = iw * l2PressScale;
+    local lh = ih * l2PressScale;
+    local rw = iw * r2PressScale;
+    local rh = ih * r2PressScale;
+    local total = lw + chordTight + ptw + chordTight + rw;
+    local leftX = cx - total * 0.5;
+    local l2Tint = l2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    local r2Tint = r2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    drawImageScaled('L2', leftX, cy - lh * 0.5, lw, lh, l2Tint);
+    drawList:AddText({ leftX + lw + chordTight, cy - pth * 0.5 }, textCol, '+');
+    drawImageScaled('R2', leftX + lw + chordTight + ptw + chordTight, cy - rh * 0.5, rw, rh, r2Tint);
 end
 
 -- Draw combo text in center for complex combos (L2R2, R2L2, L2x2, R2x2) or edit mode
@@ -934,7 +1365,13 @@ local function DrawComboText(activeCombo, centerX, topY, settings)
     end
 end
 
--- Draw palette name below crossbar (e.g., "Stuns (2/5)")
+-- Draw palette name below crossbar (e.g., "Stuns (2/5)"). The index/total count is
+-- restricted to ENABLED palettes (RB-cycle filtered) and is hidden entirely when there
+-- is only one cycleable palette (a 1/1 badge is just noise). For universal [G] scope,
+-- routes through GetCrossbarPaletteLabelIndexAndTotal which uses the universal cycle list
+-- instead of the per-job rows. (Lookup is microseconds at typical 1-10 palette counts; a
+-- per-frame label cache was tried and reverted because it could go stale on PaletteManager
+-- CRUD without a roster-version invalidation hook.)
 local function DrawPaletteName(centerX, bottomY, settings)
     if not settings.showPaletteName then return; end
 
@@ -943,10 +1380,14 @@ local function DrawPaletteName(centerX, bottomY, settings)
 
     local jobId = data.jobId or 1;
     local subjobId = data.subjobId or 0;
-    local index = palette.GetCrossbarPaletteIndex(paletteName, jobId, subjobId) or 1;
-    local total = palette.GetCrossbarPaletteCount(jobId, subjobId) or 1;
+    local index, total = palette.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId);
 
-    local displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    local displayText;
+    if index and total and total > 1 then
+        displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    else
+        displayText = paletteName;
+    end
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local fontSize = (settings.paletteNameFontSize or 10) * gs;
     local offsetX = (settings.paletteNameOffsetX or 0) * gs;
@@ -961,8 +1402,97 @@ local function DrawPaletteName(centerX, bottomY, settings)
     end
 end
 
--- Helper to draw just the left side
-local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- ============================================
+-- Palette scope icon (above the center divider)
+-- Shows the infinity glyph for Global/universal palettes, or the job icon for job-scoped.
+-- Lazily caches the infinity texture; the job-icon TextureManager has its own cache.
+-- ============================================
+local cachedInfinityPaletteTex = nil;
+
+local function GetInfinityPaletteIconTexture()
+    if cachedInfinityPaletteTex and cachedInfinityPaletteTex.image then
+        return cachedInfinityPaletteTex;
+    end
+    cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not cachedInfinityPaletteTex or not cachedInfinityPaletteTex.image then
+        cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    return cachedInfinityPaletteTex;
+end
+
+local function GetPaletteJobIconThemeFromSettings(settings)
+    local t = settings and settings.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+
+-- When showPaletteScopeIcon is nil (legacy profiles), the scope icon follows showPaletteName;
+-- explicit true/false overrides. Keeps the icon visible by default for existing users without
+-- forcing them through the settings menu after the upgrade.
+local function ShouldShowPaletteScopeIcon(settings)
+    if not settings then return false; end
+    if settings.showPaletteScopeIcon == false then return false; end
+    if settings.showPaletteScopeIcon == true then return true; end
+    return settings.showPaletteName == true;
+end
+
+-- Draws the scope marker (infinity for Global / universal, job icon otherwise) centred just
+-- above the divider. Only fires when a palette is actually active for the L2 group.
+local function DrawPaletteScopeIconAboveDivider(dividerX, dividerTopY, settings, drawList)
+    if not ShouldShowPaletteScopeIcon(settings) or not drawList then return; end
+
+    local paletteName = palette.GetActivePaletteForCombo('L2');
+    if not paletteName then return; end
+
+    local jobId = data.jobId or 1;
+    local iconTex;
+    if palette.GetCrossbarPaletteScope() == 'universal' then
+        iconTex = GetInfinityPaletteIconTexture();
+    else
+        iconTex = TextureManager.getJobIcon(jobId, GetPaletteJobIconThemeFromSettings(settings));
+    end
+
+    if not iconTex or not iconTex.image then return; end
+
+    local iconPtr = tonumber(ffi.cast('uint32_t', iconTex.image));
+    if not iconPtr then return; end
+
+    -- Size: explicit slider override (8..64 px) or auto-derive from palette-name font size.
+    local iconSize;
+    local explicitSize = tonumber(settings.paletteScopeIconSize);
+    if explicitSize and explicitSize > 0 then
+        iconSize = math.floor(math.max(8, math.min(64, explicitSize)) + 0.5);
+    else
+        local fontSize = settings.paletteNameFontSize or 10;
+        iconSize = math.max(12, math.min(22, math.floor(fontSize * 1.45)));
+        iconSize = math.floor(iconSize * 1.50 + 0.5);
+    end
+    local gapAboveLine = 3;
+    local scopeLiftY = tonumber(settings.paletteScopeIconOffsetY) or 6;
+    -- Clearance above the L2 / R2 combo-text strip at the top of the window.
+    local clearanceAboveComboText = 6;
+    -- Horizontally align with palette-name X offset so the icon stacks with the name.
+    local iconCenterX = dividerX + (settings.paletteNameOffsetX or 0);
+    local iconTopY = dividerTopY - gapAboveLine - iconSize - scopeLiftY - clearanceAboveComboText;
+    local leftX = iconCenterX - iconSize / 2;
+
+    drawList:AddImage(
+        iconPtr,
+        { leftX, iconTopY },
+        { leftX + iconSize, iconTopY + iconSize },
+        { 0, 0 },
+        { 1, 1 },
+        imgui.GetColorU32({ 1, 1, 1, 1 })
+    );
+end
+
+-- Helper to draw just the left side. `activeCombo` is threaded through so DrawSlot's dim
+-- policy can apply Ferris's "stronger dim on the inactive half while a trigger is held"
+-- behavior (settings.inactiveSideWhileTriggerDim, default 0.15) — without it the inactive
+-- half just gets settings.inactiveSlotDim (default 0.5) like 1.7.5/early-1.8.0.
+local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -970,15 +1500,40 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('L2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- Resolve slotData ONCE per slot so both prediction paths (skillchain + magic burst)
+        -- share the same fetch; previously the SC path re-fetched per branch. Cheap either
+        -- way, but cleaner now that two features need the same row.
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
+        -- Skillchain prediction: matches display.lua's coverage so the crossbar lights up the
+        -- same WS / Blood Pact / macro slots the keyboard hotbar does. Bloodpact slots use the
+        -- separate name->attributes map in skillchain.lua (bloodPactResonationMap); macro slots
+        -- run through macroparse to extract the primary /ws or /pet line and then route to the
+        -- matching predictor. Without the pet/macro branches, SMN ability slots and any /pet or
+        -- /ws macro would never get a skillchain icon overlay on the crossbar.
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        -- Magic Burst prediction: spells / magical pact rages / /ma|/pet-primary macros. The
+        -- single GetMagicBurstForSlot call internally routes by actionType + (for macros) the
+        -- macroparse primary line — mirrors the dispatch pattern used by display.lua.
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -989,8 +1544,9 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     end
 end
 
--- Helper to draw just the right side
-local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- Helper to draw just the right side. See DrawLeftSide above for the rationale on the
+-- trailing activeCombo / magicBurstEnabled parameters.
+local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -998,15 +1554,29 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('R2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- See DrawLeftSide for slotData / SC / MB routing rationale (identical logic).
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -1017,17 +1587,260 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     end
 end
 
--- Helper to draw a complete bar set (both sides) - used for non-animated drawing
+-- Helper to draw a complete bar set (both sides) - used for non-animated drawing.
+-- activeCombo flows from M.DrawWindow down to DrawSlot for the trigger-held dim policy.
 local function DrawBarSet(leftMode, rightMode, leftGroupX, leftGroupY, rightGroupX, rightGroupY,
                           slotSize, settings, leftActive, rightActive, pressedSlot,
-                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
-    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
-    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
+                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
+    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+end
+
+-- ============================================
+-- Double-Tap Preview Windows
+-- ============================================
+-- Reference floating windows that mirror the L2x2 / R2x2 bars at user-configurable scale
+-- and opacity. Rendered as independent ImGui windows AFTER the main crossbar so they have
+-- their own position/draw list (no shared primitives, no z-fighting). Drawn non-interactive
+-- (suppressActionOnClick) — the previews are visual reference only; actual slot activation
+-- still routes through the main bar's controller path.
+
+-- Return a shallow copy of settings with all layout-affecting fields scaled. Preserves the
+-- caller's settings unchanged so the main bar keeps its own layout numbers.
+--
+-- Result is cached on a (settings ref, scale, layout-key signature) tuple — the full
+-- shallow-copy is the dominant cost when the preview is on (8 slots × 2 windows × scaled
+-- settings every frame). Invalidates only when the caller passes a new settings table OR
+-- changes one of the geometry/scale inputs. This avoids the per-frame table-copy churn
+-- without going stale on slider drags (signature changes immediately).
+local previewSettingsCache = {
+    settingsRef = nil,
+    scale       = nil,
+    signature   = nil,
+    result      = nil,
+};
+
+local function MakePreviewSettings(settings, scale)
+    -- Cheap signature: only the fields MakePreviewSettings actually reads. Keep this in
+    -- sync with the scaled fields below — additions need a sig entry or the cache goes stale.
+    local sig = string.format('%s|%s|%s|%s|%s|%s|%s|%s|%s',
+        tostring(settings.slotSize), tostring(settings.slotGapV), tostring(settings.slotGapH),
+        tostring(settings.diamondSpacing), tostring(settings.groupSpacing),
+        tostring(settings.buttonIconSize), tostring(settings.buttonIconGapH), tostring(settings.buttonIconGapV),
+        tostring(settings.triggerIconScale));
+
+    if previewSettingsCache.settingsRef == settings
+        and previewSettingsCache.scale == scale
+        and previewSettingsCache.signature == sig then
+        return previewSettingsCache.result;
+    end
+
+    local s = {};
+    for k, v in pairs(settings) do s[k] = v; end
+    s.slotSize       = math.max(8, math.floor((settings.slotSize       or 40) * scale));
+    s.slotGapV       = math.max(1, math.floor((settings.slotGapV       or 2)  * scale));
+    s.slotGapH       = math.max(1, math.floor((settings.slotGapH       or 2)  * scale));
+    s.diamondSpacing = math.max(2, math.floor((settings.diamondSpacing or 16) * scale));
+    s.groupSpacing   = math.max(4, math.floor((settings.groupSpacing   or 24) * scale));
+    s.buttonIconSize = math.max(4, math.floor((settings.buttonIconSize or 24) * scale));
+    s.buttonIconGapH = math.max(1, math.floor((settings.buttonIconGapH or 2)  * scale));
+    s.buttonIconGapV = math.max(1, math.floor((settings.buttonIconGapV or 2)  * scale));
+    s.triggerIconScale = (settings.triggerIconScale or 1.0) * scale;
+
+    previewSettingsCache.settingsRef = settings;
+    previewSettingsCache.scale       = scale;
+    previewSettingsCache.signature   = sig;
+    previewSettingsCache.result      = s;
+    return s;
+end
+
+-- Draw one side of a double-tap preview using ImGui-only rendering (non-interactive).
+-- winX/winY    : top-left of the preview ImGui window (slot grid origin).
+-- side         : always 'L2' for single-group preview windows (slots start at window left).
+-- mode         : crossbar storage mode string ('L2x2', 'R2x2', 'L2', 'R2', etc.) whose slots to render.
+-- baseOp       : base opacity for the slot backgrounds (NOT dimmed) so frames stay visible.
+-- dimFactor    : 0-1 multiplier applied to icon/text rendering (mirrors main bar dim policy).
+-- targetServerId / skillchainEnabled / magicBurstEnabled: same per-slot SC/MB resolution
+--                inputs used by the main DrawLeftSide/DrawRightSide path. Letting the preview
+--                share them keeps the highlight calculus identical between live and preview
+--                (a slot that lights up on the live bar lights up on its preview).
+local function DrawPreviewSide(winX, winY, windowKey, side, mode, ps, baseOp, dimFactor, drawList, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize  = ps.slotSize or 40;
+    local contentOp = baseOp * dimFactor;
+
+    -- Slot background (flat rounded rect). slotrenderer's built-in bg path requires a D3D
+    -- slot primitive (we have none in preview), so paint it manually with baseOp so the
+    -- frame stays visible while icons dim with contentOp.
+    local bgArgb = ps.slotBackgroundColor or 0x55000000;
+    local bgA_raw = bit.rshift(bit.band(bgArgb, 0xFF000000), 24) / 255;
+    local bgA = math.max(bgA_raw, 0.55) * baseOp;
+    local bgR = bit.rshift(bit.band(bgArgb, 0x00FF0000), 16) / 255;
+    local bgG = bit.rshift(bit.band(bgArgb, 0x0000FF00), 8) / 255;
+    local bgB = bit.band(bgArgb, 0x000000FF) / 255;
+    local cornerR = math.max(4, math.min(10, math.floor(slotSize * 0.125 + 0.5)));
+    local bgU32 = imgui.GetColorU32({ bgR, bgG, bgB, bgA });
+
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        local slotX, slotY = GetSlotPositionInWindow(side, slotIndex, winX, winY, ps);
+
+        if drawList then
+            drawList:AddRectFilled({ slotX, slotY }, { slotX + slotSize, slotY + slotSize }, bgU32, cornerR);
+        end
+
+        local slotData = data.GetCrossbarSlotData(mode, slotIndex);
+        local icon = GetCachedCrossbarIcon(mode, slotIndex, slotData);
+
+        -- Per-slot skillchain + magic burst resolution — identical dispatch to DrawLeftSide
+        -- so a slot that highlights on the live crossbar highlights on its preview window
+        -- too. Without this the preview would silently omit both borders, hiding useful
+        -- "you could chain/MB from the other bar" cues exactly when the player is deciding
+        -- whether to commit to a double-tap.
+        local slotSkillchainName = nil;
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
+                slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
+            end
+        end
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+
+        slotrenderer.DrawSlot({
+            x    = slotX,
+            y    = slotY,
+            size = slotSize,
+            windowName = windowKey,
+            bind = slotData,
+            icon = icon,
+            slotBgColor = 0x00000000,
+            slotOpacity = 1.0,
+            dimFactor   = 1.0,
+            animOpacity = contentOp,
+            isPressed   = false,
+            iconPressScale = 1.0,
+            -- MP cost + quantity are intentionally OFF on the double-tap preview regardless of
+            -- the user's main-bar settings: the preview is a transient "what's on the other
+            -- bar" overlay, not an action-resolution surface, so a player glancing at it just
+            -- wants the icon + cooldown to decide if the next press is worth it. Showing MP /
+            -- charges duplicates the info on the live bar and crowds an already-small preview.
+            -- Cooldowns are kept (recastTimer* + flashCooldownUnder5) — they ARE useful here
+            -- because the preview's whole purpose is "should I commit to this bar".
+            showMpCost = false,
+            showQuantity = false,
+            showLabel = false,
+            recastTimerFontSize   = ps.recastTimerFontSize or 11,
+            recastTimerFontColor  = ps.recastTimerFontColor or 0xFFFFFFFF,
+            flashCooldownUnder5   = ps.flashCooldownUnder5 or false,
+            useHHMMCooldownFormat = ps.useHHMMCooldownFormat or false,
+            -- Skillchain + Magic Burst highlights. Colors fall back to the live-bar defaults
+            -- so the preview matches the main bar without requiring its own settings keys.
+            skillchainName  = slotSkillchainName,
+            skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44,
+            magicBurstName  = slotMagicBurstName,
+            magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF,
+            buttonId              = string.format('##dtprev_%s_%s_%d', windowKey, mode, slotIndex),
+            suppressActionOnClick = true,
+            forceImGuiIcon        = true,
+            drawCornerTextForeground = true,
+        });
+    end
+
+    if drawList and ps.showButtonIcons and contentOp > 0.05 then
+        DrawDiamondCenterIconsImGui('dpad', winX, winY, ps, true, drawList, contentOp);
+        DrawDiamondCenterIconsImGui('face', winX, winY, ps, true, drawList, contentOp);
+    end
+end
+
+-- Draw one double-tap preview window (L2x2 or R2x2 reference).
+-- windowKey : unique ImGui window name and persisted-position key.
+-- mode      : crossbar storage mode for the 8 slots displayed (e.g. 'L2x2', 'R2x2', 'L2', 'R2').
+-- ps        : scaled settings table (from MakePreviewSettings).
+-- baseOp    : base opacity (user slider * visibilityOpacity).
+-- dimFactor : 0-1 content dim (1.0 = at rest, inactiveSideWhileTriggerDim while any trigger held).
+-- settings  : raw crossbar settings (used for doubleTapPreviewLocked move-anchor gating).
+local function DrawDoubleTapPreviewWindow(windowKey, mode, ps, baseOp, dimFactor, activeCombo, settings, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize = ps.slotSize or 40;
+    local gw, gh = CalculateGroupDimensions(slotSize, ps.slotGapV or 2, ps.slotGapH or 2, ps.diamondSpacing or 16);
+    local totalW = gw;
+    local totalH = gh;
+
+    local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+    if savedPos then
+        imgui.SetNextWindowPos({savedPos.x, savedPos.y}, ImGuiCond_Always);
+    else
+        imgui.SetNextWindowPos({200, 200}, ImGuiCond_FirstUseEver);
+    end
+    imgui.SetNextWindowSize({totalW, totalH}, ImGuiCond_Always);
+
+    -- Preview windows intentionally omit NoBringToFrontOnFocus so they stay layered above the
+    -- main crossbar (which has that flag set). NoMove + the move anchor below gives us
+    -- explicit positioning control without ImGui drifting the window on focus.
+    local flags = bit.bor(
+        ImGuiWindowFlags_NoDecoration,
+        ImGuiWindowFlags_NoResize,
+        ImGuiWindowFlags_NoFocusOnAppearing,
+        ImGuiWindowFlags_NoNav,
+        ImGuiWindowFlags_NoBackground,
+        ImGuiWindowFlags_NoDocking,
+        ImGuiWindowFlags_NoMove
+    );
+
+    -- Zero window padding so the draw list clip rect matches the window bounds exactly.
+    -- Without this the default 8 px padding clips slots at the left/right edges (same fix
+    -- that landed for the main crossbar window in the previous smoke-test pass).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+    local didBegin = imgui.Begin(windowKey, true, flags);
+    imgui.PopStyleVar();
+
+    if didBegin then
+        local wX, wY = imgui.GetWindowPos();
+        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+        if savedPos == nil then
+            gConfig.windowPositions[windowKey] = {x = wX, y = wY};
+        end
+
+        local dl = imgui.GetWindowDrawList();
+        DrawPreviewSide(wX, wY, windowKey, 'L2', mode, ps, baseOp, dimFactor, dl, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled);
+    end
+    imgui.End();
+
+    -- Move anchor: independent lock so previews can be repositioned without unlocking the
+    -- main crossbar (and vice versa).
+    local previewLocked = settings and settings.doubleTapPreviewLocked;
+    if not previewLocked then
+        local pos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+        local anchorX = pos and pos.x or 200;
+        local anchorY = pos and pos.y or 200;
+        local newX, newY = drawing.DrawMoveAnchor(windowKey, anchorX, anchorY, {
+            anchorSide  = 'top',
+            windowWidth = totalW,
+        });
+        if newX ~= nil then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[windowKey] = {x = newX, y = newY};
+        end
+    end
 end
 
 -- Main draw function
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
+
+    -- Warm playerdata caches even when keyboard hotbars are disabled. Cheap on cache hit
+    -- (signature compare against job/level/equip ids), only does the heavy ability/WS scan
+    -- when the signature changes. See the require-site comment for the user-visible bug
+    -- this prevents (all JA/WS slots reading as unavailable on crossbar-only setups).
+    playerdata.RefreshCachedLists(data);
 
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local slotSize = (settings.slotSize or 48) * gs;
@@ -1037,34 +1850,12 @@ function M.DrawWindow(settings, moduleSettings)
     local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate dimensions using layout functions
-    local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local fullWidth, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local width = fullWidth;
 
-    -- Window flags (dummy window for positioning, like hotbar display.lua)
-    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
-
-    local windowName = 'Crossbar';
-    local defaultX, defaultY = GetDefaultPosition(settings);
-
-    -- Check if anchor is currently being dragged - if so, force position
-    local anchorDragging = drawing.IsAnchorDragging(windowName);
-    
-    if anchorDragging then
-        -- Use state position directly during drag for immediate response
-        imgui.SetNextWindowPos({state.windowX, state.windowY}, ImGuiCond_Always);
-    else
-        -- Apply saved position (once) or default
-        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-
-        if hasSaved then
-            ApplyWindowPosition(windowName);
-        else
-            imgui.SetNextWindowPos({defaultX, defaultY}, ImGuiCond_FirstUseEver);
-        end
-    end
-    
-    imgui.SetNextWindowSize({width, height}, ImGuiCond_Always);
-
-    -- Get current combo mode and pressed slot from controller
+    -- Get current combo mode and pressed slot from controller. Resolved BEFORE the window
+    -- size/position calls so the useSharedExpandedBar branch can shrink the window to a single
+    -- diamond and re-center it (a chord with useSharedExp on collapses to one 8-slot strip).
     local activeCombo = controller.GetActiveCombo();
     local pressedSlot = controller.GetPressedSlot();
 
@@ -1075,6 +1866,75 @@ function M.DrawWindow(settings, moduleSettings)
         activeCombo = editBar;
         pressedSlot = nil;  -- Don't show pressed state in edit mode
     end
+
+    -- Determine which bar set to display based on active combo. expandedSide == 'center' is
+    -- the useSharedExpandedBar branch (chord collapses both diamonds into one centered strip).
+    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo, settings);
+
+    -- useSharedExpandedBar special layout: shrink window to one diamond, re-center on screen X,
+    -- skip the right group draw + center divider/scope icon (they have no meaning when there's
+    -- only one diamond visible). Outside of chord, behaves identically to the standard 2-diamond
+    -- layout. exitingChordCenter catches the FIRST frame after the user releases the chord: we
+    -- restore the stashed wide-bar X so SaveCrossbarWindowSlotTopPosition doesn't persist the
+    -- narrow centered value.
+    local hideRightForSharedCenter = (isExpanded and expandedSide == 'center');
+    if hideRightForSharedCenter then
+        width = groupWidth;
+    end
+    local exitingChordCenter = state.wasSharedCenterChordLayout and (not hideRightForSharedCenter);
+
+    -- Window flags (dummy window for positioning, like hotbar display.lua)
+    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
+
+    local windowName = 'Crossbar';
+    local defaultX, defaultY = GetDefaultPosition(settings);
+
+    local function storedCrossbarPosY()
+        local posY = defaultY;
+        local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowName];
+        if savedPos and savedPos.y ~= nil then
+            posY = savedPos.y;
+        elseif state.windowY ~= nil then
+            posY = state.windowY;
+        end
+        return posY;
+    end
+
+    -- Check if anchor is currently being dragged - if so, force position
+    local anchorDragging = drawing.IsAnchorDragging(windowName);
+
+    -- state.windowX / state.windowY track the SLOT GRID origin. ImGui's window must open
+    -- CROSSBAR_WINDOW_TOP_DECOR_PAD pixels higher so the decoration above the slots
+    -- (L2/R2 triggers, combo text, R1 cpal-anchor pulse) stays inside the window's
+    -- content rect and doesn't get clipped.
+    if anchorDragging then
+        -- Use state position directly during drag for immediate response
+        imgui.SetNextWindowPos({ state.windowX, state.windowY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif hideRightForSharedCenter then
+        -- Shared-center chord: force X to screen-center each frame so the narrow window reads as
+        -- the FFXIV-style single 8-slot strip (Y persists from the last wide-bar position).
+        local io = imgui.GetIO();
+        local screenW = (io and io.DisplaySize and io.DisplaySize.x) or 1920;
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ (screenW - width) * 0.5, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif exitingChordCenter and state.lastWideCrossbarWindowX ~= nil then
+        -- First frame after chord release: re-anchor to the wide-bar X we stashed before the
+        -- chord, otherwise the user-visible position would briefly snap to the centered narrow X.
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ state.lastWideCrossbarWindowX, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    else
+        -- Apply saved position (once, slot-top -> window-top offset handled inside) or default
+        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+
+        if hasSaved then
+            ApplyCrossbarWindowPositionOnce();
+        else
+            imgui.SetNextWindowPos({ defaultX, defaultY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_FirstUseEver);
+        end
+    end
+
+    local bottomPad = GetCrossbarWindowBottomPad(settings);
+    imgui.SetNextWindowSize({ width, height + CROSSBAR_WINDOW_TOP_DECOR_PAD + bottomPad }, ImGuiCond_Always);
 
     -- Determine visibility for activeOnly display mode
     local leftVisible, rightVisible, crossbarVisible = GetVisibilityState(activeCombo, settings, isEditMode);
@@ -1100,8 +1960,14 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
-    -- Determine which bar set to display based on active combo
-    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo);
+    -- Menu-open dim: when a blocking game menu is open and the user has "Disable Crossbar
+    -- While In Menu" enabled, controller.lua already stops routing input — we additionally
+    -- dim everything the crossbar draws so it visually reads as "paused" rather than just
+    -- silently unresponsive. visibilityOpacity propagates into every slot via the per-slot
+    -- animOpacity param plus the background / border / trigger / divider alpha scales below.
+    if gamestate.IsMenuOpen() and settings.crossbarDisableInMenu ~= false then
+        visibilityOpacity = visibilityOpacity * 0.35;
+    end
 
     -- Check if animations are disabled - if so, force complete any in-progress animation
     if settings.enableTransitionAnimations == false and state.animation.active then
@@ -1143,7 +2009,11 @@ function M.DrawWindow(settings, moduleSettings)
     local leftActive, rightActive;
     if isExpanded then
         -- In expanded mode, only the expanded side is active, other side is dimmed
-        if expandedSide == 'left' then
+        if expandedSide == 'center' then
+            -- useSharedExpandedBar: only the left column is drawn (no right group exists this frame)
+            leftActive = true;
+            rightActive = false;
+        elseif expandedSide == 'left' then
             leftActive = true;
             rightActive = false;
         elseif expandedSide == 'right' then
@@ -1171,10 +2041,13 @@ function M.DrawWindow(settings, moduleSettings)
     -- Get draw list for ImGui-based rendering (behind config when open)
     local drawList = GetUIDrawList();
 
-    -- Get target server ID for skillchain prediction (cached for all slots)
+    -- Get target server ID for skillchain / magic burst prediction (cached for all slots).
+    -- Both features key off the same target so a single resolve+cache covers everything; the
+    -- per-slot SC and MB calls are no-ops when their respective enable flags are off.
     local targetServerId = nil;
     local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
-    if skillchainEnabled then
+    local magicBurstEnabled = gConfig.hotbarGlobal.magicBurstHighlightEnabled ~= false;
+    if skillchainEnabled or magicBurstEnabled then
         local mainTargetIdx = targetLib.GetTargets();
         if mainTargetIdx and mainTargetIdx ~= 0 then
             local targetEntity = GetEntity(mainTargetIdx);
@@ -1184,15 +2057,48 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
+    -- Zero out WindowPadding so the leftmost and rightmost diamond slots (which sit flush
+    -- against the window's content rect) aren't clipped by ImGui's default 8px padding.
+    -- Without this the left/right slots of each diamond render partially off-window and
+    -- their button hitboxes get pushed inward (slot interactions become unreliable).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
     -- Begin ImGui window - ALL slot rendering happens inside to enable interactions
     if imgui.Begin('Crossbar', true, windowFlags) then
-        -- Save position if moved (profile support)
-        SaveWindowPosition('Crossbar');
+        -- Save SLOT-TOP position if moved (decor-pad-aware; profile coordinate stays the
+        -- slot grid top so the saved value is meaningful even if decor pad changes later).
+        -- During the shared-center chord the X is force-centered each frame, so we MUST NOT
+        -- let SaveCrossbarWindowSlotTopPosition persist that narrow centered X — only sync Y.
+        if hideRightForSharedCenter then
+            if gConfig.windowPositions and gConfig.windowPositions[windowName] then
+                local wx, wy = imgui.GetWindowPos();
+                local s = gConfig.windowPositions[windowName];
+                local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+                if s.y ~= slotTopY then
+                    s.y = slotTopY;
+                end
+                -- Track the centered window X for free (used by lastWideCrossbarWindowX restore)
+                if s.x ~= wx then
+                    s.x = wx;
+                end
+            end
+        else
+            SaveCrossbarWindowSlotTopPosition();
+        end
         windowPosX, windowPosY = imgui.GetWindowPos();
 
-        -- Update stored position
+        -- Update stored position. state.windowY = slot grid top (window top + decor pad);
+        -- the rest of the layout code references state.windowY as the slot origin.
         state.windowX = windowPosX;
-        state.windowY = windowPosY;
+        state.windowY = windowPosY + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+
+        -- Stash the wide-bar X so that when the user releases the chord we can restore it
+        -- (otherwise the narrow centered X from this frame would be the "last" saved X).
+        if not hideRightForSharedCenter then
+            state.lastWideCrossbarWindowX = windowPosX;
+        end
+        -- Remember the layout for the NEXT frame so exitingChordCenter (above) can detect
+        -- the chord-release transition and re-anchor X.
+        state.wasSharedCenterChordLayout = hideRightForSharedCenter;
 
         -- Recalculate group positions with updated window position
         leftGroupX = state.windowX;
@@ -1244,35 +2150,36 @@ function M.DrawWindow(settings, moduleSettings)
                     -- Left side changed - animate it
                     if outOpacity > 0.01 then
                         DrawLeftSide(state.animation.fromLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Left side didn't change - draw at full opacity (with visibility fade)
                     DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
 
-            -- Draw RIGHT side (skip in activeOnly mode if not visible)
-            if not isActiveOnlyMode or rightVisible then
+            -- Draw RIGHT side (skip in activeOnly mode if not visible, or whenever the chord
+            -- collapsed both groups into a single centered strip — there is no right group).
+            if (not hideRightForSharedCenter) and (not isActiveOnlyMode or rightVisible) then
                 if state.animation.rightChanged then
                     -- Right side changed - animate it
                     if outOpacity > 0.01 then
                         DrawRightSide(state.animation.fromRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Right side didn't change - draw at full opacity (with visibility fade)
                     DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
         else
@@ -1281,12 +2188,16 @@ function M.DrawWindow(settings, moduleSettings)
                 -- ActiveOnly mode: draw only visible sides with visibility fade
                 if leftVisible then
                     DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
-                if rightVisible then
+                if (not hideRightForSharedCenter) and rightVisible then
                     DrawRightSide(state.currentRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
+            elseif hideRightForSharedCenter then
+                -- Shared-center chord: render only the (now-Shared) left column as one centered strip.
+                DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
+                    leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
             else
                 -- Normal mode: draw both sides at full opacity
                 DrawBarSet(
@@ -1295,17 +2206,21 @@ function M.DrawWindow(settings, moduleSettings)
                     slotSize, settings,
                     leftActive, rightActive,
                     pressedSlot, leftShowPressed, rightShowPressed,
-                    1.0, drawList, 0, targetServerId, skillchainEnabled
+                    1.0, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled
                 );
             end
         end
 
         imgui.End();
     end
+    -- Pop the WindowPadding style we pushed before Begin. Has to be unconditional (must match
+    -- the push even when Begin returns false / window is collapsed).
+    imgui.PopStyleVar();
 
-    -- Draw move anchor (only visible when config is open)
-    -- Only show when crossbar movement is NOT locked (uses global lock setting)
-    local crossbarLocked = gConfig and gConfig.hotbarLockMovement;
+    -- Draw move anchor (only visible when config is open).
+    -- Uses the crossbar-specific lock so Hotbar's lock toggle doesn't accidentally freeze
+    -- the crossbar (fixes the issue where Lock Crossbar was tied to Hotbar's setting).
+    local crossbarLocked = gConfig and gConfig.crossbarLockMovement;
     if not crossbarLocked then
         -- Use same window name as ImGui window so positions are shared
         local anchorNewX, anchorNewY = drawing.DrawMoveAnchor('Crossbar', state.windowX, state.windowY);
@@ -1323,22 +2238,36 @@ function M.DrawWindow(settings, moduleSettings)
     local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
     local showCenterElements = not isActiveOnlyMode;
 
-    -- Draw center divider (optional, hidden in activeOnly mode)
-    if settings.showDivider and drawList and showCenterElements then
-        local dividerX = state.windowX + groupWidth + (groupSpacing / 2);
-        local dividerY1 = state.windowY + 10;
-        local dividerY2 = state.windowY + height - 10;
+    -- Center decor (divider line, scope icon, combo text, palette name): all hidden in
+    -- activeOnly mode since that layout collapses to a single side and the divider has no meaning.
+    -- Shared-center chord layout: centerX is the middle of the (now single-diamond) window so the
+    -- scope icon / combo text / palette name still sit over the visible bar. The DIVIDER itself
+    -- is suppressed in chord since there's no longer a left/right split to divide.
+    local centerX;
+    if hideRightForSharedCenter then
+        centerX = state.windowX + width * 0.5;
+    else
+        centerX = state.windowX + groupWidth + (groupSpacing / 2);
+    end
+    local dividerTopY = state.windowY + 10;
 
+    if settings.showDivider and drawList and showCenterElements and (not hideRightForSharedCenter) then
+        local dividerY2 = state.windowY + height - 10;
         drawList:AddLine(
-            { dividerX, dividerY1 },
-            { dividerX, dividerY2 },
+            { centerX, dividerTopY },
+            { centerX, dividerY2 },
             imgui.GetColorU32({ 1, 1, 1, 0.3 }),
             2
         );
     end
 
+    -- Palette scope icon (infinity for Global / job icon for job-scoped) — drawn above the
+    -- divider's top endpoint. Same drawList as the divider so z-order is consistent.
+    if showCenterElements and drawList then
+        DrawPaletteScopeIconAboveDivider(centerX, dividerTopY, settings, drawList);
+    end
+
     -- Draw combo text in center for complex combos (hidden in activeOnly mode)
-    local centerX = state.windowX + groupWidth + (groupSpacing / 2);
     local topY = state.windowY - 4;  -- Above the window
     if showCenterElements then
         DrawComboText(activeCombo, centerX, topY, settings);
@@ -1350,9 +2279,15 @@ function M.DrawWindow(settings, moduleSettings)
         DrawPaletteName(centerX, bottomY, settings);
     end
 
-    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode)
+    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode). The shared-center
+    -- chord uses a different glyph (L2 + R2 chord centred on the single visible diamond) since
+    -- there's no left-vs-right group to position labels against.
     if drawList and showCenterElements then
-        DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        if hideRightForSharedCenter then
+            DrawTriggerIconsSharedExpandedCenter(activeCombo, leftGroupX, leftGroupY, groupWidth, settings, drawList);
+        else
+            DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        end
     end
 
     -- Draw palette modifier indicator (refresh icon when modifier key is held)
@@ -1380,6 +2315,41 @@ function M.DrawWindow(settings, moduleSettings)
                 );
             end
         end
+    end
+
+    -- Double-tap preview windows. Drawn AFTER the main crossbar so they end up in
+    -- separate ImGui windows with their own draw list / position, layered above the main
+    -- bar. Gated on both `enableDoubleTap` (the L2x2/R2x2 modes have to be enabled at all)
+    -- and `showDoubleTapPreview` (the per-feature visibility toggle). When the active combo
+    -- IS the matching double-tap, the preview swaps to the BASE L2/R2 slots as a reference
+    -- — the main bar is already showing the double-tap content.
+    if settings.enableDoubleTap and settings.showDoubleTapPreview then
+        local scale  = settings.doubleTapPreviewScale  or 0.60;
+        local baseOp = (settings.doubleTapPreviewOpacity or 1.0) * visibilityOpacity;
+        -- Skip the preview render path entirely when nothing would be visible (menu dim or
+        -- activeOnly hide). Saves the 16-slot DrawSlot + ImGui begin/end overhead per frame.
+        if baseOp <= 0.02 then return; end
+        local dimFact = settings.inactiveSideWhileTriggerDim;
+        if dimFact == nil then dimFact = 0.15; end
+        local ps = MakePreviewSettings(settings, scale);
+
+        local isL2xActive = (activeCombo == COMBO_MODES.L2_DOUBLE);
+        local isR2xActive = (activeCombo == COMBO_MODES.R2_DOUBLE);
+        local anyTriggerHeld = (activeCombo ~= COMBO_MODES.NONE);
+        local previewDim = anyTriggerHeld and dimFact or 1.0;
+
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewL2x2',
+            isL2xActive and 'L2' or 'L2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewR2x2',
+            isR2xActive and 'R2' or 'R2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
     end
 end
 
@@ -1467,6 +2437,11 @@ end
 -- Clear icon cache (call when job changes)
 function M.ClearIconCache()
     ClearCrossbarIconCache();
+    -- Mirror the wipe to actions.lua's negative-result cache so "no icon" decisions
+    -- pinned from a previous state don't survive into the new job/palette context.
+    if actions and actions.ClearNoIconCache then
+        actions.ClearNoIconCache();
+    end
 end
 
 -- Clear icon cache for a specific slot (call on targeted slot updates)
@@ -1487,6 +2462,187 @@ function M.ResetPositions()
     if gConfig.appliedPositions then
         gConfig.appliedPositions['Crossbar'] = nil;
     end
+end
+
+-- ============================================
+-- Edit Full Palette (called from config/palettemanager.lua's ImGui window)
+-- ============================================
+-- The editor draws a static representation of a crossbar row using the SAME DrawSlot path
+-- as the live HUD, so layout (diamond geometry, slot size, label position, MP/quantity)
+-- always matches what the user actually plays with. The editor differs from the HUD in:
+--   * Slot data is read from the draft layer (data.GetDraftSlotData) not the live binding.
+--   * MP / quantity / cooldown text are suppressed (showMpCost=false, showQuantity=false).
+--   * The action name renders ON the slot (labelForeground + editorMinimalView).
+--   * Drop zones use 'paled_*' IDs with dropPriority=10 so they win against the HUD zones
+--     underneath when the editor window overlaps the live crossbar.
+--   * Optional editorClipRect culls slots scrolled off the editor panel.
+-- These are all set by the local DrawSlot wrapper above; the public functions here just
+-- iterate the 8 slots of each diamond and call DrawSlot once per slot.
+
+-- Shared palette-editor slot row. Either or both of modeLeft (L2 group) and modeRight
+-- (R2 group) may be set; pass nil on a side to omit it (Pets tab filter renders single-sided rows).
+local function DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    if not state.initialized then return; end
+    if not modeLeft and not modeRight then return; end
+    local editorClipRect;
+    if clipMinX and clipMinY and clipMaxX and clipMaxY then
+        editorClipRect = { clipMinX, clipMinY, clipMaxX, clipMaxY };
+    end
+    local slotSize = settings.slotSize or 48;
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        if modeLeft then
+            local sx, sy = GetSlotPositionInWindow('L2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeLeft, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+        if modeRight then
+            local sx, sy = GetSlotPositionInWindow('R2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeRight, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+    end
+end
+
+function M.DrawPaletteEditorL2R2Row(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+function M.DrawPaletteEditorSingleRow(screenOriginX, screenOriginY, settings, modeOnly, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeOnly, nil, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+-- Trigger glyphs raised above the editor's slot cluster. glyphMode:
+--   'primary'     — L2 | R2 (one glyph per side, gap between d-pad and face).
+--   'doubleTap'   — L2 + "x2", R2 + "x2".
+--   'chordCombo'  — Left: L2+R2, Right: R2+L2 (with text "+" between).
+--   'sharedChord' — Single L2+R2 glyph centred over the shared diamond.
+-- Optional sides = { l=bool, r=bool } (default both true) — used by Pets-tab single-sided rows.
+function M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, glyphMode, sides)
+    local dl = imgui.GetWindowDrawList();
+    if not dl then return; end
+    glyphMode = glyphMode or 'primary';
+    local sl = (not sides or sides.l ~= false);
+    local sr = (not sides or sides.r ~= false);
+    local totalW, _, groupW, ghgt = GetCrossbarDimensions(settings);
+    local gs = totalW - 2 * groupW;
+    local slotSize = settings.slotSize or 48;
+    local scale = (settings.triggerIconScale or 1.0) * math.max(0.42, math.min(1.1, slotSize / 48));
+    local iw = 49 * scale;
+    local ih = 28 * scale;
+    local yLift = 35;
+    local cy = screenOriginY + ghgt * 0.5 - yLift;
+    local tint = imgui.GetColorU32({ 1, 1, 1, 0.88 });
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    local chordTight = math.max(0.5, 0.65 * scale);
+    local doubleTapImgGap = math.max(1, 2 * scale);
+
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImage(texName, ix, iy)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+    end
+
+    local function drawComboAtCenter(cx, firstTex, secondTex)
+        local ptw, pth = plusSize();
+        local gL, gR = chordTight, chordTight;
+        local total = iw + gL + ptw + gR + iw;
+        local leftX = cx - total * 0.5;
+        drawImage(firstTex, leftX, cy - ih * 0.5);
+        dl:AddText({ leftX + iw + gL, cy - pth * 0.5 }, textCol, '+');
+        drawImage(secondTex, leftX + iw + gL + ptw + gR, cy - ih * 0.5);
+    end
+
+    if glyphMode == 'sharedChord' then
+        drawComboAtCenter(screenOriginX + groupW * 0.5, 'L2', 'R2');
+        return;
+    end
+
+    if glyphMode == 'chordCombo' then
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then drawComboAtCenter(l2cx, 'L2', 'R2'); end
+        if sr then drawComboAtCenter(r2cx, 'R2', 'L2'); end
+        return;
+    end
+
+    if glyphMode == 'doubleTap' then
+        local x2Str = 'x2';
+        local tw, th = 18, 16;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize(x2Str);
+            if type(ts) == 'table' then
+                tw = ts[1] or ts.x or tw;
+                th = ts[2] or ts.y or th;
+            end
+        end
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then
+            local l2Tex = textures:GetControllerIcon('L2');
+            if l2Tex and l2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', l2Tex.image));
+                if p and p ~= 0 then
+                    local ix = l2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        if sr then
+            local r2Tex = textures:GetControllerIcon('R2');
+            if r2Tex and r2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', r2Tex.image));
+                if p and p ~= 0 then
+                    local ix = r2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        return;
+    end
+
+    -- primary
+    local l2cx = screenOriginX + groupW * 0.5;
+    local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+    if sl then drawImage('L2', l2cx - iw * 0.5, cy - ih * 0.5); end
+    if sr then drawImage('R2', r2cx - iw * 0.5, cy - ih * 0.5); end
+end
+
+-- Convenience wrapper used by the Shared (chord-fallback) row.
+function M.DrawPaletteEditorSharedChordTriggerGlyphs(screenOriginX, screenOriginY, settings)
+    M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, 'sharedChord');
+end
+
+-- Exposed so palettemanager.lua can size the editor row to match the live HUD dimensions
+-- without duplicating the math (slot size, gaps, diamond spacing, etc. all flow through here).
+function M.GetEditorCrossbarRowDimensions(settings)
+    return GetCrossbarDimensions(settings);
+end
+
+-- Legacy GDI hook (kept as a no-op for API compatibility with `palettemanager.lua`).
+-- Pre-1.8.0 this hid the persistent D3D/GDI primitives backing the editor's slot row when
+-- the editor window was not currently drawing. Under 1.8.0's imtext architecture there are
+-- no persistent objects to hide — un-emitted draw calls simply don't render. The function
+-- is retained so callers don't break and so the contract is documented; consider removing
+-- once palettemanager.lua's six call sites are updated.
+function M.HidePaletteEditorPrimitives()
 end
 
 return M;

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -11,6 +11,7 @@ local windowBg = require('libs.windowbackground');
 local drawing = require('libs.drawing');
 
 local data = require('modules.hotbar.data');
+local playerdata = require('modules.hotbar.playerdata');
 local actions = require('modules.hotbar.actions');
 local textures = require('modules.hotbar.textures');
 local macropalette = require('modules.hotbar.macropalette');
@@ -21,8 +22,13 @@ local hotbarConfig = require('config.hotbar');
 local petpalette = require('modules.hotbar.petpalette');
 local palette = require('modules.hotbar.palette');
 local skillchain = require('modules.hotbar.skillchain');
+local macroparse = require('modules.hotbar.macroparse');
 local targetLib = require('libs.target');
 local imtext = require('libs.imtext');
+-- TextureManager.DeferRelease keeps a Lua ref to wiped iconCache entries alive
+-- for one frame so palette-delete / job-change paths don't release a D3D texture
+-- that's still queued in this frame's draw list (CTD on Ashita 4.16).
+local TextureManager = require('libs.texturemanager');
 
 local M = {};
 
@@ -113,6 +119,12 @@ local function BuildBindKey(bind)
     if bind.customIconType or bind.customIconId or bind.customIconPath then
         iconPart = ':icon:' .. (bind.customIconType or '') .. ':' .. tostring(bind.customIconId or '') .. ':' .. (bind.customIconPath or '');
     end
+    -- Macros render a /ja badge overlay; its icon (whether resolved from a job-ability
+    -- name in macroText or from a macro.jaBadgeCustom* override) must invalidate the
+    -- cache when changed. Defensive guard: function lives in actions.lua (Phase 2.4).
+    if bind.actionType == 'macro' and actions.GetMacroJaBadgeIconCacheSuffix then
+        iconPart = iconPart .. (actions.GetMacroJaBadgeIconCacheSuffix(bind) or '');
+    end
     return (bind.actionType or '') .. ':' .. (bind.action or '') .. ':' .. (bind.target or '') .. iconPart;
 end
 
@@ -136,10 +148,15 @@ local function GetCachedIcon(barIndex, slotIndex, bind)
         end
     end
 
-    -- Cache miss - compute icon and (if no icon) abbreviation
+    -- Cache miss - resolve icon only (BuildCommand also builds command strings; per-frame
+    -- draw paths don't need the command, so we use GetBindIcon when available to skip that work).
     local icon = nil;
     if bind then
-        _, icon = actions.BuildCommand(bind);
+        if actions.GetBindIcon then
+            icon = actions.GetBindIcon(bind);
+        else
+            _, icon = actions.BuildCommand(bind);
+        end
     end
 
     local abbr, abbrW = nil, nil;
@@ -161,12 +178,29 @@ end
 
 -- Clear icon cache (call when slots change)
 local function ClearIconCache()
+    -- iconCache rows hold the only Lua ref to D3D textures loaded by actions.GetBindIcon
+    -- (LoadTextureFromPath wires a gc_safe_release finalizer); dropping the table mid-frame
+    -- lets Lua GC release the COM texture while AddImage queued earlier this frame still
+    -- references its pointer. Hold the old table alive until next d3d_present flushes it.
+    TextureManager.DeferRelease(iconCache);
     iconCache = {};
+    -- Mirror the wipe to actions.lua's negative-result cache; otherwise a "no icon" decision
+    -- pinned from a previous job/palette/macro state survives across cache invalidations.
+    if actions.ClearNoIconCache then
+        actions.ClearNoIconCache();
+    end
 end
 
 -- Clear icon cache for a specific slot (call on targeted slot updates)
 local function ClearIconCacheForSlot(barIndex, slotIndex)
     if iconCache[barIndex] then
+        -- Per-slot wipes (drag/drop, single rebuild) need the same deferred-release
+        -- guard as ClearIconCache so the slot's queued AddImage from earlier this frame
+        -- doesn't end up dereferencing a freed COM texture.
+        local oldRow = iconCache[barIndex][slotIndex];
+        if oldRow ~= nil then
+            TextureManager.DeferRelease(oldRow);
+        end
         iconCache[barIndex][slotIndex] = nil;
     end
 end
@@ -257,7 +291,7 @@ local function GetSlotInteraction(barIndex, slotIndex)
 end
 
 -- Draw a single hotbar slot using shared renderer
-local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings, animOpacity, skillchainName)
+local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings, animOpacity, skillchainName, magicBurstName)
     -- Get icon (and pre-resolved abbreviation, if no icon) for this slot.
     -- All three are cached together; recomputed only when bind changes.
     local icon, cachedAbbr, cachedAbbrW = GetCachedIcon(barIndex, slotIndex, bind);
@@ -313,7 +347,7 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
     p.mpCostFontSize = (barSettings and barSettings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = barSettings and barSettings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = barSettings and barSettings.labelNoMpColor or 0xFFFF4444;
-    p.mpCostAnchor = barSettings and barSettings.mpCostAnchor or 'topRight';
+    p.mpCostAnchor = barSettings and barSettings.mpCostAnchor or 'topLeft';
     p.mpCostOffsetX = (barSettings and barSettings.mpCostOffsetX or 0) * gs;
     p.mpCostOffsetY = (barSettings and barSettings.mpCostOffsetY or 0) * gs;
     p.showQuantity = barSettings and barSettings.showQuantity ~= false;
@@ -337,6 +371,11 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
     -- Skillchain highlight
     p.skillchainName = skillchainName;
     p.skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44;
+    -- Magic Burst highlight (separate from skillchain — different SC->element predictor,
+    -- different color, different corner icon). Resolved upstream in the per-slot loop so
+    -- this just plumbs the name/color through to slotrenderer.
+    p.magicBurstName = magicBurstName;
+    p.magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF;
 
     -- Render slot using shared renderer (handles ALL rendering and interactions)
     local result = slotrenderer.DrawSlot(p);
@@ -456,10 +495,14 @@ local function DrawBarWindow(barIndex, settings)
         -- drop zones earlier so they're registered when the drag activates
         local isDragging = dragdrop.IsDragging() or dragdrop.IsDragPending();
 
-        -- Get target server ID for skillchain prediction (cached for all slots)
+        -- Get target server ID for skillchain / magic burst prediction (cached for all slots).
+        -- Both features key off the same target so we resolve once per frame here and reuse
+        -- the cached server ID inside the per-slot loop. Either feature being disabled is
+        -- fine: the resolver still returns the ID, and the per-slot path early-exits below.
         local targetServerId = nil;
         local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
-        if skillchainEnabled then
+        local magicBurstEnabled = gConfig.hotbarGlobal.magicBurstHighlightEnabled ~= false;
+        if skillchainEnabled or magicBurstEnabled then
             local mainTargetIdx = targetLib.GetTargets();
             if mainTargetIdx and mainTargetIdx ~= 0 then
                 local targetEntity = GetEntity(mainTargetIdx);
@@ -481,13 +524,32 @@ local function DrawBarWindow(barIndex, settings)
                     if hideEmptySlots and not paletteOpen and not keybindEditorOpen and not isDragging and not bind then
                         -- Empty slot: skip rendering (ImGui draws are stateless, nothing to hide)
                     else
-                        -- Check for skillchain prediction on weapon skill slots
+                        -- Skillchain prediction: WS slots, Blood Pact slots, and macros whose
+                        -- primary line is /ws or /pet (parsed via macroparse).
                         local slotSkillchainName = nil;
-                        if skillchainEnabled and bind and bind.actionType == 'ws' and bind.action then
-                            -- Pass WS name directly - skillchain module handles name->ID conversion
-                            slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, bind.action);
+                        if skillchainEnabled and bind then
+                            if bind.actionType == 'ws' and bind.action then
+                                slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, bind.action);
+                            elseif bind.actionType == 'pet' and bind.action then
+                                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, bind.action);
+                            elseif bind.actionType == 'macro' and bind.macroText then
+                                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(bind.macroText);
+                                if primaryType == 'ws' and primaryName then
+                                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                                elseif primaryType == 'pet' and primaryName then
+                                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                                end
+                            end
                         end
-                        DrawSlot(barIndex, slotIndex, slotX, slotY, buttonSize, bind, barSettings, animOpacity, slotSkillchainName);
+                        -- Magic Burst prediction: spells (/ma), magical pact rages (/pet curated
+                        -- map), and /ma|/pet-primary macros. Routes via skillchain.GetMagicBurstForSlot
+                        -- so the dispatch matches the skillchain pass above; the lookup is a single
+                        -- table read after the lazy element-by-name cache is warmed.
+                        local slotMagicBurstName = nil;
+                        if magicBurstEnabled and bind then
+                            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, bind);
+                        end
+                        DrawSlot(barIndex, slotIndex, slotX, slotY, buttonSize, bind, barSettings, animOpacity, slotSkillchainName, slotMagicBurstName);
                     end
                 end
                 slotIndex = slotIndex + 1;
@@ -573,6 +635,10 @@ end
 
 function M.DrawWindow(settings)
     -- Note: dragdrop.Update() is called from init.lua before this
+
+    -- Refresh per-frame cached spell/ability/WS/item lists used by macropalette filters
+    -- and by GetBindIcon resolution for macro lines.
+    playerdata.RefreshCachedLists(data);
 
     -- Initialize textures on first draw
     if not texturesInitialized then

--- a/XIUI/modules/hotbar/skillchain.lua
+++ b/XIUI/modules/hotbar/skillchain.lua
@@ -332,6 +332,149 @@ local weaponskillResonationMap = {
 -- state = { Attributes = {}, Depth = number, WindowOpen = time, WindowClose = time }
 local resonationMap = {};
 
+-- ============================================
+-- Magic Burst (MB) state
+-- ============================================
+--
+-- A Magic Burst window opens IMMEDIATELY when a skillchain CLOSES (the SC's additional-effect
+-- message fires on the closing WS's action packet) and stays open for 7.0s — any spell whose
+-- ELEMENT matches one of the SC's burstable elements and that FINISHES casting inside the
+-- window magic-bursts for bonus damage.
+--
+-- Note: retail's MB window is ~2s-7s post-WS (you can't burst before ~2s and the window
+-- closes around 7s). We open at 0s on purpose so the player gets the visual cue at the
+-- earliest possible moment and has the full 7s of slack to start their cast — the actual
+-- burst-eligibility timing is enforced server-side anyway, so the only thing affected by
+-- the visual is when the highlight is on screen.
+--
+-- Lifetime rules (per target):
+--   * SC fires (skillchainMessageIds match)                  → write magicBurstMap entry,
+--     overwriting any prior MB state on this target. Same path catches "another SC happened
+--     during the previous MB window" → window restarts with the new SC's elements.
+--   * WS lands WITH attributes (weaponskillResonationMap)    → clear magicBurstMap entry.
+--     This matches the FFXI mechanic where a new WS overwrites the target's resonance and
+--     closes the open MB window even if the new WS itself doesn't chain.
+--   * WS lands WITHOUT attributes (Spirits Within etc.)      → MB window untouched. The WS
+--     never reaches the weapon-skill-message branch in HandleActionPacket since its row
+--     isn't in weaponskillResonationMap, so the no-op is automatic.
+--   * Target cleared / window expired (consulted lazily on every Get*)  → entry dropped.
+--
+-- Window timing constants. Open delay 0 (highlight as soon as the SC packet arrives),
+-- duration 7.0 (window closes at SC + 7s). See block comment above for rationale.
+local MB_WINDOW_OPEN_DELAY = 0.0;
+local MB_WINDOW_DURATION = 7.0;
+
+-- Per-target Magic Burst state (entity index → { Elements, ScName, WindowOpen, WindowClose }).
+-- Kept SEPARATE from resonationMap because the two have different lifetimes: resonationMap's
+-- WindowOpen/Close describe the NEXT-SC prediction window (3.5–9.8s), MB's describe the
+-- ACTUAL magic-burstable window (0.0–7.0s via the MB_WINDOW_* constants below). Trying to
+-- share one map would conflate them.
+local magicBurstMap = {};
+
+-- Resonation result → list of burstable element IDs. Element IDs match horizonspells.lua's
+-- `element` field: 0=Fire, 1=Ice, 2=Wind, 3=Earth, 4=Lightning, 5=Water, 6=Light, 7=Dark.
+-- Level-1 SCs map to one element each; Lv2 (Fusion/Frag/Distortion/Gravitation) burst two;
+-- Lv3 (Light/Darkness/Radiance/Umbra) burst four. Radiance and Umbra are the depth-3 "Light
+-- after Light" / "Darkness after Darkness" upgrades — they burst the same element set.
+local magicBurstElements = {
+    [Resonation.Liquefaction]   = { 0 },                -- Fire
+    [Resonation.Induration]     = { 1 },                -- Ice
+    [Resonation.Detonation]     = { 2 },                -- Wind
+    [Resonation.Scission]       = { 3 },                -- Earth
+    [Resonation.Impaction]      = { 4 },                -- Lightning
+    [Resonation.Reverberation]  = { 5 },                -- Water
+    [Resonation.Transfixion]    = { 6 },                -- Light
+    [Resonation.Compression]    = { 7 },                -- Dark
+    [Resonation.Fusion]         = { 0, 6 },             -- Fire + Light
+    [Resonation.Fragmentation]  = { 4, 2 },             -- Lightning + Wind
+    [Resonation.Distortion]     = { 5, 1 },             -- Water + Ice
+    [Resonation.Gravitation]    = { 3, 7 },             -- Earth + Dark
+    [Resonation.Light]          = { 0, 6, 4, 2 },       -- Fire/Light/Lightning/Wind
+    [Resonation.Darkness]       = { 5, 1, 3, 7 },       -- Water/Ice/Earth/Dark
+    [Resonation.Light2]         = { 0, 6, 4, 2 },       -- depth-3 Light upgrade
+    [Resonation.Darkness2]      = { 5, 1, 3, 7 },       -- depth-3 Darkness upgrade
+    [Resonation.Radiance]       = { 0, 6, 4, 2 },       -- Radiance burst set = Light's
+    [Resonation.Umbra]          = { 5, 1, 3, 7 },       -- Umbra burst set = Darkness's
+};
+
+-- SMN Magical Blood Pact Rage element overrides. horizon_bloodpacts.lua stores `element = 0`
+-- as a placeholder for ALL pact rows (it's a synthetic spell-shaped DB; only mp_cost +
+-- smn_lv are authoritative there), so we can't trust the resource for SMN MB eligibility.
+-- This is the curated short list: only the spell-named "Magic" Blood Pact: Rages (Fire II,
+-- Blizzard IV, etc.). The named flavor rages (Heavenly Strike, Inferno, Judgment Bolt, etc.)
+-- and the Astral Flow 1HRs are deliberately OMITTED — the user wants MB highlight scoped to
+-- just the BLM-shadow magic pacts. Names match petregistry English so /pet "Fire II" macros
+-- and crossbar pet slots resolve via the same name key. Extend cautiously and never add
+-- physical pacts here (Punch / Rock Throw / Crescent Fang / etc.) — they'd false-positive.
+local bloodPactElementMap = {
+    -- Fire (Ifrit)
+    ['Fire II']     = 0,
+    ['Fire IV']     = 0,
+    -- Ice (Shiva)
+    ['Blizzard II'] = 1,
+    ['Blizzard IV'] = 1,
+    -- Wind (Garuda)
+    ['Aero II']     = 2,
+    ['Aero IV']     = 2,
+    -- Earth (Titan)
+    ['Stone II']    = 3,
+    ['Stone IV']    = 3,
+    -- Lightning (Ramuh)
+    ['Thunder II']  = 4,
+    ['Thunder IV']  = 4,
+    -- Water (Leviathan)
+    ['Water II']    = 5,
+    ['Water IV']    = 5,
+};
+
+-- Lazy lookup: lowercase English spell name → element id (0-7), or false if the spell exists
+-- but isn't MB-eligible (no enemy-target bit, or non-elemental). Built on first request from
+-- horizonspells.lua. Same lazy-cache pattern as actions.lua's spellsByLowerNameLookup, but
+-- stays local to this module because MB is its only consumer right now.
+--
+-- MB eligibility filter (mirrors retail mechanic):
+--   * `element` must be in 0-7 (i.e. one of the eight pure elements; 8 = non-elemental excluded)
+--   * `targets` must include the enemy bit (32) — drops Protect/Raise/-na/healing-on-friendly
+--     even though those rows technically carry a `element` value (most WHM utility spells are
+--     element=6 / Light, but they can't be cast on an enemy so they could never magic burst).
+local spellElementByLowerName = nil;
+
+local function buildSpellElementLookup()
+    spellElementByLowerName = {};
+    local ok, horizonSpells = pcall(require, 'modules.hotbar.database.horizonspells');
+    if not ok or type(horizonSpells) ~= 'table' then
+        return;
+    end
+    for _, spell in pairs(horizonSpells) do
+        if spell.en and spell.en ~= '' then
+            local key = string.lower(spell.en);
+            if spellElementByLowerName[key] == nil then
+                local elem = spell.element;
+                local tgts = spell.targets or 0;
+                local enemyBit = bit.band(tgts, 32) ~= 0;
+                if elem ~= nil and elem >= 0 and elem <= 7 and enemyBit then
+                    spellElementByLowerName[key] = elem;
+                else
+                    spellElementByLowerName[key] = false;
+                end
+            end
+        end
+    end
+end
+
+local function spellNameToBurstElement(spellName)
+    if not spellName or spellName == '' then return nil; end
+    if spellElementByLowerName == nil then buildSpellElementLookup(); end
+    local v = spellElementByLowerName[string.lower(spellName)];
+    if v == false then return nil; end
+    return v;  -- number or nil
+end
+
+local function pactNameToBurstElement(pactName)
+    if not pactName or pactName == '' then return nil; end
+    return bloodPactElementMap[pactName];
+end
+
 -- Hardcoded WS name -> ID map (resource manager lookup is unreliable)
 local wsNameToIdMap = {
     -- Hand-to-Hand
@@ -438,6 +581,27 @@ local function tableContains(tbl, val)
     return false;
 end
 
+-- Blood Pact / avatar physical pacts: English ability name (as in /pet "Name") → Level-1 attributes.
+-- Horizon: omit Level 70 pacts with no SC properties (unmapped here — no false resonance).
+local bloodPactResonationMap = {
+    ['Claw'] = { Resonation.Detonation },
+    ['Rock Throw'] = { Resonation.Scission },
+    ['Axe Kick'] = { Resonation.Induration },
+    ['Punch'] = { Resonation.Liquefaction },
+    ['Shock Strike'] = { Resonation.Impaction },
+    ['Barracuda Dive'] = { Resonation.Reverberation },
+    ['Camisado'] = { Resonation.Compression },
+    ['Poison Nails'] = { Resonation.Transfixion },
+    ['Moonlit Charge'] = { Resonation.Compression },
+    ['Crescent Fang'] = { Resonation.Transfixion },
+    ['Rock Buster'] = { Resonation.Reverberation },
+    ['Burning Strike'] = { Resonation.Impaction },
+    ['Tail Whip'] = { Resonation.Detonation },
+    ['Double Punch'] = { Resonation.Compression },
+    ['Megalith Throw'] = { Resonation.Induration },
+    ['Double Slap'] = { Resonation.Scission },
+};
+
 -- Convert server ID to entity index
 local function GetIndexFromId(id)
     local entMgr = AshitaCore:GetMemoryManager():GetEntity();
@@ -463,33 +627,17 @@ local function GetIndexFromId(id)
     return 0;
 end
 
--- Get skillchain result for a WS against current target state
--- targetServerId: server ID of the target
--- wsIdOrName: weapon skill ID (number) or name (string)
--- Returns skillchain name or nil
-function M.GetSkillchainForSlot(targetServerId, wsIdOrName)
-    if not wsIdOrName then return nil; end
+-- Shared prediction: closing ability attributes vs per-target resonation window.
+local function GetSkillchainFromClosingAttributes(targetServerId, closingAttributes)
+    if not closingAttributes or #closingAttributes == 0 then return nil; end
 
-    -- Convert name to ID if needed
-    local wsId = wsIdOrName;
-    if type(wsIdOrName) == 'string' then
-        wsId = GetWSIdFromName(wsIdOrName);
-        if not wsId then return nil; end
-    end
-
-    -- Get WS attributes early (needed for all checks)
-    local wsAttributes = weaponskillResonationMap[wsId];
-    if not wsAttributes then return nil; end
-
-    -- Convert server ID to entity index if provided
     local targetIndex = nil;
     if targetServerId and targetServerId > 0x8FF then
         targetIndex = GetIndexFromId(targetServerId);
     elseif targetServerId and targetServerId > 0 and targetServerId <= 0x8FF then
-        targetIndex = targetServerId;  -- Already an entity index
+        targetIndex = targetServerId;
     end
 
-    -- Only check the player's current target
     if not targetIndex or targetIndex == 0 then
         return nil;
     end
@@ -501,22 +649,19 @@ function M.GetSkillchainForSlot(targetServerId, wsIdOrName)
 
     local now = os.clock();
 
-    -- Check if window expired
     if now > resonation.WindowClose then
         resonationMap[targetIndex] = nil;
         return nil;
     end
 
-    -- Check if window is open
     if now < resonation.WindowOpen then
         return nil;
     end
 
-    -- Check for skillchain match
     for _, sc in ipairs(possibleSkillchains) do
         local result, opening, closing = sc[1], sc[2], sc[3];
         if tableContains(resonation.Attributes, opening) then
-            if tableContains(wsAttributes, closing) then
+            if tableContains(closingAttributes, closing) then
                 return resonationNames[result];
             end
         end
@@ -525,47 +670,85 @@ function M.GetSkillchainForSlot(targetServerId, wsIdOrName)
     return nil;
 end
 
+-- Get skillchain result for a WS against current target state
+-- targetServerId: server ID of the target
+-- wsIdOrName: weapon skill ID (number) or name (string)
+-- Returns skillchain name or nil
+function M.GetSkillchainForSlot(targetServerId, wsIdOrName)
+    if not wsIdOrName then return nil; end
+
+    local wsId = wsIdOrName;
+    if type(wsIdOrName) == 'string' then
+        wsId = GetWSIdFromName(wsIdOrName);
+        if not wsId then return nil; end
+    end
+
+    local wsAttributes = weaponskillResonationMap[wsId];
+    if not wsAttributes then return nil; end
+
+    return GetSkillchainFromClosingAttributes(targetServerId, wsAttributes);
+end
+
+--- @param pactName string English pact name (e.g. /pet "Shock Strike")
+function M.GetSkillchainForBloodPact(targetServerId, pactName)
+    if not pactName then return nil; end
+    local attrs = bloodPactResonationMap[pactName];
+    return GetSkillchainFromClosingAttributes(targetServerId, attrs);
+end
+
 -- Handle action packet (0x0028)
--- XIUI's ParseActionPacket stores WS ID in .Param (not .Id like tHotBar)
+-- Type 3: weapon skill — Param is WS id. Type 13: pet/Blood Pact — Param is ability id; map name → attributes.
 function M.HandleActionPacket(actionPacket)
     if not actionPacket then return; end
 
-    -- Only process weapon skill actions (Type 3)
-    if actionPacket.Type ~= 3 then return; end
+    local actionType = actionPacket.Type;
+    if actionType ~= 3 and actionType ~= 13 then return; end
 
-    -- WS ID is stored in Param field by XIUI's packet parser
-    local wsId = actionPacket.Param;
-    if not wsId or wsId == 0 then return; end
+    local param = actionPacket.Param;
+    if not param or param == 0 then return; end
 
-    -- Process each target
+    local pactAttributes = nil;
+    if actionType == 13 then
+        local resMgr = AshitaCore:GetResourceManager();
+        local ability = resMgr and resMgr:GetAbilityById(param);
+        local pactName = ability and ability.Name and ability.Name[1];
+        if pactName then
+            pactAttributes = bloodPactResonationMap[pactName];
+        end
+    end
+
     for _, target in ipairs(actionPacket.Targets or {}) do
         local targetIndex = GetIndexFromId(target.Id);
         if targetIndex ~= 0 then
             for _, action in ipairs(target.Actions or {}) do
-                -- Check for skillchain message
                 local skillchain = nil;
                 if action.AdditionalEffect then
                     skillchain = skillchainMessageIds[action.AdditionalEffect.Message];
                 end
 
                 if skillchain == Resonation.None then
-                    -- Skillchain interrupted
                     resonationMap[targetIndex] = nil;
+                    magicBurstMap[targetIndex] = nil;
 
                 elseif skillchain then
-                    -- Skillchain occurred - update state
                     local resonation = resonationMap[targetIndex];
                     local now = os.clock();
 
+                    -- Track the "effective" resonation that we'll use for the MB lookup. The
+                    -- depth-3 upgrade branch below promotes Light → Light2 / Darkness → Darkness2,
+                    -- but magicBurstElements has identical entries for both pairs so either key
+                    -- resolves to the same element set. We capture the resolved value to keep
+                    -- the MB write trivially correct even if the upgrade table ever diverges.
+                    local effectiveSkillchain = skillchain;
                     if resonation and (now + 1) > resonation.WindowOpen and (now - 1) < resonation.WindowClose then
-                        -- Continuing existing chain
                         resonation.Depth = resonation.Depth + 1;
 
-                        -- Handle Light/Darkness level escalation
                         if skillchain == Resonation.Light and tableContains(resonation.Attributes, Resonation.Light) then
                             resonation.Attributes = { Resonation.Light2 };
+                            effectiveSkillchain = Resonation.Light2;
                         elseif skillchain == Resonation.Darkness and tableContains(resonation.Attributes, Resonation.Darkness) then
                             resonation.Attributes = { Resonation.Darkness2 };
+                            effectiveSkillchain = Resonation.Darkness2;
                         else
                             resonation.Attributes = { skillchain };
                         end
@@ -573,7 +756,6 @@ function M.HandleActionPacket(actionPacket)
                         resonation.WindowOpen = now + 3.5;
                         resonation.WindowClose = now + (9.8 - resonation.Depth);
                     else
-                        -- New chain from skillchain
                         resonation = {
                             Depth = 1,
                             Attributes = { skillchain },
@@ -583,19 +765,42 @@ function M.HandleActionPacket(actionPacket)
                         resonationMap[targetIndex] = resonation;
                     end
 
+                    -- Open / overwrite the Magic Burst window. Overwriting (rather than checking
+                    -- "is the prior MB still open?") matches the user spec: "If another
+                    -- Skillchain is performed, stop lighting the previous, switch to the new."
+                    -- The element set for an upgraded chain (Light2/Darkness2) is identical to
+                    -- the base, so the lookup is safe either way.
+                    local burstElements = magicBurstElements[effectiveSkillchain];
+                    if burstElements then
+                        magicBurstMap[targetIndex] = {
+                            Elements = burstElements,
+                            ScName = resonationNames[effectiveSkillchain] or resonationNames[skillchain],
+                            WindowOpen = now + MB_WINDOW_OPEN_DELAY,
+                            WindowClose = now + MB_WINDOW_OPEN_DELAY + MB_WINDOW_DURATION,
+                        };
+                    end
+
                 elseif weaponskillMessageIds[action.Message] then
-                    -- WS hit without skillchain - set up new resonation
-                    local attributes = weaponskillResonationMap[wsId];
-                    if attributes then
+                    local attributes = nil;
+                    if actionType == 3 then
+                        attributes = weaponskillResonationMap[param];
+                    else
+                        attributes = pactAttributes;
+                    end
+                    if attributes and #attributes > 0 then
                         local now = os.clock();
                         resonationMap[targetIndex] = {
                             Depth = 0,
                             Attributes = attributes,
-                            -- For UI prediction, show immediately (window opens now)
-                            -- Actual skillchain can land ~3-10 seconds after opener
                             WindowOpen = now,
                             WindowClose = now + 10.0,
                         };
+                        -- A WS WITH attributes overwrites the target's resonance and closes the
+                        -- prior MB window even if this WS doesn't chain (matches FFXI). WS rows
+                        -- that have NO attributes (Spirits Within etc.) never reach this branch
+                        -- because they're absent from weaponskillResonationMap / pactAttributes,
+                        -- so the MB window survives — exactly the spec'd no-op behavior.
+                        magicBurstMap[targetIndex] = nil;
                     end
                 end
             end
@@ -606,6 +811,7 @@ end
 -- Clear all state (call on zone change)
 function M.ClearState()
     resonationMap = {};
+    magicBurstMap = {};
 end
 
 -- Clear state for a specific target
@@ -614,8 +820,107 @@ function M.ClearTargetState(targetServerId)
         local targetIndex = GetIndexFromId(targetServerId);
         if targetIndex ~= 0 then
             resonationMap[targetIndex] = nil;
+            magicBurstMap[targetIndex] = nil;
         end
     end
+end
+
+-- ============================================
+-- Magic Burst public API
+-- ============================================
+
+-- Resolve a slot to its burst-eligible element (0-7) or nil if the slot can never magic burst.
+-- Routes by actionType: 'ma' → spell name lookup, 'pet' → curated SMN pact map, 'macro' →
+-- parse primary line and route accordingly. Mirrors display.lua's skillchain dispatch so the
+-- same slot types light up for both prediction paths.
+function M.GetBurstElementForSlot(slotData)
+    if not slotData or not slotData.actionType then return nil; end
+    local aType = slotData.actionType;
+    if aType == 'ma' then
+        return spellNameToBurstElement(slotData.action);
+    elseif aType == 'pet' then
+        return pactNameToBurstElement(slotData.action);
+    elseif aType == 'macro' and slotData.macroText then
+        -- macroparse loaded lazily so skillchain.lua doesn't carry a hard dep on it for the
+        -- non-macro callers (display/crossbar require it themselves already, so the cost is
+        -- a single cached `require` after first macro-slot resolution).
+        local ok, macroparse = pcall(require, 'modules.hotbar.macroparse');
+        if not ok or not macroparse or not macroparse.GetMacroPrimaryAndJaBadge then
+            return nil;
+        end
+        local pType, pName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+        if pType == 'ma' and pName then
+            return spellNameToBurstElement(pName);
+        elseif pType == 'pet' and pName then
+            return pactNameToBurstElement(pName);
+        end
+    end
+    return nil;
+end
+
+-- Returns the SC name (e.g. 'Fusion') that opened the currently-active MB window for
+-- `targetServerId`, if the window is open AND `element` matches one of its burstable
+-- elements. Returns nil otherwise. The SC name is what slotrenderer uses as the corner
+-- icon (same `assets/hotbar/skillchain/<scName>.png` files as the skillchain highlight).
+function M.GetMagicBurstForElement(targetServerId, element)
+    if element == nil then return nil; end
+
+    local targetIndex = nil;
+    if targetServerId and targetServerId > 0x8FF then
+        targetIndex = GetIndexFromId(targetServerId);
+    elseif targetServerId and targetServerId > 0 and targetServerId <= 0x8FF then
+        targetIndex = targetServerId;
+    end
+    if not targetIndex or targetIndex == 0 then return nil; end
+
+    local mb = magicBurstMap[targetIndex];
+    if not mb then return nil; end
+
+    local now = os.clock();
+    if now > mb.WindowClose then
+        magicBurstMap[targetIndex] = nil;  -- lazy GC of expired entries
+        return nil;
+    end
+    if now < mb.WindowOpen then return nil; end
+
+    for i = 1, #mb.Elements do
+        if mb.Elements[i] == element then
+            return mb.ScName;
+        end
+    end
+    return nil;
+end
+
+-- Convenience: route a slot through GetBurstElementForSlot + GetMagicBurstForElement so
+-- display.lua / crossbar.lua only need a single call per slot for MB (matches the
+-- GetSkillchainForSlot calling pattern).
+function M.GetMagicBurstForSlot(targetServerId, slotData)
+    local element = M.GetBurstElementForSlot(slotData);
+    if element == nil then return nil; end
+    return M.GetMagicBurstForElement(targetServerId, element);
+end
+
+-- Existence helper for any UI status indicator (e.g. an on-target "MB window open!" badge
+-- the user might add later). Returns the active MB entry or nil; caller is responsible for
+-- the now-check via WindowOpen / WindowClose if it wants timing info beyond "is it open".
+function M.GetMagicBurstWindow(targetServerId)
+    local targetIndex = nil;
+    if targetServerId and targetServerId > 0x8FF then
+        targetIndex = GetIndexFromId(targetServerId);
+    elseif targetServerId and targetServerId > 0 and targetServerId <= 0x8FF then
+        targetIndex = targetServerId;
+    end
+    if not targetIndex or targetIndex == 0 then return nil; end
+
+    local mb = magicBurstMap[targetIndex];
+    if not mb then return nil; end
+
+    local now = os.clock();
+    if now > mb.WindowClose then
+        magicBurstMap[targetIndex] = nil;
+        return nil;
+    end
+    return mb;
 end
 
 -- Check if skillchain window is open for any target

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -16,10 +16,35 @@ local textures = require('modules.hotbar.textures');
 local skillchain = require('modules.hotbar.skillchain');
 local statusHandler = require('handlers.statushandler');
 local imtext = require('libs.imtext');
+-- TextureManager.DeferRelease holds Lua refs alive for one frame so wiping the
+-- texturePtrCache mid-frame (e.g. palette delete fires InvalidateAllVisualCachesAfter
+-- PaletteListMutation) doesn't race the current frame's queued AddImage calls.
+local TextureManager = require('libs.texturemanager');
+-- libs/color.lua has ARGB <-> ImGui U32 + HSV<->RGB helpers we use for UTH effects.
+-- Audit pass deduped a local ArgbToImguiU32 and a local UthHsvToRgb that had identical math.
+local colorlib = require('libs.color');
+-- universal_two_hour is a Ferris addition that tracks the universal-2hr armed-slot state
+-- so the rainbow ring glow knows which slot to decorate. Loaded with pcall so 1.7.5-era
+-- forks without the module still render normal slots without crashing.
+local universalTwoHour = nil;
+do
+    local ok, mod = pcall(require, 'modules.hotbar.universal_two_hour');
+    if ok then universalTwoHour = mod; end
+end
 
 -- Deferred tooltip: stored during render, drawn after all windows to ensure z-order
 local pendingTooltipBind = nil;
 local tooltipFontSettings = nil;
+
+-- Manual double-click tracking. Using `imgui.IsMouseDoubleClicked` here is unreliable
+-- because the drag/drop system swallows the first click on slots that participate in
+-- drag (the first MouseDown starts a deferred-drag candidate which suppresses the click).
+-- We instead track the last click target and its timestamp ourselves and decide on
+-- MouseReleased(0) — that's the same point WasDragAttempted resolves, so double-click
+-- semantics stay consistent with single-click semantics.
+local lastClickButtonId = nil;
+local lastClickTime = 0;
+local DOUBLE_CLICK_INTERVAL = 0.35;
 
 -- Tooltip constants (ARGB for text colors used with imtext, ABGR/U32 for rect colors)
 local TOOLTIP_FONT_SIZE = 12;
@@ -36,10 +61,80 @@ local ACTION_TYPE_LABELS = {
 
 -- Cache for MP cost lookups (keyed by action key string)
 local mpCostCache = {};
+local mpCostCacheSize = 0;
+local MP_COST_CACHE_MAX = 4096;
 
--- Cache for action availability checks (keyed by action key string)
+-- Cache for action availability checks (keyed by action key string).
 -- Structure: { isAvailable = bool, reason = string|nil }
+-- The cache key embeds (main job, sub job, main level, sub level, party-member main/sub level)
+-- so Level Sync transitions invalidate previously-cached availabilities (a spell that was
+-- available at L75 may stop being available at synced L40). Without this the cache returns
+-- stale results across sync changes. Size-bounded by AVAILABILITY_CACHE_MAX — when exceeded
+-- the cache is reset wholesale (cheaper than LRU eviction for a frequently-rebuilt cache).
 local availabilityCache = {};
+local availabilityCacheSize = 0;
+local AVAILABILITY_CACHE_MAX = 8192;
+
+local function PutMpCostCache(key, value)
+    if mpCostCache[key] == nil then
+        mpCostCacheSize = mpCostCacheSize + 1;
+        if mpCostCacheSize > MP_COST_CACHE_MAX then
+            mpCostCache = {};
+            mpCostCacheSize = 0;
+        end
+    end
+    mpCostCache[key] = value;
+end
+
+local function PutAvailabilityCache(key, value)
+    if availabilityCache[key] == nil then
+        availabilityCacheSize = availabilityCacheSize + 1;
+        if availabilityCacheSize > AVAILABILITY_CACHE_MAX then
+            availabilityCache = {};
+            availabilityCacheSize = 0;
+        end
+    end
+    availabilityCache[key] = value;
+end
+
+-- Per-frame snapshot of (player, party, job ids, effective levels). Reset at BeginFrame
+-- and read lazily from the availability path so we only walk the MemoryManager once per
+-- frame instead of once per (slot * frame). At ~16 main-bar slots + 16 preview slots + N
+-- keyboard bars this drops the per-frame FFI walk from N*7 getters to a constant ~7. The
+-- snapshot is intentionally lazy (first slot that needs it warms it) so frames without
+-- any availability checks pay zero cost.
+--
+-- IMPORTANT: keep this declared BEFORE M.DrawSlot — Lua local-function forward references
+-- only work if the symbol is visible at the call site. Putting it after caused a
+-- "attempt to call global 'GetFrameAvailability' (a nil value)" load error.
+local frameAvail = { ready = false };
+
+local function GetFrameAvailability()
+    if frameAvail.ready then return frameAvail; end
+    local memMgr = AshitaCore:GetMemoryManager();
+    local player = memMgr and memMgr:GetPlayer();
+    if not player then
+        frameAvail.ready = true;
+        frameAvail.jobId = 0; frameAvail.subjobId = 0;
+        frameAvail.mainLevel = 0; frameAvail.subLevel = 0;
+        frameAvail.partyMain = 0; frameAvail.partySub = 0;
+        return frameAvail;
+    end
+    frameAvail.jobId     = player:GetMainJob() or 0;
+    frameAvail.subjobId  = player:GetSubJob() or 0;
+    frameAvail.mainLevel = player:GetMainJobLevel() or 0;
+    frameAvail.subLevel  = player:GetSubJobLevel() or 0;
+    local partyMain, partySub = 0, 0;
+    local party = memMgr and memMgr:GetParty();
+    if party then
+        partyMain = party:GetMemberMainJobLevel(0) or 0;
+        partySub  = party:GetMemberSubJobLevel(0) or 0;
+    end
+    frameAvail.partyMain = partyMain;
+    frameAvail.partySub  = partySub;
+    frameAvail.ready     = true;
+    return frameAvail;
+end
 
 -- Cache for item quantity lookups (keyed by itemId or itemName)
 -- Structure: { quantity = number, timestamp = number }
@@ -366,7 +461,10 @@ local assetsPath = nil;
 
 -- Reusable result table for DrawSlot to avoid GC pressure
 -- (Creating tables per-slot per-frame causes ~7200 allocations/sec)
-local drawSlotResult = { isHovered = false };
+-- Reusable result table for M.DrawSlot. `command` is the resolved command string for the
+-- slot's bind (so callers can dispatch on click without re-calling actions.BuildCommandString
+-- per click); nil for empty / unbindable slots.
+local drawSlotResult = { isHovered = false, command = nil };
 
 -- Reusable position/UV tables for AddImage (avoids per-call table allocations)
 local imgP1 = {0, 0};
@@ -399,12 +497,22 @@ end
 -- Clear all cached state
 function M.ClearAllCache()
     availabilityCache = {};
+    availabilityCacheSize = 0;
     mpCostCache = {};
+    mpCostCacheSize = 0;
     equipmentCheckCache = {};
     ninjutsuCache = {};
     itemQuantityCache = {};
     stackSizeCache = {};
     ammoStatusCache = {};
+    -- texturePtrCache holds the SOLE Lua ref to D3D textures loaded via LoadTextureFromPath
+    -- (the underlying entries have a d3d8.gc_safe_release finalizer). Dropping the table
+    -- mid-frame would let Lua GC release the COM texture while AddImage calls for it are
+    -- still queued in this frame's draw list — that's the same EXCEPTION_ACCESS_VIOLATION
+    -- pattern that TextureManager.deferRelease guards against. Hand the table off to
+    -- TextureManager.DeferRelease so it stays alive until FlushPendingReleases runs at the
+    -- top of next d3d_present.
+    TextureManager.DeferRelease(texturePtrCache);
     texturePtrCache = {};
 end
 
@@ -412,12 +520,15 @@ end
 -- Does NOT clear availability, MP cost, or item quantity caches
 -- OPTIMIZED: Use this for palette changes to avoid unnecessary recalculation cascade
 function M.ClearSlotRenderingCache()
+    -- See M.ClearAllCache for rationale; same mid-frame texture-release race applies here.
+    TextureManager.DeferRelease(texturePtrCache);
     texturePtrCache = {};
 end
 
 -- Clear availability cache (call on job change, level sync, etc.)
 function M.ClearAvailabilityCache()
     availabilityCache = {};
+    availabilityCacheSize = 0;
 end
 
 -- Clear MP cost cache (call when a slot's action/spell may have changed, e.g. macro edits).
@@ -425,6 +536,7 @@ end
 -- until the addon reloads.
 function M.ClearMPCostCache()
     mpCostCache = {};
+    mpCostCacheSize = 0;
 end
 
 -- Clear item quantity cache (call on inventory changes)
@@ -533,6 +645,146 @@ local function DrawDashedLine(drawList, x1, y1, x2, y2, color, thickness, dashLe
     end
 end
 
+-- ============================================
+-- ARGB color helpers (XIUI palette uses 0xAARRGGBB; ImGui AddText/AddRect take GetColorU32{r,g,b,a}).
+-- ScaleArgbOpacity / DimArgbColor / LerpArgbTowardWhite are slotrenderer-specific tone-mapping
+-- ops and live here; the basic ARGB<->ImGui U32 conversion is delegated to libs/color.lua.
+-- ============================================
+
+local ArgbToImguiU32 = colorlib.ARGBToU32;
+
+local function ScaleArgbOpacity(argb, opacity)
+    if not opacity or opacity >= 0.999 then return argb; end
+    local a = bit.rshift(bit.band(argb, 0xFF000000), 24);
+    a = math.floor(a * opacity);
+    if a < 0 then a = 0; elseif a > 255 then a = 255; end
+    return bit.bor(bit.lshift(a, 24), bit.band(argb, 0x00FFFFFF));
+end
+
+local function DimArgbColor(argb, factor)
+    if not factor or factor >= 0.999 then return argb; end
+    local a = bit.band(bit.rshift(argb, 24), 0xFF);
+    local r = math.floor(bit.band(bit.rshift(argb, 16), 0xFF) * factor);
+    local g = math.floor(bit.band(bit.rshift(argb, 8), 0xFF) * factor);
+    local b = math.floor(bit.band(argb, 0xFF) * factor);
+    return bit.bor(bit.lshift(a, 24), bit.lshift(r, 16), bit.lshift(g, 8), b);
+end
+
+local function LerpArgbTowardWhite(argb, t)
+    if not argb or t <= 0 then return argb; end
+    if t > 1 then t = 1; end
+    local a = bit.rshift(bit.band(argb, 0xFF000000), 24);
+    local r = bit.rshift(bit.band(argb, 0x00FF0000), 16);
+    local g = bit.rshift(bit.band(argb, 0x0000FF00), 8);
+    local b = bit.band(argb, 0x000000FF);
+    r = math.floor(r + (255 - r) * t);
+    g = math.floor(g + (255 - g) * t);
+    b = math.floor(b + (255 - b) * t);
+    return bit.bor(bit.lshift(a, 24), bit.lshift(r, 16), bit.lshift(g, 8), b);
+end
+
+-- ============================================
+-- Universal Two-Hour (UTH) visual effects: rainbow marching border + subtarget ring glow.
+-- Triggered when an action is the "armed" universal 2hr ability awaiting <stpc>/<stnpc> confirmation.
+-- All pure ImGui drawList ops; no font or persistent-primitive dependencies.
+-- ============================================
+
+-- HSV (h in [0,1)) -> RGB used by the rainbow color cycling for UTH.
+-- Thin wrapper over libs/color.lua's shared hsvToRgb so the UTH animation always
+-- stays in sync with whatever color math the rest of the addon uses.
+local function UthHsvToRgb(h, s, v)
+    h = math.fmod(h, 1.0);
+    if h < 0 then h = h + 1.0; end
+    return colorlib.hsvToRgb(h, s, v);
+end
+
+-- Skillchain-style marching dashed rect; rainbow hue shifts with animation offset + time.
+local function DrawUniversalTwoHourRainbowMarchingBorder(drawList, x1, y1, x2, y2, opacityMul)
+    if not drawList or opacityMul <= 0.01 then return; end
+    local animOffset = skillchain.GetAnimationOffset();
+    local t = os.clock();
+    local dashLen = 4;
+    local gapLen = 4;
+    local thickness = 2.5;
+    local hueBase = math.fmod(animOffset * 0.0035 + t * 0.052, 1.0);
+    local function edgeColor(edgeIdx)
+        local h = math.fmod(hueBase + edgeIdx * 0.085, 1.0);
+        local r, g, b = UthHsvToRgb(h, 0.74, 1.0);
+        return imgui.GetColorU32({ r, g, b, 0.9 * opacityMul });
+    end
+    DrawDashedLine(drawList, x1, y1, x2, y1, edgeColor(0), thickness, dashLen, gapLen, animOffset);
+    DrawDashedLine(drawList, x2, y1, x2, y2, edgeColor(1), thickness, dashLen, gapLen, animOffset);
+    DrawDashedLine(drawList, x2, y2, x1, y2, edgeColor(2), thickness, dashLen, gapLen, animOffset);
+    DrawDashedLine(drawList, x1, y2, x1, y1, edgeColor(3), thickness, dashLen, gapLen, animOffset);
+end
+
+-- Rainbow rotating rings while Universal 2 Hour waits on <stpc>/<stnpc> confirmation.
+-- Ring radii breathe (collapse / expand); dashed border stays on the slot edge.
+-- Opacity uses animOpacity * dimFactor * armFadeScale.
+local function DrawUniversalTwoHourSubtargetGlow(drawList, x, y, size, animOpacity, dimFactor, armFadeScale)
+    if not drawList or animOpacity <= 0.01 then return; end
+    armFadeScale = armFadeScale or 1.0;
+    if armFadeScale <= 0.01 then return; end
+    local cx = x + size * 0.5;
+    local cy = y + size * 0.5;
+    local t = os.clock();
+    local op = math.min(1.0, animOpacity * dimFactor) * armFadeScale;
+
+    -- Collapse toward center then expand (cosine ease per cycle) — line rings only, no filled wash over the icon.
+    local breatheMin = 0.46;
+    local breathe = breatheMin + (1.0 - breatheMin) * (0.5 + 0.5 * math.cos(t * 3.05));
+
+    local function rainbowDashRing(spin, rad, thick, segs, hueSpin, lineAlpha, dashPred)
+        rad = rad * breathe;
+        for i = 0, segs - 1 do
+            if dashPred(i) then
+                local a0 = spin + (i / segs) * math.pi * 2;
+                local a1 = spin + ((i + 1) / segs) * math.pi * 2;
+                local mid = (a0 + a1) * 0.5;
+                local hue = math.fmod(mid / (math.pi * 2) + hueSpin, 1.0);
+                local r, g, b = UthHsvToRgb(hue, 0.82, 1.0);
+                drawList:AddLine(
+                    { cx + math.cos(a0) * rad, cy + math.sin(a0) * rad },
+                    { cx + math.cos(a1) * rad, cy + math.sin(a1) * rad },
+                    imgui.GetColorU32({ r, g, b, lineAlpha * op }),
+                    thick
+                );
+            end
+        end
+    end
+
+    local spinOuter = t * 4.2;
+    local spinInner = -t * 3.1;
+    local hueTravel = t * 0.14;
+
+    rainbowDashRing(-spinOuter, size * 0.485, 2.5, 28, hueTravel + 0.08, 0.78,
+        function(i) return i % 3 ~= 2; end);
+    rainbowDashRing(spinOuter, size * 0.52, 3.2, 28, hueTravel, 0.85,
+        function(i) return i % 3 ~= 0; end);
+    rainbowDashRing(spinInner, size * 0.46, 2.2, 28, hueTravel + 0.17, 0.80,
+        function(i) return i % 3 ~= 0; end);
+
+    local ringPulse = 0.55 + 0.45 * math.sin(t * 5.1);
+    local outerRad = (size * 0.58 + ringPulse * 1.5) * breathe;
+    local outerThick = 2.2 + ringPulse * 0.35;
+    local segsO = 48;
+    for i = 0, segsO - 1 do
+        local a0 = (i / segsO) * math.pi * 2;
+        local a1 = ((i + 1) / segsO) * math.pi * 2;
+        local mid = (a0 + a1) * 0.5;
+        local hue = math.fmod(mid / (math.pi * 2) + hueTravel + 0.05, 1.0);
+        local r, g, b = UthHsvToRgb(hue, 0.75, 1.0);
+        drawList:AddLine(
+            { cx + math.cos(a0) * outerRad, cy + math.sin(a0) * outerRad },
+            { cx + math.cos(a1) * outerRad, cy + math.sin(a1) * outerRad },
+            imgui.GetColorU32({ r, g, b, 0.88 * op }),
+            outerThick
+        );
+    end
+
+    DrawUniversalTwoHourRainbowMarchingBorder(drawList, x, y, x + size, y + size, op);
+end
+
 -- Draw skillchain highlight on a slot (animated dashed border + icon)
 -- @param drawList: ImGui draw list (foreground recommended)
 -- @param x, y: Top-left corner of slot
@@ -540,7 +792,10 @@ end
 -- @param scName: Skillchain name (e.g., 'Light', 'Darkness', 'Fusion')
 -- @param color: Highlight color (ARGB)
 -- @param opacity: Overall opacity (0-1)
-local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opacity)
+-- @param iconScaleOverride, iconOxOverride, iconOyOverride: optional per-call overrides
+--        (used by the macro palette editor to push the skillchain icon out of the corner
+--        when it would otherwise overlap an action-label or BST-Ready badge).
+local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opacity, iconScaleOverride, iconOxOverride, iconOyOverride)
     if not drawList or not scName or opacity <= 0.01 then return; end
 
     -- Animation offset for marching ants effect
@@ -568,11 +823,13 @@ local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opac
     -- Left edge
     DrawDashedLine(drawList, x, y + size, x, y, lineColor, thickness, dashLen, gapLen, animOffset);
 
-    -- Draw skillchain icon in top-right corner
-    local scale = gConfig.hotbarGlobal.skillchainIconScale or 1.0;
+    -- Draw skillchain icon in top-right corner. Per-call overrides take precedence over the
+    -- global config (used by the macro palette editor to relocate the icon out of corners
+    -- that the editor uses for action labels or BST-Ready badges).
+    local scale = iconScaleOverride or gConfig.hotbarGlobal.skillchainIconScale or 1.0;
     local iconSize = math.floor(size * 0.35 * scale);
-    local offsetX = gConfig.hotbarGlobal.skillchainIconOffsetX or 0;
-    local offsetY = gConfig.hotbarGlobal.skillchainIconOffsetY or 0;
+    local offsetX = iconOxOverride or gConfig.hotbarGlobal.skillchainIconOffsetX or 0;
+    local offsetY = iconOyOverride or gConfig.hotbarGlobal.skillchainIconOffsetY or 0;
     local iconX = x + size - iconSize - 2 + offsetX;
     local iconY = y + 2 + offsetY;
 
@@ -600,17 +857,205 @@ local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opac
     end
 end
 
+-- Draw a Magic Burst highlight on a spell slot. Mirrors DrawSkillchainHighlight (dashed
+-- border + SC-name icon corner badge) so the two highlights read as a visual family, with
+-- two intentional differences:
+--   * Color is sourced from `color` (cyan-blue default), distinct from the gold skillchain
+--     border, so a glance tells the player which window is open.
+--   * Icon is placed in the BOTTOM-LEFT corner instead of top-right. Spells almost never
+--     have a charges-quantity badge to collide with there, and it keeps the corner-budget
+--     separate from MP cost (top-left), skillchain icon (top-right), and stack quantity
+--     (bottom-right). On the rare slot where MB and skillchain are both eligible (a /ws
+--     macro that also matches a /ma element via macroparse picking the wrong primary,
+--     etc.), both icons remain visible.
+-- @param drawList   ImGui draw list (window or foreground)
+-- @param x, y       Top-left of slot
+-- @param size       Slot size in pixels
+-- @param scName     Skillchain name driving the icon (e.g. 'Fusion', 'Light') — same asset
+--                   pool as DrawSkillchainHighlight (assets/hotbar/skillchain/<name>.png).
+-- @param color      Border color in ARGB (0xAARRGGBB)
+-- @param opacity    Render opacity (0-1)
+-- @param iconScaleOverride, iconOxOverride, iconOyOverride: optional per-call overrides
+--                   (mirrors DrawSkillchainHighlight's editor-corner-pushing hooks).
+local function DrawMagicBurstHighlight(drawList, x, y, size, scName, color, opacity, iconScaleOverride, iconOxOverride, iconOyOverride)
+    if not drawList or not scName or opacity <= 0.01 then return; end
+
+    local animOffset = skillchain.GetAnimationOffset();
+
+    -- Decompose ARGB. Same shape as DrawSkillchainHighlight so any future migration to a
+    -- shared helper is a single refactor (not duplicated unpack logic).
+    local a = math.floor(bit.rshift(bit.band(color, 0xFF000000), 24) * opacity);
+    local r = bit.rshift(bit.band(color, 0x00FF0000), 16) / 255;
+    local g = bit.rshift(bit.band(color, 0x0000FF00), 8) / 255;
+    local b = bit.band(color, 0x000000FF) / 255;
+    local lineColor = imgui.GetColorU32({ r, g, b, a / 255 });
+
+    local dashLen = 4;
+    local gapLen = 4;
+    local thickness = 2;
+
+    -- Phase-shift the marching ants by half a dash so the MB pattern doesn't look identical
+    -- to the skillchain pattern when (in some future build) both fire on the same slot.
+    local mbAnimOffset = (animOffset + (dashLen + gapLen) * 0.5) % (dashLen + gapLen);
+
+    DrawDashedLine(drawList, x, y, x + size, y, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+    DrawDashedLine(drawList, x + size, y, x + size, y + size, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+    DrawDashedLine(drawList, x + size, y + size, x, y + size, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+    DrawDashedLine(drawList, x, y + size, x, y, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+
+    -- Bottom-left icon corner. Reuses the skillchainIcon{Scale|OffsetX|OffsetY} global settings
+    -- so users who already tuned their SC icon size don't have to redo it; the offsets are
+    -- applied relative to the BOTTOM-LEFT anchor (not top-right) so positive Y still means
+    -- "shift down" and positive X still means "shift right" intuitively from the corner.
+    local scale = iconScaleOverride or gConfig.hotbarGlobal.skillchainIconScale or 1.0;
+    local iconSize = math.floor(size * 0.35 * scale);
+    local offsetX = iconOxOverride or gConfig.hotbarGlobal.skillchainIconOffsetX or 0;
+    local offsetY = iconOyOverride or gConfig.hotbarGlobal.skillchainIconOffsetY or 0;
+    local iconX = x + 2 + offsetX;
+    local iconY = y + size - iconSize - 2 + offsetY;
+
+    local iconPath = GetSkillchainIconsPath() .. scName .. '.png';
+    if not skillchainIconCache[scName] then
+        local tex = textures:LoadTextureFromPath(iconPath);
+        skillchainIconCache[scName] = tex;
+    end
+
+    local iconTex = skillchainIconCache[scName];
+    if iconTex and iconTex.image then
+        local iconPtr = tonumber(ffi.cast("uint32_t", iconTex.image));
+        if iconPtr then
+            local iconAlpha = math.floor(255 * opacity);
+            local iconTint = bit.bor(bit.lshift(iconAlpha, 24), 0x00FFFFFF);
+            drawList:AddImage(
+                iconPtr,
+                { iconX, iconY },
+                { iconX + iconSize, iconY + iconSize },
+                { 0, 0 }, { 1, 1 },
+                iconTint
+            );
+        end
+    end
+end
+
 -- Helper: determine if movement/drag-drop is locked for this slot
--- Shift key overrides the lock to allow dragging while locked
+-- Shift key overrides the lock to allow dragging while locked.
+-- Hotbar slots use hotbarLockMovement; crossbar slots use crossbarLockMovement;
+-- palette editor slots ('paled*' drop zones) are never locked so users can edit them.
 local function IsMovementLockedForDropZone(dropZoneId)
     if not dropZoneId then return false; end
     if imgui.GetIO().KeyShift then
         return false;
     end
-    if gConfig and gConfig.hotbarLockMovement then
-        return true;
+    if not gConfig then return false; end
+    if type(dropZoneId) == 'string' and dropZoneId:sub(1, 5) == 'paled' then
+        return false;
     end
-    return false;
+    if type(dropZoneId) == 'string' and dropZoneId:sub(1, 9) == 'crossbar_' then
+        return gConfig.crossbarLockMovement == true;
+    end
+    return gConfig.hotbarLockMovement == true;
+end
+
+-- ============================================
+-- Editor label helpers (Ferris's "Edit Full Palette" view).
+-- Crossbar editor passes `labelForeground = true` + `editorMinimalView = true` so the action
+-- name renders on the slot via ImGui drawList (not via the GDI labelFont). When the editor
+-- view is OFF but `labelForeground` is on, labels render above/below the slot with a soft wrap.
+-- ============================================
+
+local function SplitNewlinesEditor(s)
+    if not s or s == '' then return {}; end
+    local t = {};
+    local startPos = 1;
+    local len = #s;
+    while startPos <= len do
+        local nl = s:find('\n', startPos, true);
+        if not nl then
+            t[#t + 1] = s:sub(startPos);
+            break;
+        end
+        t[#t + 1] = s:sub(startPos, nl - 1);
+        startPos = nl + 1;
+    end
+    return t;
+end
+
+-- Idle abbreviation for Edit Full Palette: first 4 non-whitespace chars of the trimmed name.
+-- Full text is shown when the user hovers the slot; the abbreviation lets even cramped 32px
+-- slots show *something* recognisable while editing the palette.
+local function EditorIdleAbbrev4(fullName)
+    if not fullName or fullName == '' then return ''; end
+    local t = fullName:gsub('^%s+', ''):gsub('%s+$', '');
+    if t == '' then return ''; end
+    if #t <= 4 then return t; end
+    return t:sub(1, 4);
+end
+
+-- Wrap rule for editor labels: at most one newline, with the line closest to the slot holding
+-- a single word so the slot stays visually attached to its label.
+-- labelAboveSlot=true  → "A B C D" -> "A B C\nD"  (last word lands beside the slot)
+-- labelAboveSlot=false → "A B C D" -> "A\nB C D"  (first word lands beside the slot)
+local function EditorLabelWrapNearSlot(text, labelAboveSlot)
+    if not text or text == '' then return text; end
+    local t = text:gsub('^%s+', ''):gsub('%s+$', '');
+    if not t:find('%s') then return t; end
+    local words = {};
+    for w in t:gmatch('%S+') do words[#words + 1] = w; end
+    if #words < 2 then return t; end
+    if labelAboveSlot then
+        local last = table.remove(words);
+        return table.concat(words, ' ') .. '\n' .. last;
+    end
+    local first = table.remove(words, 1);
+    return first .. '\n' .. table.concat(words, ' ');
+end
+
+-- Pixel-snap centre X so adjacent slots' labels line up vertically (fonts at fractional X
+-- jitter visibly when neighbours sit at integer positions).
+local function EditorLabelCenterX(cx, line, fontSize)
+    local w = imtext.Measure(line, fontSize);
+    return math.floor(cx - w * 0.5 + 0.5);
+end
+
+-- Multi-line outlined label centred on slot (editorMinimalView). One imtext.Draw call per line
+-- (which already includes the 4-cardinal outline) — matches Ferris's "thin outline only, no
+-- scrim or halo" style so wrapped lines don't stack thick shadows on each other.
+local function DrawEditorMultilineCenteredOnSlot(drawList, slotX, slotY, slotSize, argbColor, multilineText, fontSize)
+    if not drawList or not multilineText or multilineText == '' or not slotSize or slotSize <= 0 then return; end
+    local raw = SplitNewlinesEditor(multilineText);
+    local lines = {};
+    for i = 1, #raw do
+        if raw[i] ~= '' then lines[#lines + 1] = raw[i]; end
+    end
+    if #lines == 0 then return; end
+    local _, lineH = imtext.Measure('Mg', fontSize);
+    local lineStep = (lineH and lineH > 0) and (lineH + 1) or (fontSize + 2);
+    local cx = slotX + slotSize * 0.5;
+    local cy = slotY + slotSize * 0.5;
+    local totalH = #lines * lineStep;
+    local topY = math.floor(cy - totalH * 0.5 + 0.5);
+    for i = 1, #lines do
+        local px = EditorLabelCenterX(cx, lines[i], fontSize);
+        imtext.Draw(drawList, lines[i], px, topY, argbColor, fontSize);
+        topY = topY + lineStep;
+    end
+end
+
+-- Multi-line outlined label centred above/below the slot (non-minimal editor view).
+local function DrawEditorMultilineCenteredAtY(drawList, cx, topY, argbColor, multilineText, fontSize)
+    if not drawList or not multilineText or multilineText == '' then return; end
+    local lines = SplitNewlinesEditor(multilineText);
+    local _, lineH = imtext.Measure('Mg', fontSize);
+    local lineStep = (lineH and lineH > 0) and (lineH + 1) or (fontSize + 2);
+    local py = math.floor(topY + 0.5);
+    for i = 1, #lines do
+        local line = lines[i];
+        if line ~= '' then
+            local px = EditorLabelCenterX(cx, line, fontSize);
+            imtext.Draw(drawList, line, px, py, argbColor, fontSize);
+        end
+        py = py + lineStep;
+    end
 end
 
 --[[
@@ -619,7 +1064,13 @@ end
     MUST be called inside an ImGui window context for interactions to work.
 
     @param params: Rendering and interaction parameters (position, bind, icon, visual settings, callbacks)
-    @return table: { isHovered } (reused - read values immediately, do NOT cache)
+        Edit Full Palette extras (set by crossbar editor only):
+        - editorClipRect: { minX, minY, maxX, maxY } — slot is hidden when fully outside the rect.
+        - editorStrictContain: bool — when true, ALL of the slot (incl. label) must be inside the rect.
+        - labelForeground: bool — draw the action name via ImGui drawList instead of any GDI font path.
+        - editorMinimalView: bool — draw the label centred on the slot (idle abbreviation, full on hover).
+        - labelAboveSlot: bool — place label above the slot rather than below.
+    @return table: { isHovered, command } (reused - read values immediately, do NOT cache)
 ]]--
 function M.DrawSlot(params)
     local x = params.x;
@@ -632,14 +1083,69 @@ function M.DrawSlot(params)
     local animOpacity = params.animOpacity or 1.0;
     local isPressed = params.isPressed or false;
 
+    -- Crossbar: use the current window draw list so MP/timer/hover overlays stack with other
+    -- ImGui windows (GetForegroundDrawList always paints above every window, which can cover
+    -- modal dialogs). Hotbar and editors keep the shared UI draw list. The selector returns
+    -- the appropriate drawList for overlays drawn on top of the slot icon.
+    local function slotOverlayDrawList()
+        if params.windowName == 'Crossbar' then
+            local wdl = imgui.GetWindowDrawList();
+            if wdl then return wdl; end
+        end
+        return GetUIDrawList();
+    end
+
     -- Reuse result table to avoid GC pressure
     -- NOTE: Caller must read values immediately, do not cache the return value
     drawSlotResult.isHovered = false;
+    drawSlotResult.command = nil;
     local result = drawSlotResult;
 
     -- Skip rendering if fully transparent
     if animOpacity <= 0.01 then
         return result;
+    end
+
+    -- Editor clip rect culling: when the crossbar's Edit Full Palette window scrolls, slots
+    -- can land outside the visible region. With all rendering on ImGui draw lists the parent
+    -- window's clip rect already culls drawing, but the slot still pays for per-frame state
+    -- checks (recast, MP, availability, hover, drag) and emits ImGui draw commands that get
+    -- discarded later. Short-circuiting here turns ~120 slots * (full pipeline) into a single
+    -- 4-comparison reject for off-screen rows.
+    local minimalEditorView = params.editorMinimalView == true;
+    do
+        local clip = params.editorClipRect;
+        if clip and clip[1] and clip[2] and clip[3] and clip[4] then
+            local fs = params.labelFontSize or 10;
+            local padTop, padBot = 4, 4;
+            if params.showLabel and params.labelText and params.labelText ~= '' then
+                if not minimalEditorView then
+                    local extraLinePad = 0;
+                    if params.labelText:find('%s') then
+                        extraLinePad = math.floor(fs * 1.05 + 0.5);
+                    end
+                    if params.labelAboveSlot then
+                        padTop = fs + 14 + extraLinePad;
+                    else
+                        padBot = fs + 14 + extraLinePad;
+                    end
+                end
+                -- editorMinimalView labels render on the slot itself, no extra pad needed.
+            end
+            local sx1 = x;
+            local sy1 = y - padTop;
+            local sx2 = x + size;
+            local sy2 = y + size + padBot;
+            if params.editorStrictContain then
+                if sx1 < clip[1] or sy1 < clip[2] or sx2 > clip[3] or sy2 > clip[4] then
+                    return result;
+                end
+            else
+                if sx2 < clip[1] or sx1 > clip[3] or sy2 < clip[2] or sy1 > clip[4] then
+                    return result;
+                end
+            end
+        end
     end
 
     -- Check hover state
@@ -651,7 +1157,11 @@ function M.DrawSlot(params)
     -- ========================================
     -- 1. Slot Background (ImGui AddImage)
     -- ========================================
-    local drawList = GetUIDrawList();
+    -- For Crossbar windows we draw to the window draw list so all of the slot's
+    -- visual layers (background -> icon -> text -> hover) stack within the window's
+    -- z-order; the shared UI draw list lands ABOVE every ImGui window which can
+    -- cover modals and tooltips.
+    local drawList = slotOverlayDrawList();
     do
         local slotTexPtr = GetCachedTexturePtr(GetSlotTexPath());
         if slotTexPtr and drawList then
@@ -715,7 +1225,7 @@ function M.DrawSlot(params)
         local mpCost = mpCostCache[bindKey];
         if mpCost == nil then
             mpCost = actions.GetMPCost(bind) or false;
-            mpCostCache[bindKey] = mpCost;
+            PutMpCostCache(bindKey, mpCost);
         end
         if mpCost and mpCost ~= false then
             local party = AshitaCore:GetMemoryManager():GetParty();
@@ -724,30 +1234,53 @@ function M.DrawSlot(params)
         end
     end
 
-    -- Check if action is available (job/level requirements)
+    -- Check if action is available (job/level requirements). Allowlist covers magic ('ma'),
+    -- job abilities ('ja'), weapon skills ('ws'), pet pacts ('pet'), and macros — macros are
+    -- validated against their resolved primary line (and optional /ja badge) so a macro that
+    -- /pet's a not-yet-learned blood pact reads as unavailable too.
     local isUnavailable = false;
     local unavailableReason = nil;
-    if bind and (bind.actionType == 'ma' or bind.actionType == 'ja' or bind.actionType == 'ws') then
-        -- Include job/subjob in cache key so cache invalidates on job change
-        local player = AshitaCore:GetMemoryManager():GetPlayer();
-        local jobId = player and player:GetMainJob() or 0;
-        local subjobId = player and player:GetSubJob() or 0;
-        local availKey = bindKey .. ':' .. jobId .. ':' .. subjobId;
+    local unavailDisplayText = nil;  -- pre-parsed 'Lv65' / 'X' string (computed at insert time)
+    if bind and (
+            bind.actionType == 'ma'
+            or bind.actionType == 'ja'
+            or bind.actionType == 'ws'
+            or bind.actionType == 'pet'
+            or bind.actionType == 'macro') then
+        local fa = GetFrameAvailability();
+        local availKey = bindKey .. ':' .. fa.jobId .. ':' .. fa.subjobId .. ':'
+            .. fa.mainLevel .. ':' .. fa.subLevel .. ':' .. fa.partyMain .. ':' .. fa.partySub;
 
         local cached = availabilityCache[availKey];
         if cached == nil then
             local available, reason = actions.IsActionAvailable(bind);
             -- Don't cache if reason is "pending" (player state invalid, e.g., during zoning)
             if reason ~= "pending" then
-                availabilityCache[availKey] = { isAvailable = available, reason = reason };
-                cached = availabilityCache[availKey];
+                -- Pre-parse the display text once at insert time so the MP-cost render path
+                -- doesn't call string.match every frame for every unavailable slot.
+                local dispText = 'X';
+                if reason then
+                    local lv = reason:match('^Lv(%d+)$');
+                    if lv then
+                        dispText = 'Lv' .. lv;
+                    else
+                        local legacyLvl = reason:match('^Lvl%.(%d+)$');
+                        if legacyLvl then
+                            dispText = 'Lv' .. legacyLvl;
+                        end
+                    end
+                end
+                local entry = { isAvailable = available, reason = reason, displayText = dispText };
+                PutAvailabilityCache(availKey, entry);
+                cached = entry;
             else
                 -- Use temp result but don't cache
-                cached = { isAvailable = available, reason = nil };
+                cached = { isAvailable = available, reason = nil, displayText = 'X' };
             end
         end
         isUnavailable = not cached.isAvailable;
         unavailableReason = cached.reason;
+        unavailDisplayText = cached.displayText;
     end
 
     -- ========================================
@@ -900,7 +1433,13 @@ function M.DrawSlot(params)
     end
 
     -- ========================================
-    -- 9. Label Text (action name below slot)
+    -- 9. Label Text (action name)
+    -- Three modes:
+    --   (a) Standard hotbar/crossbar: single line below the slot (default).
+    --   (b) labelForeground + editorMinimalView: multi-line centred ON the slot
+    --       (Edit Full Palette idle view — 4-char abbrev, full text shown via hover tooltip).
+    --   (c) labelForeground (non-minimal): multi-line centred above/below the slot
+    --       with EditorLabelWrapNearSlot soft-wrap putting one word beside the slot.
     -- ========================================
     if params.showLabel and params.labelText and params.labelText ~= '' and animOpacity > 0.5 and drawList then
         local lblFontSize = params.labelFontSize or 10;
@@ -913,10 +1452,53 @@ function M.DrawSlot(params)
         elseif notEnoughMp then
             labelColor = params.labelNoMpColor or 0xFFFF4444;
         end
-        local lblW = imtext.Measure(params.labelText, lblFontSize);
-        local labelX = x + (size - lblW) / 2 + (params.labelOffsetX or 0);
-        local labelY = y + size + 2 + (params.labelOffsetY or 0);
-        imtext.Draw(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
+
+        -- Apply animation opacity into the label color (label paths below don't otherwise modulate alpha).
+        if animOpacity < 1.0 then
+            local a = math.floor(bit.rshift(bit.band(labelColor, 0xFF000000), 24) * animOpacity);
+            if a < 0 then a = 0; elseif a > 255 then a = 255; end
+            labelColor = bit.bor(bit.lshift(a, 24), bit.band(labelColor, 0x00FFFFFF));
+        end
+
+        if params.labelForeground then
+            if minimalEditorView then
+                -- (b) On-slot view: 4-char abbrev when idle, full name on hover. Multi-line if hover label wraps.
+                local textForDraw = isHovered and params.labelText or EditorIdleAbbrev4(params.labelText);
+                if textForDraw and textForDraw ~= '' then
+                    DrawEditorMultilineCenteredOnSlot(drawList, x, y, size, labelColor, textForDraw, lblFontSize);
+                end
+            else
+                -- (c) Above/below-slot view with soft wrap so one word lands beside the slot.
+                local wrapped = EditorLabelWrapNearSlot(params.labelText, params.labelAboveSlot);
+                local cx = x + size * 0.5 + (params.labelOffsetX or 0);
+                local lineCount = 1;
+                if wrapped and wrapped:find('\n') then lineCount = 2; end
+                local _, lineH = imtext.Measure('Mg', lblFontSize);
+                local lineStep = (lineH and lineH > 0) and (lineH + 1) or (lblFontSize + 2);
+                local topY;
+                if params.labelAboveSlot then
+                    topY = y - 2 - lineStep * lineCount + (params.labelOffsetY or 0);
+                else
+                    topY = y + size + 2 + (params.labelOffsetY or 0);
+                end
+                DrawEditorMultilineCenteredAtY(drawList, cx, topY, labelColor, wrapped, lblFontSize);
+            end
+        else
+            -- (a) Default single-line render. Honors params.labelAboveSlot so the crossbar's
+            -- top diamond slot can flip its label above (otherwise the bottom slot's MP/qty
+            -- text overlaps the top slot's label). Keyboard hotbars always pass false → below.
+            local lblW = imtext.Measure(params.labelText, lblFontSize);
+            local labelX = x + (size - lblW) / 2 + (params.labelOffsetX or 0);
+            local labelY;
+            if params.labelAboveSlot then
+                local _, lblH = imtext.Measure('Mg', lblFontSize);
+                local h = (lblH and lblH > 0) and lblH or lblFontSize;
+                labelY = y - 2 - h + (params.labelOffsetY or 0);
+            else
+                labelY = y + size + 2 + (params.labelOffsetY or 0);
+            end
+            imtext.Draw(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
+        end
     end
 
     -- ========================================
@@ -930,20 +1512,24 @@ function M.DrawSlot(params)
             local mpFontSize = params.mpCostFontSize or 10;
             local mpX, mpY = GetAnchoredPosition(x, y, size, mpAnchor, params.mpCostOffsetX, params.mpCostOffsetY);
 
-            -- If action is unavailable, show "X" instead of MP cost
+            -- If action is unavailable, render either a level requirement ("Lv65") when
+            -- IsActionAvailable returned an Lv-style reason, or a plain "X" for non-level
+            -- failures (e.g. weaponskills not learned, wrong job, missing scroll). The
+            -- display text was pre-parsed by the availability cache insert above, so this
+            -- hot-path branch just reads the field — no per-frame string.match here.
             if isUnavailable then
-                local xText = "X";
+                local unavailText = unavailDisplayText or 'X';
                 local xColor = 0xFFFF4444;
                 if mpAnchor == 'topRight' or mpAnchor == 'bottomRight' then
-                    local w = imtext.Measure(xText, mpFontSize);
+                    local w = imtext.Measure(unavailText, mpFontSize);
                     mpX = mpX - w;
                 end
-                imtext.Draw(drawList, xText, mpX, mpY, xColor, mpFontSize);
+                imtext.Draw(drawList, unavailText, mpX, mpY, xColor, mpFontSize);
             else
                 local mpCost = mpCostCache[bindKey];
                 if mpCost == nil then
                     mpCost = actions.GetMPCost(bind) or false;
-                    mpCostCache[bindKey] = mpCost;
+                    PutMpCostCache(bindKey, mpCost);
                 end
                 if mpCost and mpCost ~= false then
                     local mpText = tostring(mpCost);
@@ -1069,7 +1655,33 @@ function M.DrawSlot(params)
         -- Skillchain highlight (animated dotted border + icon)
         if params.skillchainName then
             local scColor = params.skillchainColor or 0xFFD4AA44;
-            DrawSkillchainHighlight(drawList, x, y, size, params.skillchainName, scColor, animOpacity);
+            -- Per-call icon scale/offset overrides used by the macro palette editor
+            -- to push the skillchain icon out of corner badges. Falls back to
+            -- gConfig.hotbarGlobal.skillchainIcon* when not provided.
+            DrawSkillchainHighlight(drawList, x, y, size, params.skillchainName, scColor, animOpacity,
+                params.skillchainIconScale, params.skillchainIconOffsetX, params.skillchainIconOffsetY);
+        end
+
+        -- Magic Burst highlight (animated dotted border + SC-name icon in BOTTOM-LEFT corner).
+        -- Renders independently from the skillchain highlight: a slot can legitimately have
+        -- ONE of them active at a time (WS slots → skillchain prediction, spell slots → MB).
+        -- Drawing this AFTER the skillchain pass means if both ever fire on the same slot
+        -- (rare — primary-parse path would have to disagree), the MB border ends up on top.
+        if params.magicBurstName then
+            local mbColor = params.magicBurstColor or 0xFF44D4FF;
+            DrawMagicBurstHighlight(drawList, x, y, size, params.magicBurstName, mbColor, animOpacity,
+                params.skillchainIconScale, params.skillchainIconOffsetX, params.skillchainIconOffsetY);
+        end
+
+        -- Universal Two-Hour: rainbow rotating rings + marching border while the user is
+        -- confirming <stpc>/<stnpc> (or briefly after click during the arming-shimmer
+        -- fade window). universal_two_hour module decides whether this slot is the armed
+        -- ability; if the module isn't loaded (1.7.5 fork) the check is a silent no-op.
+        if bind and not isOnCooldown and universalTwoHour and universalTwoHour.ShouldGlowUniversalTwoHourSlot
+            and universalTwoHour.ShouldGlowUniversalTwoHourSlot(bind) then
+            local armScale = universalTwoHour.GetArmingShimmerOpacityScale
+                and universalTwoHour.GetArmingShimmerOpacityScale() or 1.0;
+            DrawUniversalTwoHourSubtargetGlow(drawList, x, y, size, animOpacity, dimFactor, armScale);
         end
     end
 
@@ -1080,6 +1692,10 @@ function M.DrawSlot(params)
         dragdrop.DropZone(params.dropZoneId, x, y, size, size, {
             accepts = params.dropAccepts or {'macro'},
             highlightColor = params.dropHighlightColor or 0xA8FFFFFF,
+            -- dropPriority is the tie-break for overlapping zones (e.g. Edit Full Palette preview
+            -- overlay on top of a live crossbar slot); the higher number wins via FlushDeferredDrops.
+            -- Default is nil so the existing first-registered-wins behavior is preserved.
+            dropPriority = params.dropPriority,
             onDrop = params.onDrop,
         });
     end
@@ -1111,10 +1727,30 @@ function M.DrawSlot(params)
             end
         end
 
-        -- Left click to execute (BuildCommand deferred to click time to avoid per-frame cost)
+        -- Left click / double-click. Edit Full Palette slots set `suppressActionOnClick`:
+        -- a single click on those is meaningless (no live action to fire — the slot is a
+        -- draft preview), but we still need to track the click to detect double-click and
+        -- open the macro editor. `params.suppressActionOnClick` also tells us to ignore a
+        -- cancelled-micro-drag attempt (without this, even a tiny mouse jitter between
+        -- press and release blocks the double-click pipeline).
         if isItemHovered and imgui.IsMouseReleased(0) then
-            if not dragdrop.IsDragging() and not dragdrop.WasDragAttempted() then
-                if params.onClick then
+            local ignoreCancelledMicroDrag = params.suppressActionOnClick;
+            if not dragdrop.IsDragging()
+                and (ignoreCancelledMicroDrag or not dragdrop.WasDragAttempted()) then
+                local now = os.clock();
+                local isDoubleClick = (params.buttonId == lastClickButtonId)
+                    and (now - lastClickTime) < DOUBLE_CLICK_INTERVAL;
+
+                if isDoubleClick and params.onDoubleClick then
+                    params.onDoubleClick();
+                    lastClickButtonId = nil;
+                    lastClickTime = 0;
+                elseif params.suppressActionOnClick then
+                    -- Treat as the first half of a potential double-click and do nothing
+                    -- else. Editor slots intentionally don't fire any action on single click.
+                    lastClickButtonId = params.buttonId;
+                    lastClickTime = now;
+                elseif params.onClick then
                     params.onClick();
                 elseif bind then
                     local cmd = actions.BuildCommand(bind);
@@ -1125,9 +1761,11 @@ function M.DrawSlot(params)
             end
         end
 
-        -- Right click (disabled when Lock Movement is enabled)
+        -- Right click (disabled when the slot's Lock Movement is enabled). Uses the same
+        -- per-zone lock policy as drop zones so the Hotbar lock doesn't accidentally disable
+        -- right-click-to-clear on crossbar slots (and vice versa).
         if isItemHovered and imgui.IsMouseClicked(1) and bind then
-            if params.onRightClick and not gConfig.hotbarLockMovement then
+            if params.onRightClick and not IsMovementLockedForDropZone(params.dropZoneId) then
                 params.onRightClick();
             end
         end
@@ -1159,14 +1797,20 @@ function M.DrawTooltip(bind)
         return '<' .. cleaned .. '>';
     end
 
-    -- Check if action is unavailable for current job/subjob (cached lookup)
+    -- Check if action is unavailable for current job/subjob (cached lookup). Cache key
+    -- shape MUST match the one DrawSlot uses or we'd get spurious cache misses every time
+    -- the tooltip checks: same (action key, jobs, levels, party-effective levels). Routes
+    -- through the same per-frame snapshot used by DrawSlot so we don't re-walk MM here.
     local isUnavailable = false;
-    if bind.actionType == 'ma' or bind.actionType == 'ja' or bind.actionType == 'ws' then
+    if bind.actionType == 'ma'
+        or bind.actionType == 'ja'
+        or bind.actionType == 'ws'
+        or bind.actionType == 'pet'
+        or bind.actionType == 'macro' then
         local bindKey = (bind.actionType or '') .. ':' .. (bind.action or '');
-        local player = AshitaCore:GetMemoryManager():GetPlayer();
-        local jobId = player and player:GetMainJob() or 0;
-        local subjobId = player and player:GetSubJob() or 0;
-        local availKey = bindKey .. ':' .. jobId .. ':' .. subjobId;
+        local fa = GetFrameAvailability();
+        local availKey = bindKey .. ':' .. fa.jobId .. ':' .. fa.subjobId .. ':'
+            .. fa.mainLevel .. ':' .. fa.subLevel .. ':' .. fa.partyMain .. ':' .. fa.partySub;
         local cached = availabilityCache[availKey];
         if cached then
             isUnavailable = not cached.isAvailable;
@@ -1235,6 +1879,7 @@ end
 function M.BeginFrame(fontSettings)
     pendingTooltipBind = nil;
     tooltipFontSettings = fontSettings;
+    frameAvail.ready = false;
 end
 
 -- Size of the abbreviation "pick-up" tile that follows the cursor on icon-less drags.


### PR DESCRIPTION
… and settings UI

What changed
- skillchain.lua: magicBurstMap state tracked alongside resonationMap (different lifetimes; separate keys). MB_WINDOW_OPEN_DELAY = 0.0s, MB_WINDOW_DURATION = 7.0s after skillchain close. Eligible elements resolved via magicBurstElements map covering all 14 SC tiers (Lv1 single-element through Lv3 Light/Darkness multi-element sets). SMN Magic Blood Pact Rages curated via bloodPactElementMap (12 pacts: Fire II/IV, Stone II/IV, Aero II/IV, Water II/IV, Thunder II/IV, Blizzard II/IV - physical and off-element pacts deliberately excluded). spellElementByLowerName lazy cache resolves element from horizonspells DB. Public API: GetBurstElementForSlot, GetMagicBurstForElement, GetMagicBurstForSlot, GetMagicBurstWindow. MB window clears on zone change (same hook as SC clear).
- slotrenderer.lua: DrawMagicBurstHighlight() - animated dashed border drawn via ImGui drawList alongside SC border; configurable color with pulsing opacity. params.magicBurstName branch in DrawSlot. Both SC and MB borders can appear simultaneously (distinct positions: SC top-right, MB bottom-left corner icon placement).
- display.lua, crossbar.lua: GetMagicBurstForSlot dispatch wired through all render branches; suppressed in palette editor preview. Crossbar routes actionType=='pet' and /pet-primary macros through skillchain.GetSkillchainForBloodPact for SMN Blood Pact MB eligibility (matches keyboard hotbar behavior; previously crossbar only checked actionType=='ws').
- core/settings/factories.lua: hotbarGlobal.magicBurstHighlightEnabled = false default; magicBurstHighlightColor default (cyan-blue).
- config/hotbar.lua: DrawSharedSkillchainHighlightControls includes Magic Burst checkbox + inline color picker nested under the Skillchain section. Shared icon scale/offset help text applies to both SC and MB highlight systems.

Why
- Gives players an at-a-glance Magic Burst opportunity cue without manually tracking SC results. Parallel to the existing skillchain highlight system; reuses the same imtext drawList path and hotbarGlobal settings. SMN Blood Pact coverage limited to Magic-element pacts to avoid false positives from physical pacts that cannot MB regardless of skillchain.