### PR TITLE
Macro system: palette buckets, macro parser, default seeds, and dual-…

### DIFF
--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -5,6 +5,8 @@
 
 local M = {};
 local profileManager = require('core.profile_manager');
+local macroXiuiDefaults = require('modules.hotbar.macro_xiui_defaults');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
 
 -- Migrate settings from HXUI to XIUI (one-time migration for users upgrading from HXUI)
 -- IMPORTANT: This must be called BEFORE settings.load() so that copied files are picked up
@@ -607,6 +609,20 @@ function M.MigrateIndividualSettings(gConfig, defaults)
             if petType.tpFontSize == nil then petType.tpFontSize = oldVitalsFontSize; end
         end
     end
+
+    if gConfig.petBarResizeAnchor == nil then
+        local wantsBottom = false;
+        for _, pt in ipairs(petTypeTables) do
+            if pt and pt.alignBottom then
+                wantsBottom = true;
+                break;
+            end
+        end
+        gConfig.petBarResizeAnchor = wantsBottom and 'bottom' or 'top';
+    end
+    if gConfig.petTargetSnapAnchor == 'top' and type(gConfig.petTargetSnapOffsetX) == 'number' and gConfig.petTargetSnapOffsetX >= 100 then
+        gConfig.petTargetSnapOffsetX = 0;
+    end
 end
 
 -- Migrate flat castCost* settings to nested castCost table
@@ -1053,7 +1069,116 @@ end
 
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
+-- Split legacy hotbarCrossbar.mode ('hotbar'|'crossbar'|'both') into separate visibility flags
+function M.MigrateCrossbarModuleFlags(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.crossbarEnabled == nil then
+        if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.showCrossbar ~= nil then
+            gConfig.crossbarEnabled = gConfig.hotbarCrossbar.showCrossbar;
+        else
+            gConfig.crossbarEnabled = true;
+        end
+    end
+    local hg = gConfig.hotbarGlobal;
+    if hg and hg.logPaletteNameCrossbar == nil then
+        hg.logPaletteNameCrossbar = hg.logPaletteName;
+    end
+    if hg and hg.logPaletteNameCrossbarCycleHint == nil then
+        hg.logPaletteNameCrossbarCycleHint = true;
+    end
+end
+
+function M.MigrateHotbarCrossbarLayoutFlags(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local m = gConfig.hotbarCrossbar.mode;
+    if m ~= nil then
+        if m == 'hotbar' then
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = false;
+        elseif m == 'crossbar' then
+            gConfig.hotbarShowKeyboardBars = false;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        else
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        end
+        gConfig.hotbarCrossbar.mode = nil;
+    end
+    if gConfig.hotbarShowKeyboardBars == nil then
+        gConfig.hotbarShowKeyboardBars = true;
+    end
+    if gConfig.hotbarCrossbar.showCrossbar == nil then
+        gConfig.hotbarCrossbar.showCrossbar = true;
+    end
+end
+
+-- Fold legacy hotbarShowKeyboardBars into hotbarEnabled (same intent as Hotbar → Enabled today).
+function M.MigrateHotbarShowKeyboardBarsRemoval(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.hotbarShowKeyboardBars == false and gConfig.hotbarEnabled ~= false then
+        gConfig.hotbarEnabled = false;
+    end
+    gConfig.hotbarShowKeyboardBars = nil;
+end
+
+-- Drop deprecated keys from profiles saved during older builds (macros/skillchain are hotbarGlobal only now).
+function M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local xb = gConfig.hotbarCrossbar;
+    xb.crossbarDisableXiMacros = nil;
+    xb.skillchainHighlightEnabled = nil;
+    xb.skillchainHighlightColor = nil;
+    xb.skillchainIconScale = nil;
+    xb.skillchainIconOffsetX = nil;
+    xb.skillchainIconOffsetY = nil;
+end
+
+function M.MigrateMacroGlobalUniversalTwoHour(gConfig)
+    if not gConfig then
+        return;
+    end
+    macroGlobalDefaults.SeedUniversalTwoHourIfNeeded(gConfig);
+end
+
+function M.MigrateMacroXiuiDefaults(gConfig)
+    if not gConfig then
+        return;
+    end
+    local inserted = macroXiuiDefaults.SeedIfNeeded(gConfig);
+    if inserted then
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if ok and hotbarData and hotbarData.MarkMacroLookupDirty then
+            hotbarData.MarkMacroLookupDirty();
+        end
+    end
+end
+
 function M.RunStructureMigrations(gConfig, defaults)
+    -- Run before anything touches macroDB: coalesce "4" vs 4 and dedupe macro ids (fixes wrong macro on hotbar / drag)
+    if gConfig then
+        local ok, data = pcall(require, 'modules.hotbar.data');
+        if ok and data and data.EnsureMacroDatabaseCoherence then
+            data.EnsureMacroDatabaseCoherence(gConfig);
+        end
+    end
+    M.MigrateCrossbarModuleFlags(gConfig);
+    M.MigrateHotbarCrossbarLayoutFlags(gConfig);
+    M.MigrateHotbarShowKeyboardBarsRemoval(gConfig);
+    M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig);
+    if gConfig then
+        local ok, hbData = pcall(require, 'modules.hotbar.data');
+        if ok and hbData and hbData.MigrateSlotDualMacroBindings then
+            hbData.MigrateSlotDualMacroBindings(gConfig);
+        end
+    end
     M.MigratePartyListLayoutSettings(gConfig, defaults);
     M.MigratePerPartySettings(gConfig, defaults);
     M.MigratePerPetTypeSettings(gConfig, defaults);
@@ -1067,6 +1192,8 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
     M.MigrateSlotMacroRefs(gConfig);
+    M.MigrateMacroXiuiDefaults(gConfig);
+    M.MigrateMacroGlobalUniversalTwoHour(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/modules/hotbar/macro_global_defaults.lua
+++ b/XIUI/modules/hotbar/macro_global_defaults.lua
@@ -1,0 +1,173 @@
+--[[
+  Seed default Global macros (same spirit as macro_xiui_defaults.lua for XIUI Commands).
+]]--
+
+local buckets = require('modules.hotbar.macro_palette_buckets');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
+local data = require('modules.hotbar.data');
+
+local M = {};
+
+--- Relative to addons/XIUI/ on disk (icons bundled with the addon).
+M.UNIVERSAL_TWO_HOUR_ICON_PATH = 'assets/status/HD/228.png';
+
+function M.IsUniversalTwoHourMacro(macro)
+    return macro and macro.actionType == 'ja' and macro.action == universalTwoHour.ACTION_SENTINEL;
+end
+
+local function maxMacroIdInBucket(db)
+    local maxId = 0;
+    if type(db) ~= 'table' then
+        return maxId;
+    end
+    for _, macro in ipairs(db) do
+        if macro.id and macro.id > maxId then
+            maxId = macro.id;
+        end
+    end
+    return maxId;
+end
+
+local function maxMacroIdAll(mdb)
+    local maxId = 0;
+    if not mdb or type(mdb) ~= 'table' then
+        return maxId;
+    end
+    for _, list in pairs(mdb) do
+        if type(list) == 'table' then
+            for _, macro in ipairs(list) do
+                if macro.id and macro.id > maxId then
+                    maxId = macro.id;
+                end
+            end
+        end
+    end
+    return maxId;
+end
+
+local function findUniversalTwoHourIndex(db)
+    if type(db) ~= 'table' then
+        return nil;
+    end
+    for i, macro in ipairs(db) do
+        if M.IsUniversalTwoHourMacro(macro) then
+            return i;
+        end
+    end
+    return nil;
+end
+
+--- opts.persist: when false, skip SaveSettingsToDisk (caller batches save).
+--- Returns true if macroDB was mutated.
+function M.SyncUniversalTwoHourGlobalRow(gConfig, opts)
+    if not gConfig then
+        return false;
+    end
+    opts = (type(opts) == 'table') and opts or {};
+    local persist = opts.persist ~= false;
+    if not gConfig.macroDB then
+        return false;
+    end
+    local db = gConfig.macroDB[buckets.GLOBAL];
+    if type(db) ~= 'table' then
+        return false;
+    end
+    local idx = findUniversalTwoHourIndex(db);
+    if not idx then
+        return false;
+    end
+
+    local macro = db[idx];
+    local abilityName = universalTwoHour.GetTwoHourAbilityNameForMainJob() or 'Two Hour';
+    local tgt = universalTwoHour.GetTwoHourTargetTokenForMainJob();
+    local changed = false;
+
+    if (macro.displayName or '') ~= abilityName then
+        macro.displayName = abilityName;
+        changed = true;
+    end
+    if (macro.target or '') ~= tgt then
+        macro.target = tgt;
+        changed = true;
+    end
+    if macro.customIconType ~= 'xiui_asset' or (macro.customIconPath or '') ~= M.UNIVERSAL_TWO_HOUR_ICON_PATH then
+        macro.customIconType = 'xiui_asset';
+        macro.customIconPath = M.UNIVERSAL_TWO_HOUR_ICON_PATH;
+        changed = true;
+    end
+
+    if idx ~= 1 then
+        table.remove(db, idx);
+        table.insert(db, 1, macro);
+        changed = true;
+    end
+
+    if changed then
+        data.MarkMacroLookupDirty();
+        if persist and SaveSettingsToDisk then
+            SaveSettingsToDisk();
+        end
+    end
+
+    return changed;
+end
+
+local function globalBucketHasUniversalTwoHour(db)
+    return findUniversalTwoHourIndex(db) ~= nil;
+end
+
+--- opts.force: seed even if macroGlobalUniversalTwoHourSeeded is true (empty shared library path).
+--- Returns true if a macro row was added.
+function M.SeedUniversalTwoHourIfNeeded(gConfig, opts)
+    if not gConfig then
+        return false;
+    end
+    opts = (type(opts) == 'table') and opts or {};
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    local db = gConfig.macroDB[buckets.GLOBAL];
+    if type(db) ~= 'table' then
+        db = {};
+        gConfig.macroDB[buckets.GLOBAL] = db;
+    end
+    if globalBucketHasUniversalTwoHour(db) then
+        gConfig.macroGlobalUniversalTwoHourSeeded = true;
+        M.SyncUniversalTwoHourGlobalRow(gConfig, { persist = opts.persist ~= false });
+        return false;
+    end
+    if (not opts.force) and gConfig.macroGlobalUniversalTwoHourSeeded then
+        return false;
+    end
+
+    local nextId = math.max(maxMacroIdAll(gConfig.macroDB), maxMacroIdInBucket(db));
+    if (gConfig.macroStorageScope or 'profile') == 'shared' then
+        local ok, sms = pcall(require, 'core.shared_macro_store');
+        if ok and sms and sms.GetMaxMacroIdInFrozenProfileBucket then
+            local fmax = sms.GetMaxMacroIdInFrozenProfileBucket(buckets.GLOBAL);
+            if fmax > nextId then
+                nextId = fmax;
+            end
+        end
+    end
+
+    nextId = nextId + 1;
+    table.insert(db, 1, {
+        id = nextId,
+        actionType = 'ja',
+        action = universalTwoHour.ACTION_SENTINEL,
+        target = universalTwoHour.GetTwoHourTargetTokenForMainJob(),
+        displayName = universalTwoHour.GetTwoHourAbilityNameForMainJob() or 'Two Hour',
+        customIconType = 'xiui_asset',
+        customIconPath = M.UNIVERSAL_TWO_HOUR_ICON_PATH,
+    });
+    gConfig.macroGlobalUniversalTwoHourSeeded = true;
+    M.SyncUniversalTwoHourGlobalRow(gConfig, { persist = false });
+    data.MarkMacroLookupDirty();
+    if opts.persist ~= false and SaveSettingsToDisk then
+        SaveSettingsToDisk();
+    end
+    return true;
+end
+
+return M;

--- a/XIUI/modules/hotbar/macro_palette_buckets.lua
+++ b/XIUI/modules/hotbar/macro_palette_buckets.lua
@@ -1,0 +1,25 @@
+--[[
+* Shared macro palette bucket keys (Global / Items / Equipment / XIUI / custom:*).
+* Kept in a tiny module so migrations and JSON import do not load macropalette.lua.
+]]--
+
+local M = {};
+
+M.GLOBAL = 'global';
+M.ITEMS = 'items';
+M.EQUIPMENT = 'equipment';
+M.XIUI = 'xiui';
+M.CUSTOM_PREFIX = 'custom:';
+
+function M.isCustomCategoryKey(k)
+    return type(k) == 'string' and k:sub(1, #M.CUSTOM_PREFIX) == M.CUSTOM_PREFIX;
+end
+
+function M.isReservedStringBucket(k)
+    if k == M.GLOBAL or k == M.ITEMS or k == M.EQUIPMENT or k == M.XIUI then
+        return true;
+    end
+    return M.isCustomCategoryKey(k);
+end
+
+return M;

--- a/XIUI/modules/hotbar/macro_xiui_defaults.lua
+++ b/XIUI/modules/hotbar/macro_xiui_defaults.lua
@@ -1,0 +1,92 @@
+--[[
+* One-time seed of default /xiui slash macros into the "xiui" macro bucket.
+]]--
+
+local buckets = require('modules.hotbar.macro_palette_buckets');
+
+local DEFAULT_ROWS = {
+    { displayName = 'Toggle XIUI Menu', macroText = '/xiui', action = '/xiui' },
+    { displayName = 'Open Macros', macroText = '/xiui macro', action = '/xiui macro' },
+    { displayName = 'Hotbar Palette Manager', macroText = '/xiui pal', action = '/xiui pal' },
+    { displayName = 'Crossbar Palette Manager', macroText = '/xiui cpal', action = '/xiui cpal' },
+    { displayName = 'Edit Current Palette', macroText = '/xiui cpaledit', action = '/xiui cpaledit' },
+    { displayName = 'Toggle Party List', macroText = '/xiui partylist', action = '/xiui partylist' },
+    { displayName = 'Pass All Treasure', macroText = '/xiui pass', action = '/xiui pass' },
+    { displayName = 'Toggle Treasure Pool', macroText = '/xiui tp', action = '/xiui tp' },
+    { displayName = 'Reset Gil Tracking', macroText = '/xiui gil reset', action = '/xiui gil reset' },
+};
+
+local function maxMacroId(db)
+    local maxId = 0;
+    for _, macro in ipairs(db) do
+        if macro.id and macro.id > maxId then
+            maxId = macro.id;
+        end
+    end
+    return maxId;
+end
+
+local M = {};
+
+--- True when there are no macro rows in any bucket (or macroDB is missing/empty).
+function M.IsMacroDatabaseEffectivelyEmpty(mdb)
+    if not mdb or type(mdb) ~= 'table' or next(mdb) == nil then
+        return true;
+    end
+    for _, list in pairs(mdb) do
+        if type(list) == 'table' and #list > 0 then
+            return false;
+        end
+    end
+    return true;
+end
+
+--- opts.force: seed the xiui bucket even if macroXiuiDefaultsSeeded is true (e.g. new empty Shared library).
+--- Returns true if new default rows were added.
+function M.SeedIfNeeded(gConfig, opts)
+    if not gConfig then
+        return false;
+    end
+    opts = (type(opts) == 'table') and opts or {};
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    local db = gConfig.macroDB[buckets.XIUI];
+    if type(db) ~= 'table' then
+        db = {};
+        gConfig.macroDB[buckets.XIUI] = db;
+    end
+    if #db > 0 then
+        gConfig.macroXiuiDefaultsSeeded = true;
+        return false;
+    end
+    if (not opts.force) and gConfig.macroXiuiDefaultsSeeded then
+        return false;
+    end
+
+    local nextId = maxMacroId(db);
+    if (gConfig.macroStorageScope or 'profile') == 'shared' then
+        local ok, sms = pcall(require, 'core.shared_macro_store');
+        if ok and sms and sms.GetMaxMacroIdInFrozenProfileBucket then
+            local fmax = sms.GetMaxMacroIdInFrozenProfileBucket(buckets.XIUI);
+            if fmax > nextId then
+                nextId = fmax;
+            end
+        end
+    end
+    for _, row in ipairs(DEFAULT_ROWS) do
+        nextId = nextId + 1;
+        table.insert(db, {
+            id = nextId,
+            actionType = 'macro',
+            action = row.action,
+            target = row.target,
+            displayName = row.displayName,
+            macroText = row.macroText,
+        });
+    end
+    gConfig.macroXiuiDefaultsSeeded = true;
+    return true;
+end
+
+return M;

--- a/XIUI/modules/hotbar/macroparse.lua
+++ b/XIUI/modules/hotbar/macroparse.lua
@@ -1,0 +1,155 @@
+--[[
+ * Parse multi-line FFXI macros for icon/badge logic.
+ * Primary icon priority (first matching line in macro, first 8 lines only):
+ *   (1) /ws /ma /pet  — first among these, document order
+ *   (2) /ja
+ *   (3) /item /equip
+ *   (4) any other /command with a payload (e.g. /wait 1) — "misc"
+ * When primary is ws/ma/pet and any /ja line exists, the last /ja name is the corner badge (job ability).
+]]
+
+local M = {};
+
+local function trim(s)
+    if not s then return nil; end
+    s = tostring(s):gsub('^%s+', ''):gsub('%s+$', '');
+    return (s ~= '' and s) or nil;
+end
+
+--- Extract spell/ability name after leading /command (case-insensitive on the command).
+local function extractNameAfterCommand(line, rawCmd)
+    if not line or not rawCmd then return nil; end
+    line = trim(line);
+    if not line then return nil; end
+    local cmd = line:match('^(/%S+)');
+    if not cmd or cmd:lower() ~= rawCmd:lower() then return nil; end
+    local tail = trim(line:sub(#cmd + 1));
+    if not tail or tail == '' then return nil; end
+    local quoted = tail:match('^"([^"]+)"');
+    if quoted then return trim(quoted); end
+    local unquoted = tail:match('^([^<\r\n]+)');
+    if unquoted then
+        return trim(unquoted:gsub('%s+$', ''));
+    end
+    return nil;
+end
+
+local function normalizeCmd(raw)
+    if not raw then return nil; end
+    local c = raw:lower();
+    if c == '/weaponskill' then return '/ws'; end
+    if c == '/magic' then return '/ma'; end
+    return c;
+end
+
+-- Known action types; unknown /commands become 'misc' when a name/tail exists.
+local function actionTypeForCmd(cmdLower)
+    if not cmdLower then return nil; end
+    if cmdLower == '/ws' then return 'ws'; end
+    if cmdLower == '/ma' then return 'ma'; end
+    if cmdLower == '/pet' then return 'pet'; end
+    if cmdLower == '/ja' then return 'ja'; end
+    if cmdLower == '/item' then return 'item'; end
+    if cmdLower == '/equip' then return 'equip'; end
+    return nil;
+end
+
+--- @return string|nil primaryType  ws ma pet ja item equip misc
+--- @return string|nil primaryName
+--- @return string|nil jaBadgeName  last /ja in macro when primary is ws, ma, or pet
+function M.GetMacroPrimaryAndJaBadge(macroText)
+    macroText = trim(macroText);
+    if not macroText then
+        return nil, nil, nil;
+    end
+
+    local entries = {};
+    local jaNames = {};
+    local lineIdx = 0;
+
+    for line in macroText:gmatch('[^\r\n]+') do
+        lineIdx = lineIdx + 1;
+        if lineIdx > 8 then break; end
+
+        local l = trim(line);
+        if l and l:sub(1, 1) == '/' then
+            local rawCmd = l:match('^(/%S+)');
+            if rawCmd then
+                local ncmd = normalizeCmd(rawCmd);
+                local name = extractNameAfterCommand(l, rawCmd);
+                if name and name ~= '' then
+                    local atype = actionTypeForCmd(ncmd);
+                    if not atype then
+                        atype = 'misc';
+                    end
+                    table.insert(entries, {
+                        line = lineIdx,
+                        atype = atype,
+                        name = name,
+                    });
+                    if atype == 'ja' then
+                        table.insert(jaNames, name);
+                    end
+                end
+            end
+        end
+    end
+
+    if #entries == 0 then
+        return nil, nil, nil;
+    end
+
+    -- Primary: /ws /ma /pet > /ja > /item /equip > misc (first line in each group wins).
+    local function firstWhere(pred)
+        for i = 1, #entries do
+            local e = entries[i];
+            if pred(e) then return e; end
+        end
+        return nil;
+    end
+
+    local best = firstWhere(function(e)
+        return e.atype == 'ws' or e.atype == 'ma' or e.atype == 'pet';
+    end);
+    if not best then
+        best = firstWhere(function(e) return e.atype == 'ja'; end);
+    end
+    if not best then
+        best = firstWhere(function(e)
+            return e.atype == 'item' or e.atype == 'equip';
+        end);
+    end
+    if not best then
+        best = firstWhere(function(e) return e.atype == 'misc'; end);
+    end
+    if not best then
+        best = entries[1];
+    end
+
+    local jaBadge = nil;
+    if best.atype == 'ws' or best.atype == 'ma' or best.atype == 'pet' then
+        if #jaNames > 0 then
+            jaBadge = jaNames[#jaNames];
+            if jaBadge == best.name then
+                -- Rare duplicate name; use previous /ja if any
+                jaBadge = #jaNames > 1 and jaNames[#jaNames - 1] or nil;
+            end
+        end
+    end
+
+    return best.atype, best.name, jaBadge;
+end
+
+--- True when the macro has a bottom-right /ja badge (primary is /ws, /ma, or /pet and a /ja line exists).
+function M.MacroHasJaBadgePair(macroText)
+    local pType, _, jaBadge = M.GetMacroPrimaryAndJaBadge(macroText);
+    if not jaBadge or jaBadge == '' then
+        return false;
+    end
+    if pType == 'ws' or pType == 'ma' or pType == 'pet' then
+        return true;
+    end
+    return false;
+end
+
+return M;


### PR DESCRIPTION
…binding migration

What changed
- macro_palette_buckets.lua: Bucket schema: global, items, equipment, xiui, custom:N. Custom buckets support create/rename/delete with slot cleanup via ApplyMacroPaletteBucketRemovedToSlotAction (sweeps profile + shared gConfig, clears all slot arms bound to removed bucket key).
- macroparse.lua: Multi-line macro text parser. Priority: /ws,/ma,/pet -> /ja -> /item,/equip ->
  other. Returns primary action type and command string for JA badge, skillchain/MB routing, and recast sniffing. Pure logic; no render code.
- macro_xiui_defaults.lua: Default /xiui slash macros seeded once (Toggle XIUI Menu, Open Macros, Open Palette Manager, etc.); gated by macroXiuiDefaultsSeeded flag in migration.
- macro_global_defaults.lua: Universal 2 Hour Global macro sentinel. Job -> 2-hour name map. /ja bind targets with per-job targeting tokens. Migration seed runs after XIUI defaults.
- core/settings/migration.lua: MigrateSlotDualMacroBindings upgrades legacy single-arm slot records to macroBindProfile + macroBindShared dual-arm format. MigrateSlotMacroRefs (1.8.0) preserved.

Why
- Organizes macro library by category; custom types for user-defined groupings with full cleanup on delete. Macro parser drives corner badge, SC/MB routing, and recast sniffing from a single consistent source. Default seeds give new users discoverability and a working 2-hour macro out of the box. Migration idempotently upgrades existing profiles.