### PR TITLE
Macro editor: Show All UI, spell colors, Copy, JA badge sync, spell d…

### DIFF
--- a/XIUI/modules/hotbar/customiconresolve.lua
+++ b/XIUI/modules/hotbar/customiconresolve.lua
@@ -1,0 +1,194 @@
+--[[
+ * Resolve assets/hotbar/custom/*.png paths by action name — same rules as the macro editor
+ * icon picker (recursive scan + name match). Used when textures:GetIconBySpellName misses
+ * (e.g. Ashita fs patterns differ) so /ja badges and binds still find FFXIV-style icons.
+]]--
+
+require('common');
+local iconmatch = require('modules.hotbar.iconmatch');
+
+local M = {};
+
+local customIconsDir = nil;
+local iconListCache = nil;
+
+local function getCustomIconsDir()
+    if not customIconsDir then
+        customIconsDir = string.format('%saddons\\XIUI\\assets\\hotbar\\custom\\', AshitaCore:GetInstallPath());
+    end
+    return customIconsDir;
+end
+
+-- Recursively collect PNGs (same approach as macropalette LoadCustomIcons).
+local function scanDirectoryForPngs(dir, relativePath, results, topLevelCategory)
+    relativePath = relativePath or '';
+    results = results or {};
+
+    if not ashita.fs or not ashita.fs.get_directory then
+        return results;
+    end
+
+    local contents = ashita.fs.get_directory(dir, '.*');
+    if not contents then
+        return results;
+    end
+
+    for _, entry in pairs(contents) do
+        local relPath = relativePath ~= '' and (relativePath .. '\\' .. entry) or entry;
+
+        if entry:lower():match('%.png$') then
+            local category = topLevelCategory or 'root';
+            table.insert(results, {
+                name = entry:gsub('%.png$', ''),
+                path = relPath,
+                category = category,
+            });
+        elseif not entry:match('%.') then
+            local categoryForNested = topLevelCategory or entry;
+            scanDirectoryForPngs(dir .. entry .. '\\', relPath, results, categoryForNested);
+        end
+    end
+
+    return results;
+end
+
+local function ensureIconList()
+    if iconListCache then
+        return iconListCache;
+    end
+    iconListCache = scanDirectoryForPngs(getCustomIconsDir());
+    table.sort(iconListCache, function(a, b)
+        return a.name:lower() < b.name:lower();
+    end);
+    return iconListCache;
+end
+
+local function paletteNormalizeIconMatchText(s)
+    if not s then
+        return '';
+    end
+    s = tostring(s):lower();
+    s = s:gsub('^%s+', ''):gsub('%s+$', '');
+    s = s:gsub('[\r\n\t]', ' ');
+    s = s:gsub('[%p%c%s]', '');
+    return s;
+end
+
+local function paletteBuildIconMatchNeedles(actionName)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return {};
+    end
+
+    local needles = {};
+    local function add(n)
+        n = paletteNormalizeIconMatchText(n);
+        if n ~= '' then
+            needles[n] = true;
+        end
+    end
+
+    local fullNorm = paletteNormalizeIconMatchText(actionName);
+    add(actionName);
+    local rhs = actionName:match(':%s*(.+)$');
+    if rhs then
+        add(rhs);
+    end
+    local paren = actionName:match('%(([^)]+)%)');
+    if paren then
+        add(paren);
+    end
+    local lastWord = actionName:match('([^%s]+)%s*$');
+    if lastWord then
+        local lwNorm = paletteNormalizeIconMatchText(lastWord);
+        if lwNorm ~= '' and lwNorm ~= fullNorm then
+            local weakTail = (#lwNorm < 9 and #fullNorm > #lwNorm + 4 and fullNorm:sub(-#lwNorm) == lwNorm);
+            if not weakTail then
+                add(lastWord);
+            end
+        end
+    end
+
+    local arr = {};
+    for n, _ in pairs(needles) do
+        table.insert(arr, n);
+    end
+    table.sort(arr, function(a, b)
+        return #a > #b;
+    end);
+    return arr;
+end
+
+--- @param categoryFilter string|nil 'all' or top-level folder name (e.g. 'ffxiv'); default 'all'
+--- @return string|nil Relative path under assets/hotbar/custom/ (uses \), or nil
+function M.FindRelPathForActionName(actionName, categoryFilter)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return nil;
+    end
+
+    local list = ensureIconList();
+    if not list or #list == 0 then
+        return nil;
+    end
+
+    categoryFilter = categoryFilter or 'all';
+    local filtered = list;
+    if categoryFilter ~= 'all' then
+        filtered = {};
+        for _, icon in ipairs(list) do
+            if icon.category == categoryFilter then
+                table.insert(filtered, icon);
+            end
+        end
+        if #filtered == 0 then
+            filtered = list;
+        end
+    end
+
+    local needles = paletteBuildIconMatchNeedles(actionName);
+    if #needles == 0 then
+        return nil;
+    end
+
+    for _, icon in ipairs(filtered) do
+        if icon and icon.name and icon.path then
+            local iconNorm = paletteNormalizeIconMatchText(icon.name);
+            for _, needle in ipairs(needles) do
+                if iconNorm == needle then
+                    return icon.path;
+                end
+            end
+        end
+    end
+
+    local fuzzy = {};
+    for _, icon in ipairs(filtered) do
+        if icon and icon.name and icon.path and iconmatch.IsDecentIconNameMatch(actionName, icon.name) then
+            table.insert(fuzzy, icon);
+        end
+    end
+    if #fuzzy == 1 then
+        return fuzzy[1].path;
+    end
+    if #fuzzy > 1 then
+        table.sort(fuzzy, function(x, y)
+            local sx = iconmatch.MatchQualityScore(actionName, x.name);
+            local sy = iconmatch.MatchQualityScore(actionName, y.name);
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return #iconmatch.NormalizeIconKey(x.name) > #iconmatch.NormalizeIconKey(y.name);
+        end);
+        return fuzzy[1].path;
+    end
+
+    return nil;
+end
+
+--- Call after adding/removing PNGs under hotbar/custom (or reload) so the next lookup rescans disk.
+function M.InvalidateScanCache()
+    iconListCache = nil;
+end
+
+return M;

--- a/XIUI/modules/hotbar/iconmatch.lua
+++ b/XIUI/modules/hotbar/iconmatch.lua
@@ -1,0 +1,87 @@
+--[[
+ * Shared heuristics for matching a user action name to an icon label / filename.
+ * Avoids loose substring hits (e.g. unrelated abilities) while allowing spaces/case variants.
+]]--
+
+local M = {};
+
+local function normalizeKey(s)
+    if not s then return ''; end
+    return tostring(s):lower():gsub('[^a-z0-9]', '');
+end
+
+--- True if action name and candidate icon name are the "same" or a strong alias (prefix / contained).
+---@param userActionName string What the user typed (/ma, /pet, custom icon filename stem, etc.)
+---@param candidateIconName string Display name of a custom icon entry
+---@return boolean
+function M.IsDecentIconNameMatch(userActionName, candidateIconName)
+    local a = normalizeKey(userActionName);
+    local b = normalizeKey(candidateIconName);
+    if a == '' or b == '' then
+        return false;
+    end
+    if a == b then
+        return true;
+    end
+
+    local short, long = a, b;
+    local iconNameIsShorter = false;
+    if #a > #b then
+        short, long = b, a;
+        iconNameIsShorter = true;  -- short = icon key, long = user action
+    end
+
+    -- Containment: only when the shared token is long enough (avoids "arm", "ing", etc.)
+    if #short >= 6 and long:find(short, 1, true) then
+        -- Reject weak tail-of-compound matches: e.g. icon "Attack" vs ability "Sneak Attack"
+        -- ("attack" is a suffix of "sneakattack" but is not a good match for the full name).
+        if iconNameIsShorter then
+            local pos = long:find(short, 1, true);
+            if pos and pos > 1 and pos + #short - 1 == #long then
+                if #short < 9 and #long > #short + 4 then
+                    return false;
+                end
+            end
+        end
+        return (#short / #long) >= 0.35;
+    end
+
+    -- Prefix (one string starts with the other), min 5 chars on the shorter side
+    if #short >= 5 then
+        if long:sub(1, #short) == short then
+            return (#short / #long) >= 0.45;
+        end
+        if short:sub(1, #long) == long then
+            return (#long / #short) >= 0.45;
+        end
+    end
+
+    return false;
+end
+
+function M.NormalizeIconKey(s)
+    return normalizeKey(s);
+end
+
+--- Higher score = better match for ranking fuzzy icon lists (exact > full embed > other).
+function M.MatchQualityScore(userActionName, candidateIconName)
+    local a = normalizeKey(userActionName);
+    local b = normalizeKey(candidateIconName);
+    if a == '' or b == '' then
+        return 0;
+    end
+    if a == b then
+        return 1000000;
+    end
+    -- Icon filename contains the full normalized action (e.g. sneakattack in sneakattack_icon_ffxiv)
+    if #a >= 6 and b:find(a, 1, true) then
+        return 500000 + #a * 1000 + #b;
+    end
+    -- User action contains full icon stem (short icon name, longer filenames)
+    if #b >= 6 and a:find(b, 1, true) then
+        return 300000 + #b * 1000 + #a;
+    end
+    return 10000;
+end
+
+return M;

--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 * XIUI Hotbar - Macro Palette Module
 * Provides a visual grid of user-created macros that can be dragged to hotbar slots
 ]]--
@@ -18,11 +18,142 @@ local petpalette = require('modules.hotbar.petpalette');
 local petregistry = require('modules.hotbar.petregistry');
 local playerdata = require('modules.hotbar.playerdata');
 local actiondb = require('modules.hotbar.actiondb');
+local iconmatch = require('modules.hotbar.iconmatch');
+local macroBuckets = require('modules.hotbar.macro_palette_buckets');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
+local profileManager = require('core.profile_manager');
+local sharedMacroStore = require('core.shared_macro_store');
 -- display and crossbar are loaded lazily to avoid circular dependencies
 local display = nil;
 local crossbar = nil;
 
 local M = {};
+
+-- Bundle for macropalette_macroeditor.lua (Lua 5.1: max 60 upvalues per function).
+local MP = {};
+
+MP.editingMacro = nil;
+MP.isCreatingNew = false;
+MP.currentPalettePage = 1;
+MP.editorPaletteKey = nil;
+MP.editorAutoLabel = nil;
+MP.editorAutoIconKey = nil;
+MP.editorDidInitialIconPick = false;
+MP.editorIconAutoSource = 'all';
+MP.editorCustomIconCategory = 'all';
+MP.selectedPaletteType = nil;
+MP.selectedAvatarPalette = nil;
+-- SMN only: when true, macro grid lists Base SMN + every avatar bucket together.
+MP.smnShowAllAvatarSubsets = false;
+-- BST: jug-family subset (movesKey from petregistry), nil = Base BST bucket.
+MP.selectedBstJugMovesKey = nil;
+-- BST: when true, macro grid lists Base BST + every jug:* macro bucket together.
+MP.bstShowAllJugSubsets = false;
+MP.cachedPetCommands = nil;
+MP.petAvatarFilter = 1;
+MP.searchFilter = { '' };
+-- Macro Palette window: filter tiles by display/action name (not icon-picker search).
+MP.macroPaletteSearchName = { '' };
+MP.macroNewCategoryBuf = { '' };
+MP.macroCustomRenameBuf = { '' };
+MP.macroCustomRenameTargetKey = nil; -- 'custom:N' for MacroCustomRename modal
+MP.macroCustomDeleteKey = nil; -- pending delete: confirm modal
+MP.macroCustomDeleteLabel = nil;
+MP.macroCustomDeleteN = 0;
+MP.macroMoveSourceKey = nil;
+MP.macroMoveMacroId = nil;
+MP.macroMoveDestKey = nil;
+MP._macroSearchPaletteKey = nil;
+MP._lastMacroPaletteSearch = nil;
+-- Which scope switch confirmation is open (single non-modal BeginPopup, no full-screen dim).
+MP.macroScopeConfirmKind = nil; -- 'toShared' | 'toProfile' while 'MacroScopeSwitch##xiui' is open
+MP.showAllMode = false;
+MP.showAllPetMode = false;
+MP.wsWeaponFilter = 'All';
+MP.spellTypeFilter = 'All';
+MP.abilityJobFilter = 0;
+MP.petTypeOverride = 0;
+MP.iconPickerTargetIsJaBadge = false;
+MP.iconPickerOpen = false;
+MP.iconPickerFilter = { '' };
+MP.iconPickerTab = 1;
+MP.iconPickerPage = { 1, 1, 1 };
+MP.iconPickerLastFilter = { '', '', '' };
+MP.iconPickerSpellType = 'All';
+MP.iconPickerItemType = 0;
+MP.editorImplicitActionIconDone = false;
+MP.editorIconManuallySet = false;
+-- When true, JA badge icon is not replaced by implicit /ja resolution; use "Sync JA badge" to refresh.
+MP.editorJaBadgeManuallySet = false;
+MP.editorIconPrefsHydrated = false;
+
+
+
+-- Palette / editor: GetBindIcon + ResolveMacroJaBadgeIcon do real work (macroparse, DB, texture lookup).
+-- The macro grid calls them once per tile per frame â€” cache by stable keys; clear when palette type changes.
+local PALETTE_ICON_NONE = {};
+local PALETTE_JA_NONE = {};
+
+local paletteMainIconCache = {};
+local paletteJaBadgeIconCache = {};
+local paletteIconCacheDbKey = nil;
+
+local editorPreviewIconKey = nil;
+local editorPreviewCachedIcon = nil;
+
+local function ClearEditorPreviewIconCache()
+    editorPreviewIconKey = nil;
+    editorPreviewCachedIcon = nil;
+end
+
+local function ClearPaletteJaBadgeIconCache()
+    for k in pairs(paletteJaBadgeIconCache) do
+        paletteJaBadgeIconCache[k] = nil;
+    end
+end
+
+local function BuildMacroMainIconCacheKey(macro)
+    if not macro then
+        return 'nil';
+    end
+    return table.concat({
+        tostring(macro.id or 0),
+        macro.actionType or '',
+        macro.action or '',
+        macro.target or '',
+        macro.macroText or '',
+        macro.customIconType or '',
+        tostring(macro.customIconId or ''),
+        macro.customIconPath or '',
+        macro.itemId and tostring(macro.itemId) or '',
+        tostring(macro.macroRef or ''),
+    }, '|');
+end
+
+local function BuildMacroJaBadgeCacheKey(macro)
+    if not macro then
+        return '';
+    end
+    return table.concat({
+        tostring(macro.id or 0),
+        macro.macroText or '',
+        tostring(macro.jaBadgeCustomIconType or ''),
+        tostring(macro.jaBadgeCustomIconId or ''),
+        macro.jaBadgeCustomIconPath or '',
+        tostring(macro.showJaBadgeOnMacro ~= false),
+    }, '|');
+end
+
+local function GetCachedPaletteMainIcon(macro)
+    local k = BuildMacroMainIconCacheKey(macro);
+    local hit = paletteMainIconCache[k];
+    if hit ~= nil then
+        return hit == PALETTE_ICON_NONE and nil or hit;
+    end
+    local icon = actions.GetBindIcon(macro);
+    paletteMainIconCache[k] = icon or PALETTE_ICON_NONE;
+    return icon;
+end
 
 -- ============================================
 -- Constants
@@ -30,11 +161,13 @@ local M = {};
 
 local INPUT_BUFFER_SIZE = 64;
 local MACRO_BUFFER_SIZE = 512;  -- 8 lines * ~60 chars each
-local PALETTE_COLUMNS = 6;
+local PALETTE_COLUMNS = 7;
 local PALETTE_ROWS = 6;
-local PALETTE_MACROS_PER_PAGE = PALETTE_COLUMNS * PALETTE_ROWS;  -- 36 macros per page
+local PALETTE_MACROS_PER_PAGE = PALETTE_COLUMNS * PALETTE_ROWS;  -- 42 macros per page
 local PALETTE_TILE_SIZE = 48;
 local PALETTE_TILE_GAP = 4;
+-- Slightly rounded macro grid tiles (ImGui button shape; icons draw square on top).
+local PALETTE_TILE_ROUNDING = 6;
 local PALETTE_PADDING = 8;
 
 -- XIUI Color Scheme (from components.TAB_STYLE)
@@ -70,10 +203,20 @@ end
 -- If preferAction is true, prioritize action name over displayName (for previews)
 local function GetActionAbbreviation(macro, preferAction)
     local name;
+    -- Macros: never abbreviate from raw `action` (it may be the full multiline buffer â€” yields garbage like /"S<).
+    if macro and macro.actionType == 'macro' and macro.macroText and macro.macroText ~= '' then
+        local mp = require('modules.hotbar.macroparse');
+        local _, pName = mp.GetMacroPrimaryAndJaBadge(macro.macroText);
+        if pName and pName ~= '' then
+            name = pName;
+        end
+    end
+    if not name or name == '' then
     if preferAction then
         name = macro.action or macro.displayName or '';
     else
         name = macro.displayName or macro.action or '';
+        end
     end
     if name == '' then return '?'; end
 
@@ -131,17 +274,17 @@ local function ClearAllIconCaches()
     if slotrenderer and slotrenderer.ClearSlotRenderingCache then
         slotrenderer.ClearSlotRenderingCache();
     end
-    -- Edits that change a macro's action leave the old actionType:action entry
-    -- orphaned in mpCostCache / availabilityCache. Functionally fine (the new key
-    -- naturally misses), but bounds memory across many edits.
+    -- 1.8.0 additions: edits that change a macro's action leave the old actionType:action
+    -- entry orphaned in the MP cost / availability caches. Functionally fine (the new key
+    -- naturally misses) but unbounded across many edits, so flush both during full clears.
     if slotrenderer and slotrenderer.ClearMPCostCache then
         slotrenderer.ClearMPCostCache();
     end
     if slotrenderer and slotrenderer.ClearAvailabilityCache then
         slotrenderer.ClearAvailabilityCache();
     end
-    -- Clear the icon-resolution negative cache so newly-added custom icons
-    -- on edited macros are picked up next frame.
+    -- Drop the icon-resolution negative cache so newly-added custom icons on edited
+    -- macros are picked up on the next frame instead of remaining "no icon".
     if actions and actions.ClearNoIconCache then
         actions.ClearNoIconCache();
     end
@@ -162,6 +305,8 @@ local function ClearSlotIconCache(barIndex, slotIndex)
     if display and display.ClearIconCacheForSlot then
         display.ClearIconCacheForSlot(barIndex, slotIndex);
     end
+    -- Note: per-slot slotrenderer.InvalidateSlotByKey was removed in 1.8.0. Slot rendering is
+    -- immediate-mode (no persistent prim cache); the per-frame bind hash naturally re-derives.
 end
 
 -- Helper to clear icon cache for a single crossbar slot (targeted - fast)
@@ -179,6 +324,7 @@ local function ClearCrossbarSlotIconCache(comboMode, slotIndex)
     if crossbar and crossbar.ClearIconCacheForSlot then
         crossbar.ClearIconCacheForSlot(comboMode, slotIndex);
     end
+    -- Note: per-slot slotrenderer.InvalidateSlotByKey was removed in 1.8.0. See ClearSlotIconCache above.
 end
 
 -- Action type constants (needed by DrawMacroTile and DrawMacroEditor)
@@ -187,11 +333,14 @@ local ACTION_TYPE_LABELS = {
     ma = 'Spell (ma)',
     ja = 'Ability (ja)',
     ws = 'Weaponskill (ws)',
-    item = 'Item',
+    item = 'Items',
     equip = 'Equip',
     macro = 'Macro',
     pet = 'Pet Command',
 };
+
+-- Items palette bucket: Action Type combo offers only these (order: Item, Macro, Equip).
+local ACTION_TYPES_ITEMS_BUCKET = { 'item', 'macro', 'equip' };
 
 -- Recast source types for macros (allows displaying cooldown from a different action)
 local RECAST_SOURCE_TYPES = { 'none', 'ma', 'ja', 'item', 'pet' };
@@ -240,8 +389,39 @@ local EQUIP_SLOT_MASKS = {
 -- Special key for global (non-job-specific) slot storage
 local GLOBAL_SLOT_KEY = 'global';
 
--- Special key for global macros (shared across all jobs)
-local GLOBAL_MACRO_KEY = 'global';
+-- Macro palette bucket keys (see macro_palette_buckets.lua)
+local GLOBAL_MACRO_KEY = macroBuckets.GLOBAL;
+local ITEMS_MACRO_KEY = macroBuckets.ITEMS;
+local EQUIPMENT_MACRO_KEY = macroBuckets.EQUIPMENT;
+local XIUI_MACRO_KEY = macroBuckets.XIUI;
+
+local function DefaultNewMacroBodyForPaletteKey(paletteKey)
+    if data.MacroPaletteKeysEqual(paletteKey, ITEMS_MACRO_KEY) then
+        return {
+            actionType = 'item',
+            action = '',
+            target = 't',
+            displayName = '',
+            customIconType = 'xiui_default',
+            customIconPath = 'item',
+        }, 'xiui_default::item';
+    end
+    return {
+        actionType = 'ma',
+        action = '',
+        target = 't',
+        displayName = '',
+        customIconType = 'xiui_default',
+        customIconPath = 'ma',
+    }, 'xiui_default::ma';
+end
+
+local function IsSharedJobAgnosticMacroSelection(sel)
+    if sel == GLOBAL_MACRO_KEY or sel == ITEMS_MACRO_KEY or sel == EQUIPMENT_MACRO_KEY or sel == XIUI_MACRO_KEY then
+        return true;
+    end
+    return macroBuckets.isCustomCategoryKey(sel);
+end
 
 -- Helper to deep copy a table (for migrating slot data)
 local function deepCopyTable(tbl)
@@ -293,30 +473,15 @@ end
 -- State
 -- ============================================
 
-local paletteOpen = false;
-local selectedMacroIndex = nil;
-local editingMacro = nil;
-local isCreatingNew = false;
-local currentPalettePage = 1;  -- Current page in macro palette (1-indexed)
-
--- Selected job for viewing/editing macros (nil = use current player job)
-local selectedPaletteType = nil;  -- Can be GLOBAL_MACRO_KEY or a job ID
-local selectedAvatarPalette = nil;  -- For SMN: nil = base, or avatar name like 'Ifrit'
-
--- Cached pet commands (managed locally, not in shared module)
-local cachedPetCommands = nil;
-local petAvatarFilter = 1;  -- 1 = All, 2+ = specific avatar index
-
--- Search filter for dropdowns
-local searchFilter = { '' };
-
--- Icon picker state
-local iconPickerOpen = false;
-local iconPickerFilter = { '' };
-local iconPickerTab = 1;  -- 1 = Spells, 2 = Items, 3 = Custom
-local iconPickerPage = { 1, 1, 1 };  -- Current page for each tab [spells, items, custom]
-local iconPickerLastFilter = { '', '', '' };  -- Track filter changes to reset page
-local iconPickerSpellType = 'All';  -- Current spell type filter
+-- Palette open state (table: avoids extra upvalues when palette draw uses MacroPaletteDrawEnv).
+local paletteUi = { open = false, selectedMacroIndex = nil };
+local ICON_AUTO_SOURCES = { 'all', 'spells', 'items', 'custom' };
+local ICON_AUTO_SOURCE_LABELS = {
+    ['all'] = 'All',
+    ['spells'] = 'Spells',
+    ['items'] = 'Items',
+    ['custom'] = 'Custom',
+};
 
 -- Spell type display names and order
 local SPELL_TYPE_ORDER = {
@@ -404,7 +569,6 @@ local ITEM_TYPE_ICONS = {
     [8] = 4096,   -- Fire Crystal
     [10] = 6232,  -- Furnishing item
 };
-local iconPickerItemType = 0;  -- 0 = All
 
 -- Custom icon categories (subdirectories in assets/hotbar/custom/)
 local CUSTOM_ICON_CATEGORIES = {};  -- Populated by scanning directory
@@ -432,6 +596,8 @@ local filteredSpellsCache = nil;
 local filteredSpellsCacheKey = nil;  -- "filter:type" key for cache invalidation
 local filteredItemsCache = nil;
 local filteredItemsCacheKey = nil;  -- "filter" key for cache invalidation
+local filteredCustomIconsCache = nil;
+local filteredCustomIconsCacheKey = nil;  -- filter + category for custom tab
 
 -- Icon picker grid constants
 local ICON_GRID_COLUMNS_DEFAULT = 12;  -- Default columns, recalculated based on window width
@@ -486,7 +652,7 @@ local function RefreshCachedLists()
     playerdata.RefreshCachedLists(data);
     -- Clear local pet commands cache when job changes
     if playerdata.GetCacheJobId() ~= data.jobId then
-        cachedPetCommands = nil;
+        MP.cachedPetCommands = nil;
     end
 end
 
@@ -734,8 +900,262 @@ local function LoadCustomIcons()
         if b == 'all' then return false; end
         return a:lower() < b:lower();
     end);
+
+    -- LoadCustomIcons replaces CUSTOM_ICON_CATEGORIES with a new table; keep MP.* in sync for the macro editor sub-module.
+    MP.CUSTOM_ICON_CATEGORIES = CUSTOM_ICON_CATEGORIES;
+    MP.CUSTOM_ICON_LABELS = CUSTOM_ICON_LABELS;
     
     return customIconsCache;
+end
+
+local function HydrateMacroEditorIconPrefs()
+    if not gConfig or not gConfig.macroEditorIconPrefs then
+        return;
+    end
+    local p = gConfig.macroEditorIconPrefs;
+    local src = p.iconAutoSource;
+    if src == 'all' or src == 'spells' or src == 'items' or src == 'custom' then
+        MP.editorIconAutoSource = src;
+    end
+    if type(p.customIconFolder) == 'string' and p.customIconFolder ~= '' then
+        MP.editorCustomIconCategory = p.customIconFolder;
+    end
+end
+
+local function ValidateEditorCustomIconCategoryAgainstScan()
+    LoadCustomIcons();
+    local cat = MP.editorCustomIconCategory or 'all';
+    if cat == 'all' then
+        return;
+    end
+    local found = false;
+    for _, c in ipairs(CUSTOM_ICON_CATEGORIES or {}) do
+        if c == cat then
+            found = true;
+            break;
+        end
+    end
+    if not found then
+        MP.editorCustomIconCategory = 'all';
+    end
+end
+
+local function PersistMacroEditorIconPrefs()
+    if not gConfig then
+        return;
+    end
+    if not gConfig.macroEditorIconPrefs then
+        gConfig.macroEditorIconPrefs = {};
+    end
+    gConfig.macroEditorIconPrefs.iconAutoSource = MP.editorIconAutoSource;
+    gConfig.macroEditorIconPrefs.customIconFolder = MP.editorCustomIconCategory;
+    if SaveSettingsToDisk then
+        SaveSettingsToDisk();
+    end
+end
+
+-- Rescan custom/ PNG lists (new files, addon reload) without restarting the game client.
+local function InvalidateCustomIconScanCaches()
+    customIconsCache = nil;
+    customIconsByCategoryCache = nil;
+    customCategoryIconCache = {};
+    filteredCustomIconsCache = nil;
+    filteredCustomIconsCacheKey = nil;
+    local ok, cir = pcall(require, 'modules.hotbar.customiconresolve');
+    if ok and cir and cir.InvalidateScanCache then
+        cir.InvalidateScanCache();
+    end
+end
+
+-- Normalized relative path compare for saved custom icon paths (mixed slashes).
+local function NormalizeCustomIconRelPath(p)
+    if not p then
+        return '';
+    end
+    return tostring(p):gsub('/', '\\'):gsub('^%s+', ''):gsub('%s+$', '');
+end
+
+--- Find scanned custom icon entry by path saved on a macro (path relative to assets/hotbar/custom/).
+local function FindCustomIconEntryBySavedPath(savedPath)
+    savedPath = NormalizeCustomIconRelPath(savedPath);
+    if savedPath == '' then
+        return nil;
+    end
+    LoadCustomIcons();
+    local sle = savedPath:lower();
+    for _, icon in ipairs(customIconsCache or {}) do
+        if icon.path and NormalizeCustomIconRelPath(icon.path):lower() == sle then
+            return icon;
+        end
+    end
+    local leaf = savedPath:match('[^\\/]+$') or savedPath;
+    leaf = leaf:gsub('%.png$', ''):lower();
+    for _, icon in ipairs(customIconsCache or {}) do
+        if icon.path then
+            local il = (icon.path:match('[^\\/]+$') or icon.path):gsub('%.png$', ''):lower();
+            if il == leaf then
+                return icon;
+            end
+        end
+    end
+    return nil;
+end
+
+-- Same normalization as macro editor auto-pick (matches TryAutoPickCustomIcon).
+local function PaletteNormalizeIconMatchText(s)
+    if not s then
+        return '';
+    end
+    s = tostring(s):lower();
+    s = s:gsub('^%s+', ''):gsub('%s+$', '');
+    s = s:gsub('[\r\n\t]', ' ');
+    s = s:gsub('[%p%c%s]', '');
+    return s;
+end
+
+local function PaletteBuildIconMatchNeedles(actionName)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return {};
+    end
+
+    local needles = {};
+    local function add(n)
+        n = PaletteNormalizeIconMatchText(n);
+        if n ~= '' then
+            needles[n] = true;
+        end
+    end
+
+    local fullNorm = PaletteNormalizeIconMatchText(actionName);
+    add(actionName);
+    local rhs = actionName:match(':%s*(.+)$');
+    if rhs then
+        add(rhs);
+    end
+    local paren = actionName:match('%(([^)]+)%)');
+    if paren then
+        add(paren);
+    end
+    local lastWord = actionName:match('([^%s]+)%s*$');
+    if lastWord then
+        local lwNorm = PaletteNormalizeIconMatchText(lastWord);
+        -- Do not add a last-word needle when it is only a tail of the full normalized name
+        -- (e.g. "Attack" for "Sneak Attack" â†’ sneakattack) â€” exact match would pick generic Attack.png
+        -- before fuzzy matching can prefer Sneak_Attack_*.
+        if lwNorm ~= '' and lwNorm ~= fullNorm then
+            local weakTail = (#lwNorm < 9 and #fullNorm > #lwNorm + 4 and fullNorm:sub(-#lwNorm) == lwNorm);
+            if not weakTail then
+                add(lastWord);
+            end
+        end
+    end
+
+    local arr = {};
+    for n, _ in pairs(needles) do
+        table.insert(arr, n);
+    end
+    table.sort(arr, function(a, b)
+        return #a > #b;
+    end);
+    return arr;
+end
+
+--- Best custom icon match for an action name (same rules as TryAutoPickCustomIcon). Returns icon entry or nil.
+local function ResolveBestCustomIconMatchForActionName(actionName, categoryFilter)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return nil;
+    end
+    LoadCustomIcons();
+    local category = categoryFilter or 'all';
+    local list = customIconsByCategoryCache and (customIconsByCategoryCache[category] or customIconsByCategoryCache['all']) or nil;
+    if not list or #list == 0 then
+        return nil;
+    end
+
+    local needles = PaletteBuildIconMatchNeedles(actionName);
+    if #needles == 0 then
+        return nil;
+    end
+
+    for _, icon in ipairs(list) do
+        if icon and icon.name and icon.path then
+            local iconNorm = PaletteNormalizeIconMatchText(icon.name);
+            for _, needle in ipairs(needles) do
+                if iconNorm == needle then
+                    return icon;
+                end
+            end
+        end
+    end
+
+    -- Fuzzy round: collect all decent matches, then prefer the most specific (longest normalized stem)
+    -- so short substrings don't steal the pick when several PNGs could match.
+    local fuzzy = {};
+    for _, icon in ipairs(list) do
+        if icon and icon.name and icon.path and iconmatch.IsDecentIconNameMatch(actionName, icon.name) then
+            table.insert(fuzzy, icon);
+        end
+    end
+    if #fuzzy == 1 then
+        return fuzzy[1];
+    end
+    if #fuzzy > 1 then
+        table.sort(fuzzy, function(x, y)
+            local sx = iconmatch.MatchQualityScore(actionName, x.name);
+            local sy = iconmatch.MatchQualityScore(actionName, y.name);
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return #iconmatch.NormalizeIconKey(x.name) > #iconmatch.NormalizeIconKey(y.name);
+        end);
+        return fuzzy[1];
+    end
+
+    return nil;
+end
+
+-- Icon picker search: collapse spaces, underscores, punctuation so "Sneak Attack", "sneak_attack",
+-- and "sneakattack" match the same assets (multi-word spell/ability/file names).
+local function normalizeIconPickerNameKey(s)
+    if not s then
+        return '';
+    end
+    return tostring(s):lower():gsub('[^a-z0-9]', '');
+end
+
+local function iconPickerNameMatchesFilter(name, filter)
+    if not filter or filter == '' then
+        return true;
+    end
+    if not name or name == '' then
+        return false;
+    end
+    local normName = normalizeIconPickerNameKey(name);
+    local normAll = normalizeIconPickerNameKey(filter);
+    if normAll == '' then
+        return true;
+    end
+    if normName:find(normAll, 1, true) then
+        return true;
+    end
+    local tokens = {};
+    for w in tostring(filter):gmatch('%S+') do
+        local t = normalizeIconPickerNameKey(w);
+        if t ~= '' then
+            table.insert(tokens, t);
+        end
+    end
+    if #tokens <= 1 then
+        return false;
+    end
+    for _, t in ipairs(tokens) do
+        if not normName:find(t, 1, true) then
+            return false;
+        end
+    end
+    return true;
 end
 
 -- Get custom icons filtered by category
@@ -749,24 +1169,31 @@ local function GetCustomIconsFiltered(category, filter)
         sourceList = customIconsByCategoryCache[category] or {};
     end
     
-    -- Apply text filter if any
+    -- Apply text filter if any (best matches first: full-name embed beats loose substring)
     if filter and filter ~= '' then
         local filtered = {};
-        filter = filter:lower();
         for _, icon in ipairs(sourceList) do
-            if icon.name:lower():find(filter, 1, true) then
+            if iconPickerNameMatchesFilter(icon.name or '', filter) then
                 table.insert(filtered, icon);
             end
         end
+        table.sort(filtered, function(x, y)
+            local sx = iconmatch.MatchQualityScore(filter, x.name or '');
+            local sy = iconmatch.MatchQualityScore(filter, y.name or '');
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return (x.name or '') < (y.name or '');
+        end);
         return filtered;
     end
     
     return sourceList;
 end
 
--- Load a custom icon texture by relative path (uses TextureManager with LRU caching)
+-- Load a custom icon texture by relative path (same cache as hotbar; avoids duplicate VRAM + TextureManager LRU thrash)
 local function LoadCustomIconTexture(relativePath)
-    return TextureManager.getCustomIcon(relativePath);
+    return actions.GetCustomHotbarIconTexture(relativePath);
 end
 
 -- Create a new custom icon folder
@@ -903,10 +1330,51 @@ local function PopComboStyle()
     imgui.PopStyleColor(11);
 end
 
+-- Status tier colors for "Show All" mode
+local STATUS_COLORS = {
+    ['have']        = { 0.35, 0.85, 0.35, 1.0 },
+    ['learnable']   = { 0.95, 0.78, 0.25, 1.0 },
+    ['unavailable'] = { 0.75, 0.30, 0.30, 1.0 },
+};
+
+-- Base colors per magic type (full brightness = STATUS_HAVE)
+local SPELL_TYPE_COLORS = {
+    WhiteMagic   = { 0.96, 0.92, 0.78, 1.0 },  -- eggshell/holy white
+    BlackMagic   = { 0.75, 0.50, 0.90, 1.0 },  -- purple
+    BardSong     = { 0.50, 0.80, 1.00, 1.0 },  -- light blue
+    Ninjutsu     = { 0.78, 0.60, 0.38, 1.0 },  -- scroll brown
+    SummonerPact = { 0.50, 0.75, 0.38, 1.0 },  -- moss green
+    BlueMagic    = { 0.30, 0.70, 0.95, 1.0 },  -- steel blue
+    Geomancy     = { 0.60, 0.85, 0.45, 1.0 },  -- earthy green
+    Trust        = { 0.80, 0.80, 0.80, 1.0 },  -- silver
+};
+
+-- Human-readable headers for each spell type
+local SPELL_TYPE_HEADERS = {
+    WhiteMagic   = 'White Magic',
+    BlackMagic   = 'Black Magic',
+    BardSong     = 'Songs',
+    Ninjutsu     = 'Ninjutsu',
+    SummonerPact = 'Summoning',
+    BlueMagic    = 'Blue Magic',
+    Geomancy     = 'Geomancy',
+    Trust        = 'Trust',
+};
+
+-- Canonical type display order
+local SPELL_TYPE_ORDER = {
+    'WhiteMagic', 'BlackMagic', 'BardSong', 'Ninjutsu',
+    'SummonerPact', 'BlueMagic', 'Geomancy', 'Trust',
+};
+local SPELL_TYPE_RANK = {};
+for i, t in ipairs(SPELL_TYPE_ORDER) do SPELL_TYPE_RANK[t] = i; end
+
+
 -- Draw a searchable dropdown combo box with XIUI styling
 -- showIcons: if true, will attempt to load and display item icons
 -- equipSlotFilter: if provided, only show items that can be equipped in this slot (e.g., 'main', 'head')
-local function DrawSearchableCombo(label, items, currentValue, onSelect, showIcons, equipSlotFilter)
+-- useStatusColors: if true, color text by item.status (have/learnable/unavailable)
+local function DrawSearchableCombo(label, items, currentValue, onSelect, showIcons, equipSlotFilter, itemWidth, useStatusColors)
     local displayText = currentValue ~= '' and currentValue or 'Select...';
 
     -- Get the slot mask for filtering if provided
@@ -915,16 +1383,17 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
     -- Apply XIUI styling to combo popup
     PushComboStyle();
 
-    imgui.SetNextItemWidth(220);
+    local comboW = (type(itemWidth) == 'number' and itemWidth > 0) and itemWidth or 220;
+    imgui.SetNextItemWidth(comboW);
     -- Use HeightLargest so popup fits our child window without its own scrollbar
     if imgui.BeginCombo(label, displayText, ImGuiComboFlags_HeightLargest) then
         -- Search input at top (fixed, not scrollable)
-        imgui.SetNextItemWidth(200);
+        imgui.SetNextItemWidth(math.max(80, comboW - 20));
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
-        imgui.InputText('##search' .. label, searchFilter, INPUT_BUFFER_SIZE);
+        imgui.InputText('##search' .. label, MP.searchFilter, INPUT_BUFFER_SIZE);
         imgui.PopStyleColor();
 
-        if searchFilter[1] == '' then
+        if MP.searchFilter[1] == '' then
             -- Show placeholder hint
             local inputPos = {imgui.GetItemRectMin()};
             imgui.SetCursorScreenPos({inputPos[1] + 6, inputPos[2] + 3});
@@ -937,9 +1406,13 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
         local childHeight = 200;
         imgui.BeginChild('##comboScroll' .. label, {0, childHeight}, false);
 
-        local filter = searchFilter[1]:lower();
+        local filter = MP.searchFilter[1];
         local matchCount = 0;
         local iconSize = 16;
+        local GOLD_STAR_COLOR = {1.0, 0.88, 0.12, 1.0};
+        local PINK_STAR_COLOR = {1.0, 0.45, 0.72, 1.0};
+        local lastType = nil;
+        local isSearching = filter ~= '';
 
         for _, item in ipairs(items) do
             local itemName = item.name or '';
@@ -950,48 +1423,195 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
                 passesSlotFilter = bit.band(item.slots, slotMask) ~= 0;
             end
 
-            if passesSlotFilter and (filter == '' or itemName:lower():find(filter, 1, true)) then
+            if passesSlotFilter and iconPickerNameMatchesFilter(itemName, filter) then
                 matchCount = matchCount + 1;
+
+                -- Insert type group header when type changes (only when not searching)
+                if not isSearching and item.type and item.type ~= lastType then
+                    if lastType ~= nil then
+                        imgui.Separator();
+                    end
+                    local headerLabel = SPELL_TYPE_HEADERS[item.type] or item.type;
+                    local headerColor = SPELL_TYPE_COLORS[item.type] or COLORS.textDim;
+                    imgui.TextColored(headerColor, headerLabel);
+                    lastType = item.type;
+                end
+
                 local isSelected = currentValue == itemName;
+                local uid = item.id or matchCount;
+                local isSpellWithType = item.type and SPELL_TYPE_COLORS[item.type] ~= nil;
 
-                -- Determine text color: gold if selected, blue if usable, default otherwise
-                local textColor = nil;
-                if isSelected then
-                    textColor = COLORS.gold;
-                elseif item.usable then
-                    textColor = COLORS.usable;
-                end
+                if isSpellWithType and not isSelected then
+                    -- â”€â”€ Two-color spell rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+                    -- [level] â†’ magic type color; name â†’ status color.
+                    -- Use one hit target (InvisibleButton): overlapping Selectable + Text ate clicks.
+                    local levelColor = SPELL_TYPE_COLORS[item.type];
+                    local nameColor = (item.status and STATUS_COLORS[item.status]) or COLORS.text;
+                    local rowW = math.max(60, comboW - 24);
+                    local padY = 2;
+                    local lineH = imgui.GetTextLineHeight();
+                    local rowH = lineH + padY * 2;
 
-                if textColor then
-                    imgui.PushStyleColor(ImGuiCol_Text, textColor);
-                end
+                    imgui.InvisibleButton('##item' .. uid, {rowW, rowH});
+                    local clicked = imgui.IsItemClicked();
+                    local hovered = imgui.IsItemHovered();
 
-                -- Show icon if enabled and item has an id
-                if showIcons and item.id then
-                    -- Use memory-only loading (no PNG creation) for browsing
-                    local icon = actions.GetItemIconForBrowsing(item.id);
-                    if icon and icon.image then
-                        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
-                        if iconPtr then
-                            imgui.Image(iconPtr, {iconSize, iconSize});
-                            imgui.SameLine();
+                    local dl = imgui.GetWindowDrawList();
+                    local rmin = {imgui.GetItemRectMin()};
+                    local tx = rmin[1] + 6;
+                    local ty = rmin[2] + padY;
+                    local curX = tx;
+                    if item.level then
+                        local lvlStr = '[' .. tostring(item.level) .. '] ';
+                        dl:AddText({curX, ty}, imgui.GetColorU32(levelColor), lvlStr);
+                        local lw = imgui.CalcTextSize(lvlStr);
+                        curX = curX + ((type(lw) == 'table' and (lw[1] or lw.x)) or lw);
+                    end
+                    dl:AddText({curX, ty}, imgui.GetColorU32(nameColor), itemName);
+                    local nw = imgui.CalcTextSize(itemName);
+                    curX = curX + ((type(nw) == 'table' and (nw[1] or nw.x)) or nw);
+
+                    local starCol, starTip = nil, nil;
+                    if item.pinkStarTooltip then
+                        starCol = PINK_STAR_COLOR;
+                        starTip = item.pinkStarTooltip;
+                    elseif item.familyVarianceReason then
+                        starCol = GOLD_STAR_COLOR;
+                        starTip = item.familyVarianceReason;
+                    end
+                    if starCol then
+                        dl:AddText({curX + 4, ty}, imgui.GetColorU32(starCol), '*');
+                    end
+
+                    if hovered then
+                        if starTip then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(starTip);
+                            imgui.EndTooltip();
+                        elseif item.reason then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(item.reason);
+                            imgui.EndTooltip();
                         end
                     end
-                end
 
-                local itemLabel = item.level and string.format('[%d] %s', item.level, itemName) or itemName;
-                -- Add quantity for items with count > 1
-                if item.count and item.count > 1 then
-                    itemLabel = itemLabel .. ' x' .. item.count;
-                end
-                if imgui.Selectable(itemLabel .. '##item' .. (item.id or matchCount), isSelected) then
-                    onSelect(item);
-                    searchFilter[1] = '';
-                    imgui.CloseCurrentPopup();
-                end
+                    if clicked then
+                        onSelect(item);
+                        MP.searchFilter[1] = '';
+                        imgui.CloseCurrentPopup();
+                    end
+                else
+                    -- â”€â”€ Standard single-color rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+                    local textColor = nil;
+                    if isSelected then
+                        textColor = COLORS.gold;
+                    elseif useStatusColors and item.status and STATUS_COLORS[item.status] then
+                        textColor = STATUS_COLORS[item.status];
+                    elseif item.usable then
+                        textColor = COLORS.usable;
+                    end
 
-                if textColor then
-                    imgui.PopStyleColor();
+                    local starCol, starTip = nil, nil;
+                    if item.familyVarianceReason then
+                        starCol = GOLD_STAR_COLOR;
+                        starTip = item.familyVarianceReason;
+                    elseif item.pinkStarTooltip then
+                        starCol = PINK_STAR_COLOR;
+                        starTip = item.pinkStarTooltip;
+                    end
+
+                    if starCol and starTip then
+                        local baseCol = isSelected and COLORS.gold or (textColor or COLORS.text);
+                        local rowW = math.max(60, comboW - 24);
+                        local rowH = math.max(iconSize + 4, imgui.GetTextLineHeight() + 6);
+
+                        imgui.InvisibleButton('##item' .. uid, {rowW, rowH});
+                        local clicked = imgui.IsItemClicked();
+                        local hovered = imgui.IsItemHovered();
+
+                        local dl = imgui.GetWindowDrawList();
+                        local rmin = {imgui.GetItemRectMin()};
+                        local curX = rmin[1] + 4;
+                        local curY = rmin[2] + 2;
+
+                        if showIcons and item.id then
+                            local icon = actions.GetItemIconForBrowsing(item.id);
+                            if icon and icon.image then
+                                local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+                                if iconPtr then
+                                    dl:AddImage(iconPtr, {curX, curY}, {curX + iconSize, curY + iconSize});
+                                    curX = curX + iconSize + 6;
+                                end
+                            end
+                        end
+
+                        local labelMain = itemName;
+                        if item.level then
+                            labelMain = string.format('[%d] %s', item.level, itemName);
+                        elseif item.reqStr then
+                            labelMain = string.format('%s  (%s)', itemName, item.reqStr);
+                        end
+                        if item.count and item.count > 1 then
+                            labelMain = labelMain .. ' x' .. item.count;
+                        end
+
+                        local ty = curY + math.max(0, (rowH - imgui.GetTextLineHeight()) / 2 - 2);
+                        dl:AddText({curX, ty}, imgui.GetColorU32(baseCol), labelMain);
+                        local lw = imgui.CalcTextSize(labelMain);
+                        curX = curX + ((type(lw) == 'table' and (lw[1] or lw.x)) or lw);
+                        dl:AddText({curX + 4, ty}, imgui.GetColorU32(starCol), '*');
+
+                        if hovered then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(starTip);
+                            imgui.EndTooltip();
+                        end
+
+                        if clicked then
+                            onSelect(item);
+                            MP.searchFilter[1] = '';
+                            imgui.CloseCurrentPopup();
+                        end
+                    else
+                        if textColor then imgui.PushStyleColor(ImGuiCol_Text, textColor); end
+
+                        -- Show icon if enabled and item has an id
+                        if showIcons and item.id then
+                            local icon = actions.GetItemIconForBrowsing(item.id);
+                            if icon and icon.image then
+                                local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+                                if iconPtr then
+                                    imgui.Image(iconPtr, {iconSize, iconSize});
+                                    imgui.SameLine();
+                                end
+                            end
+                        end
+
+                        local itemLabel;
+                        if item.level then
+                            itemLabel = string.format('[%d] %s', item.level, itemName);
+                        elseif item.reqStr then
+                            itemLabel = string.format('%s  (%s)', itemName, item.reqStr);
+                        else
+                            itemLabel = itemName;
+                        end
+                        if item.count and item.count > 1 then
+                            itemLabel = itemLabel .. ' x' .. item.count;
+                        end
+                        if imgui.Selectable(itemLabel .. '##item' .. uid, isSelected) then
+                            onSelect(item);
+                            MP.searchFilter[1] = '';
+                            imgui.CloseCurrentPopup();
+                        end
+
+                        if item.reason and imgui.IsItemHovered() then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(item.reason);
+                            imgui.EndTooltip();
+                        end
+
+                        if textColor then imgui.PopStyleColor(); end
+                    end
                 end
             end
         end
@@ -1013,34 +1633,127 @@ end
 -- Macro Database Functions
 -- ============================================
 
+-- Clear SMN avatar / BST jug subset palette UI state (when switching macro type or job bucket).
+local function ClearSmnMacroSubsetUi()
+    MP.selectedAvatarPalette = nil;
+    MP.smnShowAllAvatarSubsets = false;
+end
+
+local function ClearBstJugMacroSubsetUi()
+    MP.selectedBstJugMovesKey = nil;
+    MP.bstShowAllJugSubsets = false;
+end
+
+local function ResetPetJobMacroPaletteSubsets()
+    ClearSmnMacroSubsetUi();
+    ClearBstJugMacroSubsetUi();
+end
+
 -- Get current effective type for the palette (selected type or player's current job)
--- Returns GLOBAL_MACRO_KEY for global macros, a job ID, or a composite key like "15:avatar:ifrit"
+-- Returns GLOBAL_MACRO_KEY, ITEMS_MACRO_KEY, a job ID, or a composite key like "15:avatar:ifrit"
 local function GetEffectivePaletteType()
-    if selectedPaletteType then
+    if MP.selectedPaletteType then
         -- If Global is selected, return the global key
-        if selectedPaletteType == GLOBAL_MACRO_KEY then
+        if MP.selectedPaletteType == GLOBAL_MACRO_KEY then
             return GLOBAL_MACRO_KEY;
         end
+        if MP.selectedPaletteType == ITEMS_MACRO_KEY then
+            return ITEMS_MACRO_KEY;
+        end
+        if MP.selectedPaletteType == EQUIPMENT_MACRO_KEY then
+            return EQUIPMENT_MACRO_KEY;
+        end
+        if MP.selectedPaletteType == XIUI_MACRO_KEY then
+            return XIUI_MACRO_KEY;
+        end
+        if type(MP.selectedPaletteType) == 'string' and macroBuckets.isCustomCategoryKey(MP.selectedPaletteType) then
+            return MP.selectedPaletteType;
+        end
         -- If a valid job ID is selected
-        if type(selectedPaletteType) == 'number' and selectedPaletteType > 0 then
+        if type(MP.selectedPaletteType) == 'number' and MP.selectedPaletteType > 0 then
             -- Check for SMN avatar-specific palette
-            if selectedPaletteType == petregistry.JOB_SMN and selectedAvatarPalette then
-                local avatarKey = petregistry.avatars[selectedAvatarPalette];
+            if MP.selectedPaletteType == petregistry.JOB_SMN and MP.selectedAvatarPalette then
+                local avatarKey = petregistry.avatars[MP.selectedAvatarPalette];
                 if avatarKey then
-                    return string.format('%d:avatar:%s', selectedPaletteType, avatarKey);
+                    return string.format('%d:avatar:%s', MP.selectedPaletteType, avatarKey);
                 end
             end
-            return selectedPaletteType;
+            if MP.selectedPaletteType == petregistry.JOB_BST and MP.selectedBstJugMovesKey then
+                return petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(MP.selectedBstJugMovesKey);
+            end
+            return MP.selectedPaletteType;
         end
     end
     -- Default to current player job
     return data.jobId or 1;
+end
+-- Exposed for crossbar drop: must match fallbacks in HandleDropOnSlot (not raw job id for Global/items/etc.)
+M.GetEffectivePaletteType = GetEffectivePaletteType;
+
+--- True when macros are being saved under the Items palette bucket (`macroDB.items`).
+function M.EditorMacroPaletteKeyIsItems(saveKey)
+    local k = saveKey;
+    if k == nil then
+        k = MP.editorPaletteKey;
+    end
+    if k == nil then
+        k = GetEffectivePaletteType();
+    end
+    return data.MacroPaletteKeysEqual(k, ITEMS_MACRO_KEY);
+end
+
+--- Restrict editor to item/macro/equip types when Saving To (or editing) Items palette; coerce illegal types to Item.
+function M.ClampMacroEditorForItemsPalette()
+    if not MP.editingMacro then
+        return;
+    end
+    if not M.EditorMacroPaletteKeyIsItems(MP.editorPaletteKey) then
+        return;
+    end
+    local allowed = { item = true, macro = true, equip = true };
+    local at = MP.editingMacro.actionType or 'item';
+    if not allowed[at] then
+        MP.editingMacro.actionType = 'item';
+        MP.editingMacro.action = '';
+        MP.editorFields.action[1] = '';
+        MP.searchFilter[1] = '';
+        MP.editingMacro.recastSourceType = nil;
+        MP.editingMacro.recastSourceAction = nil;
+        MP.editingMacro.recastSourceItemId = nil;
+        MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES, 'none');
+        MP.editorFields.recastSourceAction[1] = '';
+        MP.editingMacro.showJaBadgeOnMacro = nil;
+        MP.editingMacro.customIconType = 'xiui_default';
+        MP.editingMacro.customIconPath = 'item';
+        MP.editorAutoIconKey = 'xiui_default::item';
+        MP.editorImplicitActionIconDone = false;
+    end
+    MP.editorFields.actionType[1] = MP.FindIndex(ACTION_TYPES, MP.editingMacro.actionType or 'item');
 end
 
 -- Get display name for a palette type key
 local function GetPaletteDisplayName(typeKey)
     if typeKey == GLOBAL_MACRO_KEY then
         return 'Global';
+    end
+    if typeKey == ITEMS_MACRO_KEY then
+        return 'Items';
+    end
+    if typeKey == EQUIPMENT_MACRO_KEY then
+        return 'Equipment';
+    end
+    if typeKey == XIUI_MACRO_KEY then
+        return 'XIUI Commands';
+    end
+    if type(typeKey) == 'string' and macroBuckets.isCustomCategoryKey(typeKey) then
+        if gConfig and gConfig.macroCustomCategories then
+            for _, entry in ipairs(gConfig.macroCustomCategories) do
+                if entry.key == typeKey then
+                    return entry.label or typeKey;
+                end
+            end
+        end
+        return typeKey;
     end
     if type(typeKey) == 'number' then
         return jobs[typeKey] or 'Unknown';
@@ -1055,45 +1768,355 @@ local function GetPaletteDisplayName(typeKey)
                     return string.format('%s (%s)', jobs[tonumber(jobId)] or 'SMN', name);
                 end
             end
+        elseif jobId and petType == petregistry.PET_TYPE_JUG and petId then
+            local petLabel = petregistry.GetDisplayNameForKey(petregistry.PET_TYPE_JUG .. ':' .. petId);
+            return string.format('%s (%s)', jobs[tonumber(jobId)] or 'BST', petLabel);
         end
     end
     return tostring(typeKey);
 end
 
+local function CountMacrosInPalette(paletteKey)
+    if gConfig and gConfig.macroDB and gConfig.macroDB[paletteKey] then
+        return #gConfig.macroDB[paletteKey];
+    end
+    return 0;
+end
+
+-- Cache key so search/icon caches reset when toggling SMN "all subsets" view.
+local SMN_ALL_SUBSETS_VIEW_TAG = '__all_subsets__';
+local BST_ALL_SUBSETS_VIEW_TAG = '__bst_all_jug_subsets__';
+
+local function IsSmnAllSubsetsPaletteView()
+    return MP.selectedPaletteType == petregistry.JOB_SMN and MP.smnShowAllAvatarSubsets;
+end
+
+local function IsBstAllSubsetsPaletteView()
+    return MP.selectedPaletteType == petregistry.JOB_BST and MP.bstShowAllJugSubsets;
+end
+
+--- Stable jug subset rows: picker families (deduped by slug) then extra jug:* keys (e.g. Lynx, Arctic).
+local function BstJugSubsetEntriesOrdered()
+    local rows = {};
+    local seen = {};
+    local jid = petregistry.JOB_BST;
+    for _, row in ipairs(petregistry.GetBstJugReadyFamilyPickerList()) do
+        local slug = row.movesKey:lower();
+        if not seen[slug] then
+            seen[slug] = true;
+            table.insert(rows, {
+                movesKey = row.movesKey,
+                label = row.name,
+                fullKey = petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(row.movesKey),
+            });
+        end
+    end
+    local extras = {};
+    for _, pk in ipairs(petregistry.GetAvailablePetKeys(jid)) do
+        local slug = pk:match('^jug:(.+)$');
+        if slug and not seen[slug] then
+            local mk = petregistry.MovesKeyFromBstMacroPaletteSlug(slug);
+            if mk then
+                seen[slug] = true;
+                table.insert(extras, {
+                    movesKey = mk,
+                    label = petregistry.GetDisplayNameForKey(pk),
+                    fullKey = string.format('%d:%s:%s', jid, petregistry.PET_TYPE_JUG, slug),
+                });
+            end
+        end
+    end
+    table.sort(extras, function(a, b)
+        return (a.label or '') < (b.label or '');
+    end);
+    for _, e in ipairs(extras) do
+        table.insert(rows, e);
+    end
+    return rows;
+end
+
+local function CountBstAllJugSubsetsMacros()
+    local n = CountMacrosInPalette(petregistry.JOB_BST);
+    for _, ent in ipairs(BstJugSubsetEntriesOrdered()) do
+        n = n + CountMacrosInPalette(ent.fullKey);
+    end
+    return n;
+end
+
+local function BuildBstAllJugSubsetsRows()
+    local out = {};
+    local jid = petregistry.JOB_BST;
+    if not gConfig or not gConfig.macroDB then
+        return out;
+    end
+    local baseDb = gConfig.macroDB[jid];
+    if baseDb then
+        for _, m in ipairs(baseDb) do
+            table.insert(out, { macro = m, paletteKey = jid, subsetLabel = 'Base BST' });
+        end
+    end
+    for _, ent in ipairs(BstJugSubsetEntriesOrdered()) do
+        local adb = gConfig.macroDB[ent.fullKey];
+        if adb then
+            for _, m in ipairs(adb) do
+                table.insert(out, { macro = m, paletteKey = ent.fullKey, subsetLabel = ent.label });
+            end
+        end
+    end
+    return out;
+end
+
+local function CountSmnAllSubsetsMacros()
+    local n = 0;
+    local jid = petregistry.JOB_SMN;
+    if not gConfig or not gConfig.macroDB then
+        return 0;
+    end
+    local base = gConfig.macroDB[jid];
+    if base then
+        n = n + #base;
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local ak = petregistry.avatars[avatar];
+        if ak then
+            local fk = string.format('%d:avatar:%s', jid, ak);
+            local adb = gConfig.macroDB[fk];
+            if adb then
+                n = n + #adb;
+            end
+        end
+    end
+    return n;
+end
+
+--- Flatten Base SMN + each avatar macro bucket (order: base, then avatars list order).
+local function BuildSmnAllSubsetsRows()
+    local rows = {};
+    local jid = petregistry.JOB_SMN;
+    if not gConfig or not gConfig.macroDB then
+        return rows;
+    end
+    local baseDb = gConfig.macroDB[jid];
+    if baseDb then
+        for _, m in ipairs(baseDb) do
+            table.insert(rows, { macro = m, paletteKey = jid, subsetLabel = 'Base SMN' });
+        end
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local ak = petregistry.avatars[avatar];
+        if ak then
+            local fk = string.format('%d:avatar:%s', jid, ak);
+            local adb = gConfig.macroDB[fk];
+            if adb then
+                for _, m in ipairs(adb) do
+                    table.insert(rows, { macro = m, paletteKey = fk, subsetLabel = avatar });
+                end
+            end
+        end
+    end
+    return rows;
+end
+
+local function EnsureMacroCustomCategoriesList()
+    if not gConfig.macroCustomCategories then
+        gConfig.macroCustomCategories = {};
+    end
+    if not gConfig.macroCustomNextSeq or gConfig.macroCustomNextSeq < 1 then
+        gConfig.macroCustomNextSeq = 1;
+    end
+end
+
+local function AddMacroCustomCategory(displayLabel)
+    EnsureMacroCustomCategoriesList();
+    local label = tostring(displayLabel or ''):match('^%s*(.-)%s*$') or '';
+    if label == '' then
+        return nil;
+    end
+    local key = macroBuckets.CUSTOM_PREFIX .. tostring(gConfig.macroCustomNextSeq);
+    gConfig.macroCustomNextSeq = gConfig.macroCustomNextSeq + 1;
+    table.insert(gConfig.macroCustomCategories, { key = key, label = label });
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    if not gConfig.macroDB[key] then
+        gConfig.macroDB[key] = {};
+    end
+    return key;
+end
+
+local function RemoveMacroCustomCategory(remKey)
+    if not gConfig.macroCustomCategories then
+        return;
+    end
+    for i, e in ipairs(gConfig.macroCustomCategories) do
+        if e.key == remKey then
+            table.remove(gConfig.macroCustomCategories, i);
+            break;
+        end
+    end
+    if gConfig.macroDB and gConfig.macroDB[remKey] then
+        gConfig.macroDB[remKey] = nil;
+    end
+end
+
+--- Numeric job id from a save key (Global â†’ nil; composite SMN avatar keys â†’ job id).
+local function EditorSaveKeyToJobId(saveKey)
+    if saveKey == GLOBAL_MACRO_KEY or saveKey == ITEMS_MACRO_KEY or saveKey == EQUIPMENT_MACRO_KEY or saveKey == XIUI_MACRO_KEY then
+        return nil;
+    end
+    if type(saveKey) == 'string' and macroBuckets.isCustomCategoryKey(saveKey) then
+        return nil;
+    end
+    if type(saveKey) == 'number' then
+        return saveKey;
+    end
+    if type(saveKey) == 'string' then
+        local jid = saveKey:match('^(%d+):');
+        if jid then
+            return tonumber(jid);
+        end
+    end
+    return nil;
+end
+
+-- While creating an SMN macro, set Save Sub Type to match Avatar Filter when filter is a specific avatar (not "All").
+local function SyncSaveSubTypeFromPetAvatarFilter()
+    if not MP.isCreatingNew then
+        return;
+    end
+    local saveJid = EditorSaveKeyToJobId(MP.editorPaletteKey);
+    if saveJid ~= petregistry.JOB_SMN then
+        return;
+    end
+    if MP.petAvatarFilter <= 1 then
+        return;
+    end
+    local avatarList = petregistry.GetAvatarList();
+    local avatar = avatarList[MP.petAvatarFilter - 1];
+    if not avatar then
+        return;
+    end
+    local avatarKey = petregistry.avatars[avatar];
+    if not avatarKey then
+        return;
+    end
+    MP.editorPaletteKey = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
+end
+
+-- Align create-macro Avatar Filter with "Saving To" / "Save Sub Type" for SMN (independent of Macro Palette window avatar).
+local function SyncPetAvatarFilterFromSaveSubType()
+    local key = MP.editorPaletteKey;
+    if not key then
+        return;
+    end
+    local jid = EditorSaveKeyToJobId(key);
+    if jid ~= petregistry.JOB_SMN then
+        return;
+    end
+    if type(key) == 'number' and key == petregistry.JOB_SMN then
+        MP.petAvatarFilter = 1;
+        MP.cachedPetCommands = nil;
+        return;
+    end
+    if type(key) == 'string' then
+        local jobId, petType, petId = key:match('^(%d+):([^:]+):(.+)$');
+        if jobId and tonumber(jobId) == petregistry.JOB_SMN and petType == 'avatar' and petId then
+            local avatarList = petregistry.GetAvatarList();
+            for i, name in ipairs(avatarList) do
+                if petregistry.avatars[name] == petId then
+                    MP.petAvatarFilter = i + 1;
+                    MP.cachedPetCommands = nil;
+                    return;
+                end
+            end
+        end
+    end
+end
+
+local function SyncBstJugFamilyFromSaveSubType()
+    local key = MP.editorPaletteKey;
+    if not MP.editingMacro then
+        return;
+    end
+    if not key or type(key) ~= 'string' then
+        return;
+    end
+    local jobId, petType, petId = key:match('^(%d+):([^:]+):(.+)$');
+    if not jobId or tonumber(jobId) ~= petregistry.JOB_BST then
+        return;
+    end
+    if petType ~= petregistry.PET_TYPE_JUG then
+        return;
+    end
+    local mk = petregistry.MovesKeyFromBstMacroPaletteSlug(petId);
+    if not mk then
+        return;
+    end
+    MP.editingMacro.bstJugReadyMovesKey = mk;
+    MP.editingMacro.bstJugReadyFamilyLabel = nil;
+    for _, row in ipairs(petregistry.GetBstJugReadyFamilyPickerList()) do
+        if row.movesKey == mk then
+            MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+            break;
+        end
+    end
+end
+
+-- While creating a BST Ready (Use) macro, align Save Sub Type with the picked jug family (SMN avatar parity).
+local function SyncSaveSubTypeFromBstJugFamily()
+    if not MP.isCreatingNew then
+        return;
+    end
+    if EditorSaveKeyToJobId(MP.editorPaletteKey) ~= petregistry.JOB_BST then
+        return;
+    end
+    local mk = MP.editingMacro and MP.editingMacro.bstJugReadyMovesKey;
+    if not mk or mk == '' then
+        return;
+    end
+    MP.editorPaletteKey = petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(mk);
+end
+
+local function SyncMacroEditorSubtypeFieldsFromSaveKey()
+    SyncPetAvatarFilterFromSaveSubType();
+    SyncBstJugFamilyFromSaveSubType();
+end
+
 -- Sync palette to current player job (call on job change)
 function M.SyncToCurrentJob()
-    -- Only sync if not viewing Global - preserve Global selection across job changes
-    if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+    -- Only sync when viewing a job bucket â€” preserve shared/custom macro categories across job changes
+    if not IsSharedJobAgnosticMacroSelection(MP.selectedPaletteType) then
+        MP.selectedPaletteType = data.jobId or 1;
     end
     -- Clear spell/ability/item caches so they rebuild for new job
     playerdata.ClearCache();
-    cachedPetCommands = nil;
-    petAvatarFilter = 1;
-    selectedAvatarPalette = nil;
+    MP.cachedPetCommands = nil;
+    MP.petAvatarFilter = 1;
+    ResetPetJobMacroPaletteSubsets();
     -- Close editor window if open (spells/abilities are job-specific)
-    if editingMacro then
-        editingMacro = nil;
-        isCreatingNew = false;
-        searchFilter[1] = '';
-        iconPickerOpen = false;
+    if MP.editingMacro then
+        MP.editingMacro = nil;
+        MP.isCreatingNew = false;
+        MP.searchFilter[1] = '';
+        MP.iconPickerOpen = false;
+        ClearEditorPreviewIconCache();
     end
     -- Clear macro selection (macros are per-type)
-    selectedMacroIndex = nil;
+    paletteUi.selectedMacroIndex = nil;
     -- If palette is open, immediately refresh the caches
-    if paletteOpen then
+    if paletteUi.open then
         RefreshCachedLists();
     end
 end
 
 -- Clear pet commands cache (call on pet change for BST)
 function M.ClearPetCommandsCache()
-    cachedPetCommands = nil;
+    MP.cachedPetCommands = nil;
 end
 
 -- Get the macro database for selected type (Global or job-specific)
-function M.GetMacroDatabase()
-    local typeKey = GetEffectivePaletteType();
+function M.GetMacroDatabase(typeKeyOverride)
+    local typeKey = typeKeyOverride or GetEffectivePaletteType();
 
     if not gConfig.macroDB then
         gConfig.macroDB = {};
@@ -1106,20 +2129,42 @@ function M.GetMacroDatabase()
     return gConfig.macroDB[typeKey], typeKey;
 end
 
--- Add a new macro to the database
-function M.AddMacro(macroData)
-    local db, _ = M.GetMacroDatabase();
+local function markSharedMacroLibraryDirtyIfNeeded()
+    if gConfig and sharedMacroStore.IsSharedScope(gConfig) then
+        sharedMacroStore.MarkSharedLibraryDirty();
+    end
+end
 
-    -- Generate unique ID
+-- Add a new macro to the database
+function M.AddMacro(macroData, typeKeyOverride)
+    local db, typeKey = M.GetMacroDatabase(typeKeyOverride);
+
+    if typeKey == macroBuckets.GLOBAL and macroGlobalDefaults.IsUniversalTwoHourMacro(macroData) then
+        for _, ex in ipairs(db) do
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(ex) then
+                return nil;
+            end
+        end
+    end
+
+    -- Generate unique ID (per palette bucket). In Shared scope, also consider the frozen profile
+    -- library so new ids never collide with profile hotbar macroRef values in the same bucket.
     local maxId = 0;
     for _, macro in ipairs(db) do
         if macro.id and macro.id > maxId then
             maxId = macro.id;
         end
     end
+    if gConfig and sharedMacroStore.IsSharedScope(gConfig) then
+        local fmax = sharedMacroStore.GetMaxMacroIdInFrozenProfileBucket(typeKey);
+        if fmax > maxId then
+            maxId = fmax;
+        end
+    end
 
     macroData.id = maxId + 1;
     table.insert(db, macroData);
+    markSharedMacroLibraryDirtyIfNeeded();
     SaveSettingsToDisk();
     data.MarkMacroLookupDirty();
 
@@ -1127,13 +2172,17 @@ function M.AddMacro(macroData)
 end
 
 -- Update an existing macro
-function M.UpdateMacro(macroId, macroData)
-    local db = M.GetMacroDatabase();
+function M.UpdateMacro(macroId, macroData, typeKeyOverride)
+    local db = M.GetMacroDatabase(typeKeyOverride);
 
     for i, macro in ipairs(db) do
         if macro.id == macroId then
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                return false;
+            end
             macroData.id = macroId;  -- Preserve ID
             db[i] = macroData;
+            markSharedMacroLibraryDirtyIfNeeded();
             SaveSettingsToDisk();
             -- Clear icon cache so hotbar slots referencing this macro update
             ClearAllIconCaches();
@@ -1145,43 +2194,64 @@ function M.UpdateMacro(macroId, macroData)
     return false;
 end
 
--- Clear all hotbar/crossbar slots that reference a specific macro ID
--- For Global macros, clears from ALL jobs' slot actions
-local function ClearSlotsReferencingMacro(macroId, typeKey)
-    local isGlobalMacro = (typeKey == GLOBAL_MACRO_KEY);
+-- Macro IDs are unique only within one macroDB[typeKey] table; the same numeric id can exist
+-- in Global and in each job palette. Clearing by macroRef alone removed unrelated slots.
+local function CountPaletteBucketsWithMacroId(macroId)
+    if not gConfig or not gConfig.macroDB then
+        return 0;
+    end
+    local n = 0;
+    for _, macros in pairs(gConfig.macroDB) do
+        if type(macros) == 'table' then
+            for _, m in ipairs(macros) do
+                if m.id == macroId then
+                    n = n + 1;
+                    break;
+                end
+            end
+        end
+    end
+    return n;
+end
 
-    -- Clear from all hotbars (1-6)
+-- deletedTypeKey / onlyBucketForThisId / deleteKind: see data.ApplyMacroDeleteToSlotAction
+local function ClearMacroSlotsInConfigTable(cfg, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    if not cfg then
+        return false;
+    end
+    local changed = false;
     for barIndex = 1, 6 do
         local configKey = 'hotbarBar' .. barIndex;
-        if gConfig[configKey] and gConfig[configKey].slotActions then
-            local barSettings = gConfig[configKey];
-
-            -- Clear from ALL storage keys (macro could be on any job:subjob combination)
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
             for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
                 if jobSlotActions then
                     for slotIndex, slotAction in pairs(jobSlotActions) do
-                        if slotAction and slotAction.macroRef == macroId then
-                            jobSlotActions[slotIndex] = { cleared = true };
+                        local newSlot, chg = data.ApplyMacroDeleteToSlotAction(
+                            slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, { cleared = true });
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
                         end
                     end
                 end
             end
         end
     end
-
-    -- Clear from crossbar (all combo modes, all storage keys)
-    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
-        local crossbarSettings = gConfig.hotbarCrossbar;
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
         local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
-
         for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
             if jobSlotActions then
                 for _, comboMode in ipairs(comboModes) do
                     local comboSlots = jobSlotActions[comboMode];
                     if comboSlots then
                         for slotIndex, slotAction in pairs(comboSlots) do
-                            if slotAction and slotAction.macroRef == macroId then
-                                comboSlots[slotIndex] = nil;
+                            local newSlot, chg = data.ApplyMacroDeleteToSlotAction(
+                                slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, nil);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
                             end
                         end
                     end
@@ -1189,18 +2259,207 @@ local function ClearSlotsReferencingMacro(macroId, typeKey)
             end
         end
     end
+    return changed;
 end
 
--- Delete a macro from the database
-function M.DeleteMacro(macroId)
-    local db, typeKey = M.GetMacroDatabase();
+-- Clear every slot that references a removed macroDB bucket (entire key deleted).
+local function ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, removedBucketKey, deleteKind)
+    if not cfg or removedBucketKey == nil then
+        return false;
+    end
+    local changed = false;
+    for barIndex = 1, 6 do
+        local configKey = 'hotbarBar' .. barIndex;
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
+            for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
+                if jobSlotActions then
+                    for slotIndex, slotAction in pairs(jobSlotActions) do
+                        local newSlot, chg = data.ApplyMacroPaletteBucketRemovedToSlotAction(
+                            slotAction, removedBucketKey, deleteKind, { cleared = true });
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
+        local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+        for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
+            if jobSlotActions then
+                for _, comboMode in ipairs(comboModes) do
+                    local comboSlots = jobSlotActions[comboMode];
+                    if comboSlots then
+                        for slotIndex, slotAction in pairs(comboSlots) do
+                            local newSlot, chg = data.ApplyMacroPaletteBucketRemovedToSlotAction(
+                                slotAction, removedBucketKey, deleteKind, nil);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return changed;
+end
+
+local function RemoveCustomCategoryFromProfileMeta(cfg, remKey)
+    if not cfg or not cfg.macroCustomCategories or not remKey then
+        return false;
+    end
+    for i, e in ipairs(cfg.macroCustomCategories) do
+        if e.key == remKey then
+            table.remove(cfg.macroCustomCategories, i);
+            return true;
+        end
+    end
+    return false;
+end
+
+-- Shared library: the bucket is global; other profiles' layouts may still list it or have slots. Sync metadata and slots.
+local function SweepOtherProfilesForSharedCustomCategoryDelete(remKey, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg then
+                local chg = ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, remKey, 'profile');
+                if ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, remKey, 'shared') then
+                    chg = true;
+                end
+                if RemoveCustomCategoryFromProfileMeta(cfg, remKey) then
+                    chg = true;
+                end
+                if chg then
+                    profileManager.SaveProfileSettings(name, cfg);
+                end
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Display label only; storage key stays 'custom:N' (macro data and hotbar macroPaletteKey refs unchanged).
+local function ApplyRenameMacroCustomCategory(catKey, newLabel)
+    if not catKey or not macroBuckets.isCustomCategoryKey(catKey) then
+        return false;
+    end
+    local label = tostring(newLabel or ''):match('^%s*(.-)%s*$') or '';
+    if label == '' then
+        return false;
+    end
+    EnsureMacroCustomCategoriesList();
+    for _, e in ipairs(gConfig.macroCustomCategories) do
+        if e.key == catKey then
+            e.label = label;
+            return true;
+        end
+    end
+    return false;
+end
+
+-- Remove a custom bucket: clear all hotbar/crossbar slot refs, delete macro rows, and sync other profiles in shared mode.
+local function DeleteMacroCustomCategoryCompletely(remKey)
+    if not remKey or not macroBuckets.isCustomCategoryKey(remKey) then
+        return false;
+    end
+    local inShared = (gConfig.macroStorageScope or 'profile') == 'shared';
+    -- Custom buckets use one palette key, but a slot may have profile+shared library arms; clear both.
+    ClearMacroSlotsInConfigForRemovedPaletteBucket(gConfig, remKey, 'profile');
+    ClearMacroSlotsInConfigForRemovedPaletteBucket(gConfig, remKey, 'shared');
+    RemoveMacroCustomCategory(remKey);
+    if inShared and config and config.currentProfile then
+        SweepOtherProfilesForSharedCustomCategoryDelete(remKey, config.currentProfile);
+    end
+    markSharedMacroLibraryDirtyIfNeeded();
+    if MP.selectedPaletteType == remKey then
+        MP.selectedPaletteType = GLOBAL_MACRO_KEY;
+    end
+    ResetPetJobMacroPaletteSubsets();
+    paletteUi.selectedMacroIndex = nil;
+    MP.currentPalettePage = 1;
+    MP.macroCustomRenameTargetKey = nil;
+    playerdata.ClearCache();
+    MP.cachedPetCommands = nil;
+    MP.petAvatarFilter = 1;
+    SaveSettingsToDisk();
+    ClearAllIconCaches();
+    data.InvalidateConfigDerivedCaches();
+    data.MarkMacroLookupDirty();
+    return true;
+end
+
+-- After deleting a global shared macro: clear that ref on all other profile files (current gConfig was already cleared + saved)
+local function SweepOtherProfilesForSharedMacroDelete(macroId, typeKey, onlyBucket, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg and ClearMacroSlotsInConfigTable(cfg, macroId, typeKey, onlyBucket, 'shared') then
+                profileManager.SaveProfileSettings(name, cfg);
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Shared macro library: update bindings on other profiles after MoveMacro (same as delete sweep, but rewrite refs).
+local function SweepOtherProfilesForSharedMacroMove(oldId, oldKey, newId, newKey, onlyBucket, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg and data.RewriteMacroPaletteBindingsInConfig(cfg, oldId, oldKey, newId, newKey, onlyBucket, false) then
+                profileManager.SaveProfileSettings(name, cfg);
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Clear hotbar/crossbar live config (gConfig). Edit Full Palette draft buffers are not scanned here;
+-- dead macroRef in an open draft fixes on Apply (resolve) or when the user edits the slot.
+local function ClearSlotsReferencingMacro(macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    ClearMacroSlotsInConfigTable(gConfig, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind);
+end
+
+-- Delete a macro from the database (optional typeKeyOverride targets a specific macroDB bucket).
+function M.DeleteMacro(macroId, typeKeyOverride)
+    local db, typeKey = M.GetMacroDatabase(typeKeyOverride);
+    local deleteKind = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') and 'shared' or 'profile';
 
     for i, macro in ipairs(db) do
         if macro.id == macroId then
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                return false;
+            end
+            local onlyBucketForThisId = (CountPaletteBucketsWithMacroId(macroId) == 1);
             table.remove(db, i);
-            -- Clear any hotbar/crossbar slots referencing this macro
-            ClearSlotsReferencingMacro(macroId, typeKey);
+            ClearSlotsReferencingMacro(macroId, typeKey, onlyBucketForThisId, deleteKind);
+            markSharedMacroLibraryDirtyIfNeeded();
             SaveSettingsToDisk();
+            if deleteKind == 'shared' and config and config.currentProfile then
+                SweepOtherProfilesForSharedMacroDelete(macroId, typeKey, onlyBucketForThisId, config.currentProfile);
+            end
             -- Clear icon cache so hotbar slots update immediately
             ClearAllIconCaches();
             data.MarkMacroLookupDirty();
@@ -1209,6 +2468,56 @@ function M.DeleteMacro(macroId)
     end
 
     return false;
+end
+
+--- Copy a macro row into destPaletteKey with a new id, rewrite bindings that pointed at (macroId, sourcePaletteKey), then remove the source row.
+--- Profile + shared arms are both updated on current layout; other profiles are swept when macro storage is shared.
+function M.MoveMacroToPalette(macroId, sourcePaletteKey, destPaletteKey)
+    if not gConfig or not gConfig.macroDB or not macroId or sourcePaletteKey == nil or destPaletteKey == nil then
+        return false;
+    end
+    if data.MacroPaletteKeysEqual(sourcePaletteKey, destPaletteKey) then
+        return false;
+    end
+    local dbSrc = gConfig.macroDB[sourcePaletteKey];
+    if type(dbSrc) ~= 'table' then
+        return false;
+    end
+    local macroRow = nil;
+    local macroIdx = nil;
+    for i, m in ipairs(dbSrc) do
+        if m.id == macroId then
+            macroRow = m;
+            macroIdx = i;
+            break;
+        end
+    end
+    if not macroRow then
+        return false;
+    end
+    if macroGlobalDefaults.IsUniversalTwoHourMacro(macroRow) then
+        return false;
+    end
+    local copy = deepCopyTable(macroRow);
+    copy.id = nil;
+    local newId = M.AddMacro(copy, destPaletteKey);
+    if not newId then
+        return false;
+    end
+    local onlyBucketForThisId = (CountPaletteBucketsWithMacroId(macroId) == 1);
+    data.RewriteMacroPaletteBindingsInConfig(gConfig, macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId, true);
+    data.RewriteMacroPaletteBindingsInDraft(macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId);
+    local deleteKind = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') and 'shared' or 'profile';
+    if deleteKind == 'shared' and config and config.currentProfile then
+        SweepOtherProfilesForSharedMacroMove(macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId, config.currentProfile);
+    end
+    table.remove(dbSrc, macroIdx);
+    markSharedMacroLibraryDirtyIfNeeded();
+    SaveSettingsToDisk();
+    ClearAllIconCaches();
+    data.InvalidateConfigDerivedCaches();
+    data.MarkMacroLookupDirty();
+    return true;
 end
 
 -- Get a macro by ID
@@ -1224,19 +2533,103 @@ function M.GetMacroById(macroId)
     return nil;
 end
 
+-- opts.bindTargetSlot = { comboMode = string, slotIndex = number } — when present AND the
+-- editor enters "creating new" mode (slotData nil), the first successful Save will write the
+-- new macro's binding into that crossbar draft slot. Consumed exactly once on first Save;
+-- cleared on Cancel/close to prevent stale binds carrying over to unrelated sessions.
+function M.OpenEditorForSlotData(slotData, opts)
+    ClearEditorPreviewIconCache();
+    MP.editorDidInitialIconPick = false;
+    MP.editorImplicitActionIconDone = false;
+    MP.editorIconManuallySet = false;
+    MP.editorJaBadgeManuallySet = false;
+    MP.showAllMode = false;
+    MP.showAllPetMode = false;
+    MP.spellTypeFilter = 'All';
+    MP.abilityJobFilter = 0;
+    MP.petTypeOverride = 0;
+    MP.editorIconPrefsHydrated = false;
+    MP.pendingNewMacroBindTarget = nil;
+
+    if slotData and slotData.macroRef then
+        local paletteKey = slotData.macroPaletteKey or data.jobId or 1;
+        local macro = data.GetMacroById(slotData.macroRef, paletteKey);
+        if macro then
+            MP.editingMacro = deep_copy_table(macro);
+            MP.isCreatingNew = false;
+            MP.editorPaletteKey = paletteKey;
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            RefreshCachedLists();
+            return;
+        end
+    end
+
+    if slotData then
+        MP.editingMacro = deep_copy_table(slotData);
+        MP.isCreatingNew = false;
+        MP.editorPaletteKey = slotData.macroPaletteKey or GetEffectivePaletteType();
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+    else
+        MP.isCreatingNew = true;
+        MP.editorPaletteKey = GetEffectivePaletteType();
+        local body, autoKey = DefaultNewMacroBodyForPaletteKey(MP.editorPaletteKey);
+        MP.editingMacro = body;
+        MP.editorAutoIconKey = autoKey;
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+        if opts and opts.bindTargetSlot and opts.bindTargetSlot.comboMode and opts.bindTargetSlot.slotIndex then
+            MP.pendingNewMacroBindTarget = {
+                comboMode = opts.bindTargetSlot.comboMode,
+                slotIndex = opts.bindTargetSlot.slotIndex,
+            };
+        end
+    end
+    RefreshCachedLists();
+end
+
+-- Open the macro editor as a new macro pre-filled with a raw macro text command.
+-- The palette window is opened automatically; the user can choose where to save.
+function M.OpenNewMacroWithText(macroText, displayName)
+    M.OpenPalette();
+    ClearEditorPreviewIconCache();
+    MP.isCreatingNew              = true;
+    MP.editorDidInitialIconPick   = false;
+    MP.editorImplicitActionIconDone = false;
+    MP.editorIconManuallySet      = false;
+    MP.editorJaBadgeManuallySet   = false;
+    MP.editingMacro = {
+        actionType  = 'macro',
+        macroText   = macroText,
+        displayName = displayName or '',
+        action      = '',
+    };
+    if MP.editorFields and MP.FindIndex then
+        MP.editorFields.actionType[1]       = MP.FindIndex(MP.ACTION_TYPES or {}, 'macro');
+        MP.editorFields.action[1]           = '';
+        MP.editorFields.target[1]           = MP.FindIndex(MP.TARGET_OPTIONS or {}, 't');
+        MP.editorFields.displayName[1]      = displayName or '';
+        MP.editorFields.macroText[1]        = macroText;
+        MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES or {}, 'none');
+        MP.editorFields.recastSourceAction[1] = '';
+    end
+end
+
 -- ============================================
 -- Drag & Drop Functions (using dragdrop library)
 -- ============================================
 
 -- Start dragging a macro from the palette
-function M.StartDragMacro(macroIndex, macroData)
+function M.StartDragMacro(macroIndex, macroData, macroPaletteKeyOverride)
     -- Get icon for this macro
     local icon = actions.GetBindIcon(macroData);
 
     -- Include palette key in data so crossbar drops know which palette the macro came from
     local dragData = {};
     for k, v in pairs(macroData) do dragData[k] = v; end
-    dragData.macroPaletteKey = GetEffectivePaletteType();
+    dragData.macroPaletteKey = macroPaletteKeyOverride or GetEffectivePaletteType();
+    dragData.macroSourceStore = M.GetMacroSourceTagForDrops();
 
     dragdrop.StartDrag('macro', {
         data = dragData,
@@ -1248,22 +2641,32 @@ end
 
 -- Start dragging from a hotbar slot
 function M.StartDragSlot(barIndex, slotIndex, slotData)
-    -- Empty/orphaned slot - nothing to drag
+    -- 1.8.0 defensive guard: empty/orphaned slots have nothing to drag; dragdrop.StartDrag
+    -- with a nil payload bypassed the displayName fallback below and started a "ghost" drag
+    -- in 1.7.5 that confused the drop-zone logic. Bail early instead.
     if not slotData then return; end
-
     -- Get icon for this slot
     local icon = actions.GetBindIcon(slotData);
-
+    -- Raw slot preserves dual profile/shared macro arms (resolved slotData is flattened)
+    local raw = data.GetRawHotbarSlotAction(barIndex, slotIndex);
     dragdrop.StartDrag('slot', {
-        data = slotData,
+        data = raw,
         barIndex = barIndex,
         slotIndex = slotIndex,
-        label = slotData.displayName or slotData.action or 'Slot',
+        label = slotData and (slotData.displayName or slotData.action) or 'Slot',
         icon = icon,
     });
 end
 
 -- Clear drag state
+-- 'shared' | 'profile' â€” which library new hotbar/crossbar binds refer to (for delete + cross-scope resolution)
+function M.GetMacroSourceTagForDrops()
+    if gConfig and (gConfig.macroStorageScope or 'profile') == 'shared' then
+        return 'shared';
+    end
+    return 'profile';
+end
+
 function M.ClearDrag()
     dragdrop.CancelDrag();
 end
@@ -1313,53 +2716,58 @@ function M.HandleDropOnSlot(payload, targetBarIndex, targetSlotIndex)
     local jobSlotActions = ensureSlotActionsStructure(gConfig[configKey], storageKey);
 
     if payload.type == 'macro' then
-        -- Dragging from palette to slot - store only the macro reference.
-        -- macroDB is the single source of truth for action/macroText/displayName/etc.
+        -- Dragging from palette to slot
         local macroData = payload.data;
         if macroData then
-            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite({
-                macroRef = macroData.id,
-                macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType(),
-            });
+            local macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType();
+            local arm = {};
+            for k, v in pairs(macroData) do arm[k] = v; end
+            arm.macroPaletteKey = macroPaletteKey;
+            arm.macroRef = macroData.id;
+            local existing = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+            local store = arm.macroSourceStore or M.GetMacroSourceTagForDrops();
+            local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+            jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(built);
             MarkHotbarDirty();
         end
 
     elseif payload.type == 'slot' then
-        -- Dragging from slot to slot (swap or move)
+        -- Dragging from slot to slot (swap)
         local sourceBarIndex = payload.barIndex;
         local sourceSlotIndex = payload.slotIndex;
-        local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
-
-        local sourceData = data.BuildSlotDataForWrite(payload.data);
-
-        -- Get target slot data
-        local targetBind = data.GetKeybindForSlot(targetBarIndex, targetSlotIndex);
-        local targetData;
-        if targetBind then
-            targetData = data.BuildSlotDataForWrite(targetBind);
-        else
-            -- Target slot is empty - mark as cleared
-            targetData = { cleared = true };
+        if sourceBarIndex == targetBarIndex and sourceSlotIndex == targetSlotIndex then
+            return false;
         end
-
-        -- Ensure source config structure exists
+        local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
         if not gConfig[sourceConfigKey] then
             gConfig[sourceConfigKey] = {};
         end
-        -- Use pet-aware storage key for source bar
         local sourceStorageKey = data.GetStorageKeyForBar(sourceBarIndex);
         local sourceJobSlotActions = ensureSlotActionsStructure(gConfig[sourceConfigKey], sourceStorageKey);
-
-        -- Swap the slots
-        jobSlotActions[targetSlotIndex] = sourceData;
-        sourceJobSlotActions[sourceSlotIndex] = targetData;
-
+        local sourceRaw = data.GetRawHotbarSlotAction(sourceBarIndex, sourceSlotIndex);
+        local targetRaw = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+        local newTarget, newSource = data.SwapActiveMacroArmsInPlace(sourceRaw, targetRaw);
+        jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(newTarget);
+        sourceJobSlotActions[sourceSlotIndex] = data.FinalizeHotbarRawSlotForStorage(newSource);
         MarkHotbarDirty();
 
     elseif payload.type == 'crossbar_slot' then
         -- Dragging from crossbar to hotbar (one-way copy, doesn't clear source)
-        if payload.data then
-            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite(payload.data);
+        local crossRaw = payload.data;
+        if crossRaw and not crossRaw.cleared then
+            local existing = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+            local isMacro = data.IsMacroSlotDualLayout(crossRaw)
+                or (crossRaw.macroRef and (not crossRaw.actionType or crossRaw.actionType == 'macro'));
+            if isMacro then
+                local arm = select(1, data._GetActiveMacroBindingFromSlot(crossRaw));
+                if arm and arm.macroRef then
+                    local store = arm.macroSourceStore or M.GetMacroSourceTagForDrops();
+                    local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                    jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(built);
+                end
+            else
+                jobSlotActions[targetSlotIndex] = deepCopyTable(crossRaw);
+            end
             MarkHotbarDirty();
         end
     end
@@ -1386,14 +2794,15 @@ end
 -- ============================================
 
 function M.OpenPalette()
-    paletteOpen = true;
-    selectedMacroIndex = nil;
-    editingMacro = nil;
-    isCreatingNew = false;
+    paletteUi.open = true;
+    paletteUi.selectedMacroIndex = nil;
+    MP.editingMacro = nil;
+    MP.isCreatingNew = false;
+    ClearEditorPreviewIconCache();
 
-    -- Sync to current player job when opening (unless Global was selected)
-    if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+    -- Sync to current player job when opening (unless a shared or custom category was selected)
+    if not IsSharedJobAgnosticMacroSelection(MP.selectedPaletteType) then
+        MP.selectedPaletteType = data.jobId or 1;
     end
 
     -- Refresh spell/ability/weaponskill caches
@@ -1406,19 +2815,30 @@ function M.ClosePalette()
         SaveSettingsToDisk();
         hotbarDataDirty = false;
     end
-    paletteOpen = false;
-    selectedMacroIndex = nil;
-    editingMacro = nil;
-    isCreatingNew = false;
-    currentPalettePage = 1;  -- Reset to page 1
+    paletteUi.open = false;
+    paletteUi.selectedMacroIndex = nil;
+    MP.editingMacro = nil;
+    MP.isCreatingNew = false;
+    MP.currentPalettePage = 1;  -- Reset to page 1
+    if MP.macroPaletteSearchName then
+        MP.macroPaletteSearchName[1] = '';
+    end
+    MP._lastMacroPaletteSearch = nil;
+    MP.editorDidInitialIconPick = false;
+    MP.editorIconManuallySet = false;
+    MP.editorJaBadgeManuallySet = false;
+    ClearEditorPreviewIconCache();
+    paletteMainIconCache = {};
+    ClearPaletteJaBadgeIconCache();
+    paletteIconCacheDbKey = nil;
 end
 
 function M.IsPaletteOpen()
-    return paletteOpen;
+    return paletteUi.open;
 end
 
 function M.TogglePalette()
-    if paletteOpen then
+    if paletteUi.open then
         M.ClosePalette();
     else
         M.OpenPalette();
@@ -1427,7 +2847,7 @@ end
 
 -- Draw a single macro tile (used in palette)
 local function DrawMacroTile(macro, index, x, y, size)
-    local isSelected = selectedMacroIndex == index;
+    local isSelected = paletteUi.selectedMacroIndex == index;
     local isHovered = false;
 
     -- Set cursor position
@@ -1446,13 +2866,13 @@ local function DrawMacroTile(macro, index, x, y, size)
         imgui.PushStyleColor(ImGuiCol_ButtonActive, COLORS.bgLight);
     end
 
-    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4);
+    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, PALETTE_TILE_ROUNDING);
     imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
     imgui.PushStyleColor(ImGuiCol_Border, isSelected and COLORS.gold or COLORS.border);
 
     local buttonId = string.format('##macrotile%d', index);
     if imgui.Button(buttonId, {size, size}) then
-        selectedMacroIndex = index;
+        paletteUi.selectedMacroIndex = index;
     end
 
     imgui.PopStyleColor(4);
@@ -1508,17 +2928,21 @@ local function DrawMacroTile(macro, index, x, y, size)
         imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {8, 6});
         imgui.BeginTooltip();
-        imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
-        imgui.Spacing();
-        imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
-        if macro.actionType ~= 'macro' and macro.target then
-            local formattedTarget = FormatTargetForDisplay(macro.target);
-            if formattedTarget then
-                imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+        if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+            imgui.TextColored(COLORS.gold, '2-Hour Ability');
+        else
+            imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
+            if macro.actionType ~= 'macro' and macro.target then
+                local formattedTarget = FormatTargetForDisplay(macro.target);
+                if formattedTarget then
+                    imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                end
             end
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
         end
-        imgui.Spacing();
-        imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
         imgui.EndTooltip();
         imgui.PopStyleVar();
         imgui.PopStyleColor(2);
@@ -1572,43 +2996,353 @@ for i, job in ipairs(JOB_LIST) do
     JOB_ID_MAP[job.id] = i;
 end
 
--- Draw the palette window
-function M.DrawPalette()
-    if not paletteOpen then
+local function PickDefaultMacroMoveDestination(sourceKey)
+    local order = { GLOBAL_MACRO_KEY, ITEMS_MACRO_KEY, EQUIPMENT_MACRO_KEY, XIUI_MACRO_KEY };
+    for _, k in ipairs(order) do
+        if not data.MacroPaletteKeysEqual(k, sourceKey) then
+            return k;
+        end
+    end
+    EnsureMacroCustomCategoriesList();
+    for _, cat in ipairs(gConfig and gConfig.macroCustomCategories or {}) do
+        local k = cat.key;
+        if not data.MacroPaletteKeysEqual(k, sourceKey) then
+            return k;
+        end
+    end
+    for _, job in ipairs(JOB_LIST) do
+        if not data.MacroPaletteKeysEqual(job.id, sourceKey) then
+            return job.id;
+        end
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local avatarKey = petregistry.avatars[avatar];
+        if avatarKey then
+            local fk = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
+            if not data.MacroPaletteKeysEqual(fk, sourceKey) then
+                return fk;
+            end
+        end
+    end
+    for _, pk in ipairs(petregistry.GetAvailablePetKeys(petregistry.JOB_BST)) do
+        local slug = pk:match('^jug:(.+)$');
+        if slug then
+            local fk = string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug);
+            if not data.MacroPaletteKeysEqual(fk, sourceKey) then
+                return fk;
+            end
+        end
+    end
+    return GLOBAL_MACRO_KEY;
+end
+
+-- Bottom-right /ja badge on macro tiles (same corner style as small status icons on slots).
+-- Declared before M.DrawPalette so palette grid can call it (Lua local scope).
+local function DrawMacroJaBadgeOverlay(drawList, macro, x, y, boxSize)
+    if not drawList or not macro or macro.actionType ~= 'macro' or not macro.macroText then
         return;
     end
+    if macro.showJaBadgeOnMacro == false then
+        return;
+    end
+    local jaName = actions.GetMacroJaBadgeAbilityName(macro.macroText);
+    if not jaName or jaName == '' then
+        return;
+    end
+    local jbKey = BuildMacroJaBadgeCacheKey(macro);
+    local jaIcon = paletteJaBadgeIconCache[jbKey];
+    if jaIcon == nil then
+        jaIcon = actions.ResolveMacroJaBadgeIcon(macro) or PALETTE_JA_NONE;
+        paletteJaBadgeIconCache[jbKey] = jaIcon;
+    end
+    if jaIcon == PALETTE_JA_NONE or not jaIcon.image then
+        return;
+    end
+    local iconPtr = tonumber(ffi.cast('uint32_t', jaIcon.image));
+    if not iconPtr or iconPtr == 0 then
+        return;
+    end
+    local iconSize = math.max(10, math.floor(boxSize * 0.35));
+    local padding = 2;
+    local iconX = x + boxSize - iconSize - padding;
+    local iconY = y + boxSize - iconSize - padding;
+    drawList:AddImage(iconPtr, {iconX, iconY}, {iconX + iconSize, iconY + iconSize});
+end
+
+-- Draw icon preview box with current icon (macro editor); must be above DrawIconButton users.
+local function DrawIconPreview(macro, x, y, size)
+    local drawList = imgui.GetWindowDrawList();
+    if not drawList then return; end
+
+    local bgColor = imgui.GetColorU32({0.1, 0.09, 0.08, 0.95});
+    local borderColor = imgui.GetColorU32(COLORS.border);
+    drawList:AddRectFilled({x, y}, {x + size, y + size}, bgColor, 4);
+    drawList:AddRect({x, y}, {x + size, y + size}, borderColor, 4, 0, 1);
+
+    local pvKey = BuildMacroMainIconCacheKey(macro);
+    if pvKey ~= editorPreviewIconKey then
+        editorPreviewIconKey = pvKey;
+        editorPreviewCachedIcon = actions.GetBindIcon(macro);
+    end
+    local icon = editorPreviewCachedIcon;
+    if icon and icon.image then
+        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+        if iconPtr then
+            local padding = 4;
+            drawList:AddImage(
+                iconPtr,
+                {x + padding, y + padding},
+                {x + size - padding, y + size - padding}
+            );
+        end
+    else
+        local abbr = GetActionAbbreviation(macro, true);
+        local textSize = imgui.CalcTextSize(abbr);
+        local textX = x + (size - textSize) / 2;
+        local textY = y + (size - 14) / 2;
+        local textColor = imgui.GetColorU32(COLORS.gold);
+        drawList:AddText({textX, textY}, textColor, abbr);
+    end
+
+    DrawMacroJaBadgeOverlay(drawList, macro, x, y, size);
+end
+
+-- Draw the palette window (Lua 5.1: max 60 upvalues per function; heavy body uses MacroPaletteDrawEnv.)
+local MacroPaletteDrawEnv = {};
+
+local function InitMacroPaletteDrawEnv()
+    local E = MacroPaletteDrawEnv;
+    E.imgui = imgui;
+    E.ffi = ffi;
+    E.data = data;
+    E.actions = actions;
+    E.textures = textures;
+    E.dragdrop = dragdrop;
+    E.petregistry = petregistry;
+    E.playerdata = playerdata;
+    E.petpalette = petpalette;
+    E.sharedMacroStore = sharedMacroStore;
+    E.macroBuckets = macroBuckets;
+    E.COLORS = COLORS;
+    E.MP = MP;
+    E.M = M;
+    E.paletteUi = paletteUi;
+    E.JOB_LIST = JOB_LIST;
+    E.INPUT_BUFFER_SIZE = INPUT_BUFFER_SIZE;
+    E.GLOBAL_MACRO_KEY = GLOBAL_MACRO_KEY;
+    E.ITEMS_MACRO_KEY = ITEMS_MACRO_KEY;
+    E.EQUIPMENT_MACRO_KEY = EQUIPMENT_MACRO_KEY;
+    E.XIUI_MACRO_KEY = XIUI_MACRO_KEY;
+    E.PALETTE_COLUMNS = PALETTE_COLUMNS;
+    E.PALETTE_ROWS = PALETTE_ROWS;
+    E.PALETTE_MACROS_PER_PAGE = PALETTE_MACROS_PER_PAGE;
+    E.PALETTE_TILE_SIZE = PALETTE_TILE_SIZE;
+    E.PALETTE_TILE_GAP = PALETTE_TILE_GAP;
+    E.PALETTE_TILE_ROUNDING = PALETTE_TILE_ROUNDING;
+    E.SMN_ALL_SUBSETS_VIEW_TAG = SMN_ALL_SUBSETS_VIEW_TAG;
+    E.BST_ALL_SUBSETS_VIEW_TAG = BST_ALL_SUBSETS_VIEW_TAG;
+    E.ACTION_TYPE_LABELS = ACTION_TYPE_LABELS;
+    E.RefreshCachedLists = RefreshCachedLists;
+    E.BuildSmnAllSubsetsRows = BuildSmnAllSubsetsRows;
+    E.BuildBstAllJugSubsetsRows = BuildBstAllJugSubsetsRows;
+    E.IsSmnAllSubsetsPaletteView = IsSmnAllSubsetsPaletteView;
+    E.IsBstAllSubsetsPaletteView = IsBstAllSubsetsPaletteView;
+    E.GetPaletteDisplayName = GetPaletteDisplayName;
+    E.PushWindowStyle = PushWindowStyle;
+    E.PopWindowStyle = PopWindowStyle;
+    E.PushComboStyle = PushComboStyle;
+    E.PopComboStyle = PopComboStyle;
+    E.ClearAllIconCaches = ClearAllIconCaches;
+    E.ResetPetJobMacroPaletteSubsets = ResetPetJobMacroPaletteSubsets;
+    E.EnsureMacroCustomCategoriesList = EnsureMacroCustomCategoriesList;
+    E.AddMacroCustomCategory = AddMacroCustomCategory;
+    E.markSharedMacroLibraryDirtyIfNeeded = markSharedMacroLibraryDirtyIfNeeded;
+    E.ApplyRenameMacroCustomCategory = ApplyRenameMacroCustomCategory;
+    E.DeleteMacroCustomCategoryCompletely = DeleteMacroCustomCategoryCompletely;
+    E.CountMacrosInPalette = CountMacrosInPalette;
+    E.CountSmnAllSubsetsMacros = CountSmnAllSubsetsMacros;
+    E.CountBstAllJugSubsetsMacros = CountBstAllJugSubsetsMacros;
+    E.GetEffectivePaletteType = GetEffectivePaletteType;
+    E.ClearBstJugMacroSubsetUi = ClearBstJugMacroSubsetUi;
+    E.ClearSmnMacroSubsetUi = ClearSmnMacroSubsetUi;
+    E.BstJugSubsetEntriesOrdered = BstJugSubsetEntriesOrdered;
+    E.SyncMacroEditorSubtypeFieldsFromSaveKey = SyncMacroEditorSubtypeFieldsFromSaveKey;
+    E.GetCachedPaletteMainIcon = GetCachedPaletteMainIcon;
+    E.DrawMacroJaBadgeOverlay = DrawMacroJaBadgeOverlay;
+    E.FormatTargetForDisplay = FormatTargetForDisplay;
+    E.ClearEditorPreviewIconCache = ClearEditorPreviewIconCache;
+end
+
+InitMacroPaletteDrawEnv();
+
+local function DrawPaletteBody()
+    local E = MacroPaletteDrawEnv;
+    local imgui = E.imgui;
+    local ffi = E.ffi;
+    local data = E.data;
+    local actions = E.actions;
+    local textures = E.textures;
+    local dragdrop = E.dragdrop;
+    local petregistry = E.petregistry;
+    local playerdata = E.playerdata;
+    local petpalette = E.petpalette;
+    local sharedMacroStore = E.sharedMacroStore;
+    local macroBuckets = E.macroBuckets;
+    local COLORS = E.COLORS;
+    local MP = E.MP;
+    local M = E.M;
+    local paletteUi = E.paletteUi;
+    local JOB_LIST = E.JOB_LIST;
+    local INPUT_BUFFER_SIZE = E.INPUT_BUFFER_SIZE;
+    local GLOBAL_MACRO_KEY = E.GLOBAL_MACRO_KEY;
+    local ITEMS_MACRO_KEY = E.ITEMS_MACRO_KEY;
+    local EQUIPMENT_MACRO_KEY = E.EQUIPMENT_MACRO_KEY;
+    local XIUI_MACRO_KEY = E.XIUI_MACRO_KEY;
+    local PALETTE_COLUMNS = E.PALETTE_COLUMNS;
+    local PALETTE_ROWS = E.PALETTE_ROWS;
+    local PALETTE_MACROS_PER_PAGE = E.PALETTE_MACROS_PER_PAGE;
+    local PALETTE_TILE_SIZE = E.PALETTE_TILE_SIZE;
+    local PALETTE_TILE_GAP = E.PALETTE_TILE_GAP;
+    local PALETTE_TILE_ROUNDING = E.PALETTE_TILE_ROUNDING;
+    local SMN_ALL_SUBSETS_VIEW_TAG = E.SMN_ALL_SUBSETS_VIEW_TAG;
+    local BST_ALL_SUBSETS_VIEW_TAG = E.BST_ALL_SUBSETS_VIEW_TAG;
+    local ACTION_TYPE_LABELS = E.ACTION_TYPE_LABELS;
+    local RefreshCachedLists = E.RefreshCachedLists;
+    local BuildSmnAllSubsetsRows = E.BuildSmnAllSubsetsRows;
+    local BuildBstAllJugSubsetsRows = E.BuildBstAllJugSubsetsRows;
+    local IsSmnAllSubsetsPaletteView = E.IsSmnAllSubsetsPaletteView;
+    local IsBstAllSubsetsPaletteView = E.IsBstAllSubsetsPaletteView;
+    local GetPaletteDisplayName = E.GetPaletteDisplayName;
+    local PushWindowStyle = E.PushWindowStyle;
+    local PopWindowStyle = E.PopWindowStyle;
+    local PushComboStyle = E.PushComboStyle;
+    local PopComboStyle = E.PopComboStyle;
+    local ClearAllIconCaches = E.ClearAllIconCaches;
+    local ResetPetJobMacroPaletteSubsets = E.ResetPetJobMacroPaletteSubsets;
+    local EnsureMacroCustomCategoriesList = E.EnsureMacroCustomCategoriesList;
+    local AddMacroCustomCategory = E.AddMacroCustomCategory;
+    local markSharedMacroLibraryDirtyIfNeeded = E.markSharedMacroLibraryDirtyIfNeeded;
+    local ApplyRenameMacroCustomCategory = E.ApplyRenameMacroCustomCategory;
+    local DeleteMacroCustomCategoryCompletely = E.DeleteMacroCustomCategoryCompletely;
+    local CountMacrosInPalette = E.CountMacrosInPalette;
+    local CountSmnAllSubsetsMacros = E.CountSmnAllSubsetsMacros;
+    local CountBstAllJugSubsetsMacros = E.CountBstAllJugSubsetsMacros;
+    local GetEffectivePaletteType = E.GetEffectivePaletteType;
+    local ClearBstJugMacroSubsetUi = E.ClearBstJugMacroSubsetUi;
+    local ClearSmnMacroSubsetUi = E.ClearSmnMacroSubsetUi;
+    local BstJugSubsetEntriesOrdered = E.BstJugSubsetEntriesOrdered;
+    local SyncMacroEditorSubtypeFieldsFromSaveKey = E.SyncMacroEditorSubtypeFieldsFromSaveKey;
+    local GetCachedPaletteMainIcon = E.GetCachedPaletteMainIcon;
+    local DrawMacroJaBadgeOverlay = E.DrawMacroJaBadgeOverlay;
+    local FormatTargetForDisplay = E.FormatTargetForDisplay;
+    local ClearEditorPreviewIconCache = E.ClearEditorPreviewIconCache;
 
     -- Continuously check for job changes while palette is open
     -- This catches cases where job changed but cache wasn't refreshed properly
     RefreshCachedLists();
 
-    -- Initialize selectedPaletteType to current job if not set
-    if not selectedPaletteType then
-        selectedPaletteType = data.jobId or 1;
+    -- Initialize MP.selectedPaletteType to current job if not set
+    if not MP.selectedPaletteType then
+        MP.selectedPaletteType = data.jobId or 1;
     end
 
-    local db, typeKey = M.GetMacroDatabase();
+    local smnMergeMeta = nil;
+    local bstMergeMeta = nil;
+    local db;
+    local typeKey;
+    if IsSmnAllSubsetsPaletteView() then
+        smnMergeMeta = BuildSmnAllSubsetsRows();
+        db = {};
+        for i, row in ipairs(smnMergeMeta) do
+            db[i] = row.macro;
+        end
+        typeKey = petregistry.JOB_SMN;
+    elseif IsBstAllSubsetsPaletteView() then
+        bstMergeMeta = BuildBstAllJugSubsetsRows();
+        db = {};
+        for i, row in ipairs(bstMergeMeta) do
+            db[i] = row.macro;
+        end
+        typeKey = petregistry.JOB_BST;
+    else
+        db, typeKey = M.GetMacroDatabase();
+    end
+
+    local paletteViewCacheKey = smnMergeMeta and (tostring(petregistry.JOB_SMN) .. ':' .. SMN_ALL_SUBSETS_VIEW_TAG)
+        or (bstMergeMeta and (tostring(petregistry.JOB_BST) .. ':' .. BST_ALL_SUBSETS_VIEW_TAG))
+        or typeKey;
+    if MP._macroSearchPaletteKey ~= paletteViewCacheKey then
+        MP._macroSearchPaletteKey = paletteViewCacheKey;
+        MP.macroPaletteSearchName[1] = '';
+        MP._lastMacroPaletteSearch = nil;
+    end
+    if paletteIconCacheDbKey ~= paletteViewCacheKey then
+        paletteMainIconCache = {};
+        paletteJaBadgeIconCache = {};
+        paletteIconCacheDbKey = paletteViewCacheKey;
+    end
     local isGlobal = (typeKey == GLOBAL_MACRO_KEY);
+    local isItems = (typeKey == ITEMS_MACRO_KEY);
+    local isEquipment = (typeKey == EQUIPMENT_MACRO_KEY);
+    local isXiui = (typeKey == XIUI_MACRO_KEY);
+    local isCustomMacroBucket = macroBuckets.isCustomCategoryKey(typeKey);
+    local isSharedMacroPalette = isGlobal or isItems or isEquipment or isXiui or isCustomMacroBucket;
     local typeName = GetPaletteDisplayName(typeKey);
     local currentPlayerJob = data.jobId or 1;
-    -- For SMN with avatar selected, check base job ID
     local baseJobId = type(typeKey) == 'number' and typeKey or tonumber(tostring(typeKey):match('^(%d+)'));
-    local isViewingCurrentJob = (not isGlobal and baseJobId == currentPlayerJob);
+    local isViewingCurrentJob = (not isSharedMacroPalette and baseJobId == currentPlayerJob);
 
-    -- Calculate pagination
-    local totalMacros = #db;
+    -- Name filter (substring match on display name or action name; case-insensitive)
+    local needleRaw = (MP.macroPaletteSearchName[1] or ''):match('^%s*(.-)%s*$') or '';
+    if MP._lastMacroPaletteSearch ~= needleRaw then
+        MP._lastMacroPaletteSearch = needleRaw;
+        MP.currentPalettePage = 1;
+    end
+
+    local filteredIndices = {};
+    if needleRaw == '' then
+        for i = 1, #db do
+            filteredIndices[i] = i;
+        end
+    else
+        local needle = needleRaw:lower();
+        for i = 1, #db do
+            local m = db[i];
+            local disp = (m.displayName or ''):lower();
+            local act = (m.action or ''):lower();
+            if disp:find(needle, 1, true) or act:find(needle, 1, true) then
+                table.insert(filteredIndices, i);
+            end
+        end
+    end
+
+    if paletteUi.selectedMacroIndex then
+        local selOk = false;
+        for _, fi in ipairs(filteredIndices) do
+            if fi == paletteUi.selectedMacroIndex then
+                selOk = true;
+                break;
+            end
+        end
+        if not selOk then
+            paletteUi.selectedMacroIndex = nil;
+        end
+    end
+
+    -- Calculate pagination (filtered list)
+    local totalMacros = #filteredIndices;
     local totalPages = math.max(1, math.ceil(totalMacros / PALETTE_MACROS_PER_PAGE));
 
     -- Clamp current page to valid range
-    if currentPalettePage > totalPages then
-        currentPalettePage = totalPages;
+    if MP.currentPalettePage > totalPages then
+        MP.currentPalettePage = totalPages;
     end
-    if currentPalettePage < 1 then
-        currentPalettePage = 1;
+    if MP.currentPalettePage < 1 then
+        MP.currentPalettePage = 1;
     end
 
     -- Calculate how many macros/rows on this page
-    local startIdx = (currentPalettePage - 1) * PALETTE_MACROS_PER_PAGE + 1;
+    local startIdx = (MP.currentPalettePage - 1) * PALETTE_MACROS_PER_PAGE + 1;
     local endIdx = math.min(startIdx + PALETTE_MACROS_PER_PAGE - 1, totalMacros);
     local macrosOnPage = math.max(0, endIdx - startIdx + 1);
     local rowsOnPage = math.max(1, math.ceil(macrosOnPage / PALETTE_COLUMNS));
@@ -1629,9 +3363,161 @@ function M.DrawPalette()
     PushWindowStyle();
 
     if imgui.Begin('Macro Palette###MacroPalette', isOpen, windowFlags) then
-        -- Header with gold accent
-        imgui.TextColored(COLORS.gold, 'Drag macros to your hotbar slots');
-        imgui.Spacing();
+        -- Header: instruction (left) + macro source toggle (right, S = Shared, P = Profile)
+        do
+            local scopeShared = (gConfig.macroStorageScope or 'profile') == 'shared';
+            local scopeBtnSize = 22;
+            imgui.TextColored(COLORS.gold, 'Drag macros to your hotbar slots');
+            imgui.SameLine();
+            -- GetContentRegionAvail: use (w,h) or table [1]/[2]; do not use .x â€” sugar Vector can error (see palettemanager GetContentRegionAvailHeight).
+            local availW, availH = imgui.GetContentRegionAvail();
+            if type(availW) == 'table' then
+                availW = availW[1] or 0;
+            end
+            availW = tonumber(availW) or 0;
+            imgui.SetCursorPosX(imgui.GetCursorPosX() + availW - scopeBtnSize);
+            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, scopeBtnSize * 0.5);
+            imgui.PushStyleVar(ImGuiStyleVar_FramePadding, { 0, 0 });
+            if scopeShared then
+                imgui.PushStyleColor(ImGuiCol_Button, { 0.35, 0.30, 0.18, 0.95 });
+                imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.50, 0.44, 0.28, 1.0 });
+                imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.45, 0.40, 0.24, 1.0 });
+            else
+                imgui.PushStyleColor(ImGuiCol_Button, { 0.14, 0.13, 0.11, 0.95 });
+                imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.22, 0.20, 0.16, 1.0 });
+                imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.18, 0.16, 0.13, 1.0 });
+            end
+            local scopeLabel = scopeShared and 'S##MacroScopeToggle' or 'P##MacroScopeToggle';
+            if imgui.Button(scopeLabel, { scopeBtnSize, scopeBtnSize }) then
+                if scopeShared then
+                    MP.macroScopeConfirmKind = 'toProfile';
+                else
+                    MP.macroScopeConfirmKind = 'toShared';
+                end
+                imgui.OpenPopup('MacroScopeSwitch##xiui');
+            end
+            imgui.PopStyleColor(3);
+            imgui.PopStyleVar(2);
+            if imgui.IsItemHovered() then
+                imgui.BeginTooltip();
+                imgui.PushTextWrapPos(400);
+                local profName = (GetCurrentProfileName and GetCurrentProfileName()) or (config and config.currentProfile) or 'current';
+                if scopeShared then
+                    imgui.TextColored(COLORS.gold, 'Shared is active (S)');
+                    imgui.Spacing();
+                    imgui.TextWrapped('This macro set is available here and is shared with all XIUI profiles that use Shared (SharedMacros.lua). Click the button to edit this character\'s profile-only macros instead.');
+                else
+                    imgui.TextColored(COLORS.text, 'Profile is active (P)');
+                    imgui.Spacing();
+                    imgui.TextWrapped('This macro set is available on the "' .. tostring(profName) .. '" profile only. Click the button to use the shared macro list instead (all profiles on Shared).');
+                end
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'Your hotbar/crossbar layout is not removed when you switch. Icons and actions use the active library; a slot that pointed at the other library may look empty until you switch back or re-drag a macro. The palette and bars refresh when you change mode.');
+                imgui.PopTextWrapPos();
+                imgui.EndTooltip();
+            end
+        end
+
+        -- Macro scope confirm: non-modal BeginPopup (palettemanager copy flow) = no full-screen dim; anchor to this window.
+        do
+            imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+            imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+            imgui.PushStyleColor(ImGuiCol_TitleBg, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_TitleBgActive, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_FrameBg, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLORS.bgLight);
+            imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+
+            local SCOPE_MODAL_W = 420;
+            local estPopupH = 200;
+            local aboveGap = 6;
+            imgui.SetNextWindowSize({ SCOPE_MODAL_W, 0 }, ImGuiCond_Appearing);
+            local wx, wy = imgui.GetWindowPos();
+            local wiw, wih = imgui.GetWindowSize();
+            if type(wx) == 'table' then
+                local t = wx;
+                wx, wy = tonumber(t[1]) or 0, tonumber(t[2] or 0) or 0;
+            else
+                wx, wy = tonumber(wx) or 0, tonumber(wy) or 0;
+            end
+            if type(wiw) == 'table' then
+                local t = wiw;
+                wiw, wih = tonumber(t[1]) or 0, tonumber(t[2] or 0) or 0;
+            else
+                wiw, wih = tonumber(wiw) or 0, tonumber(wih) or 0;
+            end
+            local posX = wx + (wiw - SCOPE_MODAL_W) * 0.5;
+            if posX < 2 then
+                posX = 2;
+            end
+            -- Prefer just above the palette; if that would be off-screen, sit on the top of the palette (overlaps header strip).
+            local posY = wy - aboveGap - estPopupH;
+            if posY < 2 then
+                posY = wy + 6;
+            end
+            imgui.SetNextWindowPos({ posX, posY }, ImGuiCond_Always);
+
+            if imgui.BeginPopup('MacroScopeSwitch##xiui') then
+                local function closeScopePopup()
+                    MP.macroScopeConfirmKind = nil;
+                    imgui.CloseCurrentPopup();
+                end
+
+                if MP.macroScopeConfirmKind == 'toShared' then
+                    imgui.TextColored(COLORS.gold, 'Switch to shared macros?');
+                    imgui.TextWrapped('You will use the global list (SharedMacros.lua) for every profile set to Shared. Your profile-only macros stay saved in this .lua if you switch back.');
+                    imgui.Spacing();
+                    imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
+                    if imgui.Button('Switch##ssok', { 100, 24 }) then
+                        sharedMacroStore.ApplySwitchToShared(gConfig);
+                        data.InvalidateConfigDerivedCaches();
+                        SaveSettingsToDisk();
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        RefreshCachedLists();
+                        ClearAllIconCaches();
+                        closeScopePopup();
+                    end
+                    imgui.PopStyleColor();
+                    imgui.SameLine();
+                    if imgui.Button('Cancel##sscancel', { 100, 24 }) then
+                        closeScopePopup();
+                    end
+                elseif MP.macroScopeConfirmKind == 'toProfile' then
+                    imgui.TextColored(COLORS.gold, 'Switch to profile-only macros?');
+                    imgui.TextWrapped('You will use only this profile file again. The shared file is not changed.');
+                    imgui.Spacing();
+                    imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
+                    if imgui.Button('Switch##spok', { 100, 24 }) then
+                        if (gConfig.macroStorageScope or 'profile') == 'shared' then
+                            SaveSettingsToDisk();
+                        end
+                        sharedMacroStore.ApplySwitchToProfile(gConfig);
+                        data.InvalidateConfigDerivedCaches();
+                        SaveSettingsToDisk();
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        RefreshCachedLists();
+                        ClearAllIconCaches();
+                        closeScopePopup();
+                    end
+                    imgui.PopStyleColor();
+                    imgui.SameLine();
+                    if imgui.Button('Cancel##spcancel', { 100, 24 }) then
+                        closeScopePopup();
+                    end
+                else
+                    closeScopePopup();
+                end
+                imgui.EndPopup();
+            end
+
+            imgui.PopStyleColor(9);
+        end
+
+        imgui.Dummy({ 0, 4 });
 
         -- Type selector row
         imgui.TextColored(COLORS.textDim, 'Type:');
@@ -1639,7 +3525,7 @@ function M.DrawPalette()
 
         -- Style the combo popup
         PushComboStyle();
-        imgui.PushItemWidth(100);
+        imgui.PushItemWidth(148);
 
         -- Helper to get macro count for a type (Global or job ID)
         local function getMacroCount(key)
@@ -1649,8 +3535,8 @@ function M.DrawPalette()
             return 0;
         end
 
-        -- Build display label with macro count
-        local macroCount = getMacroCount(typeKey);
+        -- Build display label with macro count (uses current grid, including SMN / BST "all subsets" merge)
+        local macroCount = #db;
         local displayLabel = macroCount > 0 and string.format('%s (%d)', typeName, macroCount) or typeName;
 
         if imgui.BeginCombo('##TypeSelect', displayLabel, ImGuiComboFlags_None) then
@@ -1671,15 +3557,15 @@ function M.DrawPalette()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
             end
 
-            if imgui.Selectable(globalLabel, globalSelected) then
-                selectedPaletteType = GLOBAL_MACRO_KEY;
-                selectedAvatarPalette = nil;
-                selectedMacroIndex = nil;
-                currentPalettePage = 1;
+                if imgui.Selectable(globalLabel, globalSelected) then
+                    MP.selectedPaletteType = GLOBAL_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
                 -- Clear caches to force refresh
                 playerdata.ClearCache();
-                cachedPetCommands = nil;
-                petAvatarFilter = 1;
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
             end
             imgui.PopStyleColor();
 
@@ -1687,12 +3573,140 @@ function M.DrawPalette()
                 imgui.SetItemDefaultFocus();
             end
 
-            -- Separator between Global and jobs
+            -- Items bucket (gear / consumables â€” not tied to a job)
+            local itemsSelected = isItems;
+            local itemsMacroCount = getMacroCount(ITEMS_MACRO_KEY);
+            local itemsLabel = 'Items';
+            if itemsMacroCount > 0 then
+                itemsLabel = string.format('Items (%d)', itemsMacroCount);
+            end
+
+            if itemsMacroCount > 0 and not itemsSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif itemsSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(itemsLabel, itemsSelected) then
+                    MP.selectedPaletteType = ITEMS_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if itemsSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- Equipment bucket (gear swap macros, all jobs)
+            local equipSelected = isEquipment;
+            local equipMacroCount = getMacroCount(EQUIPMENT_MACRO_KEY);
+            local equipLabel = 'Equipment';
+            if equipMacroCount > 0 then
+                equipLabel = string.format('Equipment (%d)', equipMacroCount);
+            end
+
+            if equipMacroCount > 0 and not equipSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif equipSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(equipLabel, equipSelected) then
+                    MP.selectedPaletteType = EQUIPMENT_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if equipSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- XIUI slash-command shortcuts (seeded defaults; editable like any macro bucket)
+            local xiuiSelected = isXiui;
+            local xiuiMacroCount = getMacroCount(XIUI_MACRO_KEY);
+            local xiuiLabel = 'XIUI Commands';
+            if xiuiMacroCount > 0 then
+                xiuiLabel = string.format('XIUI Commands (%d)', xiuiMacroCount);
+            end
+
+            if xiuiMacroCount > 0 and not xiuiSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif xiuiSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(xiuiLabel, xiuiSelected) then
+                    MP.selectedPaletteType = XIUI_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if xiuiSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- Player-defined categories (keys under macroDB["custom:N"])
+            EnsureMacroCustomCategoriesList();
+            for _, cat in ipairs(gConfig.macroCustomCategories) do
+                local cKey = cat.key;
+                local cSel = (MP.selectedPaletteType == cKey);
+                local cCount = getMacroCount(cKey);
+                local cLabel = cat.label or cKey;
+                if cCount > 0 then
+                    cLabel = string.format('%s (%d)', cLabel, cCount);
+                end
+
+                if cCount > 0 and not cSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                elseif cSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+
+                if imgui.Selectable(cLabel, cSel) then
+                    MP.selectedPaletteType = cKey;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    playerdata.ClearCache();
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
+                end
+                imgui.PopStyleColor();
+
+                if cSel then
+                    imgui.SetItemDefaultFocus();
+                end
+            end
+
+            -- Separator between non-job buckets and jobs
             imgui.Separator();
 
             -- Job options
             for i, job in ipairs(JOB_LIST) do
-                local isSelected = (not isGlobal and job.id == typeKey);
+                local isSelected = (not isSharedMacroPalette and MP.selectedPaletteType == job.id);
                 local jobMacroCount = getMacroCount(job.id);
 
                 -- Build label with indicators
@@ -1723,14 +3737,14 @@ function M.DrawPalette()
                 end
 
                 if imgui.Selectable(label, isSelected) then
-                    selectedPaletteType = job.id;
-                    selectedAvatarPalette = nil;  -- Clear avatar selection when switching jobs
-                    selectedMacroIndex = nil;  -- Clear selection when switching types
-                    currentPalettePage = 1;    -- Reset to page 1 when switching types
+                    MP.selectedPaletteType = job.id;
+                    ResetPetJobMacroPaletteSubsets(); -- Clear avatar / jug subset selection when switching jobs
+                    paletteUi.selectedMacroIndex = nil;  -- Clear selection when switching types
+                    MP.currentPalettePage = 1;    -- Reset to page 1 when switching types
                     -- Clear caches to force refresh
                     playerdata.ClearCache();
-                    cachedPetCommands = nil;
-                    petAvatarFilter = 1;
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
                 end
 
                 imgui.PopStyleColor();
@@ -1744,28 +3758,298 @@ function M.DrawPalette()
         imgui.PopItemWidth();
         PopComboStyle();
 
-        -- Avatar sub-palette dropdown (only for SMN)
-        -- Use selectedPaletteType (the job ID) not typeKey (which may be composite like "15:avatar:ifrit")
-        if not isGlobal and selectedPaletteType == petregistry.JOB_SMN then
+        local catAddBtnSize = (imgui.GetFrameHeight and imgui.GetFrameHeight()) or 24;
+        imgui.SameLine(0, 6);
+        if imgui.Button('+##macroCatAddBtn', { catAddBtnSize, catAddBtnSize }) then
+            imgui.OpenPopup('MacroAddCustomCategory##xiui');
+        end
+        if imgui.IsItemHovered() then
+            imgui.BeginTooltip();
+            imgui.Text('Add a custom type.');
+            imgui.EndTooltip();
+        end
+
+        if isCustomMacroBucket and typeKey then
+            imgui.SameLine(0, 8);
+            imgui.PushStyleColor(ImGuiCol_Button, { 0.62, 0.12, 0.1, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.78, 0.2, 0.16, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.7, 0.16, 0.12, 1.0 });
+            if imgui.Button('-##macroCatDelToolbar', { catAddBtnSize, catAddBtnSize }) then
+                MP.macroCustomDeleteKey = typeKey;
+                MP.macroCustomDeleteLabel = GetPaletteDisplayName(typeKey);
+                MP.macroCustomDeleteN = CountMacrosInPalette(typeKey);
+                imgui.OpenPopup('MacroCustomCatDelete##xiui');
+            end
+            imgui.PopStyleColor(3);
+            if imgui.IsItemHovered() then
+                imgui.BeginTooltip();
+                imgui.Text('Delete this custom type. Macros in the group are removed; any hotbar or crossbar slot that holds one of those macros reverts to an empty slot. Other slots are unchanged.');
+                imgui.EndTooltip();
+            end
+            imgui.SameLine(0, 8);
+            if imgui.SmallButton('Rename##macroCatRenToolbar') then
+                MP.macroCustomRenameTargetKey = typeKey;
+                MP.macroCustomRenameBuf[1] = GetPaletteDisplayName(typeKey);
+                imgui.OpenPopup('MacroCustomRename##xiui');
+            end
+        end
+
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroAddCustomCategory##xiui') then
+            imgui.TextColored(COLORS.textDim, 'New category name');
+            imgui.SetNextItemWidth(240);
+            imgui.InputText('##macroNewCatPopup', MP.macroNewCategoryBuf, INPUT_BUFFER_SIZE);
+            imgui.Spacing();
+            if imgui.Button('Add##macroCatAddPopup', { 100, 24 }) then
+                local nk = AddMacroCustomCategory(MP.macroNewCategoryBuf[1]);
+                if nk then
+                    MP.selectedPaletteType = nk;
+                    ResetPetJobMacroPaletteSubsets();
+                    MP.macroNewCategoryBuf[1] = '';
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    playerdata.ClearCache();
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
+                    markSharedMacroLibraryDirtyIfNeeded();
+                    SaveSettingsToDisk();
+                    data.MarkMacroLookupDirty();
+                    imgui.CloseCurrentPopup();
+                end
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Rename custom type (modal; opened from toolbar)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroCustomRename##xiui') then
+            local rk = MP.macroCustomRenameTargetKey;
+            if rk and macroBuckets.isCustomCategoryKey(rk) then
+                imgui.TextColored(COLORS.textDim, 'Display name (macros and slot data keep the same type key).');
+                imgui.SetNextItemWidth(300);
+                imgui.InputText('##mcrenfield', MP.macroCustomRenameBuf, INPUT_BUFFER_SIZE);
+                imgui.Spacing();
+                if imgui.Button('Apply##mcrenconf', { 100, 24 }) then
+                    if ApplyRenameMacroCustomCategory(rk, MP.macroCustomRenameBuf[1]) then
+                        markSharedMacroLibraryDirtyIfNeeded();
+                        SaveSettingsToDisk();
+                        MP.macroCustomRenameTargetKey = nil;
+                        imgui.CloseCurrentPopup();
+                    end
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##mcrencan', { 100, 24 }) then
+                    MP.macroCustomRenameTargetKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            else
+                MP.macroCustomRenameTargetKey = nil;
+                imgui.CloseCurrentPopup();
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Confirm delete for a custom type (modal; opened from red - button)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroCustomCatDelete##xiui') then
+            local dk = MP.macroCustomDeleteKey;
+            if dk and macroBuckets.isCustomCategoryKey(dk) then
+                local n = tonumber(MP.macroCustomDeleteN) or 0;
+                local lab = tostring(MP.macroCustomDeleteLabel or dk);
+                imgui.TextColored(COLORS.gold, 'Delete this custom type?');
+                imgui.PushTextWrapPos(440);
+                local macroW = n == 1 and '1 macro' or (string.format('%d macros', n));
+                imgui.TextWrapped(string.format('This permanently removes %s saved under "%s" (macro text, icons, and palette data for that type).', macroW, lab));
+                imgui.TextWrapped('On every hotbar and crossbar, any slot that contains a macro from this type reverts to an empty slot. All other slots are unchanged.');
+                if (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') then
+                    imgui.TextWrapped('Shared macro mode: the type is removed from the shared library, and other XIUI profiles get the same per-slot updates anywhere their bars referenced these macros.');
+                end
+                imgui.PopTextWrapPos();
+                imgui.Spacing();
+                if imgui.Button('Delete##mcdelconf', { 100, 24 }) then
+                    DeleteMacroCustomCategoryCompletely(dk);
+                    MP.macroCustomDeleteKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##mcdelcan', { 100, 24 }) then
+                    MP.macroCustomDeleteKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            else
+                MP.macroCustomDeleteKey = nil;
+                imgui.CloseCurrentPopup();
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Move macro to another palette bucket (modal)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroMoveToPalette##xiui') then
+            local srcK = MP.macroMoveSourceKey;
+            local mid = MP.macroMoveMacroId;
+            if not srcK or not mid then
+                MP.macroMoveSourceKey = nil;
+                MP.macroMoveMacroId = nil;
+                MP.macroMoveDestKey = nil;
+                imgui.CloseCurrentPopup();
+            else
+                imgui.TextColored(COLORS.gold, 'Move macro');
+                imgui.PushTextWrapPos(440);
+                imgui.TextWrapped(
+                    'Creates a copy in the destination palette with a new internal id, removes it from the source palette, '
+                        .. 'and updates hotbar and crossbar bindings so slots that already use this macro keep working.');
+                imgui.PopTextWrapPos();
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'From');
+                imgui.SameLine(0, 8);
+                imgui.Text(GetPaletteDisplayName(srcK));
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'To');
+                imgui.SameLine(0, 8);
+                PushComboStyle();
+                imgui.SetNextItemWidth(360);
+                if imgui.BeginCombo('##macroMoveDest', GetPaletteDisplayName(MP.macroMoveDestKey), ImGuiComboFlags_None) then
+                    local function offerMoveDest(key)
+                        if data.MacroPaletteKeysEqual(key, srcK) then
+                            return;
+                        end
+                        local cnt = CountMacrosInPalette(key);
+                        local lab = GetPaletteDisplayName(key);
+                        if cnt > 0 then
+                            lab = string.format('%s (%d)', lab, cnt);
+                        end
+                        local sel = data.MacroPaletteKeysEqual(key, MP.macroMoveDestKey);
+                        if sel then
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                        elseif cnt > 0 then
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                        else
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                        end
+                        if imgui.Selectable(lab, sel) then
+                            MP.macroMoveDestKey = key;
+                        end
+                        imgui.PopStyleColor();
+                    end
+                    offerMoveDest(GLOBAL_MACRO_KEY);
+                    offerMoveDest(ITEMS_MACRO_KEY);
+                    offerMoveDest(EQUIPMENT_MACRO_KEY);
+                    offerMoveDest(XIUI_MACRO_KEY);
+                    EnsureMacroCustomCategoriesList();
+                    for _, cat in ipairs(gConfig.macroCustomCategories or {}) do
+                        offerMoveDest(cat.key);
+                    end
+                    imgui.Separator();
+                    for _, job in ipairs(JOB_LIST) do
+                        offerMoveDest(job.id);
+                    end
+                    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+                        local avatarKey = petregistry.avatars[avatar];
+                        if avatarKey then
+                            offerMoveDest(string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey));
+                        end
+                    end
+                    for _, pk in ipairs(petregistry.GetAvailablePetKeys(petregistry.JOB_BST)) do
+                        local slug = pk:match('^jug:(.+)$');
+                        if slug then
+                            offerMoveDest(string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug));
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                PopComboStyle();
+                imgui.Spacing();
+                local canApply = MP.macroMoveDestKey ~= nil and not data.MacroPaletteKeysEqual(MP.macroMoveDestKey, srcK);
+                if not canApply then
+                    imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.45);
+                end
+                if imgui.Button('Move##macroMoveApply', {100, 26}) and canApply then
+                    if M.MoveMacroToPalette(mid, srcK, MP.macroMoveDestKey) then
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.macroMoveSourceKey = nil;
+                        MP.macroMoveMacroId = nil;
+                        MP.macroMoveDestKey = nil;
+                        imgui.CloseCurrentPopup();
+                    end
+                end
+                if not canApply then
+                    imgui.PopStyleVar();
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##macroMoveCancel', {100, 26}) then
+                    MP.macroMoveSourceKey = nil;
+                    MP.macroMoveMacroId = nil;
+                    MP.macroMoveDestKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- SMN: base / all avatars merged / single avatar (own row so the window stays narrow)
+        if not isSharedMacroPalette and MP.selectedPaletteType == petregistry.JOB_SMN then
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Sub-type:');
             imgui.SameLine();
             local avatarList = petregistry.GetAvatarList();
-            local avatarLabel = selectedAvatarPalette or 'Base SMN';
-
-            -- Count macros for current avatar selection
-            local avatarMacroCount = 0;
-            local currentAvatarKey = GetEffectivePaletteType();
-            if gConfig.macroDB and gConfig.macroDB[currentAvatarKey] then
-                avatarMacroCount = #gConfig.macroDB[currentAvatarKey];
-            end
-            if avatarMacroCount > 0 then
-                avatarLabel = string.format('%s (%d)', avatarLabel, avatarMacroCount);
+            local allSubCount = CountSmnAllSubsetsMacros();
+            local avatarLabel;
+            if MP.smnShowAllAvatarSubsets then
+                avatarLabel = allSubCount > 0 and string.format('All subsets (%d)', allSubCount) or 'All subsets';
+            else
+                avatarLabel = MP.selectedAvatarPalette or 'Base SMN';
+                local avatarMacroCount = 0;
+                local currentAvatarKey = GetEffectivePaletteType();
+                if gConfig.macroDB and gConfig.macroDB[currentAvatarKey] then
+                    avatarMacroCount = #gConfig.macroDB[currentAvatarKey];
+                end
+                if avatarMacroCount > 0 then
+                    avatarLabel = string.format('%s (%d)', avatarLabel, avatarMacroCount);
+                end
             end
 
             PushComboStyle();
-            imgui.SetNextItemWidth(140);
+            imgui.SetNextItemWidth(148);
             if imgui.BeginCombo('##AvatarPalette', avatarLabel, ImGuiComboFlags_None) then
-                -- Base SMN option
-                local isBaseSelected = selectedAvatarPalette == nil;
+                -- All subsets: one grid with Base SMN + every avatar bucket
+                local allSubLabel = allSubCount > 0 and string.format('All subsets (%d)', allSubCount) or 'All subsets';
+                local allSubSel = MP.smnShowAllAvatarSubsets;
+                if allSubSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif allSubCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+                if imgui.Selectable(allSubLabel, allSubSel) then
+                    ClearBstJugMacroSubsetUi();
+                    MP.smnShowAllAvatarSubsets = true;
+                    MP.selectedAvatarPalette = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+                if allSubSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                local isBaseSelected = (not MP.smnShowAllAvatarSubsets and MP.selectedAvatarPalette == nil);
                 local baseMacroCount = 0;
                 if gConfig.macroDB and gConfig.macroDB[petregistry.JOB_SMN] then
                     baseMacroCount = #gConfig.macroDB[petregistry.JOB_SMN];
@@ -1781,10 +4065,12 @@ function M.DrawPalette()
                 end
 
                 if imgui.Selectable(baseLabel, isBaseSelected) then
-                    selectedAvatarPalette = nil;
-                    selectedMacroIndex = nil;
-                    currentPalettePage = 1;
-                    cachedPetCommands = nil;  -- Refresh pet commands for new avatar
+                    ClearBstJugMacroSubsetUi();
+                    MP.smnShowAllAvatarSubsets = false;
+                    MP.selectedAvatarPalette = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
                 end
                 imgui.PopStyleColor();
 
@@ -1794,9 +4080,8 @@ function M.DrawPalette()
 
                 imgui.Separator();
 
-                -- Avatar options
                 for _, avatar in ipairs(avatarList) do
-                    local isSelected = selectedAvatarPalette == avatar;
+                    local isSelected = (not MP.smnShowAllAvatarSubsets and MP.selectedAvatarPalette == avatar);
                     local avatarKey = petregistry.avatars[avatar];
                     local fullKey = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
                     local macroCount = 0;
@@ -1814,10 +4099,12 @@ function M.DrawPalette()
                     end
 
                     if imgui.Selectable(label, isSelected) then
-                        selectedAvatarPalette = avatar;
-                        selectedMacroIndex = nil;
-                        currentPalettePage = 1;
-                        cachedPetCommands = nil;  -- Refresh pet commands for new avatar
+                        ClearBstJugMacroSubsetUi();
+                        MP.smnShowAllAvatarSubsets = false;
+                        MP.selectedAvatarPalette = avatar;
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        MP.cachedPetCommands = nil;
                     end
                     imgui.PopStyleColor();
 
@@ -1830,10 +4117,134 @@ function M.DrawPalette()
             PopComboStyle();
         end
 
+        -- BST: Base / all jug families merged / single jug family (parity with SMN Sub-type)
+        if not isSharedMacroPalette and MP.selectedPaletteType == petregistry.JOB_BST then
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Sub-type:');
+            imgui.SameLine();
+            local bstJugList = BstJugSubsetEntriesOrdered();
+            local allBstSubCount = CountBstAllJugSubsetsMacros();
+            local bstSubLabel;
+            if MP.bstShowAllJugSubsets then
+                bstSubLabel = allBstSubCount > 0 and string.format('All subsets (%d)', allBstSubCount) or 'All subsets';
+            else
+                bstSubLabel = 'Base BST';
+                if MP.selectedBstJugMovesKey ~= nil then
+                    bstSubLabel = MP.selectedBstJugMovesKey;
+                    for _, ent in ipairs(bstJugList) do
+                        if ent.movesKey == MP.selectedBstJugMovesKey then
+                            bstSubLabel = ent.label;
+                            break;
+                        end
+                    end
+                end
+                local curBstKey = GetEffectivePaletteType();
+                local bstFamMacroCount = 0;
+                if gConfig.macroDB and gConfig.macroDB[curBstKey] then
+                    bstFamMacroCount = #gConfig.macroDB[curBstKey];
+                end
+                if bstFamMacroCount > 0 then
+                    bstSubLabel = string.format('%s (%d)', bstSubLabel, bstFamMacroCount);
+                end
+            end
+
+            PushComboStyle();
+            imgui.SetNextItemWidth(148);
+            if imgui.BeginCombo('##BstJugPalette', bstSubLabel, ImGuiComboFlags_None) then
+                local allBstLabel = allBstSubCount > 0 and string.format('All subsets (%d)', allBstSubCount) or 'All subsets';
+                local allBstSel = MP.bstShowAllJugSubsets;
+                if allBstSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif allBstSubCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+                if imgui.Selectable(allBstLabel, allBstSel) then
+                    ClearSmnMacroSubsetUi();
+                    MP.bstShowAllJugSubsets = true;
+                    MP.selectedBstJugMovesKey = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+                if allBstSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                local bstBaseSel = (not MP.bstShowAllJugSubsets and MP.selectedBstJugMovesKey == nil);
+                local bstBaseMacroCount = 0;
+                if gConfig.macroDB and gConfig.macroDB[petregistry.JOB_BST] then
+                    bstBaseMacroCount = #gConfig.macroDB[petregistry.JOB_BST];
+                end
+                local bstBaseLabel = bstBaseMacroCount > 0 and string.format('Base BST (%d)', bstBaseMacroCount) or 'Base BST';
+
+                if bstBaseSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif bstBaseMacroCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+
+                if imgui.Selectable(bstBaseLabel, bstBaseSel) then
+                    ClearSmnMacroSubsetUi();
+                    MP.bstShowAllJugSubsets = false;
+                    MP.selectedBstJugMovesKey = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+
+                if bstBaseSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                for _, ent in ipairs(bstJugList) do
+                    local jugSel = (not MP.bstShowAllJugSubsets and MP.selectedBstJugMovesKey == ent.movesKey);
+                    local jugMc = 0;
+                    if gConfig.macroDB and gConfig.macroDB[ent.fullKey] then
+                        jugMc = #gConfig.macroDB[ent.fullKey];
+                    end
+                    local jugLab = jugMc > 0 and string.format('%s (%d)', ent.label, jugMc) or ent.label;
+
+                    if jugSel then
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                    elseif jugMc > 0 then
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                    else
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                    end
+
+                    if imgui.Selectable(jugLab, jugSel) then
+                        ClearSmnMacroSubsetUi();
+                        MP.bstShowAllJugSubsets = false;
+                        MP.selectedBstJugMovesKey = ent.movesKey;
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        MP.cachedPetCommands = nil;
+                    end
+                    imgui.PopStyleColor();
+
+                    if jugSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            PopComboStyle();
+        end
+
         -- Pet Palette section (only show if selected palette type is a pet job AND any bar has petAware enabled)
         local isPetJob = false;
-        if selectedPaletteType and type(selectedPaletteType) == 'number' then
-            isPetJob = petregistry.IsPetJob(selectedPaletteType);
+        if MP.selectedPaletteType and type(MP.selectedPaletteType) == 'number' then
+            isPetJob = petregistry.IsPetJob(MP.selectedPaletteType);
         end
 
         local hasPetAwareBar = false;
@@ -1934,8 +4345,8 @@ function M.DrawPalette()
 
                         imgui.Separator();
 
-                        -- Spirits section
-                        imgui.TextColored(COLORS.textDim, 'Spirits');
+                        -- Elementals (SMN spirit pets)
+                        imgui.TextColored(COLORS.textDim, 'Elementals');
                         for _, summon in ipairs(allSummons) do
                             if summon.category == 'spirit' then
                                 local petKey = petregistry.GetPetKeyForSummon(summon.name);
@@ -1969,6 +4380,36 @@ function M.DrawPalette()
         end
 
         imgui.Spacing();
+        imgui.TextColored(COLORS.textDim, 'Search by name:');
+        imgui.SetNextItemWidth(math.min(180, gridWidth));
+        imgui.InputText('##MacroPaletteNameSearch', MP.macroPaletteSearchName, INPUT_BUFFER_SIZE);
+        imgui.ShowHelp('Filters the macro grid by display name or action name (case-insensitive).');
+
+        imgui.Spacing();
+
+        local function rowPaletteKeyForGridIdx(idx)
+            if smnMergeMeta and smnMergeMeta[idx] then
+                return smnMergeMeta[idx].paletteKey;
+            end
+            if bstMergeMeta and bstMergeMeta[idx] then
+                return bstMergeMeta[idx].paletteKey;
+            end
+            return typeKey;
+        end
+        local function rowSubsetLabelForGridIdx(idx)
+            if smnMergeMeta and smnMergeMeta[idx] then
+                return smnMergeMeta[idx].subsetLabel;
+            end
+            if bstMergeMeta and bstMergeMeta[idx] then
+                return bstMergeMeta[idx].subsetLabel;
+            end
+            return nil;
+        end
+
+        local hasSelection = paletteUi.selectedMacroIndex and db[paletteUi.selectedMacroIndex];
+        local universalLocked = hasSelection and macroGlobalDefaults.IsUniversalTwoHourMacro(db[paletteUi.selectedMacroIndex]);
+        local copyEnabled = hasSelection and not universalLocked;
+        local editDelEnabled = hasSelection and not universalLocked;
 
         -- Button row with XIUI button styling
         imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
@@ -1979,14 +4420,67 @@ function M.DrawPalette()
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
 
         if imgui.Button('+ New Macro', {115, 26}) then
-            isCreatingNew = true;
-            editingMacro = {
-                actionType = 'ma',
-                action = '',
-                target = 't',
-                displayName = '',
-            };
-            selectedMacroIndex = nil;
+            MP.isCreatingNew = true;
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
+            paletteUi.selectedMacroIndex = nil;
+            MP.editorPaletteKey = GetEffectivePaletteType();
+            local body, autoKey = DefaultNewMacroBodyForPaletteKey(MP.editorPaletteKey);
+            MP.editingMacro = body;
+            MP.editorAutoIconKey = autoKey;
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+        end
+
+        imgui.SameLine();
+
+        if not copyEnabled then
+            imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
+        end
+        if imgui.Button('Copy', {60, 26}) and copyEnabled then
+            MP.editingMacro = deep_copy_table(db[paletteUi.selectedMacroIndex]);
+            MP.editingMacro.id = nil;
+            MP.isCreatingNew = true;
+            MP.editorPaletteKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
+            ClearEditorPreviewIconCache();
+        end
+        if not copyEnabled then
+            imgui.PopStyleVar();
+        end
+
+        imgui.SameLine();
+
+        if not copyEnabled then
+            imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
+        end
+        if imgui.Button('Move', {52, 26}) and copyEnabled then
+            MP.macroMoveSourceKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            MP.macroMoveMacroId = db[paletteUi.selectedMacroIndex].id;
+            MP.macroMoveDestKey = PickDefaultMacroMoveDestination(MP.macroMoveSourceKey);
+            imgui.OpenPopup('MacroMoveToPalette##xiui');
+        end
+        if not copyEnabled then
+            imgui.PopStyleVar();
         end
 
         imgui.PopStyleColor(5);
@@ -1994,37 +4488,48 @@ function M.DrawPalette()
 
         imgui.SameLine();
 
-        -- Edit/Delete buttons (always visible, disabled when no selection)
-        local hasSelection = selectedMacroIndex and db[selectedMacroIndex];
-
-        if not hasSelection then
+        -- Edit/Delete buttons (always visible, disabled when no selection or Universal 2Hr locked)
+        if not editDelEnabled then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
         end
 
-        if imgui.Button('Edit', {60, 26}) and hasSelection then
-            editingMacro = deep_copy_table(db[selectedMacroIndex]);
-            isCreatingNew = false;
+        if imgui.Button('Edit', {60, 26}) and editDelEnabled then
+            MP.editingMacro = deep_copy_table(db[paletteUi.selectedMacroIndex]);
+            MP.isCreatingNew = false;
+            MP.editorPaletteKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
         end
 
         imgui.SameLine();
 
         -- Delete button with danger styling (or dimmed when disabled)
-        if hasSelection then
+        if editDelEnabled then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.dangerDim);
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.danger);
             imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.9, 0.35, 0.35, 1.0});
         end
 
-        if imgui.Button('Delete', {60, 26}) and hasSelection then
-            M.DeleteMacro(db[selectedMacroIndex].id);
-            selectedMacroIndex = nil;
+        if imgui.Button('Delete', {60, 26}) and editDelEnabled then
+            M.DeleteMacro(db[paletteUi.selectedMacroIndex].id, rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex));
+            paletteUi.selectedMacroIndex = nil;
         end
 
-        if hasSelection then
+        if editDelEnabled then
             imgui.PopStyleColor(3);
         end
 
-        if not hasSelection then
+        if not editDelEnabled then
             imgui.PopStyleVar();
         end
 
@@ -2036,12 +4541,16 @@ function M.DrawPalette()
         if #db == 0 then
             imgui.TextColored(COLORS.textDim, 'No macros yet.');
             imgui.TextColored(COLORS.textMuted, 'Click "+ New Macro" to create one.');
+        elseif totalMacros == 0 then
+            imgui.TextColored(COLORS.textDim, 'No macros match your search.');
+            imgui.TextColored(COLORS.textMuted, 'Clear the search field or try different text.');
         else
             -- Draw grid row by row using standard ImGui layout
             for row = 0, rowsOnPage - 1 do
                 for col = 0, PALETTE_COLUMNS - 1 do
-                    local idx = startIdx + row * PALETTE_COLUMNS + col;
-                    if idx <= endIdx then
+                    local pos = startIdx + row * PALETTE_COLUMNS + col;
+                    if pos <= endIdx then
+                        local idx = filteredIndices[pos];
                         local macro = db[idx];
                         if macro then
                             if col > 0 then
@@ -2049,7 +4558,7 @@ function M.DrawPalette()
                             end
 
                             -- Draw the tile inline
-                            local isSelected = selectedMacroIndex == idx;
+                            local isSelected = paletteUi.selectedMacroIndex == idx;
 
                             if isSelected then
                                 imgui.PushStyleColor(ImGuiCol_Button, {0.15, 0.13, 0.08, 0.95});
@@ -2061,7 +4570,7 @@ function M.DrawPalette()
                                 imgui.PushStyleColor(ImGuiCol_ButtonActive, COLORS.bgLight);
                             end
 
-                            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4);
+                            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, PALETTE_TILE_ROUNDING);
                             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
                             imgui.PushStyleColor(ImGuiCol_Border, isSelected and COLORS.gold or COLORS.border);
 
@@ -2069,18 +4578,17 @@ function M.DrawPalette()
                             local buttonPos = {imgui.GetCursorScreenPos()};
 
                             if imgui.Button(buttonId, {PALETTE_TILE_SIZE, PALETTE_TILE_SIZE}) then
-                                selectedMacroIndex = idx;
+                                paletteUi.selectedMacroIndex = idx;
                             end
 
                             imgui.PopStyleColor(4);
                             imgui.PopStyleVar(2);
 
                             -- Draw icon on top of button, or abbreviation if no icon
-                            local icon = actions.GetBindIcon(macro);
-                            local iconRendered = false;
-                            if icon and icon.image then
                                 local drawList = imgui.GetWindowDrawList();
-                                if drawList then
+                            local icon = GetCachedPaletteMainIcon(macro);
+                            local iconRendered = false;
+                            if icon and icon.image and drawList then
                                     local iconSize = PALETTE_TILE_SIZE - 8;
                                     local iconX = buttonPos[1] + 4;
                                     local iconY = buttonPos[2] + 4;
@@ -2090,6 +4598,8 @@ function M.DrawPalette()
                                         iconRendered = true;
                                     end
                                 end
+                            if drawList then
+                                DrawMacroJaBadgeOverlay(drawList, macro, buttonPos[1], buttonPos[2], PALETTE_TILE_SIZE);
                             end
 
                             -- No icon - show abbreviated action name
@@ -2108,7 +4618,7 @@ function M.DrawPalette()
                             -- Handle drag
                             if imgui.IsItemActive() and imgui.IsMouseDragging(0, 3) then
                                 if not dragdrop.IsDragging() and not dragdrop.IsDragPending() then
-                                    M.StartDragMacro(idx, macro);
+                                    M.StartDragMacro(idx, macro, rowPaletteKeyForGridIdx(idx));
                                 end
                             end
 
@@ -2118,17 +4628,25 @@ function M.DrawPalette()
                                 imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
                                 imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {8, 6});
                                 imgui.BeginTooltip();
-                                imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
-                                imgui.Spacing();
-                                imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
-                                if macro.actionType ~= 'macro' and macro.target then
-                                    local formattedTarget = FormatTargetForDisplay(macro.target);
-                                    if formattedTarget then
-                                        imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                                if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                                    imgui.TextColored(COLORS.gold, '2-Hour Ability');
+                                else
+                                    imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
+                                    local subLbl = rowSubsetLabelForGridIdx(idx);
+                                    if subLbl then
+                                        imgui.TextColored(COLORS.textMuted, 'Subset: ' .. subLbl);
                                     end
+                                    imgui.Spacing();
+                                    imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
+                                    if macro.actionType ~= 'macro' and macro.target then
+                                        local formattedTarget = FormatTargetForDisplay(macro.target);
+                                        if formattedTarget then
+                                            imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                                        end
+                                    end
+                                    imgui.Spacing();
+                                    imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
                                 end
-                                imgui.Spacing();
-                                imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
                                 imgui.EndTooltip();
                                 imgui.PopStyleVar();
                                 imgui.PopStyleColor(2);
@@ -2156,13 +4674,13 @@ function M.DrawPalette()
         imgui.SetCursorPosX(paginationStartX);
 
         -- Previous button (disabled when on first page)
-        local canGoPrev = currentPalettePage > 1;
+        local canGoPrev = MP.currentPalettePage > 1;
         if not canGoPrev then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.3);
         end
         if imgui.Button('<##PrevPage', {30, 22}) and canGoPrev then
-            currentPalettePage = currentPalettePage - 1;
-            selectedMacroIndex = nil;
+            MP.currentPalettePage = MP.currentPalettePage - 1;
+            paletteUi.selectedMacroIndex = nil;
         end
         if not canGoPrev then
             imgui.PopStyleVar();
@@ -2171,7 +4689,7 @@ function M.DrawPalette()
         imgui.SameLine();
 
         -- Page indicator
-        local pageText = string.format('Page %d / %d', currentPalettePage, totalPages);
+        local pageText = string.format('Page %d / %d', MP.currentPalettePage, totalPages);
         local textWidth = imgui.CalcTextSize(pageText);
         imgui.SetCursorPosX(paginationStartX + (paginationWidth - textWidth) / 2);
         imgui.TextColored(COLORS.textDim, pageText);
@@ -2180,13 +4698,13 @@ function M.DrawPalette()
         imgui.SetCursorPosX(paginationStartX + paginationWidth - 30);
 
         -- Next button (disabled when on last page)
-        local canGoNext = currentPalettePage < totalPages;
+        local canGoNext = MP.currentPalettePage < totalPages;
         if not canGoNext then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.3);
         end
         if imgui.Button('>##NextPage', {30, 22}) and canGoNext then
-            currentPalettePage = currentPalettePage + 1;
-            selectedMacroIndex = nil;
+            MP.currentPalettePage = MP.currentPalettePage + 1;
+            paletteUi.selectedMacroIndex = nil;
         end
         if not canGoNext then
             imgui.PopStyleVar();
@@ -2202,9 +4720,22 @@ function M.DrawPalette()
     end
 
     -- Draw macro editor popup if needed
-    if editingMacro then
+    if MP.editingMacro then
         M.DrawMacroEditor();
     end
+end
+
+function M.DrawPalette()
+    -- Macro editor must draw even when the palette list is closed (e.g. opened from Edit Full Palette
+    -- via double-click); otherwise MP.editingMacro is set but no window is ever drawn.
+    if not paletteUi.open then
+        if MP.editingMacro then
+            RefreshCachedLists();
+            M.DrawMacroEditor();
+        end
+        return;
+    end
+    DrawPaletteBody();
 end
 
 -- ============================================
@@ -2269,40 +4800,6 @@ local function FindIndex(array, value)
     return 1;
 end
 
--- Draw icon preview box with current icon
-local function DrawIconPreview(macro, x, y, size)
-    local drawList = imgui.GetWindowDrawList();
-    if not drawList then return; end
-
-    -- Draw background box
-    local bgColor = imgui.GetColorU32({0.1, 0.09, 0.08, 0.95});
-    local borderColor = imgui.GetColorU32(COLORS.border);
-    drawList:AddRectFilled({x, y}, {x + size, y + size}, bgColor, 4);
-    drawList:AddRect({x, y}, {x + size, y + size}, borderColor, 4, 0, 1);
-
-    -- Draw icon if available
-    local icon = actions.GetBindIcon(macro);
-    if icon and icon.image then
-        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
-        if iconPtr then
-            local padding = 4;
-            drawList:AddImage(
-                iconPtr,
-                {x + padding, y + padding},
-                {x + size - padding, y + size - padding}
-            );
-        end
-    else
-        -- No icon - show abbreviated action name (prefer action for preview)
-        local abbr = GetActionAbbreviation(macro, true);
-        local textSize = imgui.CalcTextSize(abbr);
-        local textX = x + (size - textSize) / 2;
-        local textY = y + (size - 14) / 2;
-        local textColor = imgui.GetColorU32(COLORS.gold);
-        drawList:AddText({textX, textY}, textColor, abbr);
-    end
-end
-
 -- Helper to draw an icon button (works around ImageButton signature issues)
 local function DrawIconButton(id, icon, size, isSelected, tooltipText)
     local clicked = false;
@@ -2357,12 +4854,12 @@ end
 
 -- Draw the icon picker popup
 local function DrawIconPicker()
-    if not iconPickerOpen or not editingMacro then
+    if not MP.iconPickerOpen or not MP.editingMacro then
         return;
     end
 
     -- Start item loading when items tab is selected
-    if iconPickerTab == 2 then
+    if MP.iconPickerTab == 2 then
         StartItemIconLoading();
         LoadItemIconBatch();  -- Load a batch each frame
     end
@@ -2389,7 +4886,7 @@ local function DrawIconPicker()
         local tabWidth = 70;
 
         -- Spells tab
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2397,7 +4894,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Spells', {tabWidth, 24}) then
-            iconPickerTab = 1;
+            MP.iconPickerTab = 1;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2405,7 +4902,7 @@ local function DrawIconPicker()
         imgui.SameLine();
 
         -- Items tab
-        if iconPickerTab == 2 then
+        if MP.iconPickerTab == 2 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2413,7 +4910,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Items', {tabWidth, 24}) then
-            iconPickerTab = 2;
+            MP.iconPickerTab = 2;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2421,7 +4918,7 @@ local function DrawIconPicker()
         imgui.SameLine();
 
         -- Custom tab
-        if iconPickerTab == 3 then
+        if MP.iconPickerTab == 3 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2429,7 +4926,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Custom', {tabWidth, 24}) then
-            iconPickerTab = 3;
+            MP.iconPickerTab = 3;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2441,10 +4938,18 @@ local function DrawIconPicker()
         imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.danger);
         imgui.PushStyleColor(ImGuiCol_Border, COLORS.danger);
         if imgui.Button('Clear', {50, 24}) then
-            editingMacro.customIconType = nil;
-            editingMacro.customIconId = nil;
-            editingMacro.customIconPath = nil;
-            iconPickerOpen = false;
+            if MP.iconPickerTargetIsJaBadge then
+                MP.editingMacro.jaBadgeCustomIconType = nil;
+                MP.editingMacro.jaBadgeCustomIconId = nil;
+                MP.editingMacro.jaBadgeCustomIconPath = nil;
+                MP.editorJaBadgeManuallySet = false;
+            else
+                MP.editingMacro.customIconType = nil;
+                MP.editingMacro.customIconId = nil;
+                MP.editingMacro.customIconPath = nil;
+            end
+            MP.editorAutoIconKey = nil;
+            MP.iconPickerOpen = false;
         end
         imgui.PopStyleColor(3);
 
@@ -2456,10 +4961,10 @@ local function DrawIconPicker()
         imgui.TextColored(COLORS.goldDim, 'Search:');
         imgui.SameLine();
         imgui.SetNextItemWidth(200);
-        imgui.InputText('##iconSearch', iconPickerFilter, INPUT_BUFFER_SIZE);
+        imgui.InputText('##iconSearch', MP.iconPickerFilter, INPUT_BUFFER_SIZE);
 
         -- Show loading status for items tab (count shown near page navigation)
-        if iconPickerTab == 2 and itemIconLoadState.loading then
+        if MP.iconPickerTab == 2 and itemIconLoadState.loading then
             imgui.SameLine();
             imgui.TextColored(COLORS.textMuted, string.format('Loading... %d%%', GetItemLoadProgress()));
         end
@@ -2467,7 +4972,7 @@ local function DrawIconPicker()
         imgui.Spacing();
 
         -- Spell type filter buttons with icons (only for spells tab)
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             local filterIconSize = 24;
             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
             imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {3, 3});
@@ -2475,7 +4980,7 @@ local function DrawIconPicker()
 
             for i, spellType in ipairs(SPELL_TYPE_ORDER) do
                 local tooltip = SPELL_TYPE_LABELS[spellType] or spellType;
-                local isSelected = iconPickerSpellType == spellType;
+                local isSelected = MP.iconPickerSpellType == spellType;
 
                 if isSelected then
                     imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
@@ -2492,8 +4997,8 @@ local function DrawIconPicker()
 
                 -- Use DrawIconButton which works on all Ashita versions
                 if DrawIconButton('##spellFilter' .. i, icon, filterIconSize, isSelected, tooltip) then
-                    iconPickerSpellType = spellType;
-                    iconPickerPage[1] = 1;
+                    MP.iconPickerSpellType = spellType;
+                    MP.iconPickerPage[1] = 1;
                 end
 
                 if i < #SPELL_TYPE_ORDER then
@@ -2506,7 +5011,7 @@ local function DrawIconPicker()
         end
 
         -- Item type filter buttons with icons (only for items tab)
-        if iconPickerTab == 2 then
+        if MP.iconPickerTab == 2 then
             local filterIconSize = 24;
             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
             imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {3, 3});
@@ -2514,7 +5019,7 @@ local function DrawIconPicker()
 
             for i, itemType in ipairs(ITEM_TYPE_ORDER) do
                 local tooltip = ITEM_TYPE_LABELS[itemType] or tostring(itemType);
-                local isSelected = iconPickerItemType == itemType;
+                local isSelected = MP.iconPickerItemType == itemType;
                 local itemId = ITEM_TYPE_ICONS[itemType];
 
                 -- Get item icon texture
@@ -2522,8 +5027,8 @@ local function DrawIconPicker()
 
                 -- Use DrawIconButton which works on all Ashita versions
                 if DrawIconButton('##itemFilter' .. i, icon, filterIconSize, isSelected, tooltip) then
-                    iconPickerItemType = itemType;
-                    iconPickerPage[2] = 1;
+                    MP.iconPickerItemType = itemType;
+                    MP.iconPickerPage[2] = 1;
                 end
 
                 if i < #ITEM_TYPE_ORDER then
@@ -2536,7 +5041,7 @@ local function DrawIconPicker()
         end
 
         -- Custom icon category filter buttons (only for custom tab)
-        if iconPickerTab == 3 then
+        if MP.iconPickerTab == 3 then
             -- Load categories if not loaded
             LoadCustomIcons();
             
@@ -2569,7 +5074,7 @@ local function DrawIconPicker()
                     imgui.PushStyleColor(ImGuiCol_Text, COLORS.goldDim);
                     if imgui.Button(letter .. '##customFilter' .. i, {filterIconSize, filterIconSize}) then
                         customIconCategory = category;
-                        iconPickerPage[3] = 1;
+                        MP.iconPickerPage[3] = 1;
                         customIconsCacheKey = nil;
                     end
                     imgui.PopStyleColor(3);
@@ -2582,7 +5087,7 @@ local function DrawIconPicker()
                     -- Use DrawIconButton for categories with icons
                     if DrawIconButton('##customFilter' .. i, categoryIcon, filterIconSize, isSelected, tooltip) then
                         customIconCategory = category;
-                        iconPickerPage[3] = 1;
+                        MP.iconPickerPage[3] = 1;
                         customIconsCacheKey = nil;  -- Invalidate cache
                     end
                 end
@@ -2629,7 +5134,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
             
-            if imgui.BeginPopupModal('Create Custom Folder##newFolderPopup', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+            if imgui.BeginPopup('Create Custom Folder##newFolderPopup') then
                 imgui.TextColored(COLORS.goldDim, 'Folder name:');
                 imgui.SetNextItemWidth(250);
                 imgui.InputText('##newFolderInput', newFolderName, 64);
@@ -2656,60 +5161,62 @@ local function DrawIconPicker()
             imgui.PopStyleColor(9);
         end
 
-        local filter = iconPickerFilter[1]:lower();
-        local currentPage = iconPickerPage[iconPickerTab];
+        local filter = MP.iconPickerFilter[1];
+        local currentPage = MP.iconPickerPage[MP.iconPickerTab];
 
         -- Build cache key for filtered results
         local cacheKey;
-        if iconPickerTab == 1 then
-            cacheKey = filter .. ':spell:' .. iconPickerSpellType;
-        elseif iconPickerTab == 2 then
-            cacheKey = filter .. ':item:' .. tostring(iconPickerItemType);
-        elseif iconPickerTab == 3 then
+        if MP.iconPickerTab == 1 then
+            cacheKey = filter .. ':spell:' .. MP.iconPickerSpellType;
+        elseif MP.iconPickerTab == 2 then
+            cacheKey = filter .. ':item:' .. tostring(MP.iconPickerItemType);
+        elseif MP.iconPickerTab == 3 then
             cacheKey = filter .. ':custom:' .. customIconCategory;
         end
 
         -- Reset page and invalidate cache if filter/type changed
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             if cacheKey ~= filteredSpellsCacheKey then
-                iconPickerPage[1] = 1;
+                MP.iconPickerPage[1] = 1;
                 currentPage = 1;
                 filteredSpellsCache = nil;
                 filteredSpellsCacheKey = cacheKey;
             end
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             if cacheKey ~= filteredItemsCacheKey then
-                iconPickerPage[2] = 1;
+                MP.iconPickerPage[2] = 1;
                 currentPage = 1;
                 filteredItemsCache = nil;
                 filteredItemsCacheKey = cacheKey;
             end
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             if cacheKey ~= customIconsCacheKey then
-                iconPickerPage[3] = 1;
+                MP.iconPickerPage[3] = 1;
                 currentPage = 1;
                 customIconsCacheKey = cacheKey;
+                filteredCustomIconsCache = nil;
+                filteredCustomIconsCacheKey = nil;
             end
         end
 
         -- Build filtered list (with caching to avoid rebuilding every frame)
         local filteredItems = {};
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             if filteredSpellsCache then
                 filteredItems = filteredSpellsCache;
             else
                 local allSpells = GetAllSpells();
                 for _, spell in ipairs(allSpells) do
                     local spellName = spell.name or '';
-                    local matchesFilter = (filter == '' or spellName:lower():find(filter, 1, true));
-                    local matchesType = (iconPickerSpellType == 'All' or spell.type == iconPickerSpellType);
+                    local matchesFilter = iconPickerNameMatchesFilter(spellName, filter);
+                    local matchesType = (MP.iconPickerSpellType == 'All' or spell.type == MP.iconPickerSpellType);
                     if matchesFilter and matchesType then
                         table.insert(filteredItems, spell);
                     end
                 end
                 filteredSpellsCache = filteredItems;
             end
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             -- Only use cache if: cache exists, not loading, and cache has items (or items DB is empty)
             local cacheValid = filteredItemsCache
                 and not itemIconLoadState.loading
@@ -2720,8 +5227,8 @@ local function DrawIconPicker()
             else
                 -- Use pre-filtered type list if available and a specific type is selected
                 local sourceItems;
-                if iconPickerItemType ~= 0 and itemIconLoadState.itemsByType[iconPickerItemType] then
-                    sourceItems = itemIconLoadState.itemsByType[iconPickerItemType];
+                if MP.iconPickerItemType ~= 0 and itemIconLoadState.itemsByType[MP.iconPickerItemType] then
+                    sourceItems = itemIconLoadState.itemsByType[MP.iconPickerItemType];
                 else
                     sourceItems = itemIconLoadState.items;
                 end
@@ -2735,7 +5242,7 @@ local function DrawIconPicker()
                         -- Apply text filter
                         for _, item in ipairs(sourceItems) do
                             local itemName = item.name or '';
-                            if itemName:lower():find(filter, 1, true) then
+                            if iconPickerNameMatchesFilter(itemName, filter) then
                                 table.insert(filteredItems, item);
                             end
                         end
@@ -2747,23 +5254,28 @@ local function DrawIconPicker()
                     filteredItemsCache = filteredItems;
                 end
             end
-        elseif iconPickerTab == 3 then
-            -- Custom icons - use pre-filtered category list
+        elseif MP.iconPickerTab == 3 then
+            if filteredCustomIconsCache and filteredCustomIconsCacheKey == cacheKey then
+                filteredItems = filteredCustomIconsCache;
+            else
             filteredItems = GetCustomIconsFiltered(customIconCategory, filter);
+                filteredCustomIconsCache = filteredItems;
+                filteredCustomIconsCacheKey = cacheKey;
+            end
         end
 
         local totalItems = #filteredItems;
         local totalPages = math.max(1, math.ceil(totalItems / ICONS_PER_PAGE));
 
         -- Show filtered count for spells and custom (items count shown near page navigation only)
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             local allSpells = GetAllSpells();
             local countText = string.format('%d of %d spells', totalItems, #allSpells);
-            if iconPickerSpellType ~= 'All' then
-                countText = countText .. ' (' .. (SPELL_TYPE_LABELS[iconPickerSpellType] or iconPickerSpellType) .. ')';
+            if MP.iconPickerSpellType ~= 'All' then
+                countText = countText .. ' (' .. (SPELL_TYPE_LABELS[MP.iconPickerSpellType] or MP.iconPickerSpellType) .. ')';
             end
             imgui.TextColored(COLORS.textMuted, countText);
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             local allCustom = LoadCustomIcons();
             local countText = string.format('%d of %d custom icons', totalItems, #allCustom);
             if customIconCategory ~= 'all' then
@@ -2790,16 +5302,10 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Text, COLORS.goldDim);
             if imgui.Button('Refresh##refreshCustom', {60, 18}) then
-                -- Clear all caches to force rescan
-                customIconsCache = nil;
-                customIconsByCategoryCache = {};
-                customCategoryIconCache = {};
+                InvalidateCustomIconScanCaches();
                 customIconsCacheKey = nil;
-                -- Clear TextureManager custom icons cache
-                TextureManager.clearCategory('custom_icons');
-                -- Also clear the action module's custom icon cache
                 actions.ClearCustomIconCache();
-                -- Reset progressive loading
+                TextureManager.clearCategory('custom_icons');
                 ResetIconLoading();
             end
             imgui.PopStyleColor(3);
@@ -2813,7 +5319,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgMedium);
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             
-            if imgui.BeginPopupModal('Delete Folder##deleteFolderPopup', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+            if imgui.BeginPopup('Delete Folder##deleteFolderPopup') then
                 local categoryLabel = CUSTOM_ICON_LABELS[deleteFolderTarget] or deleteFolderTarget or '';
                 local iconCount = customIconsByCategoryCache[deleteFolderTarget] and #customIconsByCategoryCache[deleteFolderTarget] or 0;
                 
@@ -2857,7 +5363,7 @@ local function DrawIconPicker()
         -- Clamp current page
         if currentPage > totalPages then
             currentPage = totalPages;
-            iconPickerPage[iconPickerTab] = currentPage;
+            MP.iconPickerPage[MP.iconPickerTab] = currentPage;
         end
 
         -- Page navigation UI
@@ -2873,7 +5379,7 @@ local function DrawIconPicker()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textMuted);
             end
             if imgui.Button('<##prevPage', {30, 22}) and canGoPrev then
-                iconPickerPage[iconPickerTab] = currentPage - 1;
+                MP.iconPickerPage[MP.iconPickerTab] = currentPage - 1;
             end
             if not canGoPrev then
                 imgui.PopStyleColor(3);
@@ -2894,7 +5400,7 @@ local function DrawIconPicker()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textMuted);
             end
             if imgui.Button('>##nextPage', {30, 22}) and canGoNext then
-                iconPickerPage[iconPickerTab] = currentPage + 1;
+                MP.iconPickerPage[MP.iconPickerTab] = currentPage + 1;
             end
             if not canGoNext then
                 imgui.PopStyleColor(3);
@@ -2928,7 +5434,7 @@ local function DrawIconPicker()
 
         local displayedCount = 0;
 
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             -- Spell icons - render current page from filtered list
             if totalItems == 0 then
                 imgui.TextColored(COLORS.textMuted, 'No matching spells found');
@@ -2961,11 +5467,25 @@ local function DrawIconPicker()
                                 tooltipText = spell.name .. ' (' .. (SPELL_TYPE_LABELS[spell.type] or spell.type) .. ')';
                             end
 
-                            local isSelected = editingMacro.customIconType == 'spell' and editingMacro.customIconId == spell.id;
+                            local isSelected;
+                            if MP.iconPickerTargetIsJaBadge then
+                                isSelected = MP.editingMacro.jaBadgeCustomIconType == 'spell' and MP.editingMacro.jaBadgeCustomIconId == spell.id;
+                            else
+                                isSelected = MP.editingMacro.customIconType == 'spell' and MP.editingMacro.customIconId == spell.id;
+                            end
                             if DrawIconButton('##spell' .. spell.id, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                                editingMacro.customIconType = 'spell';
-                                editingMacro.customIconId = spell.id;
-                                iconPickerOpen = false;
+                                if MP.iconPickerTargetIsJaBadge then
+                                    MP.editingMacro.jaBadgeCustomIconType = 'spell';
+                                    MP.editingMacro.jaBadgeCustomIconId = spell.id;
+                                    MP.editingMacro.jaBadgeCustomIconPath = nil;
+                                    MP.editorJaBadgeManuallySet = true;
+                                else
+                                    MP.editingMacro.customIconType = 'spell';
+                                    MP.editingMacro.customIconId = spell.id;
+                                    MP.editingMacro.customIconPath = nil;
+                                end
+                                MP.editorAutoIconKey = nil;
+                                MP.iconPickerOpen = false;
                             end
 
                             displayedCount = displayedCount + 1;
@@ -2974,7 +5494,7 @@ local function DrawIconPicker()
                 end
             end
 
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             -- Item icons - render current page from filtered list with progressive loading
             if itemIconLoadState.loading and #itemIconLoadState.items == 0 then
                 imgui.TextColored(COLORS.textMuted, 'Loading item database...');
@@ -2985,7 +5505,7 @@ local function DrawIconPicker()
                 local loadCacheKey = cacheKey .. ':' .. tostring(currentPage);
                 if iconLoadState.currentCacheKey ~= loadCacheKey then
                     iconLoadState.currentPage = currentPage;
-                    iconLoadState.currentTab = iconPickerTab;
+                    iconLoadState.currentTab = MP.iconPickerTab;
                     iconLoadState.currentCacheKey = loadCacheKey;
                     iconLoadState.loadedCount = 0;
                     iconLoadState.pageIconCache = {};
@@ -3046,11 +5566,25 @@ local function DrawIconPicker()
                             tooltipText = item.name .. ' (' .. typeLabel .. ')';
                         end
 
-                        local isSelected = editingMacro.customIconType == 'item' and editingMacro.customIconId == item.id;
-                        if DrawIconButton('##item' .. item.id, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                            editingMacro.customIconType = 'item';
-                            editingMacro.customIconId = item.id;
-                            iconPickerOpen = false;
+                        local isSelectedItem;
+                        if MP.iconPickerTargetIsJaBadge then
+                            isSelectedItem = MP.editingMacro.jaBadgeCustomIconType == 'item' and MP.editingMacro.jaBadgeCustomIconId == item.id;
+                        else
+                            isSelectedItem = MP.editingMacro.customIconType == 'item' and MP.editingMacro.customIconId == item.id;
+                        end
+                        if DrawIconButton('##item' .. item.id, icon, ICON_GRID_SIZE, isSelectedItem, tooltipText) then
+                            if MP.iconPickerTargetIsJaBadge then
+                                MP.editingMacro.jaBadgeCustomIconType = 'item';
+                                MP.editingMacro.jaBadgeCustomIconId = item.id;
+                                MP.editingMacro.jaBadgeCustomIconPath = nil;
+                                MP.editorJaBadgeManuallySet = true;
+                            else
+                                MP.editingMacro.customIconType = 'item';
+                                MP.editingMacro.customIconId = item.id;
+                                MP.editingMacro.customIconPath = nil;
+                            end
+                            MP.editorAutoIconKey = nil;
+                            MP.iconPickerOpen = false;
                         end
 
                         displayedCount = displayedCount + 1;
@@ -3058,7 +5592,7 @@ local function DrawIconPicker()
                 end
             end
         
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             -- Custom icons - render from custom directory with progressive loading
             if totalItems == 0 then
                 if customIconCategory ~= 'all' then
@@ -3098,9 +5632,9 @@ local function DrawIconPicker()
             else
                 -- Check if page/tab/filter changed - reset icon cache
                 local loadCacheKey = cacheKey .. ':' .. tostring(currentPage);
-                if iconLoadState.currentCacheKey ~= loadCacheKey or iconLoadState.currentTab ~= iconPickerTab then
+                if iconLoadState.currentCacheKey ~= loadCacheKey or iconLoadState.currentTab ~= MP.iconPickerTab then
                     iconLoadState.currentPage = currentPage;
-                    iconLoadState.currentTab = iconPickerTab;
+                    iconLoadState.currentTab = MP.iconPickerTab;
                     iconLoadState.currentCacheKey = loadCacheKey;
                     iconLoadState.loadedCount = 0;
                     iconLoadState.pageIconCache = {};
@@ -3159,12 +5693,25 @@ local function DrawIconPicker()
                             tooltipText = customIcon.name .. ' (' .. categoryLabel .. ')';
                         end
 
-                        local isSelected = editingMacro.customIconType == 'custom' and editingMacro.customIconPath == customIcon.path;
-                        if DrawIconButton('##custom' .. itemIdx, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                            editingMacro.customIconType = 'custom';
-                            editingMacro.customIconPath = customIcon.path;
-                            editingMacro.customIconId = nil;
-                            iconPickerOpen = false;
+                        local isSelectedCust;
+                        if MP.iconPickerTargetIsJaBadge then
+                            isSelectedCust = MP.editingMacro.jaBadgeCustomIconType == 'custom' and MP.editingMacro.jaBadgeCustomIconPath == customIcon.path;
+                        else
+                            isSelectedCust = MP.editingMacro.customIconType == 'custom' and MP.editingMacro.customIconPath == customIcon.path;
+                        end
+                        if DrawIconButton('##custom' .. itemIdx, icon, ICON_GRID_SIZE, isSelectedCust, tooltipText) then
+                            if MP.iconPickerTargetIsJaBadge then
+                                MP.editingMacro.jaBadgeCustomIconType = 'custom';
+                                MP.editingMacro.jaBadgeCustomIconPath = customIcon.path;
+                                MP.editingMacro.jaBadgeCustomIconId = nil;
+                                MP.editorJaBadgeManuallySet = true;
+                            else
+                                MP.editingMacro.customIconType = 'custom';
+                                MP.editingMacro.customIconPath = customIcon.path;
+                                MP.editingMacro.customIconId = nil;
+                            end
+                            MP.editorAutoIconKey = nil;
+                            MP.iconPickerOpen = false;
                         end
 
                         displayedCount = displayedCount + 1;
@@ -3181,12 +5728,13 @@ local function DrawIconPicker()
     PopWindowStyle();
 
     if not isOpen[1] then
-        iconPickerOpen = false;
-        iconPickerFilter[1] = '';
-        iconPickerPage = { 1, 1, 1 };  -- Reset pages
-        iconPickerLastFilter = { '', '', '' };
-        iconPickerSpellType = 'All';  -- Reset spell type filter
-        iconPickerItemType = 0;  -- Reset item type filter (0 = All)
+        MP.iconPickerOpen = false;
+        MP.iconPickerTargetIsJaBadge = false;
+        MP.iconPickerFilter[1] = '';
+        MP.iconPickerPage = { 1, 1, 1 };  -- Reset pages
+        MP.iconPickerLastFilter = { '', '', '' };
+        MP.iconPickerSpellType = 'All';  -- Reset spell type filter
+        MP.iconPickerItemType = 0;  -- Reset item type filter (0 = All)
         customIconCategory = 'all';  -- Reset custom category filter
         -- Clear filter caches when picker closes
         filteredSpellsCache = nil;
@@ -3194,626 +5742,570 @@ local function DrawIconPicker()
         filteredItemsCache = nil;
         filteredItemsCacheKey = nil;
         customIconsCacheKey = nil;
+        filteredCustomIconsCache = nil;
+        filteredCustomIconsCacheKey = nil;
         -- Reset progressive icon loading
         ResetIconLoading();
     end
 end
 
-function M.DrawMacroEditor()
-    if not editingMacro then
+-- When opening the icon picker (Change), align tab / filters with the resolved icon; search text is always the
+-- primary action name (what auto-pick matched against), not the resolved spell/item/custom label.
+-- Implemented on M (not a file-local) so M.DrawMacroEditor does not gain an extra upvalue (Lua 5.1 limit: 60).
+function M.ApplyIconPickerContextFromEditor(forJaBadgeArg)
+    if not MP.editingMacro then
         return;
     end
 
-    -- Initialize editor fields from editing macro
-    editorFields.actionType[1] = FindIndex(ACTION_TYPES, editingMacro.actionType or 'ma');
-    editorFields.action[1] = editingMacro.action or '';
-    editorFields.target[1] = FindIndex(TARGET_OPTIONS, editingMacro.target or 't');
-    editorFields.displayName[1] = editingMacro.displayName or '';
-    editorFields.equipSlot[1] = FindIndex(EQUIP_SLOTS, editingMacro.equipSlot or 'main');
-    editorFields.macroText[1] = editingMacro.macroText or '';
-    editorFields.recastSourceType[1] = FindIndex(RECAST_SOURCE_TYPES, editingMacro.recastSourceType or 'none');
-    editorFields.recastSourceAction[1] = editingMacro.recastSourceAction or '';
+    local forJaBadge = forJaBadgeArg and true or false;
+    MP.iconPickerTargetIsJaBadge = forJaBadge;
 
-    local title = isCreatingNew and 'Create Macro###MacroEditor' or 'Edit Macro###MacroEditor';
-    local isOpen = { true };
+    local pType;
+    local pName;
+    local jaBadgeName;
 
-    imgui.SetNextWindowSize({420, 480}, ImGuiCond_FirstUseEver);
+    if MP.editingMacro.actionType == 'macro' then
+        local mp = require('modules.hotbar.macroparse');
+        pType, pName, jaBadgeName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+    else
+        pType = MP.editingMacro.actionType;
+        pName = MP.editingMacro.action;
+    end
 
-    -- Apply XIUI styling
-    PushWindowStyle();
-
-    if imgui.Begin(title, isOpen, ImGuiWindowFlags_NoCollapse) then
-        -- Icon preview section at the top right (uses window-relative positioning for scrolling)
-        local iconPreviewSize = 64;
-        local contentWidth = imgui.GetContentRegionAvail();
-        local iconPreviewX = contentWidth - iconPreviewSize - 10;
-
-        -- Draw icon preview and Change button together
-        local startCursorY = imgui.GetCursorPosY();
-        imgui.SetCursorPosX(iconPreviewX);
-
-        -- Get screen position for icon preview (DrawIconPreview needs screen coords)
-        local screenPos = {imgui.GetCursorScreenPos()};
-        DrawIconPreview(editingMacro, screenPos[1], screenPos[2], iconPreviewSize);
-
-        -- Change Icon button below preview (use window-relative SetCursorPos for scroll support)
-        imgui.SetCursorPos({iconPreviewX - 10, startCursorY + iconPreviewSize + 8});
-        imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
-        imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
-        if imgui.Button('Change', {iconPreviewSize + 20, 22}) then
-            iconPickerOpen = true;
-            iconPickerFilter[1] = '';
+    if forJaBadge then
+        if not jaBadgeName or jaBadgeName == '' then
+            return;
         end
-        imgui.PopStyleColor();
-        imgui.PopStyleVar();
+        pType = 'ja';
+        pName = jaBadgeName;
+    end
 
-        -- Reset cursor for main content (left side, use window-relative positioning)
-        imgui.SetCursorPos({8, startCursorY});
+    if pName then
+        pName = tostring(pName);
+        pName = pName:match('^%s*(.-)%s*$') or pName;
+        if pName == '' then
+            pName = nil;
+        end
+    end
 
-        -- Action Type dropdown with label
-        imgui.TextColored(COLORS.goldDim, 'Action Type');
-        PushComboStyle();
-        imgui.SetNextItemWidth(240);
-        local currentType = ACTION_TYPES[editorFields.actionType[1]];
-        if imgui.BeginCombo('##actionType', ACTION_TYPE_LABELS[currentType] or 'Select...') then
-            for i, actionType in ipairs(ACTION_TYPES) do
-                local isSelected = editorFields.actionType[1] == i;
-                if isSelected then
-                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
-                end
-                if imgui.Selectable(ACTION_TYPE_LABELS[actionType], isSelected) then
-                    editorFields.actionType[1] = i;
-                    editingMacro.actionType = actionType;
-                    -- Clear action when type changes
-                    editingMacro.action = '';
-                    editorFields.action[1] = '';
-                    searchFilter[1] = '';
-                    -- Clear recast source fields when changing away from macro type
-                    if actionType ~= 'macro' then
-                        editingMacro.recastSourceType = nil;
-                        editingMacro.recastSourceAction = nil;
-                        editingMacro.recastSourceItemId = nil;
-                        editorFields.recastSourceType[1] = 1;  -- Reset to 'none'
-                        editorFields.recastSourceAction[1] = '';
+    local ct = forJaBadge and MP.editingMacro.jaBadgeCustomIconType or MP.editingMacro.customIconType;
+    local cid = forJaBadge and MP.editingMacro.jaBadgeCustomIconId or MP.editingMacro.customIconId;
+    local cp = forJaBadge and MP.editingMacro.jaBadgeCustomIconPath or MP.editingMacro.customIconPath;
+
+    local src = MP.editorIconAutoSource or 'all';
+
+    -- Custom XIUI icon actually on the macro, or the same match auto-pick would use first (/pet before spell, etc.).
+    local customEntryForPicker = nil;
+    if ct == 'custom' and cp and tostring(cp) ~= '' then
+        customEntryForPicker = FindCustomIconEntryBySavedPath(cp);
+        if not customEntryForPicker then
+            local base = tostring(cp):match('[^\\/]+$') or '';
+            base = base:gsub('%.png$', '');
+            if base ~= '' then
+                customEntryForPicker = { name = base, category = 'all' };
+            end
+        end
+    elseif ct ~= 'spell' and ct ~= 'item' and pName then
+        -- Match AutoPick order: item id â†’ spell id (for /ma) before inferring a custom PNG.
+        local exactItemId = (MP.editingMacro.itemId and tonumber(MP.editingMacro.itemId)) or actiondb.GetItemId(pName);
+        local maSpellId = (pType == 'ma' and pName) and actions.GetSpellIdByEnglishName(pName, 'ma') or nil;
+        local tryInfer = (pType == 'pet' or pType == 'ja' or pType == 'ws')
+            or (src == 'custom' and pType == 'ma')
+            or (pType == 'ma' and pName and not maSpellId and (src == 'all' or src == 'custom'))
+            or ((pType == 'item' or pType == 'equip') and (not exactItemId or exactItemId == 0));
+        if tryInfer then
+            customEntryForPicker = ResolveBestCustomIconMatchForActionName(pName, MP.editorCustomIconCategory or 'all');
                     end
                 end
-                if isSelected then
-                    imgui.PopStyleColor();
+
+    if customEntryForPicker then
+        MP.iconPickerTab = 3;
+    elseif src == 'items' then
+        MP.iconPickerTab = 2;
+    elseif src == 'custom' then
+        MP.iconPickerTab = 3;
+    elseif src == 'spells' then
+        MP.iconPickerTab = 1;
+    else
+        if pType == 'item' or pType == 'equip' then
+            MP.iconPickerTab = 2;
+        else
+            MP.iconPickerTab = 1;
+                end
+            end
+
+    MP.iconPickerPage[1] = 1;
+    MP.iconPickerPage[2] = 1;
+    MP.iconPickerPage[3] = 1;
+
+    filteredSpellsCache = nil;
+    filteredSpellsCacheKey = nil;
+    filteredItemsCache = nil;
+    filteredItemsCacheKey = nil;
+    customIconsCacheKey = nil;
+    filteredCustomIconsCache = nil;
+    filteredCustomIconsCacheKey = nil;
+    ResetIconLoading();
+
+    local function mapHorizonTypeToSpellFilter(dbType)
+        if not dbType or dbType == 'All' then
+            return nil;
+        end
+        if dbType == 'BloodPact' then
+            return 'SummonerPact';
+        end
+        for _, st in ipairs(SPELL_TYPE_ORDER) do
+            if st == dbType then
+                return dbType;
+            end
+        end
+        return nil;
+    end
+
+    if MP.iconPickerTab == 2 then
+        MP.iconPickerSpellType = 'All';
+        -- Search shows the action text auto-pick matched against, not the resolved item's canonical name.
+        if pName and (pType == 'item' or pType == 'equip') then
+            MP.iconPickerFilter[1] = pName;
+        else
+            MP.iconPickerFilter[1] = '';
+        end
+        return;
+    end
+
+    if MP.iconPickerTab == 3 then
+        MP.iconPickerSpellType = 'All';
+        -- Same: search = user/primary-line text that drove matching; folder still reflects the picked asset.
+        MP.iconPickerFilter[1] = pName or '';
+        if customEntryForPicker then
+            if customEntryForPicker.category and customEntryForPicker.category ~= 'root' then
+                customIconCategory = customEntryForPicker.category;
+            else
+                customIconCategory = 'all';
+            end
+        end
+        return;
+    end
+
+    -- Spells tab: spell-type filter from resolved id/row; search = primary action text (what matching used).
+    do
+        local horizonSpells = require('modules.hotbar.database.horizonspells');
+        local hid;
+
+        if ct == 'spell' and cid then
+            hid = tonumber(cid);
+        elseif not forJaBadge then
+            local at = tostring(MP.editingMacro.actionType or '');
+            local maOrPet = false;
+            if at == 'macro' then
+                local mp = require('modules.hotbar.macroparse');
+                local pt = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+                maOrPet = (pt == 'ma' or pt == 'pet');
+            elseif at == 'ma' or at == 'pet' then
+                maOrPet = true;
+            end
+            if maOrPet then
+                local _, rid = actions.GetBindIcon(MP.editingMacro);
+                if rid and type(rid) == 'number' and horizonSpells[rid] and horizonSpells[rid].en then
+                    hid = rid;
+                end
+            end
+        end
+
+        if hid then
+            local h = horizonSpells[hid];
+            if h and h.en then
+                local bt = mapHorizonTypeToSpellFilter(h.type);
+                if bt then
+                    MP.iconPickerSpellType = bt;
+                else
+                    MP.iconPickerSpellType = 'All';
+                end
+                MP.iconPickerFilter[1] = pName or '';
+                return;
+            end
+        end
+    end
+
+    local spellRow = nil;
+    if pName and (pType == 'ma' or pType == 'pet') then
+        spellRow = actions.GetHorizonSpellForIconResolution(pName, pType);
+    end
+
+    local bestType = spellRow and mapHorizonTypeToSpellFilter(spellRow.type) or nil;
+
+    if bestType then
+        MP.iconPickerSpellType = bestType;
+        MP.iconPickerFilter[1] = pName or '';
+    elseif pType == 'ma' or pType == 'pet' then
+        MP.iconPickerSpellType = 'All';
+        MP.iconPickerFilter[1] = pName or '';
+    else
+        MP.iconPickerSpellType = 'All';
+        MP.iconPickerFilter[1] = pName or '';
+    end
+end
+
+-- Title-bar display name for the macro editor (e.g. "WHM", "Global", "SMN (Ifrit)").
+function M.GetEditorSaveDisplayName()
+    local saveKey = MP.editorPaletteKey or GetEffectivePaletteType();
+    return GetPaletteDisplayName(saveKey);
+end
+
+-- Compact save-target toolbar drawn just below the title bar in create mode.
+function M.DrawMacroEditorSaveToSection(creatingNew, contentWidth)
+    local function applyEditorSaveKey(newKey)
+        MP.editorPaletteKey = newKey;
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+    end
+
+    local saveKey = MP.editorPaletteKey or GetEffectivePaletteType();
+    local currentPlayerJob = data.jobId or 1;
+
+    if not creatingNew then
+        return;
+    end
+
+    local function mc(k)
+        return CountMacrosInPalette(k);
+    end
+    local function labelTextWidth(str)
+        local sz = imgui.CalcTextSize(tostring(str or ''));
+        if type(sz) == 'table' then
+            return sz[1] or sz.x or 0;
+        end
+        return tonumber(sz) or 0;
+    end
+
+    imgui.TextColored(COLORS.textDim, 'Saving To');
+    imgui.SameLine(0, 6);
+
+    local maxOptW = labelTextWidth(GetPaletteDisplayName(saveKey));
+    local gCount = mc(GLOBAL_MACRO_KEY);
+    local gLabel = gCount > 0 and string.format('Global (%d)', gCount) or 'Global';
+    maxOptW = math.max(maxOptW, labelTextWidth(gLabel));
+    local iCount = mc(ITEMS_MACRO_KEY);
+    local iLabel = iCount > 0 and string.format('Items (%d)', iCount) or 'Items';
+    maxOptW = math.max(maxOptW, labelTextWidth(iLabel));
+    local eCount = mc(EQUIPMENT_MACRO_KEY);
+    local eLabel = eCount > 0 and string.format('Equipment (%d)', eCount) or 'Equipment';
+    maxOptW = math.max(maxOptW, labelTextWidth(eLabel));
+    local xCount = mc(XIUI_MACRO_KEY);
+    local xLabel = xCount > 0 and string.format('XIUI Commands (%d)', xCount) or 'XIUI Commands';
+    maxOptW = math.max(maxOptW, labelTextWidth(xLabel));
+    EnsureMacroCustomCategoriesList();
+    for _, cat in ipairs(gConfig.macroCustomCategories) do
+        local ck = cat.key;
+        local cCount = mc(ck);
+        local cLab = cat.label or ck;
+        if cCount > 0 then
+            cLab = string.format('%s (%d)', cLab, cCount);
+        end
+        maxOptW = math.max(maxOptW, labelTextWidth(cLab));
+    end
+    for _, job in ipairs(JOB_LIST) do
+        local jCount = mc(job.id);
+        local label = job.name;
+        if jCount > 0 then
+            label = string.format('%s (%d)', label, jCount);
+        end
+        if job.id == currentPlayerJob then
+            label = label .. '  *';
+        end
+        if job.id == data.subjobId then
+            label = label .. '  /sub';
+        end
+        maxOptW = math.max(maxOptW, labelTextWidth(label));
+    end
+    local fp = imgui.GetStyle().FramePadding;
+    local fpX = (type(fp) == 'table' and (fp.x or fp[1])) or 8;
+    local comboW = maxOptW + (fpX * 2) + 28;
+    comboW = math.max(80, math.min(comboW, contentWidth * 0.4));
+
+    PushComboStyle();
+    imgui.SetNextItemWidth(comboW);
+    if imgui.BeginCombo('##macroEditorSavePalette', GetPaletteDisplayName(saveKey), ImGuiComboFlags_None) then
+        local gSel = (saveKey == GLOBAL_MACRO_KEY);
+        if gSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif gCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(gLabel, gSel) then
+            applyEditorSaveKey(GLOBAL_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local itemsSel = (saveKey == ITEMS_MACRO_KEY);
+        if itemsSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif iCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(iLabel, itemsSel) then
+            applyEditorSaveKey(ITEMS_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local equipSel = (saveKey == EQUIPMENT_MACRO_KEY);
+        if equipSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif eCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(eLabel, equipSel) then
+            applyEditorSaveKey(EQUIPMENT_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local xiuiSel = (saveKey == XIUI_MACRO_KEY);
+        if xiuiSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif xCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(xLabel, xiuiSel) then
+            applyEditorSaveKey(XIUI_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        for _, cat in ipairs(gConfig.macroCustomCategories) do
+            local ck = cat.key;
+            local cCount = mc(ck);
+            local cLab = cat.label or ck;
+            if cCount > 0 then
+                cLab = string.format('%s (%d)', cLab, cCount);
+            end
+            local cSel = (saveKey == ck);
+            if cSel then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            elseif cCount > 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+            if imgui.Selectable(cLab, cSel) then
+                applyEditorSaveKey(ck);
+            end
+            imgui.PopStyleColor();
+        end
+
+        imgui.Separator();
+
+        for _, job in ipairs(JOB_LIST) do
+            local jCount = mc(job.id);
+            local label = job.name;
+            if jCount > 0 then
+                label = string.format('%s (%d)', label, jCount);
+            end
+            if job.id == currentPlayerJob then
+                label = label .. '  *';
+            end
+            if job.id == data.subjobId then
+                label = label .. '  /sub';
+            end
+            local jSel = (EditorSaveKeyToJobId(saveKey) == job.id);
+            if jSel then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            elseif jCount > 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+            if imgui.Selectable(label, jSel) then
+                applyEditorSaveKey(job.id);
+            end
+            imgui.PopStyleColor();
+        end
+        imgui.EndCombo();
+    end
+    PopComboStyle();
+
+    -- SMN sub-type combo on the same line
+    if EditorSaveKeyToJobId(saveKey) == petregistry.JOB_SMN then
+        imgui.SameLine(0, 10);
+        imgui.TextColored(COLORS.textDim, '/');
+        imgui.SameLine(0, 10);
+
+        local avatarList = petregistry.GetAvatarList();
+        local currentLabel = 'Base SMN';
+        if type(saveKey) == 'string' then
+            local jobId, petType, petId = saveKey:match('^(%d+):([^:]+):(.+)$');
+            if jobId and tonumber(jobId) == petregistry.JOB_SMN and petType == 'avatar' and petId then
+                for name, key in pairs(petregistry.avatars) do
+                    if key == petId then
+                        currentLabel = name;
+                        break;
+                    end
+                end
+            end
+        end
+
+        local subMaxW = labelTextWidth('Base SMN');
+        for _, av in ipairs(avatarList) do
+            subMaxW = math.max(subMaxW, labelTextWidth(av));
+        end
+        local subComboW = subMaxW + (fpX * 2) + 28;
+        subComboW = math.max(80, math.min(subComboW, contentWidth * 0.35));
+
+        PushComboStyle();
+        imgui.SetNextItemWidth(subComboW);
+        if imgui.BeginCombo('##SaveAvatarPalette', currentLabel, ImGuiComboFlags_None) then
+            local isBaseSelected = (type(saveKey) == 'number' and saveKey == petregistry.JOB_SMN);
+            if imgui.Selectable('Base SMN', isBaseSelected) then
+                applyEditorSaveKey(petregistry.JOB_SMN);
+            end
+            imgui.Separator();
+            for _, avatar in ipairs(avatarList) do
+                local avatarKey = petregistry.avatars[avatar];
+                local fullKey = avatarKey and string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey) or nil;
+                local isSelected = (fullKey ~= nil and saveKey == fullKey);
+                if imgui.Selectable(avatar, isSelected) then
+                    applyEditorSaveKey(fullKey);
                 end
             end
             imgui.EndCombo();
         end
         PopComboStyle();
-
-        imgui.Spacing();
-        imgui.Spacing();
-
-        -- Dynamic fields based on action type
-        currentType = ACTION_TYPES[editorFields.actionType[1]];
-
-        if currentType == 'ma' then
-            -- Spell: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Spell');
-            local spells = GetCachedSpells();
-            if spells and #spells > 0 then
-                DrawSearchableCombo('##spellCombo', spells, editingMacro.action or '', function(spell)
-                    editingMacro.action = spell.name;
-                    editorFields.action[1] = spell.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = spell.name;
-                        editorFields.displayName[1] = spell.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No spells available for this job');
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'ja' then
-            -- Ability: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Ability');
-            local abilities = GetCachedAbilities();
-            if abilities and #abilities > 0 then
-                DrawSearchableCombo('##abilityCombo', abilities, editingMacro.action or '', function(ability)
-                    editingMacro.action = ability.name;
-                    editorFields.action[1] = ability.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = ability.name;
-                        editorFields.displayName[1] = ability.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No abilities available');
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'ws' then
-            -- Weaponskill: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Weaponskill');
-            local weaponskills = GetCachedWeaponskills();
-            if weaponskills and #weaponskills > 0 then
-                DrawSearchableCombo('##wsCombo', weaponskills, editingMacro.action or '', function(ws)
-                    editingMacro.action = ws.name;
-                    editorFields.action[1] = ws.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = ws.name;
-                        editorFields.displayName[1] = ws.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No weaponskills available');
-            end
-
-            -- Target dropdown (default to <t>)
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'item' then
-            -- Item: Searchable dropdown or manual input
-            imgui.TextColored(COLORS.goldDim, 'Item');
-            local items = GetCachedItems();
-            if items and #items > 0 then
-                DrawSearchableCombo('##itemCombo', items, editingMacro.action or '', function(item)
-                    editingMacro.action = item.name;
-                    editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
-                    editorFields.action[1] = item.name;
-                    editingMacro.displayName = item.name;
-                    editorFields.displayName[1] = item.name;
-                end, true);  -- Show icons
-                imgui.SameLine();
-                imgui.TextColored(COLORS.textMuted, '(' .. #items .. ')');
-            else
-                imgui.TextColored(COLORS.textMuted, 'No items found in storage');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type item name:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##itemName', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'equip' then
-            -- Equipment slot dropdown
-            imgui.TextColored(COLORS.goldDim, 'Equipment Slot');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##equipSlot', EQUIP_SLOT_LABELS[EQUIP_SLOTS[editorFields.equipSlot[1]]] or 'Select...') then
-                for i, slot in ipairs(EQUIP_SLOTS) do
-                    local isSelected = editorFields.equipSlot[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(EQUIP_SLOT_LABELS[slot], isSelected) then
-                        editorFields.equipSlot[1] = i;
-                        editingMacro.equipSlot = slot;
-                        -- Clear item selection when slot changes (old item may not fit new slot)
-                        editingMacro.action = '';
-                        editingMacro.itemId = nil;
-                        editingMacro.displayName = '';
-                        editorFields.action[1] = '';
-                        editorFields.displayName[1] = '';
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-            -- Item: Searchable dropdown or manual input (filtered by selected equipment slot)
-            imgui.Spacing();
-            local selectedSlot = EQUIP_SLOTS[editorFields.equipSlot[1]];
-            imgui.TextColored(COLORS.goldDim, 'Item (' .. EQUIP_SLOT_LABELS[selectedSlot] .. ')');
-            local equipItems = GetCachedItems();
-            if equipItems and #equipItems > 0 then
-                DrawSearchableCombo('##equipItemCombo', equipItems, editingMacro.action or '', function(item)
-                    editingMacro.action = item.name;
-                    editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
-                    editorFields.action[1] = item.name;
-                    editingMacro.displayName = item.name;
-                    editorFields.displayName[1] = item.name;
-                end, true, selectedSlot);  -- Show icons, filter by selected slot
-                imgui.SameLine();
-                imgui.TextColored(COLORS.textMuted, '(' .. #equipItems .. ')');
-            else
-                imgui.TextColored(COLORS.textMuted, 'No items found in storage');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type item name:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##equipItemName', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-        elseif currentType == 'macro' then
-            -- Raw macro command (8 lines like native FFXI macro editor)
-            imgui.TextColored(COLORS.goldDim, 'Macro Commands (8 lines)');
-
-            -- Style the multiline input
-            imgui.PushStyleColor(ImGuiCol_FrameBg, COLORS.bgMedium);
-            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLORS.bgLight);
-            imgui.PushStyleColor(ImGuiCol_FrameBgActive, COLORS.bgLight);
-
-            -- 8 rows * ~16px line height + padding
-            local lineHeight = imgui.GetTextLineHeight();
-            local inputHeight = (lineHeight * 8) + 8;
-
-            if imgui.InputTextMultiline('##macroText', editorFields.macroText, MACRO_BUFFER_SIZE, {280, inputHeight}) then
-                editingMacro.macroText = editorFields.macroText[1];
-                editingMacro.action = editorFields.macroText[1];
-            end
-
-            imgui.PopStyleColor(3);
-            imgui.ShowHelp('Enter commands, one per line (e.g., /ma "Cure" <stpc>)');
-
-            -- Recast Source section (optional)
-            imgui.Spacing();
-            imgui.Spacing();
-            if imgui.TreeNode('Recast Source (Optional)##recastSource') then
-                imgui.TextColored(COLORS.textMuted, 'Show cooldown from a different action');
-                imgui.Spacing();
-
-                -- Recast source type dropdown
-                imgui.TextColored(COLORS.goldDim, 'Source Type');
-                PushComboStyle();
-                imgui.SetNextItemWidth(240);
-                local currentRecastType = RECAST_SOURCE_TYPES[editorFields.recastSourceType[1]] or 'none';
-                if imgui.BeginCombo('##recastSourceType', RECAST_SOURCE_LABELS[currentRecastType] or 'None') then
-                    for i, sourceType in ipairs(RECAST_SOURCE_TYPES) do
-                        local isSelected = editorFields.recastSourceType[1] == i;
-                        if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                        if imgui.Selectable(RECAST_SOURCE_LABELS[sourceType], isSelected) then
-                            editorFields.recastSourceType[1] = i;
-                            if sourceType == 'none' then
-                                editingMacro.recastSourceType = nil;
-                                editingMacro.recastSourceAction = nil;
-                                editingMacro.recastSourceItemId = nil;
-                            else
-                                editingMacro.recastSourceType = sourceType;
-                            end
-                            -- Clear action when type changes
-                            editingMacro.recastSourceAction = nil;
-                            editingMacro.recastSourceItemId = nil;
-                            editorFields.recastSourceAction[1] = '';
-                        end
-                        if isSelected then imgui.PopStyleColor(); end
-                    end
-                    imgui.EndCombo();
-                end
-                PopComboStyle();
-
-                -- Show action selector based on recast source type
-                currentRecastType = RECAST_SOURCE_TYPES[editorFields.recastSourceType[1]] or 'none';
-
-                if currentRecastType == 'ma' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Spell');
-                    local spells = GetCachedSpells();
-                    if spells and #spells > 0 then
-                        DrawSearchableCombo('##recastSpellCombo', spells, editingMacro.recastSourceAction or '', function(spell)
-                            editingMacro.recastSourceAction = spell.name;
-                            editorFields.recastSourceAction[1] = spell.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No spells available');
-                    end
-
-                elseif currentRecastType == 'ja' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Ability');
-                    local abilities = GetCachedAbilities();
-                    if abilities and #abilities > 0 then
-                        DrawSearchableCombo('##recastAbilityCombo', abilities, editingMacro.recastSourceAction or '', function(ability)
-                            editingMacro.recastSourceAction = ability.name;
-                            editorFields.recastSourceAction[1] = ability.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No abilities available');
-                    end
-
-                elseif currentRecastType == 'item' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Item');
-                    local items = GetCachedItems();
-                    if items and #items > 0 then
-                        DrawSearchableCombo('##recastItemCombo', items, editingMacro.recastSourceAction or '', function(item)
-                            editingMacro.recastSourceAction = item.name;
-                            editingMacro.recastSourceItemId = item.id;
-                            editorFields.recastSourceAction[1] = item.name;
-                        end, true);  -- Show icons
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No items available');
-                    end
-
-                elseif currentRecastType == 'pet' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Pet Command');
-                    -- Use current job for pet commands
-                    local viewedJobId = selectedPaletteType;
-                    if type(viewedJobId) ~= 'number' then
-                        viewedJobId = playerdata.GetCacheJobId() or 0;
-                    end
-                    local petCommands = GetPetCommandsForJob(viewedJobId, selectedAvatarPalette, nil);
-                    if petCommands and #petCommands > 0 then
-                        DrawSearchableCombo('##recastPetCombo', petCommands, editingMacro.recastSourceAction or '', function(cmd)
-                            editingMacro.recastSourceAction = cmd.name;
-                            editorFields.recastSourceAction[1] = cmd.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No pet commands available');
-                    end
-                end
-
-                imgui.TreePop();
-            end
-
-        elseif currentType == 'pet' then
-            -- For SMN, show avatar filter dropdown
-            -- Use the VIEWED palette's job, not necessarily the player's current job
-            local viewedJobId = selectedPaletteType;
-            if type(viewedJobId) ~= 'number' then
-                viewedJobId = playerdata.GetCacheJobId() or 0;
-            end
-            local avatarList = petregistry.GetAvatarList();
-
-            if viewedJobId == petregistry.JOB_SMN then
-                imgui.TextColored(COLORS.goldDim, 'Avatar Filter');
-                PushComboStyle();
-                imgui.SetNextItemWidth(240);
-                local filterLabel = petAvatarFilter == 1 and 'All Avatars' or avatarList[petAvatarFilter - 1];
-                if imgui.BeginCombo('##avatarFilter', filterLabel) then
-                    -- "All" option
-                    local isAllSelected = petAvatarFilter == 1;
-                    if isAllSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable('All Avatars', isAllSelected) then
-                        petAvatarFilter = 1;
-                        cachedPetCommands = nil;  -- Clear cache to rebuild
-                    end
-                    if isAllSelected then imgui.PopStyleColor(); end
-
-                    imgui.Separator();
-
-                    -- Individual avatars
-                    for i, avatar in ipairs(avatarList) do
-                        local isSelected = petAvatarFilter == i + 1;
-                        if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                        if imgui.Selectable(avatar, isSelected) then
-                            petAvatarFilter = i + 1;
-                            cachedPetCommands = nil;  -- Clear cache to rebuild
-                        end
-                        if isSelected then imgui.PopStyleColor(); end
-                    end
-                    imgui.EndCombo();
-                end
-                PopComboStyle();
-                imgui.Spacing();
-            end
-
-            -- Build pet commands cache if needed
-            if not cachedPetCommands then
-                local avatarName = nil;
-                local activePetName = nil;
-                if viewedJobId == petregistry.JOB_SMN then
-                    -- Prefer the macro palette's avatar selection, then the filter
-                    if selectedAvatarPalette then
-                        avatarName = selectedAvatarPalette;
-                    elseif petAvatarFilter > 1 then
-                        avatarName = avatarList[petAvatarFilter - 1];
-                    end
-                elseif viewedJobId == petregistry.JOB_BST then
-                    -- Get the active pet's entity name for BST ready moves
-                    activePetName = petpalette.GetCurrentPetEntityName();
-                end
-                cachedPetCommands = GetPetCommandsForJob(viewedJobId, avatarName, activePetName);
-            end
-
-            -- Pet command dropdown
-            imgui.TextColored(COLORS.goldDim, 'Pet Command');
-            if cachedPetCommands and #cachedPetCommands > 0 then
-                DrawSearchableCombo('##petCommandCombo', cachedPetCommands, editingMacro.action or '', function(cmd)
-                    editingMacro.action = cmd.name;
-                    editorFields.action[1] = cmd.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = cmd.name;
-                        editorFields.displayName[1] = cmd.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No pet commands available for this job');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type command:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##petCommandManual', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-        end
-
-        -- Slot Label input (for all types)
-        imgui.Spacing();
-        imgui.Spacing();
-        imgui.TextColored(COLORS.goldDim, 'Slot Label');
-        imgui.SetNextItemWidth(240);
-        if imgui.InputText('##displayName', editorFields.displayName, 32) then
-            editingMacro.displayName = editorFields.displayName[1];
-        end
-        if currentType ~= 'macro' then
-            imgui.ShowHelp('Short label shown on the slot (e.g., "Cure3"). Leave empty to use action name.');
-        else
-            imgui.ShowHelp('Label shown on the slot for this macro.');
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Save button with success styling
-        imgui.PushStyleColor(ImGuiCol_Button, COLORS.success);
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.5, 0.8, 0.5, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.6, 0.9, 0.6, 1.0});
-        imgui.PushStyleColor(ImGuiCol_Text, {0.1, 0.1, 0.1, 1.0});
-
-        if imgui.Button('Save', {90, 28}) then
-            -- Validate before saving
-            local canSave = false;
-
-            if currentType == 'macro' then
-                canSave = (editingMacro.macroText or '') ~= '';
-                if canSave and (editingMacro.displayName or '') == '' then
-                    editingMacro.displayName = 'Macro';
-                end
-                -- Clear target for macro type (targets are embedded in macro text)
-                editingMacro.target = nil;
-            else
-                canSave = (editingMacro.action or '') ~= '';
-                if canSave and (editingMacro.displayName or '') == '' then
-                    editingMacro.displayName = editingMacro.action;
-                end
-            end
-
-            if canSave then
-                -- Look up itemId for item/equip macros if not already set
-                -- This handles cases where user typed item name manually instead of selecting from dropdown
-                if (currentType == 'item' or currentType == 'equip') and not editingMacro.itemId and editingMacro.action then
-                    editingMacro.itemId = actiondb.GetItemId(editingMacro.action);
-                end
-
-                if isCreatingNew then
-                    M.AddMacro(editingMacro);
-                    -- Navigate to last page to show the new macro
-                    local db = M.GetMacroDatabase();
-                    currentPalettePage = math.max(1, math.ceil(#db / PALETTE_MACROS_PER_PAGE));
-                else
-                    M.UpdateMacro(editingMacro.id, editingMacro);
-                end
-                editingMacro = nil;
-                isCreatingNew = false;
-                searchFilter[1] = '';
-                iconPickerOpen = false;
-                iconPickerFilter[1] = '';
-            end
-        end
-
-        imgui.PopStyleColor(4);
-
-        imgui.SameLine();
-
-        -- Cancel button
-        if imgui.Button('Cancel', {90, 28}) then
-            editingMacro = nil;
-            isCreatingNew = false;
-            searchFilter[1] = '';
-            iconPickerOpen = false;
-            iconPickerFilter[1] = '';
-        end
     end
 
-    imgui.End();
-    PopWindowStyle();
+    if EditorSaveKeyToJobId(saveKey) == petregistry.JOB_BST then
+        imgui.SameLine(0, 10);
+        imgui.TextColored(COLORS.textDim, '/');
+        imgui.SameLine(0, 10);
 
-    if not isOpen[1] then
-        editingMacro = nil;
-        isCreatingNew = false;
-        searchFilter[1] = '';
-        iconPickerOpen = false;
-        iconPickerFilter[1] = '';
+        local currentJugLabel = 'Base BST';
+        if type(saveKey) == 'string' then
+            local jobId, petType, petId = saveKey:match('^(%d+):([^:]+):(.+)$');
+            if jobId and tonumber(jobId) == petregistry.JOB_BST and petType == petregistry.PET_TYPE_JUG and petId then
+                currentJugLabel = petregistry.GetDisplayNameForKey(petregistry.PET_TYPE_JUG .. ':' .. petId);
+            end
+        end
+
+        local subMaxW = labelTextWidth('Base BST');
+        local bstPetKeys = petregistry.GetAvailablePetKeys(petregistry.JOB_BST);
+        for _, pk in ipairs(bstPetKeys) do
+            local slug = pk:match('^jug:(.+)$');
+            if slug then
+                subMaxW = math.max(subMaxW, labelTextWidth(petregistry.GetDisplayNameForKey(pk)));
+            end
+        end
+        local subComboW = subMaxW + (fpX * 2) + 28;
+        subComboW = math.max(80, math.min(subComboW, contentWidth * 0.35));
+
+        PushComboStyle();
+        imgui.SetNextItemWidth(subComboW);
+        if imgui.BeginCombo('##SaveBstJugPalette', currentJugLabel, ImGuiComboFlags_None) then
+            local isBaseSelected = (type(saveKey) == 'number' and saveKey == petregistry.JOB_BST);
+            if imgui.Selectable('Base BST', isBaseSelected) then
+                applyEditorSaveKey(petregistry.JOB_BST);
+            end
+            imgui.Separator();
+            for _, pk in ipairs(bstPetKeys) do
+                local slug = pk:match('^jug:(.+)$');
+                if slug then
+                    local fullKey = string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug);
+                    local label = petregistry.GetDisplayNameForKey(pk);
+                    local isSelected = (saveKey == fullKey);
+                    if imgui.Selectable(label, isSelected) then
+                        applyEditorSaveKey(fullKey);
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        PopComboStyle();
     end
 
-    -- Draw icon picker if open
-    DrawIconPicker();
+    imgui.SameLine(0, 6);
+    imgui.ShowHelp('Palette this macro is saved to.');
+    imgui.Separator();
+    imgui.Spacing();
 end
+
+-- Macro editor: macropalette_macroeditor.lua (Lua 5.1 max 60 upvalues per function).
+do
+    MP.M = M;
+    MP.imgui = imgui;
+    MP.ffi = ffi;
+    MP.actions = actions;
+    MP.data = data;
+    MP.textures = textures;
+    MP.petregistry = petregistry;
+    MP.actiondb = actiondb;
+    MP.playerdata = playerdata;
+    MP.petpalette = petpalette;
+    MP.components = components;
+    MP.COLORS = COLORS;
+    MP.jobs = jobs;
+    MP.ACTION_TYPES = ACTION_TYPES;
+    MP.ACTION_TYPES_ITEMS_BUCKET = ACTION_TYPES_ITEMS_BUCKET;
+    MP.ACTION_TYPE_LABELS = ACTION_TYPE_LABELS;
+    MP.RECAST_SOURCE_TYPES = RECAST_SOURCE_TYPES;
+    MP.RECAST_SOURCE_LABELS = RECAST_SOURCE_LABELS;
+    MP.TARGET_OPTIONS = TARGET_OPTIONS;
+    MP.TARGET_LABELS = TARGET_LABELS;
+    MP.EQUIP_SLOTS = EQUIP_SLOTS;
+    MP.EQUIP_SLOT_LABELS = EQUIP_SLOT_LABELS;
+    MP.ICON_AUTO_SOURCES = ICON_AUTO_SOURCES;
+    MP.ICON_AUTO_SOURCE_LABELS = ICON_AUTO_SOURCE_LABELS;
+    MP.INPUT_BUFFER_SIZE = INPUT_BUFFER_SIZE;
+    MP.MACRO_BUFFER_SIZE = MACRO_BUFFER_SIZE;
+    MP.PALETTE_MACROS_PER_PAGE = PALETTE_MACROS_PER_PAGE;
+    MP.SPELL_TYPE_ORDER = SPELL_TYPE_ORDER;
+    MP.SPELL_TYPE_LABELS = SPELL_TYPE_LABELS;
+    MP.SPELL_TYPE_JOB_ICONS = SPELL_TYPE_JOB_ICONS;
+    MP.editorFields = editorFields;
+    MP.CUSTOM_ICON_CATEGORIES = CUSTOM_ICON_CATEGORIES;
+    MP.CUSTOM_ICON_LABELS = CUSTOM_ICON_LABELS;
+    MP.FindIndex = FindIndex;
+    MP.DrawSearchableCombo = DrawSearchableCombo;
+    MP.DrawIconButton = DrawIconButton;
+    MP.DrawIconPreview = DrawIconPreview;
+    MP.PushComboStyle = PushComboStyle;
+    MP.PopComboStyle = PopComboStyle;
+    MP.PushWindowStyle = PushWindowStyle;
+    MP.PopWindowStyle = PopWindowStyle;
+    MP.LoadCustomIcons = LoadCustomIcons;
+    MP.InvalidateCustomIconScanCaches = InvalidateCustomIconScanCaches;
+    MP.GetCachedSpells = GetCachedSpells;
+    MP.GetCachedAbilities = GetCachedAbilities;
+    MP.GetCachedWeaponskills = GetCachedWeaponskills;
+    MP.GetCachedItems = GetCachedItems;
+    MP.GetPetCommandsForJob = GetPetCommandsForJob;
+    MP.EditorSaveKeyToJobId = EditorSaveKeyToJobId;
+    MP.ITEMS_MACRO_KEY = ITEMS_MACRO_KEY;
+    MP.EQUIPMENT_MACRO_KEY = EQUIPMENT_MACRO_KEY;
+    MP.XIUI_MACRO_KEY = XIUI_MACRO_KEY;
+    MP.ResolveBestCustomIconMatchForActionName = ResolveBestCustomIconMatchForActionName;
+    MP.SyncSaveSubTypeFromPetAvatarFilter = SyncSaveSubTypeFromPetAvatarFilter;
+    MP.SyncSaveSubTypeFromBstJugFamily = SyncSaveSubTypeFromBstJugFamily;
+    MP.SyncPetAvatarFilterFromSaveSubType = SyncPetAvatarFilterFromSaveSubType;
+    MP.ClearEditorPreviewIconCache = ClearEditorPreviewIconCache;
+    MP.ClearPaletteJaBadgeIconCache = ClearPaletteJaBadgeIconCache;
+    MP.HydrateMacroEditorIconPrefs = HydrateMacroEditorIconPrefs;
+    MP.ValidateEditorCustomIconCategoryAgainstScan = ValidateEditorCustomIconCategoryAgainstScan;
+    MP.PersistMacroEditorIconPrefs = PersistMacroEditorIconPrefs;
+    MP.DrawIconPicker = DrawIconPicker;
+    MP.paletteMainIconCache = paletteMainIconCache;
+    MP.paletteJaBadgeIconCache = paletteJaBadgeIconCache;
+end
+
+local runMacroEditor = require('modules.hotbar.macropalette_macroeditor')(MP);
+
+function M.DrawMacroEditor()
+    runMacroEditor();
+end
+
 
 -- ============================================
 -- Dragdrop Library Accessors (for display.lua)
@@ -3857,3 +6349,4 @@ end
 data.SetSlotDataChangedCallback(MarkHotbarDirty);
 
 return M;
+

--- a/XIUI/modules/hotbar/macropalette_macroeditor.lua
+++ b/XIUI/modules/hotbar/macropalette_macroeditor.lua
@@ -1,0 +1,1787 @@
+return function(MP)
+    return function()
+    if not MP.editingMacro then
+        return;
+    end
+
+    if not MP.editorIconPrefsHydrated then
+        MP.HydrateMacroEditorIconPrefs();
+        MP.ValidateEditorCustomIconCategoryAgainstScan();
+        MP.editorIconPrefsHydrated = true;
+    end
+
+    -- Legacy: `action` was set to the full multiline buffer; normalize to the parsed primary name.
+    if MP.editingMacro.actionType == 'macro' and MP.editingMacro.macroText and MP.editingMacro.macroText ~= '' then
+        local a = tostring(MP.editingMacro.action or '');
+        local looksLikeFullMacro = (a:find('\n') or a:find('\r') or a:match('^%s*/'));
+        if looksLikeFullMacro or a == '' then
+            local mp = require('modules.hotbar.macroparse');
+            local _, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText);
+            if pName and pName ~= '' then
+                MP.editingMacro.action = pName;
+            end
+        end
+    end
+
+    -- Initialize editor fields from editing macro
+    MP.editorFields.actionType[1] = MP.FindIndex(MP.ACTION_TYPES, MP.editingMacro.actionType or 'ma');
+    MP.editorFields.action[1] = MP.editingMacro.action or '';
+    MP.editorFields.target[1] = MP.FindIndex(MP.TARGET_OPTIONS, MP.editingMacro.target or 't');
+    MP.editorFields.displayName[1] = MP.editingMacro.displayName or '';
+    MP.editorFields.equipSlot[1] = MP.FindIndex(MP.EQUIP_SLOTS, MP.editingMacro.equipSlot or 'main');
+    MP.editorFields.macroText[1] = MP.editingMacro.macroText or '';
+    MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES, MP.editingMacro.recastSourceType or 'none');
+    MP.editorFields.recastSourceAction[1] = MP.editingMacro.recastSourceAction or '';
+
+    MP.M.ClampMacroEditorForItemsPalette();
+
+    local saveDisplayName = MP.M.GetEditorSaveDisplayName and MP.M.GetEditorSaveDisplayName() or nil;
+    local titlePrefix = MP.isCreatingNew and 'Create Macro' or 'Edit Macro';
+    local title;
+    if saveDisplayName and saveDisplayName ~= '' then
+        title = titlePrefix .. ' - ' .. saveDisplayName .. '###MacroEditor';
+    else
+        title = titlePrefix .. '###MacroEditor';
+    end
+    local isOpen = { true };
+
+    -- Track whether the Slot Label is currently "auto" (same as action). This lets new selections refresh it.
+    do
+        local dn = (MP.editingMacro.displayName or '');
+        local act = (MP.editingMacro.action or '');
+        if dn ~= '' and act ~= '' and dn == act then
+            MP.editorAutoLabel = dn;
+        end
+    end
+
+    local function AutoSetDisplayName(newLabel)
+        if not newLabel or newLabel == '' then return; end
+        local current = (MP.editingMacro.displayName or '');
+        if current == '' or (MP.editorAutoLabel and current == MP.editorAutoLabel) then
+            MP.editingMacro.displayName = newLabel;
+            MP.editorFields.displayName[1] = newLabel;
+            MP.editorAutoLabel = newLabel;
+        end
+    end
+
+    local function ApplyDefaultEditorTargetForJaAbility(abilityName)
+        if abilityName == 'Reward' or abilityName == 'Call Beast' then
+            MP.editorFields.target[1] = MP.FindIndex(MP.TARGET_OPTIONS, 'me');
+            MP.editingMacro.target = 'me';
+        end
+    end
+
+    local function ApplyDefaultEditorTargetForPetCommand(commandName)
+        if commandName == 'Ready'
+            or commandName == 'Ready (Recast)'
+            or commandName == 'Ready (Use)' then
+            MP.editorFields.target[1] = MP.FindIndex(MP.TARGET_OPTIONS, 'me');
+            MP.editingMacro.target = 'me';
+        end
+    end
+
+    --- Primary Pet Command combo shows synthetic Ready rows when jug progression is enabled; map saved macro.action back to the visible row label.
+    local function BstPetPrimaryComboCurrentLabel(macro, viewedPetJobId)
+        if (macro.actionType or '') ~= 'pet' then
+            return macro.action or '';
+        end
+        if viewedPetJobId ~= MP.petregistry.JOB_BST or not MP.petregistry.IsBstJugReadyMovesEnabled() then
+            return macro.action or '';
+        end
+        local act = macro.action or '';
+        if act == 'Ready' then
+            return 'Ready (Recast)';
+        end
+        if macro.bstReadyMode == 'use' and act == '' then
+            return 'Ready (Use)';
+        end
+        if MP.petregistry.IsBstJugReadyMoveName(act) then
+            return 'Ready (Use)';
+        end
+        return act;
+    end
+
+    -- Pet commands follow "Saving To" + Avatar Filter in the editor, not the separate Macro Palette avatar.
+    local function GetEditorPetJobId()
+        if MP.editorPaletteKey and MP.EditorSaveKeyToJobId then
+            local jid = MP.EditorSaveKeyToJobId(MP.editorPaletteKey);
+            if jid then
+                return jid;
+            end
+        end
+        local viewedJobId = MP.selectedPaletteType;
+        if type(viewedJobId) == 'number' then
+            return viewedJobId;
+        end
+        return MP.playerdata.GetCacheJobId() or 0;
+    end
+
+    local function SmnAvatarNameFromEditorFilter(avatarList)
+        if MP.petAvatarFilter <= 1 then
+            return nil;
+        end
+        return avatarList[MP.petAvatarFilter - 1];
+    end
+
+    local function GetCurrentActionNameForIcon()
+        local t = tostring(MP.editingMacro.actionType or '');
+        if t == '' then return nil; end
+        if t == 'macro' then return nil; end
+        local name = tostring(MP.editingMacro.action or '');
+        if name == '' then return nil; end
+        return name;
+    end
+
+    -- Implicit auto-pick (no force): only when no icon is stored yet, and not already synced to MP.editorAutoIconKey.
+    -- Matching MP.editorAutoIconKey means "already applied"; re-pick only via Sync (force=true) or first-open block.
+    local function ShouldAllowImplicitAutoIconPick()
+        local t = MP.editingMacro.customIconType;
+        local id = MP.editingMacro.customIconId;
+        local p = MP.editingMacro.customIconPath;
+        local curKey = tostring(t or '') .. ':' .. tostring(id or '') .. ':' .. tostring(p or '');
+        if MP.editorAutoIconKey and curKey == MP.editorAutoIconKey then
+            return false;
+        end
+        if t == nil and id == nil and (p == nil or p == '') then
+            return true;
+        end
+        return false;
+    end
+
+    local function SetIconSpell(spellId)
+        if not spellId then return; end
+        MP.editingMacro.customIconType = 'spell';
+        MP.editingMacro.customIconId = spellId;
+        MP.editingMacro.customIconPath = nil;
+        MP.editorAutoIconKey = 'spell:' .. tostring(spellId) .. ':';
+    end
+
+    local function SetIconItem(itemId)
+        if not itemId then return; end
+        MP.editingMacro.customIconType = 'item';
+        MP.editingMacro.customIconId = itemId;
+        MP.editingMacro.customIconPath = nil;
+        MP.editorAutoIconKey = 'item:' .. tostring(itemId) .. ':';
+    end
+
+    local function SetIconCustom(customPath)
+        if not customPath or customPath == '' then return; end
+        MP.editingMacro.customIconType = 'custom';
+        MP.editingMacro.customIconPath = customPath;
+        MP.editingMacro.customIconId = nil;
+        MP.editorAutoIconKey = 'custom::' .. tostring(customPath);
+    end
+
+    -- Fallback PNGs in addons/XIUI/assets/icons/ (ma.png, ja.png, macro.png, refresh.png, …)
+    local function SetIconXiuiDefault(stem)
+        if not stem or stem == '' then
+            stem = 'refresh';
+        end
+        MP.editingMacro.customIconType = 'xiui_default';
+        MP.editingMacro.customIconPath = stem;
+        MP.editingMacro.customIconId = nil;
+        MP.editorAutoIconKey = 'xiui_default::' .. stem;
+    end
+
+    local function DefaultIconStemForActionType(at)
+        if at == 'ma' then return 'ma'; end
+        if at == 'ja' then return 'ja'; end
+        if at == 'ws' then return 'ws'; end
+        if at == 'item' then return 'item'; end
+        if at == 'equip' then return 'equip'; end
+        if at == 'pet' then return 'pet'; end
+        if at == 'macro' then return 'macro'; end
+        return 'refresh';
+    end
+
+    local function TryAutoPickCustomIcon(actionName)
+        local icon = MP.ResolveBestCustomIconMatchForActionName(actionName, MP.editorCustomIconCategory or 'all');
+        if icon and icon.path then
+            SetIconCustom(icon.path);
+            return true;
+        end
+        return false;
+    end
+
+    -- Game spell icon: player's cache first, then horizon DB (context-aware for /ma vs /pet duplicates).
+    local function TryAutoPickSpellIconByActionName(actionName, actionType)
+        if not actionName or actionName == '' then
+            return false;
+        end
+        if actionType ~= 'ma' and actionType ~= 'pet' then
+            return false;
+        end
+        local spells = MP.GetCachedSpells();
+        if spells then
+            for _, s in ipairs(spells) do
+                if s and s.name and s.id and string.lower(s.name) == string.lower(actionName) then
+                    SetIconSpell(s.id);
+                    return true;
+                end
+            end
+        end
+        local spellId = MP.actions.GetSpellIdByEnglishName(actionName, actionType);
+        if spellId then
+            SetIconSpell(spellId);
+            return true;
+        end
+        return false;
+    end
+
+    -- Game item texture by item/equip action + itemId / name lookup.
+    local function TryAutoPickItemIconByAction(actionName, actionType)
+        if actionType ~= 'item' and actionType ~= 'equip' then
+            return false;
+        end
+        local itemId = MP.editingMacro.itemId;
+        if (not itemId or itemId == 0) and actionName and actionName ~= '' then
+            itemId = MP.actiondb.GetItemId(actionName);
+        end
+        if itemId and itemId ~= 0 then
+            SetIconItem(itemId);
+            return true;
+        end
+        return false;
+    end
+
+    local function VirtualStemForParsedPrimary(pType)
+        if pType == 'ma' then return 'ma'; end
+        if pType == 'ja' then return 'ja'; end
+        if pType == 'ws' then return 'ws'; end
+        if pType == 'pet' then return 'pet'; end
+        if pType == 'item' then return 'item'; end
+        if pType == 'equip' then return 'equip'; end
+        return 'macro';
+    end
+
+    -- Resolve icon from parsed macro lines (primary /ws /ma /pet …) using the same source rules as other types.
+    local function PickIconForMacroParsedPrimary()
+        local mp = require('modules.hotbar.macroparse');
+        local pType, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+        if not pName or pName == '' then
+            SetIconXiuiDefault('macro');
+            return;
+        end
+        local src = MP.editorIconAutoSource;
+        if src == 'all' then
+            if pType == 'ma' and TryAutoPickSpellIconByActionName(pName, 'ma') then return; end
+            -- /pet and /ja: custom assets (SMN folders, Summoning, etc.) before horizon "spell" ids — school magic ≠ blood pact
+            if pType == 'pet' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                if TryAutoPickSpellIconByActionName(pName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if pType == 'ja' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            if (pType == 'item' or pType == 'equip') and TryAutoPickItemIconByAction(pName, pType) then return; end
+            if TryAutoPickCustomIcon(pName) then return; end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+            return;
+        end
+        if src == 'spells' then
+            if pType == 'ma' and TryAutoPickSpellIconByActionName(pName, 'ma') then return; end
+            if pType == 'pet' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                if TryAutoPickSpellIconByActionName(pName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if pType == 'ja' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+            return;
+        end
+        if src == 'items' then
+            if (pType == 'item' or pType == 'equip') and TryAutoPickItemIconByAction(pName, pType) then return; end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+            return;
+        end
+        if src == 'custom' then
+            if TryAutoPickCustomIcon(pName) then return; end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+        end
+    end
+
+    local function SyncMacroSlotLabelFromParsedCommands()
+        local mp = require('modules.hotbar.macroparse');
+        local _, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+        if pName and pName ~= '' then
+            MP.editingMacro.displayName = pName;
+            MP.editorFields.displayName[1] = pName;
+            MP.editorAutoLabel = pName;
+        end
+    end
+
+    -- Clear JA badge overrides so the badge uses default resolution for the current /ja line (GetBindIcon ja).
+    local function SyncJaBadgeIconFromMacro()
+        MP.editorJaBadgeManuallySet = false;
+        MP.editingMacro.jaBadgeCustomIconType = nil;
+        MP.editingMacro.jaBadgeCustomIconId = nil;
+        MP.editingMacro.jaBadgeCustomIconPath = nil;
+        if MP.ClearPaletteJaBadgeIconCache then
+            MP.ClearPaletteJaBadgeIconCache();
+        end
+    end
+
+    local function AutoPickIconForSelection(force)
+        if not MP.editingMacro then return; end
+        if not force and not ShouldAllowImplicitAutoIconPick() then return; end
+
+        local actionType = tostring(MP.editingMacro.actionType or '');
+        if actionType == 'macro' then
+            PickIconForMacroParsedPrimary();
+            return;
+        end
+
+        local actionName = GetCurrentActionNameForIcon();
+        if not actionName or actionName == '' then
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        local src = MP.editorIconAutoSource;
+        if src == 'all' then
+            if actionType == 'ma' and TryAutoPickSpellIconByActionName(actionName, 'ma') then return; end
+            if actionType == 'pet' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                if TryAutoPickSpellIconByActionName(actionName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if actionType == 'ja' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            if TryAutoPickItemIconByAction(actionName, actionType) then return; end
+            if TryAutoPickCustomIcon(actionName) then return; end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        if src == 'spells' then
+            if actionType == 'ma' and TryAutoPickSpellIconByActionName(actionName, 'ma') then return; end
+            if actionType == 'pet' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                if TryAutoPickSpellIconByActionName(actionName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if actionType == 'ja' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        if src == 'items' then
+            if TryAutoPickItemIconByAction(actionName, actionType) then return; end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        if src == 'custom' then
+            if TryAutoPickCustomIcon(actionName) then return; end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+        end
+    end
+
+    local function RefreshEditorAutoIconKey()
+        local t = MP.editingMacro.customIconType;
+        local id = MP.editingMacro.customIconId;
+        local p = MP.editingMacro.customIconPath;
+        if t == nil and id == nil and (p == nil or p == '') then
+            MP.editorAutoIconKey = nil;
+        else
+            MP.editorAutoIconKey = tostring(t or '') .. ':' .. tostring(id or '') .. ':' .. tostring(p or '');
+        end
+    end
+
+    -- Dropdown picks = intentional action change: icon should follow; clear manual flag.
+    local function SyncEditorIconAfterListPick()
+        MP.editorIconManuallySet = false;
+        AutoPickIconForSelection(true);
+        RefreshEditorAutoIconKey();
+    end
+
+    -- One-time implicit auto-pick when typing (manual action / macro lines).
+    -- Skipped when the user has manually chosen an icon via the Change button.
+    local function TryFirstImplicitActionIconAuto()
+        if MP.editorImplicitActionIconDone then
+            return;
+        end
+        if MP.editorIconManuallySet then
+            return;
+        end
+        -- Use force=false so saved/manual icons are not overwritten when macro text changes
+        -- (AutoPickIconForSelection(true) bypasses ShouldAllowImplicitAutoIconPick).
+        AutoPickIconForSelection(false);
+        MP.editorImplicitActionIconDone = true;
+        RefreshEditorAutoIconKey();
+    end
+
+    -- First editor frame: align MP.editorAutoIconKey with the saved macro (no automatic icon refresh on open).
+    if not MP.editorDidInitialIconPick then
+        MP.editorDidInitialIconPick = true;
+        RefreshEditorAutoIconKey();
+    end
+
+    -- Manual resize: do NOT use AlwaysAutoResize — it fights the resize grip every frame.
+    MP.imgui.SetNextWindowSize({520, 680}, ImGuiCond_FirstUseEver);
+    MP.imgui.SetNextWindowSizeConstraints({480, 320}, {1000, 900});
+
+    -- Apply XIUI styling
+    MP.PushWindowStyle();
+
+    if MP.imgui.Begin(title, isOpen, ImGuiWindowFlags_NoCollapse) then
+        local avail = MP.imgui.GetContentRegionAvail();
+        local contentWidth = (type(avail) == 'table' and avail[1]) or avail or 400;
+        local miniToolBtn = 22;
+        local uiIconRefresh = MP.actions.LoadXiuiAssetIcon('refresh');
+        local uiIconSync = MP.actions.LoadXiuiAssetIcon('sync');
+        local uiIconFolder = MP.actions.LoadXiuiAssetIcon('folder');
+
+        -- ── Save-target toolbar (create mode) ──
+        MP.M.DrawMacroEditorSaveToSection(MP.isCreatingNew, contentWidth);
+
+        -- ── Layout metrics ──
+        local iconPreviewSize = 56;
+        local previewInset = 2;
+        local hasJaBadge = false;
+        do
+            local mp = require('modules.hotbar.macroparse');
+            hasJaBadge = MP.editingMacro.actionType == 'macro' and mp.MacroHasJaBadgePair(MP.editingMacro.macroText or '');
+        end
+        local iconPanelW = 198;
+        local iconPanelPad = 10;
+        -- Wider window → wider fields (icon column stays fixed width).
+        local fieldW = math.max(120, math.min(contentWidth - iconPanelW - 24, 640));
+        local changeBtnW = iconPreviewSize;
+        local showFolder = (MP.editorIconAutoSource == 'custom');
+
+        -- ── Action Type (left column, top) ──
+        local topY = MP.imgui.GetCursorPosY();
+
+        MP.imgui.TextColored(MP.COLORS.goldDim, 'Action Type');
+        MP.PushComboStyle();
+        MP.imgui.SetNextItemWidth(fieldW);
+        local typesForCombo = MP.ACTION_TYPES;
+        if MP.M.EditorMacroPaletteKeyIsItems(MP.editorPaletteKey) then
+            typesForCombo = MP.ACTION_TYPES_ITEMS_BUCKET;
+        end
+        local currentType = MP.ACTION_TYPES[MP.editorFields.actionType[1]];
+        if MP.imgui.BeginCombo('##actionType', MP.ACTION_TYPE_LABELS[currentType] or 'Select...') then
+            for _, actionType in ipairs(typesForCombo) do
+                local i = MP.FindIndex(MP.ACTION_TYPES, actionType);
+                local isSelected = MP.editorFields.actionType[1] == i;
+                if isSelected then
+                    MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold);
+                end
+                if MP.imgui.Selectable(MP.ACTION_TYPE_LABELS[actionType], isSelected) then
+                    MP.editorFields.actionType[1] = i;
+                    MP.editingMacro.actionType = actionType;
+                    MP.editingMacro.action = '';
+                    MP.editorFields.action[1] = '';
+                    MP.searchFilter[1] = '';
+                    if actionType ~= 'macro' then
+                        MP.editingMacro.recastSourceType = nil;
+                        MP.editingMacro.recastSourceAction = nil;
+                        MP.editingMacro.recastSourceItemId = nil;
+                        MP.editorFields.recastSourceType[1] = 1;
+                        MP.editorFields.recastSourceAction[1] = '';
+                        MP.editingMacro.showJaBadgeOnMacro = nil;
+                    end
+                    if actionType == 'pet' then
+                        MP.SyncSaveSubTypeFromPetAvatarFilter();
+                        MP.SyncSaveSubTypeFromBstJugFamily();
+                    end
+                    MP.editorImplicitActionIconDone = false;
+                end
+                if isSelected then
+                    MP.imgui.PopStyleColor();
+                end
+            end
+            MP.imgui.EndCombo();
+        end
+        MP.PopComboStyle();
+
+        -- Remember Y after action type so dynamic fields flow right below
+        local yAfterActionType = MP.imgui.GetCursorPosY();
+
+        -- Icon panel height: Custom + JA badge stacks the left column taller than the preview column;
+        -- JA block must start below BOTH or labels overlap ("Folder" vs "JA badge").
+        local function estimateIconPanelTotalH()
+            local frameH = (MP.imgui.GetFrameHeight and MP.imgui.GetFrameHeight()) or 28;
+            local tls = (MP.imgui.GetTextLineHeightWithSpacing and MP.imgui.GetTextLineHeightWithSpacing()) or 20;
+            local tl = (MP.imgui.GetTextLineHeight and MP.imgui.GetTextLineHeight()) or 14;
+            local iconRowH = math.max(miniToolBtn, tl + 2);
+            local hLeft = iconPanelPad + iconRowH + tls + frameH + tls + frameH;
+            if showFolder then
+                hLeft = hLeft + tls + frameH + tls + tl + 6 + miniToolBtn;
+            end
+            local previewTop = iconPanelPad + previewInset;
+            local hRight = previewTop + iconPreviewSize + 4 + 20;
+            local core = math.max(hLeft, hRight);
+            if hasJaBadge then
+                -- Label + spacing + checkbox row + SameLine Change (needs extra slack; some ImGui builds clip low)
+                core = core + 8 + tl + 8 + tls + frameH + 28;
+                if showFolder then
+                    core = core + 16;
+                end
+            end
+            return core + iconPanelPad + 8;
+        end
+
+        -- ── Icon sub-container (float to top-right) ──
+        local iconPanelX = contentWidth - iconPanelW;
+        local iconPanelTotalH = estimateIconPanelTotalH();
+
+        MP.imgui.SetCursorPos({iconPanelX, topY});
+        MP.imgui.PushStyleColor(ImGuiCol_ChildBg, {0.18, 0.16, 0.11, 0.95});
+
+        local iconPanelScreenPos = {MP.imgui.GetCursorScreenPos()};
+        -- Optional vertical scrollbar when Macro + Custom (tall stack); avoids clipped buttons if estimate is short
+        local iconChildFlags = 0;
+        if hasJaBadge and showFolder and ImGuiWindowFlags_AlwaysVerticalScrollbar ~= nil then
+            iconChildFlags = ImGuiWindowFlags_AlwaysVerticalScrollbar;
+        end
+        if MP.imgui.BeginChild('##iconPanel', {iconPanelW, iconPanelTotalH}, false, iconChildFlags) then
+            local innerAvail = MP.imgui.GetContentRegionAvail();
+            local innerW = (type(innerAvail) == 'table' and innerAvail[1]) or innerAvail or iconPanelW;
+
+            -- Manual insets since WindowPadding isn't reliable in this ImGui
+            MP.imgui.SetCursorPos({iconPanelPad, iconPanelPad});
+            local usableW = innerW - iconPanelPad * 2;
+            local previewGap = 22;
+
+            -- Left column: source combo + optional folder
+            local leftColW = usableW - iconPreviewSize - previewGap;
+
+            -- Icon label + tool buttons (first row)
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Icon');
+            MP.imgui.SameLine(0, 4);
+            if MP.DrawIconButton('##macroEditorIconReset', uiIconRefresh, miniToolBtn, false,
+                    'Reset icon to type default') then
+                SetIconXiuiDefault(DefaultIconStemForActionType(tostring(MP.editingMacro.actionType or '')));
+            end
+            MP.imgui.SameLine(0, 2);
+            if MP.DrawIconButton('##macroEditorIconSync', uiIconSync, miniToolBtn, false,
+                    'Sync main slot icon from current action or macro lines') then
+                MP.editorIconManuallySet = false;
+                AutoPickIconForSelection(true);
+                RefreshEditorAutoIconKey();
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Choosing from the list syncs the main icon. For Macro type, text edits do not change the main icon after you use Change — press Sync to refresh, or Sync after typing.');
+
+            -- Source combo
+            MP.imgui.SetCursorPosX(iconPanelPad);
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(leftColW);
+            local srcLabel = MP.ICON_AUTO_SOURCE_LABELS[MP.editorIconAutoSource] or 'All';
+            if MP.imgui.BeginCombo('##iconAutoSource', srcLabel, ImGuiComboFlags_None) then
+                for _, src in ipairs(MP.ICON_AUTO_SOURCES) do
+                    local isSel = (MP.editorIconAutoSource == src);
+                    if MP.imgui.Selectable(MP.ICON_AUTO_SOURCE_LABELS[src] or src, isSel) then
+                        MP.editorIconAutoSource = src;
+                        MP.PersistMacroEditorIconPrefs();
+                    end
+                    if isSel then MP.imgui.SetItemDefaultFocus(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+            -- Custom icon source: category combo then folder row (finish left column before preview / JA block)
+            if showFolder then
+                MP.LoadCustomIcons();
+
+                -- Category sub-menu
+                MP.imgui.SetCursorPosX(iconPanelPad);
+                local categories = MP.CUSTOM_ICON_CATEGORIES or { 'all' };
+                if not MP.editorCustomIconCategory then MP.editorCustomIconCategory = 'all'; end
+                local catLabel = MP.CUSTOM_ICON_LABELS[MP.editorCustomIconCategory] or MP.editorCustomIconCategory or 'All';
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(leftColW);
+                if MP.imgui.BeginCombo('##iconCustomFolder', catLabel, ImGuiComboFlags_None) then
+                    local isAll = (MP.editorCustomIconCategory == 'all');
+                    if MP.imgui.Selectable(MP.CUSTOM_ICON_LABELS['all'] or 'All', isAll) then
+                        MP.editorCustomIconCategory = 'all';
+                        MP.PersistMacroEditorIconPrefs();
+                    end
+                    MP.imgui.Separator();
+                    for _, cat in ipairs(categories) do
+                        if cat ~= 'all' then
+                            local isSel = (MP.editorCustomIconCategory == cat);
+                            local catLbl = MP.CUSTOM_ICON_LABELS[cat] or cat;
+                            if MP.imgui.Selectable(catLbl, isSel) then
+                                MP.editorCustomIconCategory = cat;
+                                MP.PersistMacroEditorIconPrefs();
+                            end
+                            if isSel then MP.imgui.SetItemDefaultFocus(); end
+                        end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                -- Folder open button
+                MP.imgui.SetCursorPosX(iconPanelPad);
+                MP.imgui.TextColored(MP.COLORS.textDim, 'Folder');
+                MP.imgui.SameLine(0, 4);
+                if MP.DrawIconButton('##openXiuiAssetsFolder', uiIconFolder, miniToolBtn, false,
+                        'Open assets folder in Explorer') then
+                    local assetsRoot = string.format('%saddons\\XIUI\\assets\\', AshitaCore:GetInstallPath());
+                    if ashita and ashita.fs and not ashita.fs.exists(assetsRoot) then
+                        ashita.fs.create_directory(assetsRoot);
+                    end
+                    os.execute('explorer "' .. assetsRoot .. '"');
+                end
+            end
+
+            local yLeftEnd = MP.imgui.GetCursorPosY();
+
+            -- Preview + main Change (right column), top-aligned with icon row
+            local previewX = innerW - iconPreviewSize - iconPanelPad - previewInset;
+            local previewTopY = iconPanelPad + previewInset;
+            MP.imgui.SetCursorPos({previewX, previewTopY});
+            local screenPos = {MP.imgui.GetCursorScreenPos()};
+            MP.DrawIconPreview(MP.editingMacro, screenPos[1], screenPos[2], iconPreviewSize);
+
+            MP.imgui.SetCursorPos({previewX, previewTopY + iconPreviewSize + 4});
+            MP.imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
+            MP.imgui.PushStyleColor(ImGuiCol_Border, MP.COLORS.gold);
+            if MP.imgui.Button('Change##macroEditorIconChange', {changeBtnW, 20}) then
+                MP.InvalidateCustomIconScanCaches();
+                MP.iconPickerTargetIsJaBadge = false;
+                MP.iconPickerOpen = true;
+                MP.editorIconManuallySet = true;
+                MP.M.ApplyIconPickerContextFromEditor(false);
+            end
+            MP.imgui.PopStyleColor();
+            MP.imgui.PopStyleVar();
+
+            local yRightEnd = previewTopY + iconPreviewSize + 4 + 20;
+
+            -- JA badge block starts below the taller of the left stack or the preview column (no overlap with Folder row)
+            if hasJaBadge then
+                if MP.editingMacro.showJaBadgeOnMacro == nil then
+                    MP.editingMacro.showJaBadgeOnMacro = true;
+                end
+                local jaY = math.max(yLeftEnd, yRightEnd) + 8;
+                MP.imgui.SetCursorPos({iconPanelPad, jaY});
+                MP.imgui.TextColored(MP.COLORS.textDim, 'JA badge');
+                MP.imgui.SameLine(0, 4);
+                if MP.DrawIconButton('##macroEditorJaBadgeSync', uiIconSync, miniToolBtn, false,
+                        'Sync JA badge icon from the current /ja line (clears a manual badge icon)') then
+                    SyncJaBadgeIconFromMacro();
+                end
+                MP.imgui.SameLine(0, 2);
+                MP.imgui.ShowHelp('After you pick a badge icon with Change, it stays until you Sync here. Macro text edits do not override a manual badge icon.');
+                MP.imgui.Spacing();
+                MP.imgui.SetCursorPosX(iconPanelPad);
+                local showJaBadgeBuf = { MP.editingMacro.showJaBadgeOnMacro ~= false };
+                if MP.imgui.Checkbox('Use JA Badge##showJaBadgeMacro', showJaBadgeBuf) then
+                    MP.editingMacro.showJaBadgeOnMacro = showJaBadgeBuf[1];
+                end
+                MP.imgui.SameLine(0, 8);
+                MP.imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
+                MP.imgui.PushStyleColor(ImGuiCol_Border, MP.COLORS.gold);
+                if MP.imgui.Button('Change##macroJaBadgeIconChange', {changeBtnW, 20}) then
+                    MP.InvalidateCustomIconScanCaches();
+                    MP.iconPickerOpen = true;
+                    MP.editorJaBadgeManuallySet = true;
+                    MP.M.ApplyIconPickerContextFromEditor(true);
+                end
+                MP.imgui.PopStyleColor();
+                MP.imgui.PopStyleVar();
+            end
+        end
+        MP.imgui.EndChild();
+        MP.imgui.PopStyleColor();
+
+        -- Draw gold border manually (child border style not reliable in this ImGui)
+        local drawList = MP.imgui.GetWindowDrawList();
+        if drawList then
+            local bx = iconPanelScreenPos[1] or iconPanelScreenPos.x or 0;
+            local by = iconPanelScreenPos[2] or iconPanelScreenPos.y or 0;
+            local borderCol = MP.imgui.GetColorU32(MP.COLORS.gold);
+            drawList:AddRect({bx, by}, {bx + iconPanelW, by + iconPanelTotalH}, borderCol, 4, 0, 1.5);
+        end
+
+        -- ── Continue left column below Action Type ──
+        MP.imgui.SetCursorPos({8, yAfterActionType});
+        MP.imgui.Spacing();
+
+        -- Dynamic fields based on action type
+        currentType = MP.ACTION_TYPES[MP.editorFields.actionType[1]];
+
+        if currentType == 'ma' then
+            -- Spell: Show searchable dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Spell');
+            MP.imgui.SameLine();
+            local showAllSpells = { MP.showAllMode };
+            if MP.imgui.Checkbox('Show All##showAllSpells', showAllSpells) then
+                MP.showAllMode = showAllSpells[1];
+                MP.playerdata.ClearExpandedCaches();
+                if MP.showAllMode and MP.spellTypeFilter == 'All' then
+                    local jobTypes = MP.playerdata.GetMagicTypesForJob();
+                    if #jobTypes > 0 then
+                        MP.spellTypeFilter = jobTypes[1].key;
+                        MP.playerdata.ClearExpandedCaches();
+                    end
+                end
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Green = known, Yellow = learnable (right job/level), Red = unavailable');
+            local spells;
+            local useStatusColors = false;
+            if MP.showAllMode then
+                -- Magic Type filter dropdown
+                local filterLabel = MP.playerdata.GetMagicTypeLabel(MP.spellTypeFilter);
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if MP.imgui.BeginCombo('##spellTypeFilter', filterLabel) then
+                    local allTypes = MP.playerdata.GetAllMagicTypes();
+                    local jobTypes = MP.playerdata.GetMagicTypesForJob();
+                    local jobSet = {};
+                    for _, jt in ipairs(jobTypes) do jobSet[jt.key] = true; end
+
+                    for _, mt in ipairs(allTypes) do
+                        local isSel = (MP.spellTypeFilter == mt.key);
+                        local label = mt.label;
+                        if jobSet[mt.key] then label = label .. '  [Current]'; end
+                        if isSel then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(label, isSel) then
+                            MP.spellTypeFilter = mt.key;
+                            MP.playerdata.ClearExpandedCaches();
+                        end
+                        if isSel then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                spells = MP.playerdata.GetAllSpellsForCurrentJob(MP.spellTypeFilter);
+                useStatusColors = true;
+            else
+                spells = MP.GetCachedSpells();
+            end
+            if spells and #spells > 0 then
+                MP.DrawSearchableCombo('##spellCombo', spells, MP.editingMacro.action or '', function(spell)
+                    MP.editingMacro.action = spell.name;
+                    MP.editorFields.action[1] = spell.name;
+                    AutoSetDisplayName(spell.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No spells available for this job');
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'ja' then
+            -- Ability: Show searchable dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Ability');
+            MP.imgui.SameLine();
+            local showAllJA = { MP.showAllMode };
+            if MP.imgui.Checkbox('Show All##showAllAbilities', showAllJA) then
+                MP.showAllMode = showAllJA[1];
+                MP.playerdata.ClearExpandedCaches();
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Green = known, Yellow = learnable (right job/level), Red = unavailable.\nUse the Job filter to browse abilities for any job.');
+            local abilities;
+            local useStatusColors = false;
+            if MP.showAllMode then
+                -- Job filter dropdown (only shown when Show All is on)
+                local player = AshitaCore:GetMemoryManager():GetPlayer();
+                local mainJobId = player and player:GetMainJob() or 0;
+                local subJobId = player and player:GetSubJob() or 0;
+                local mainJobAbbr = MP.jobs[mainJobId] or '???';
+                local subJobAbbr = (subJobId and subJobId > 0) and MP.jobs[subJobId] or nil;
+
+                local filterLabel;
+                if MP.abilityJobFilter == 0 then
+                    if subJobAbbr then
+                        filterLabel = mainJobAbbr .. ' + ' .. subJobAbbr .. ' (Current)';
+                    else
+                        filterLabel = mainJobAbbr .. ' (Current)';
+                    end
+                else
+                    filterLabel = MP.jobs[MP.abilityJobFilter] or '???';
+                end
+
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Job');
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if MP.imgui.BeginCombo('##abilityJobFilter', filterLabel) then
+                    -- "Current Jobs" option (main + sub)
+                    local isAutoSelected = MP.abilityJobFilter == 0;
+                    if isAutoSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    local autoLabel;
+                    if subJobAbbr then
+                        autoLabel = mainJobAbbr .. ' + ' .. subJobAbbr .. ' (Current)';
+                    else
+                        autoLabel = mainJobAbbr .. ' (Current)';
+                    end
+                    if MP.imgui.Selectable(autoLabel, isAutoSelected) then
+                        if MP.abilityJobFilter ~= 0 then
+                            MP.abilityJobFilter = 0;
+                            MP.playerdata.ClearExpandedCaches();
+                        end
+                    end
+                    if isAutoSelected then MP.imgui.PopStyleColor(); end
+
+                    MP.imgui.Separator();
+
+                    -- All 15 base jobs (HorizonXI cap)
+                    for jid = 1, 15 do
+                        local abbr = MP.jobs[jid] or '???';
+                        local label = abbr;
+                        if jid == mainJobId then
+                            label = label .. '  [Main]';
+                        elseif jid == subJobId then
+                            label = label .. '  [Sub]';
+                        end
+                        local isSelected = MP.abilityJobFilter == jid;
+                        if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(label, isSelected) then
+                            if MP.abilityJobFilter ~= jid then
+                                MP.abilityJobFilter = jid;
+                                MP.playerdata.ClearExpandedCaches();
+                            end
+                        end
+                        if isSelected then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                abilities = MP.playerdata.GetAllAbilitiesForCurrentJob(MP.abilityJobFilter);
+                useStatusColors = true;
+            else
+                abilities = MP.GetCachedAbilities();
+            end
+            if abilities and #abilities > 0 then
+                MP.DrawSearchableCombo('##abilityCombo', abilities, MP.editingMacro.action or '', function(ability)
+                    MP.editingMacro.action = ability.name;
+                    MP.editorFields.action[1] = ability.name;
+                    AutoSetDisplayName(ability.name);
+                    ApplyDefaultEditorTargetForJaAbility(ability.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No abilities available');
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'ws' then
+            -- Weaponskill: Show searchable dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Weaponskill');
+            MP.imgui.SameLine();
+            local showAllWS = { MP.showAllMode };
+            if MP.imgui.Checkbox('Show All##showAllWS', showAllWS) then
+                MP.showAllMode = showAllWS[1];
+                MP.playerdata.ClearExpandedCaches();
+                if MP.showAllMode then
+                    -- Default filter to the weapon type matching current known WS
+                    local currentWs = MP.GetCachedWeaponskills();
+                    if currentWs and #currentWs > 0 then
+                        local wsDb = require('modules.hotbar.database.ws_weapon_types');
+                        for _, ws in ipairs(currentWs) do
+                            local info = wsDb[ws.name];
+                            if info then
+                                MP.wsWeaponFilter = info.weapon;
+                                break;
+                            end
+                        end
+                    end
+                end
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Green = known, Red = not yet learned. Filter by weapon type below.');
+            local weaponskills;
+            local useStatusColors = false;
+            if MP.showAllMode then
+                -- Weapon type filter dropdown
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if MP.imgui.BeginCombo('##wsWeaponFilter', MP.wsWeaponFilter) then
+                    if MP.imgui.Selectable('All', MP.wsWeaponFilter == 'All') then
+                        MP.wsWeaponFilter = 'All';
+                        MP.playerdata.ClearExpandedCaches();
+                    end
+                    local weaponTypes = MP.playerdata.GetWeaponTypes();
+                    for _, wt in ipairs(weaponTypes) do
+                        local isSel = (MP.wsWeaponFilter == wt);
+                        if isSel then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(wt, isSel) then
+                            MP.wsWeaponFilter = wt;
+                            MP.playerdata.ClearExpandedCaches();
+                        end
+                        if isSel then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                local allWs = MP.playerdata.GetAllWeaponskillsExpanded();
+                if MP.wsWeaponFilter ~= 'All' then
+                    local filtered = {};
+                    for _, ws in ipairs(allWs) do
+                        if ws.weapon == MP.wsWeaponFilter then
+                            table.insert(filtered, ws);
+                        end
+                    end
+                    weaponskills = filtered;
+                else
+                    weaponskills = allWs;
+                end
+                useStatusColors = true;
+            else
+                weaponskills = MP.GetCachedWeaponskills();
+            end
+            if weaponskills and #weaponskills > 0 then
+                MP.DrawSearchableCombo('##wsCombo', weaponskills, MP.editingMacro.action or '', function(ws)
+                    MP.editingMacro.action = ws.name;
+                    MP.editorFields.action[1] = ws.name;
+                    AutoSetDisplayName(ws.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No weaponskills available');
+            end
+
+            -- Target dropdown (default to <t>)
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'item' then
+            -- Item: Searchable dropdown or manual input
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Item');
+            local items = MP.GetCachedItems();
+            if items and #items > 0 then
+                MP.DrawSearchableCombo('##itemCombo', items, MP.editingMacro.action or '', function(item)
+                    MP.editingMacro.action = item.name;
+                    MP.editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
+                    MP.editorFields.action[1] = item.name;
+                    AutoSetDisplayName(item.name);
+                    SyncEditorIconAfterListPick();
+                end, true, nil, fieldW);  -- Show icons
+                MP.imgui.SameLine();
+                MP.imgui.TextColored(MP.COLORS.textMuted, '(' .. #items .. ')');
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No items found in storage');
+            end
+
+            -- Manual input fallback
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Or type item name:');
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.InputText('##itemName', MP.editorFields.action, MP.INPUT_BUFFER_SIZE) then
+                MP.editingMacro.action = MP.editorFields.action[1];
+                AutoSetDisplayName(MP.editingMacro.action);
+                if (MP.editingMacro.action or '') ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'equip' then
+            -- Equipment slot dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Equipment Slot');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##equipSlot', MP.EQUIP_SLOT_LABELS[MP.EQUIP_SLOTS[MP.editorFields.equipSlot[1]]] or 'Select...') then
+                for i, slot in ipairs(MP.EQUIP_SLOTS) do
+                    local isSelected = MP.editorFields.equipSlot[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.EQUIP_SLOT_LABELS[slot], isSelected) then
+                        MP.editorFields.equipSlot[1] = i;
+                        MP.editingMacro.equipSlot = slot;
+                        -- Clear item selection when slot changes (old item may not fit new slot)
+                        MP.editingMacro.action = '';
+                        MP.editingMacro.itemId = nil;
+                        MP.editingMacro.displayName = '';
+                        MP.editorFields.action[1] = '';
+                        MP.editorFields.displayName[1] = '';
+                        MP.editorImplicitActionIconDone = false;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+            -- Item: Searchable dropdown or manual input (filtered by selected equipment slot)
+            MP.imgui.Spacing();
+            local selectedSlot = MP.EQUIP_SLOTS[MP.editorFields.equipSlot[1]];
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Item (' .. MP.EQUIP_SLOT_LABELS[selectedSlot] .. ')');
+            local equipItems = MP.GetCachedItems();
+            if equipItems and #equipItems > 0 then
+                MP.DrawSearchableCombo('##equipItemCombo', equipItems, MP.editingMacro.action or '', function(item)
+                    MP.editingMacro.action = item.name;
+                    MP.editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
+                    MP.editorFields.action[1] = item.name;
+                    AutoSetDisplayName(item.name);
+                    SyncEditorIconAfterListPick();
+                end, true, selectedSlot, fieldW);  -- Show icons, filter by selected slot
+                MP.imgui.SameLine();
+                MP.imgui.TextColored(MP.COLORS.textMuted, '(' .. #equipItems .. ')');
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No items found in storage');
+            end
+
+            -- Manual input fallback
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Or type item name:');
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.InputText('##equipItemName', MP.editorFields.action, MP.INPUT_BUFFER_SIZE) then
+                MP.editingMacro.action = MP.editorFields.action[1];
+                AutoSetDisplayName(MP.editingMacro.action);
+                if (MP.editingMacro.action or '') ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+        elseif currentType == 'macro' then
+            -- Raw macro command (8 lines like native FFXI macro editor)
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Macro Commands (8 lines)');
+
+            -- Style the multiline input
+            MP.imgui.PushStyleColor(ImGuiCol_FrameBg, MP.COLORS.bgMedium);
+            MP.imgui.PushStyleColor(ImGuiCol_FrameBgHovered, MP.COLORS.bgLight);
+            MP.imgui.PushStyleColor(ImGuiCol_FrameBgActive, MP.COLORS.bgLight);
+
+            -- 8 rows * ~16px line height + padding
+            local lineHeight = MP.imgui.GetTextLineHeight();
+            local inputHeight = (lineHeight * 8) + 8;
+
+            if MP.imgui.InputTextMultiline('##macroText', MP.editorFields.macroText, MP.MACRO_BUFFER_SIZE, {math.max(120, fieldW), inputHeight}) then
+                MP.editingMacro.macroText = MP.editorFields.macroText[1];
+                local mp = require('modules.hotbar.macroparse');
+                local _, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+                MP.editingMacro.action = (pName and pName ~= '') and pName or '';
+                if pName and pName ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+            MP.imgui.PopStyleColor(3);
+            MP.imgui.ShowHelp('Enter commands, one per line (e.g., /ma "Cure" <stpc>)');
+
+            -- Recast Source section (optional)
+            MP.imgui.Spacing();
+            MP.imgui.Spacing();
+            if MP.imgui.TreeNode('Recast Source (Optional)##recastSource') then
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'Show cooldown from a different action');
+                MP.imgui.Spacing();
+
+                -- Recast source type dropdown
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Source Type');
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                local currentRecastType = MP.RECAST_SOURCE_TYPES[MP.editorFields.recastSourceType[1]] or 'none';
+                if MP.imgui.BeginCombo('##recastSourceType', MP.RECAST_SOURCE_LABELS[currentRecastType] or 'None') then
+                    for i, sourceType in ipairs(MP.RECAST_SOURCE_TYPES) do
+                        local isSelected = MP.editorFields.recastSourceType[1] == i;
+                        if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(MP.RECAST_SOURCE_LABELS[sourceType], isSelected) then
+                            MP.editorFields.recastSourceType[1] = i;
+                            if sourceType == 'none' then
+                                MP.editingMacro.recastSourceType = nil;
+                                MP.editingMacro.recastSourceAction = nil;
+                                MP.editingMacro.recastSourceItemId = nil;
+                            else
+                                MP.editingMacro.recastSourceType = sourceType;
+                            end
+                            -- Clear action when type changes
+                            MP.editingMacro.recastSourceAction = nil;
+                            MP.editingMacro.recastSourceItemId = nil;
+                            MP.editorFields.recastSourceAction[1] = '';
+                        end
+                        if isSelected then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                -- Show action selector based on recast source type
+                currentRecastType = MP.RECAST_SOURCE_TYPES[MP.editorFields.recastSourceType[1]] or 'none';
+
+                if currentRecastType == 'ma' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Spell');
+                    local spells = MP.GetCachedSpells();
+                    if spells and #spells > 0 then
+                        MP.DrawSearchableCombo('##recastSpellCombo', spells, MP.editingMacro.recastSourceAction or '', function(spell)
+                            MP.editingMacro.recastSourceAction = spell.name;
+                            MP.editorFields.recastSourceAction[1] = spell.name;
+                        end, nil, nil, fieldW);
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No spells available');
+                    end
+
+                elseif currentRecastType == 'ja' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Ability');
+                    local abilities = MP.GetCachedAbilities();
+                    if abilities and #abilities > 0 then
+                        MP.DrawSearchableCombo('##recastAbilityCombo', abilities, MP.editingMacro.recastSourceAction or '', function(ability)
+                            MP.editingMacro.recastSourceAction = ability.name;
+                            MP.editorFields.recastSourceAction[1] = ability.name;
+                        end, nil, nil, fieldW);
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No abilities available');
+                    end
+
+                elseif currentRecastType == 'item' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Item');
+                    local items = MP.GetCachedItems();
+                    if items and #items > 0 then
+                        MP.DrawSearchableCombo('##recastItemCombo', items, MP.editingMacro.recastSourceAction or '', function(item)
+                            MP.editingMacro.recastSourceAction = item.name;
+                            MP.editingMacro.recastSourceItemId = item.id;
+                            MP.editorFields.recastSourceAction[1] = item.name;
+                        end, true, nil, fieldW);  -- Show icons
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No items available');
+                    end
+
+                elseif currentRecastType == 'pet' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Pet Command');
+                    local viewedJobId = GetEditorPetJobId();
+                    local avatarName = nil;
+                    if viewedJobId == MP.petregistry.JOB_SMN then
+                        avatarName = SmnAvatarNameFromEditorFilter(MP.petregistry.GetAvatarList());
+                    end
+                    local petCommands = MP.GetPetCommandsForJob(viewedJobId, avatarName, nil);
+                    if petCommands and #petCommands > 0 then
+                        MP.DrawSearchableCombo('##recastPetCombo', petCommands, MP.editingMacro.recastSourceAction or '', function(cmd)
+                        MP.editingMacro.recastSourceAction = cmd.petMacroAction or cmd.name;
+                        MP.editorFields.recastSourceAction[1] = MP.editingMacro.recastSourceAction;
+                        end, nil, nil, fieldW);
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No pet commands available');
+                    end
+                end
+
+                MP.imgui.TreePop();
+            end
+
+        elseif currentType == 'pet' then
+            -- ── Pet Type selector ──────────────────────────────────
+            local PET_TYPE_OPTIONS = {
+                { id = MP.petregistry.JOB_SMN, label = 'Avatar (SMN)' },
+                { id = MP.petregistry.JOB_BST, label = 'Beast (BST)' },
+                { id = MP.petregistry.JOB_DRG, label = 'Wyvern (DRG)' },
+                { id = MP.petregistry.JOB_PUP, label = 'Automaton (PUP)' },
+            };
+
+            -- Resolve default pet type from player's current job
+            local defaultPetJobId = GetEditorPetJobId();
+            if not MP.petregistry.IsPetJob(defaultPetJobId) then
+                defaultPetJobId = MP.petregistry.JOB_SMN;
+            end
+
+            local viewedJobId;
+            if MP.petTypeOverride > 0 then
+                viewedJobId = MP.petTypeOverride;
+            else
+                viewedJobId = defaultPetJobId;
+            end
+
+            -- Find the label for the current selection
+            local petTypeLabel = '???';
+            for _, opt in ipairs(PET_TYPE_OPTIONS) do
+                if opt.id == viewedJobId then
+                    petTypeLabel = opt.label;
+                    break;
+                end
+            end
+
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Pet Type');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##petTypeSelector', petTypeLabel) then
+                for _, opt in ipairs(PET_TYPE_OPTIONS) do
+                    local isSelected = viewedJobId == opt.id;
+                    local label = opt.label;
+                    if opt.id == defaultPetJobId then
+                        label = label .. '  [Current]';
+                    end
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(label, isSelected) then
+                        if viewedJobId ~= opt.id then
+                            MP.petTypeOverride = opt.id;
+                            MP.cachedPetCommands = nil;
+                            MP.showAllPetMode = false;
+                            MP.petAvatarFilter = 1;
+                        end
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+            MP.imgui.Spacing();
+
+            -- ── Avatar Filter (SMN only) ───────────────────────────
+            local avatarList = MP.petregistry.GetAvatarList();
+            if viewedJobId == MP.petregistry.JOB_SMN then
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Avatar');
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                local filterLabel = MP.petAvatarFilter == 1 and 'All Avatars' or avatarList[MP.petAvatarFilter - 1];
+                if MP.imgui.BeginCombo('##avatarFilter', filterLabel) then
+                    local isAllSelected = MP.petAvatarFilter == 1;
+                    if isAllSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable('All Avatars', isAllSelected) then
+                        MP.petAvatarFilter = 1;
+                        MP.cachedPetCommands = nil;
+                    end
+                    if isAllSelected then MP.imgui.PopStyleColor(); end
+
+                    MP.imgui.Separator();
+
+                    for i, avatar in ipairs(avatarList) do
+                        local isSelected = MP.petAvatarFilter == i + 1;
+                        if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(avatar, isSelected) then
+                            MP.petAvatarFilter = i + 1;
+                            MP.cachedPetCommands = nil;
+                        end
+                        if isSelected then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+                MP.imgui.Spacing();
+            end
+
+            -- ── Show All toggle (SMN/BST only) ────────────────────
+            local supportShowAll = (viewedJobId == MP.petregistry.JOB_SMN or viewedJobId == MP.petregistry.JOB_BST);
+
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Pet Command');
+            if supportShowAll then
+                MP.imgui.SameLine();
+                local showAllPet = { MP.showAllPetMode };
+                if MP.imgui.Checkbox('Show All##showAllPet', showAllPet) then
+                    MP.showAllPetMode = showAllPet[1];
+                    MP.cachedPetCommands = nil;
+                end
+                MP.imgui.SameLine(0, 2);
+                if viewedJobId == MP.petregistry.JOB_BST then
+                    MP.imgui.ShowHelp('Green = available at your level, Red = too high level');
+                else
+                    MP.imgui.ShowHelp('Green = available at your level, Red = too high level.\nBlood pacts shown with level requirements.');
+                end
+            end
+
+            -- ── Resolve player level for the selected pet job ──────
+            local player = AshitaCore:GetMemoryManager():GetPlayer();
+            local mainJobId = player and player:GetMainJob() or 0;
+            local mainJobLevel = player and player:GetMainJobLevel() or 0;
+            local subJobId = player and player:GetSubJob() or 0;
+            local subJobLevel = player and player:GetSubJobLevel() or 0;
+
+            local petJobLevel = 0;
+            if viewedJobId == mainJobId then
+                petJobLevel = mainJobLevel;
+            elseif viewedJobId == subJobId then
+                petJobLevel = subJobLevel;
+            end
+
+            local bstActivePetForReady = nil;
+            if viewedJobId == MP.petregistry.JOB_BST then
+                bstActivePetForReady = MP.petpalette.GetCurrentPetEntityName();
+                local act0 = MP.editingMacro.action or '';
+                if act0 == 'Ready' and MP.editingMacro.bstReadyMode == nil then
+                    MP.editingMacro.bstReadyMode = 'recast';
+                end
+                if MP.petregistry.IsBstJugReadyMovesEnabled() and act0 ~= ''
+                    and MP.petregistry.IsBstJugReadyMoveName(act0) then
+                    if MP.editingMacro.bstJugReadyMovesKey == nil then
+                        MP.editingMacro.bstJugReadyMovesKey = MP.petregistry.ResolveBstJugMovesKeyFromMoveName(act0);
+                    end
+                    if MP.editingMacro.bstJugReadyMovesKey and MP.editingMacro.bstJugReadyFamilyLabel == nil then
+                        for _, row in ipairs(MP.petregistry.GetBstJugReadyFamilyPickerList()) do
+                            if row.movesKey == MP.editingMacro.bstJugReadyMovesKey then
+                                MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+                                break;
+                            end
+                        end
+                    end
+                end
+            end
+
+            -- ── Build the command list ─────────────────────────────
+            local petCommands;
+            local useStatusColors = false;
+
+            if supportShowAll then
+                -- SMN/BST: always use expanded data so level-gating is applied
+                local avatarName = nil;
+                local activePetName = nil;
+                if viewedJobId == MP.petregistry.JOB_SMN then
+                    avatarName = SmnAvatarNameFromEditorFilter(avatarList);
+                elseif viewedJobId == MP.petregistry.JOB_BST then
+                    activePetName = bstActivePetForReady;
+                end
+
+                local expandedList;
+                if viewedJobId == MP.petregistry.JOB_BST then
+                    expandedList = MP.petregistry.GetBstPetCommandsExpanded(petJobLevel, activePetName);
+                else
+                    expandedList = MP.petregistry.GetBloodPactsExpanded(avatarName, petJobLevel);
+                end
+
+                if MP.showAllPetMode then
+                    petCommands = expandedList;
+                    useStatusColors = true;
+                else
+                    petCommands = {};
+                    for _, cmd in ipairs(expandedList) do
+                        if cmd.status == MP.petregistry.STATUS_HAVE then
+                            table.insert(petCommands, cmd);
+                        end
+                    end
+                end
+            else
+                -- DRG/PUP: standard cached list
+                if not MP.cachedPetCommands then
+                    MP.cachedPetCommands = MP.GetPetCommandsForJob(viewedJobId, nil, nil);
+                end
+                petCommands = MP.cachedPetCommands;
+            end
+
+            -- ── Pet command selector dropdown ──────────────────────
+            MP.imgui.SetNextItemWidth(fieldW);
+            local petPrimaryComboValue = BstPetPrimaryComboCurrentLabel(MP.editingMacro, viewedJobId);
+            if petCommands and #petCommands > 0 then
+                MP.DrawSearchableCombo('##petCommandCombo', petCommands, petPrimaryComboValue, function(cmd)
+                    if cmd.bstReadySynthetic == 'recast' then
+                        MP.editingMacro.action = cmd.petMacroAction or 'Ready';
+                        MP.editingMacro.bstReadyMode = 'recast';
+                        MP.editingMacro.bstJugReadyMovesKey = nil;
+                        MP.editingMacro.bstJugReadyFamilyLabel = nil;
+                    elseif cmd.bstReadySynthetic == 'use' then
+                        MP.editingMacro.bstReadyMode = 'use';
+                        MP.editingMacro.action = '';
+                        MP.editingMacro.bstJugReadyMovesKey = nil;
+                        MP.editingMacro.bstJugReadyFamilyLabel = nil;
+                    else
+                        MP.editingMacro.bstReadyMode = nil;
+                        MP.editingMacro.action = cmd.name;
+                        MP.editingMacro.bstJugReadyMovesKey = nil;
+                        MP.editingMacro.bstJugReadyFamilyLabel = nil;
+                    end
+                    MP.editorFields.action[1] = MP.editingMacro.action or '';
+                    AutoSetDisplayName(cmd.name);
+                    ApplyDefaultEditorTargetForPetCommand(cmd.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No pet commands available');
+            end
+
+            local showBstJugPicker = viewedJobId == MP.petregistry.JOB_BST
+                and MP.petregistry.IsBstJugReadyMovesEnabled()
+                and (MP.editingMacro.bstReadyMode == 'use'
+                    or MP.petregistry.IsBstJugReadyMoveName(MP.editingMacro.action or ''));
+
+            if showBstJugPicker then
+                MP.imgui.Spacing();
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Family');
+                MP.imgui.SameLine(0, 2);
+                MP.imgui.ShowHelp('Jug pet families (same Ready abilities per family as SMN avatars share blood pact pools). Pick family, then the Ready move.');
+                local famList = MP.petregistry.GetBstJugReadyFamilyPickerList();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if famList and #famList > 0 then
+                    MP.DrawSearchableCombo('##bstJugFamilyCombo', famList, MP.editingMacro.bstJugReadyFamilyLabel or '', function(row)
+                        MP.editingMacro.bstJugReadyMovesKey = row.movesKey;
+                        MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+                        local movesFam = MP.petregistry.GetReadyMovesForFamilyMovesKey(row.movesKey);
+                        local curAct = MP.editingMacro.action or '';
+                        local moveStillOk = false;
+                        if movesFam and curAct ~= '' then
+                            for _, m in ipairs(movesFam) do
+                                if m.name == curAct then
+                                    moveStillOk = true;
+                                    break;
+                                end
+                            end
+                        end
+                        if not moveStillOk then
+                            MP.editingMacro.action = '';
+                            MP.editorFields.action[1] = '';
+                        end
+                        SyncEditorIconAfterListPick();
+                        MP.SyncSaveSubTypeFromBstJugFamily();
+                    end, nil, nil, fieldW, false);
+                end
+
+                MP.imgui.Spacing();
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Jug Ready ability');
+                MP.imgui.SameLine(0, 2);
+                MP.imgui.ShowHelp('/pet uses this ability name; charges match your jug. A * beside a Ready move appears only when some jugs in that picker row do not learn it — hover for detail.');
+                local jugMoves = {};
+                local mk = MP.editingMacro.bstJugReadyMovesKey;
+                if mk then
+                    local rm = MP.petregistry.GetReadyMovesForFamilyMovesKey(mk);
+                    if rm then
+                        for _, m in ipairs(rm) do
+                            table.insert(jugMoves, m);
+                        end
+                    end
+                end
+                MP.imgui.SetNextItemWidth(fieldW);
+                if #jugMoves > 0 then
+                    MP.DrawSearchableCombo('##bstJugReadyMoveCombo', jugMoves, MP.editingMacro.action or '', function(move)
+                        MP.editingMacro.action = move.name;
+                        MP.editingMacro.bstReadyMode = nil;
+                        MP.editorFields.action[1] = move.name;
+                        AutoSetDisplayName(move.name);
+                        SyncEditorIconAfterListPick();
+                    end, nil, nil, fieldW, false);
+                elseif MP.editingMacro.bstJugReadyMovesKey then
+                    MP.imgui.TextColored(MP.COLORS.textMuted, 'No Ready moves for this family in database');
+                else
+                    MP.imgui.TextColored(MP.COLORS.textMuted, 'Select a family first');
+                end
+            end
+
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Or type manually:');
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.InputText('##petCommandManual', MP.editorFields.action, MP.INPUT_BUFFER_SIZE) then
+                MP.editingMacro.action = MP.editorFields.action[1];
+                AutoSetDisplayName(MP.editingMacro.action);
+                if (MP.editingMacro.action or '') ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+        end
+
+        -- Ensure we're past both left column and icon panel before continuing
+        local yAfterFields = MP.imgui.GetCursorPosY();
+        local yAfterIconPanel = topY + iconPanelTotalH + 4;
+        if yAfterIconPanel > yAfterFields then
+            MP.imgui.SetCursorPosY(yAfterIconPanel);
+        end
+
+        -- Slot Label input (for all types)
+        MP.imgui.Spacing();
+        MP.imgui.Separator();
+        MP.imgui.Spacing();
+        MP.imgui.TextColored(MP.COLORS.goldDim, 'Slot Label');
+        MP.imgui.SameLine(0, 6);
+        if MP.DrawIconButton('##macroEditorSlotLabelReset', uiIconRefresh, miniToolBtn, false,
+                'Clear slot label (on save, uses action name, or "Macro" for macro type)') then
+            MP.editingMacro.displayName = '';
+            MP.editorFields.displayName[1] = '';
+            MP.editorAutoLabel = nil;
+        end
+        if currentType == 'macro' then
+            MP.imgui.SameLine(0, 4);
+            if MP.DrawIconButton('##macroEditorSlotLabelSync', uiIconSync, miniToolBtn, false,
+                    'Sync label from parsed macro (prioritized /ws > /ma > /pet > /ja )') then
+                SyncMacroSlotLabelFromParsedCommands();
+            end
+        end
+        MP.imgui.SameLine(0, 6);
+        MP.imgui.SetNextItemWidth(math.max(80, contentWidth * 0.45));
+        if MP.imgui.InputText('##displayName', MP.editorFields.displayName, 32) then
+            MP.editingMacro.displayName = MP.editorFields.displayName[1];
+            MP.editorAutoLabel = nil; -- User manually edited the label; don't auto-overwrite on future selections.
+        end
+        if currentType ~= 'macro' then
+            MP.imgui.ShowHelp('Short label shown on the slot (e.g., "Cure3"). Leave empty to use action name.');
+        else
+            MP.imgui.ShowHelp('Label on the slot. Sync sets it from the prioritized command in macro text (same order as icon sync).');
+        end
+
+        MP.imgui.Spacing();
+        MP.imgui.Separator();
+        MP.imgui.Spacing();
+
+        local function SyncMacroEditorBuffersToEditingMacro()
+            local atIdx = MP.editorFields.actionType[1];
+            if type(atIdx) == 'number' and atIdx >= 1 and atIdx <= #MP.ACTION_TYPES then
+                MP.editingMacro.actionType = MP.ACTION_TYPES[atIdx];
+            end
+            local tgIdx = MP.editorFields.target[1];
+            if type(tgIdx) == 'number' and tgIdx >= 1 and tgIdx <= #MP.TARGET_OPTIONS then
+                MP.editingMacro.target = MP.TARGET_OPTIONS[tgIdx];
+            end
+            local eqIdx = MP.editorFields.equipSlot[1];
+            if type(eqIdx) == 'number' and eqIdx >= 1 and eqIdx <= #MP.EQUIP_SLOTS then
+                MP.editingMacro.equipSlot = MP.EQUIP_SLOTS[eqIdx];
+            end
+            local rsIdx = MP.editorFields.recastSourceType[1];
+            if type(rsIdx) == 'number' and rsIdx >= 1 and rsIdx <= #MP.RECAST_SOURCE_TYPES then
+                MP.editingMacro.recastSourceType = MP.RECAST_SOURCE_TYPES[rsIdx];
+            end
+            MP.editingMacro.recastSourceAction = MP.editorFields.recastSourceAction[1] or '';
+            MP.editingMacro.macroText = MP.editorFields.macroText[1] or '';
+            local actBuf = tostring(MP.editorFields.action[1] or ''):match('^%s*(.-)%s*$') or '';
+            if MP.editingMacro.actionType ~= 'macro' then
+                MP.editingMacro.action = actBuf;
+            end
+        end
+
+        local function SaveMacro(shouldCloseEditor)
+            SyncMacroEditorBuffersToEditingMacro();
+
+            -- Validate before saving
+            local canSave = false;
+
+            if currentType == 'macro' then
+                canSave = (MP.editingMacro.macroText or '') ~= '';
+                if canSave and (MP.editingMacro.displayName or '') == '' then
+                    MP.editingMacro.displayName = 'Macro';
+                end
+                -- Clear target for macro type (targets are embedded in macro text)
+                MP.editingMacro.target = nil;
+            else
+                canSave = (MP.editingMacro.action or '') ~= '';
+                if canSave and (MP.editingMacro.displayName or '') == '' then
+                    MP.editingMacro.displayName = MP.editingMacro.action;
+                end
+            end
+
+            if not canSave then
+                return;
+            end
+
+            local okMg, mgd = pcall(require, 'modules.hotbar.macro_global_defaults');
+            if okMg and mgd and mgd.IsUniversalTwoHourMacro(MP.editingMacro) and not MP.isCreatingNew then
+                return;
+            end
+
+            -- Look up itemId for item/equip macros if not already set
+            -- This handles cases where user typed item name manually instead of selecting from dropdown
+            if (currentType == 'item' or currentType == 'equip') and not MP.editingMacro.itemId and MP.editingMacro.action then
+                MP.editingMacro.itemId = MP.actiondb.GetItemId(MP.editingMacro.action);
+            end
+
+            if MP.isCreatingNew then
+                -- AddMacro mutates macroData.id; keep editor selections by inserting a copy.
+                local macroCopy = deep_copy_table(MP.editingMacro);
+                macroCopy.id = nil;
+                MP.M.AddMacro(macroCopy, MP.editorPaletteKey);
+                -- Navigate to last page to show the new macro
+                local db = MP.M.GetMacroDatabase();
+                MP.currentPalettePage = math.max(1, math.ceil(#db / MP.PALETTE_MACROS_PER_PAGE));
+
+                -- Ensure editor stays in "Create" mode (no id should be present)
+                MP.editingMacro.id = nil;
+
+                -- EFP double-click auto-bind: when the editor was opened from a double-click on
+                -- an empty Edit Full Palette slot, OpenEditorForSlotData stashed the target slot
+                -- coords. Now that AddMacro has minted an id on macroCopy, write the binding into
+                -- the EFP draft so the slot reflects the new macro on the next frame. One-shot
+                -- (cleared below) so "Save & Add Another" doesn't repeatedly stomp the same slot.
+                local target = MP.pendingNewMacroBindTarget;
+                if target and macroCopy.id then
+                    local okData, dataLib = pcall(require, 'modules.hotbar.data');
+                    if okData and dataLib and dataLib.SetDraftSlotData and dataLib.BuildMacroSlotAfterDrop then
+                        local arm = {};
+                        for k, v in pairs(macroCopy) do arm[k] = v; end
+                        arm.macroRef = macroCopy.id;
+                        arm.macroPaletteKey = arm.macroPaletteKey or MP.editorPaletteKey;
+                        local store = (MP.M.GetMacroSourceTagForDrops and MP.M.GetMacroSourceTagForDrops()) or 'profile';
+                        arm.macroSourceStore = arm.macroSourceStore or store;
+                        local existing;
+                        if dataLib.GetCrossbarSlotRawForSwapOverlay and dataLib.NormalizeCrossbarSlotRawForSwap then
+                            existing = dataLib.NormalizeCrossbarSlotRawForSwap(
+                                dataLib.GetCrossbarSlotRawForSwapOverlay(target.comboMode, target.slotIndex)
+                            );
+                        end
+                        local built = dataLib.BuildMacroSlotAfterDrop(arm, store, existing);
+                        dataLib.SetDraftSlotData(target.comboMode, target.slotIndex, built);
+                        -- Visual refresh so the EFP preview picks up the new binding next frame.
+                        -- 1.8.0 immediate-mode renderer has no persistent slot prim cache; the
+                        -- crossbar icon-cache clear is the only refresh needed to surface the new
+                        -- binding on the next frame.
+                        local okCb, crossbar = pcall(require, 'modules.hotbar.crossbar');
+                        if okCb and crossbar and crossbar.ClearIconCacheForSlot then
+                            crossbar.ClearIconCacheForSlot(target.comboMode, target.slotIndex);
+                        end
+                    end
+                    MP.pendingNewMacroBindTarget = nil;
+                end
+            else
+                MP.M.UpdateMacro(MP.editingMacro.id, MP.editingMacro, MP.editorPaletteKey);
+            end
+
+            MP.paletteMainIconCache = {};
+            if MP.ClearPaletteJaBadgeIconCache then
+                MP.ClearPaletteJaBadgeIconCache();
+            end
+
+            if shouldCloseEditor then
+                MP.editingMacro = nil;
+                MP.isCreatingNew = false;
+                MP.searchFilter[1] = '';
+                MP.iconPickerOpen = false;
+                MP.iconPickerFilter[1] = '';
+                MP.editorPaletteKey = nil;
+                MP.editorDidInitialIconPick = false;
+                MP.editorJaBadgeManuallySet = false;
+                MP.ClearEditorPreviewIconCache();
+            end
+        end
+
+        -- Save buttons
+        MP.imgui.PushStyleColor(ImGuiCol_Button, MP.COLORS.success);
+        MP.imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.5, 0.8, 0.5, 1.0});
+        MP.imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.6, 0.9, 0.6, 1.0});
+        MP.imgui.PushStyleColor(ImGuiCol_Text, {0.1, 0.1, 0.1, 1.0});
+
+        if MP.imgui.Button('Save & Close', {110, 28}) then
+            SaveMacro(true);
+        end
+
+        MP.imgui.SameLine(0, 8);
+
+        if MP.imgui.Button('Save & Add Another', {150, 28}) then
+            SaveMacro(false);
+        end
+
+        MP.imgui.PopStyleColor(4);
+
+        MP.imgui.SameLine(0, 12);
+
+        if MP.imgui.Button('Cancel', {80, 28}) then
+            MP.editingMacro = nil;
+            MP.isCreatingNew = false;
+            MP.searchFilter[1] = '';
+            MP.iconPickerOpen = false;
+            MP.iconPickerFilter[1] = '';
+            MP.editorPaletteKey = nil;
+            MP.editorDidInitialIconPick = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.pendingNewMacroBindTarget = nil;
+            MP.ClearEditorPreviewIconCache();
+        end
+    end
+
+    MP.imgui.End();
+    MP.PopWindowStyle();
+
+    if not isOpen[1] then
+        MP.editingMacro = nil;
+        MP.isCreatingNew = false;
+        MP.searchFilter[1] = '';
+        MP.iconPickerOpen = false;
+        MP.iconPickerFilter[1] = '';
+        MP.editorPaletteKey = nil;
+        MP.editorJaBadgeManuallySet = false;
+        MP.pendingNewMacroBindTarget = nil;
+        MP.ClearEditorPreviewIconCache();
+    end
+
+    -- Draw icon picker if open
+    MP.DrawIconPicker();
+    end
+end

--- a/XIUI/modules/hotbar/playerdata.lua
+++ b/XIUI/modules/hotbar/playerdata.lua
@@ -19,6 +19,23 @@ local cachedItems = nil;
 local cacheJobId = nil;
 local cacheSubJobId = nil;
 
+-- Full invalidation signature (job/level/equip/level sync) + periodic WS-count poll
+local cacheFullSignature = nil;
+local lastWsCountPollClock = 0;
+local lastCachedWsAbilityCount = -1;
+local WS_ABILITY_COUNT_POLL_INTERVAL = 0.75;
+local lastEquipSignaturePollClock = 0;
+local EQUIP_SIGNATURE_POLL_INTERVAL = 0.6;
+
+local equipmentWs = require('modules.hotbar.equipment_ws');
+local horizonRetailOnlyJa = require('modules.hotbar.database.horizon_retail_only_job_abilities');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
+-- Pre-existing name->id hashmap module (built lazily, session-cached). Replaces several
+-- per-call O(1024) `for abilityId = 1, 1024 do ... resMgr:GetAbilityById(...)` scans for
+-- name-based lookups. Audit pass: both 1.8.0 and Ferris kept this module but neither
+-- propagated it into playerdata.lua's scans.
+local actiondb = require('modules.hotbar.actiondb');
+
 -- ============================================
 -- Container Definitions
 -- ============================================
@@ -58,6 +75,59 @@ local function IsGarbageSpellName(name)
 end
 
 -- ============================================
+-- Spell Sorting Helpers
+-- ============================================
+
+-- Base type rank (canonical display order when no job context)
+local BASE_TYPE_RANK = {
+    WhiteMagic=1, BlackMagic=2, BardSong=3, Ninjutsu=4,
+    SummonerPact=5, BlueMagic=6, Geomancy=7, Trust=8,
+};
+
+-- Which type to surface first for each job
+local JOB_PRIMARY_TYPE = {
+    [3]  = 'WhiteMagic',    -- WHM
+    [4]  = 'BlackMagic',    -- BLM
+    [5]  = 'WhiteMagic',    -- RDM (has both; white magic is their healing focus)
+    [7]  = 'WhiteMagic',    -- PLD
+    [8]  = 'BlackMagic',    -- DRK
+    [10] = 'BardSong',      -- BRD
+    [13] = 'Ninjutsu',      -- NIN
+    [15] = 'SummonerPact',  -- SMN
+    [16] = 'BlueMagic',     -- BLU
+    [20] = 'WhiteMagic',    -- SCH
+    [21] = 'Geomancy',      -- GEO
+};
+
+--- Build a sort comparator for spells, context-aware by job.
+--- Primary type for the given job sorts to the top.
+--- Within SummonerPact, avatars come before spirits.
+---@param mainJobId number
+--- Spells sort by type group, then level, then name. Status is communicated by colour only.
+---@return function
+local function MakeSpellSortFn(mainJobId)
+    local primaryType = JOB_PRIMARY_TYPE[mainJobId];
+    return function(a, b)
+        local ra = BASE_TYPE_RANK[a.type] or 9;
+        local rb = BASE_TYPE_RANK[b.type] or 9;
+        if primaryType then
+            if a.type == primaryType then ra = 0; end
+            if b.type == primaryType then rb = 0; end
+        end
+        if ra ~= rb then return ra < rb; end
+        -- Within SummonerPact: avatars before spirits
+        if a.type == 'SummonerPact' and b.type == 'SummonerPact' then
+            local aIsSpirit = a.name:find(' Spirit') ~= nil;
+            local bIsSpirit = b.name:find(' Spirit') ~= nil;
+            if aIsSpirit ~= bIsSpirit then return not aIsSpirit; end
+        end
+        -- Sort by level then name; status is communicated by text colour alone
+        if a.level ~= b.level then return a.level < b.level; end
+        return a.name < b.name;
+    end;
+end
+
+-- ============================================
 -- Player Data Retrieval Functions
 -- ============================================
 
@@ -73,61 +143,75 @@ function M.GetPlayerSpells()
     local subJobId = player:GetSubJob();
     local subJobLevel = player:GetSubJobLevel();
     local resMgr = AshitaCore:GetResourceManager();
+    local horizonSpells = require('modules.hotbar.database.horizonspells');
+
+    -- Build id → horizonspells entry and name → type lookups in one pass.
+    -- Using the horizonspells `levels` table for job/level data avoids the
+    -- unreliable LevelRequired indexing in Ashita's resource manager (the
+    -- offset between Ashita's C++ array and Lua indexing is inconsistent).
+    -- This is the same data source used by GetAllSpellsForCurrentJob (Show All
+    -- mode), which is known to work correctly.
+    -- When the same spell name exists as both a castable spell and a SummonerPact
+    -- blood pact, prefer the non-blood-pact type so spells like "Blizzard II"
+    -- sort into the correct section rather than the Rage section.
+    local horizonById = {};
+    local spellTypeByName = {};
+    for _, s in pairs(horizonSpells) do
+        -- Exclude unlearnable entries (NPC/monster-only variants like Sleepga id=363).
+        -- They share names with the learnable versions and would otherwise cause duplicates.
+        if s.id and not s.unlearnable then horizonById[s.id] = s; end
+        if s.en and s.type and not s.unlearnable then
+            local existing = spellTypeByName[s.en];
+            if not existing or (s.type ~= 'SummonerPact' and existing == 'SummonerPact') then
+                spellTypeByName[s.en] = s.type;
+            end
+        end
+    end
 
     local spells = {};
-    local addedSpells = {};  -- Track by spell ID to avoid duplicates
+    local addedSpells = {};
 
-    for spellId = 1, 1024 do
-        -- Skip trust spells (IDs 896+)
-        if spellId >= 896 then
-            break;
-        end
-
+    for spellId = 1, 895 do
         if player:HasSpell(spellId) then
             local spell = resMgr:GetSpellById(spellId);
             if spell and spell.Name and spell.Name[1] and spell.Name[1] ~= '' then
                 local spellName = spell.Name[1];
 
-                -- Skip garbage/test spell names
-                if not IsGarbageSpellName(spellName) then
-                    -- LevelRequired array uses jobId + 1 offset
-                    -- WHM (jobId=3) -> LevelRequired[4], BLM (jobId=4) -> LevelRequired[5]
-                    local mainReqLevel = spell.LevelRequired[mainJobId + 1] or 0;
-                    local subReqLevel = subJobId > 0 and (spell.LevelRequired[subJobId + 1] or 0) or 0;
+                if not IsGarbageSpellName(spellName) and not addedSpells[spellName] then
+                    -- Use horizonspells levels table for job filtering — same indexing
+                    -- ([mainJobId] directly, e.g. [4]=BLM) as the working Show All path.
+                    local hSpell = horizonById[spellId];
+                    local hLevels = hSpell and hSpell.levels;
+                    local mainReqLevel = (hLevels and hLevels[mainJobId]) or 0;
+                    local subReqLevel = (subJobId > 0 and hLevels and hLevels[subJobId]) or 0;
 
-                    -- Filter invalid level values (0 = can't learn, 255 = can't learn)
                     local validMainReq = mainReqLevel > 0 and mainReqLevel < 255;
                     local validSubReq = subReqLevel > 0 and subReqLevel < 255;
 
-                    -- Check if castable by main job
-                    local canCastMain = validMainReq and mainReqLevel <= mainJobLevel;
-                    -- Check if castable by sub job
-                    local canCastSub = validSubReq and subReqLevel <= subJobLevel;
-
-                    if (canCastMain or canCastSub) and not addedSpells[spellId] then
-                        -- Use main job level if castable, otherwise sub job level
-                        local displayLevel = canCastMain and mainReqLevel or subReqLevel;
-                        local source = canCastMain and 'main' or 'sub';
+                    -- Spell must belong to the player's current job or subjob.
+                    -- We don't require canCast (level >= req) because HorizonXI may
+                    -- grant spells at different thresholds than the static DB records;
+                    -- HasSpell() already proves the player can cast it.
+                    local isForCurrentJob = validMainReq or validSubReq;
+                    if isForCurrentJob then
+                        local displayLevel = validMainReq and mainReqLevel or subReqLevel;
+                        local source = validMainReq and 'main' or 'sub';
 
                         table.insert(spells, {
                             id = spellId,
                             name = spellName,
                             level = displayLevel,
                             source = source,
+                            type = (hSpell and hSpell.type) or spellTypeByName[spellName] or 'Unknown',
                         });
-                        addedSpells[spellId] = true;
+                        addedSpells[spellName] = true;
                     end
                 end
             end
         end
     end
 
-    table.sort(spells, function(a, b)
-        if a.level == b.level then
-            return a.name < b.name;
-        end
-        return a.level < b.level;
-    end);
+    table.sort(spells, MakeSpellSortFn(mainJobId));
 
     return spells;
 end
@@ -158,10 +242,13 @@ local ABILITY_TYPE = {
     RuneWard          = 22,
     RuneEffusion      = 23,
 };
+-- Backward-compat alias for Ferris's existing code paths.
+local ABILITY_TYPE_WEAPON_SKILL = ABILITY_TYPE.WeaponSkill;
 
--- Pet commands to filter out from ability list (these belong in Pet Command section)
+-- Pet commands shown under Pet Command in the macro UI — excluded from the Job Ability dropdown only.
+-- Players may still macro these as `/ja "Name"` in-game; IsAbilityInCache() accepts them when HasAbility is true.
+-- Note: 'Assault' (BST pet) intentionally OMITTED — confusable with the Treasures of Aht Urhgan in-game system.
 local PET_COMMAND_NAMES = {
-    ['Assault'] = true,
     ['Retreat'] = true,
     ['Stay'] = true,
     ['Heel'] = true,
@@ -170,20 +257,17 @@ local PET_COMMAND_NAMES = {
     ['Fight'] = true,
     ['Sic'] = true,
     ['Ready'] = true,
-    -- SMN commands
     ['Avatar\'s Favor'] = true,
-    -- DRG commands
     ['Steady Wing'] = true,
-    -- PUP commands
     ['Deploy'] = true,
     ['Retrieve'] = true,
     ['Activate'] = true,
     ['Deactivate'] = true,
 };
 
--- FFXI macro-maker subcategory headers ("Sambas", "Waltzes", etc.) are present
--- as ability entries in the resource manager and HasAbility() returns true for
--- them, but they aren't executable. Filter them out of the JA dropdown.
+-- FFXI macro-maker subcategory headers ("Sambas", "Waltzes", etc.) are present as ability
+-- entries in the resource manager and HasAbility() returns true for them, but they aren't
+-- executable. Filter them out of the JA dropdown and IsAbilityInCache.
 local CATEGORY_PLACEHOLDER_NAMES = {
     ['Sambas']         = true,
     ['Waltzes']        = true,
@@ -194,8 +278,48 @@ local CATEGORY_PLACEHOLDER_NAMES = {
     ['Flourishes III'] = true,
 };
 
+local function sortRankFamiliarFirst(name)
+    return (name == 'Familiar') and 0 or 1;
+end
+
+local function horizonHasBstReadyPetCommand()
+    local ha = require('modules.hotbar.database.horizon_abilities');
+    local row = ha['Ready'];
+    return row ~= nil and row.pet == true;
+end
+
+local function playerHasLearnedNonWsAbilityByName(abilityName)
+    if horizonRetailOnlyJa[abilityName] then
+        return false;
+    end
+    if not abilityName or abilityName == '' then
+        return false;
+    end
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then
+        return false;
+    end
+    local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then
+        return false;
+    end
+    -- Audit win: O(1) name->id via actiondb (session-cached lazy hashmap) replaces the
+    -- O(1024) scan that was here. Same semantics: confirm player has learned it AND it
+    -- is not a weapon-skill type. Falls back to scan if actiondb returns nil (e.g. before
+    -- the lookup table is populated for some edge resource-manager state).
+    local id = actiondb.GetAbilityId(abilityName);
+    if id and id > 0 and player:HasAbility(id) then
+        local ability = resMgr:GetAbilityById(id);
+        if ability and ability.Name and ability.Name[1] == abilityName then
+            local abilityType = ability.Type or 0;
+            return abilityType ~= ABILITY_TYPE_WEAPON_SKILL;
+        end
+    end
+    return false;
+end
+
 --- Get player's available job abilities (includes both main job and subjob abilities)
---- Filters out weapon skills (Type 3) and pet commands
+--- Filters out weapon skills (Type 3) and PET_COMMAND_NAMES (those stay in the Pet Command picker).
 ---@return table Array of {id, name, source} where source is 'main' or 'sub'
 function M.GetPlayerAbilities()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
@@ -206,31 +330,35 @@ function M.GetPlayerAbilities()
     local subJobId = player:GetSubJob();
     local subJobLevel = player:GetSubJobLevel();
     local resMgr = AshitaCore:GetResourceManager();
+    local horizonAbilities = require('modules.hotbar.database.horizon_abilities');
 
     local abilities = {};
-    local addedAbilities = {};  -- Track by ability ID to avoid duplicates
+    local addedAbilities = {};
 
-    -- Scan ability IDs 1-1024 (job abilities can be in higher ranges like 500+)
     for abilityId = 1, 1024 do
         if player:HasAbility(abilityId) then
             local ability = resMgr:GetAbilityById(abilityId);
             if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
                 local abilityType = ability.Type or 0;
-                local abilityName = ability.Name[1];
 
-                -- Exclude: weapon skills (separate dropdown), passive traits (not
-                -- macroable), pet commands (separate section), and subcategory
-                -- header placeholders ("Sambas", "Waltzes", etc.).
-                local isWeaponSkill = abilityType == ABILITY_TYPE.WeaponSkill;
-                local isTrait       = abilityType == ABILITY_TYPE.Trait;
-                if not isWeaponSkill
-                    and not isTrait
+                local abilityName = ability.Name[1];
+                -- Exclude: weapon skills (separate dropdown), passive traits (not macroable),
+                -- pet commands (separate section), Horizon retail-only entries, and FFXI's
+                -- subcategory header placeholders ("Sambas", "Waltzes", etc.).
+                if not horizonRetailOnlyJa[abilityName]
+                    and abilityType ~= ABILITY_TYPE.WeaponSkill
+                    and abilityType ~= ABILITY_TYPE.Trait
                     and not PET_COMMAND_NAMES[abilityName]
-                    and not CATEGORY_PLACEHOLDER_NAMES[abilityName]
-                then
+                    and not CATEGORY_PLACEHOLDER_NAMES[abilityName] then
 
                     if not addedAbilities[abilityId] then
                         local source = 'main';
+                        local displayLevel = nil;
+
+                        local dbEntry = horizonAbilities[abilityName];
+                        if dbEntry and dbEntry.level then
+                            displayLevel = dbEntry.level;
+                        end
 
                         if ability.Level then
                             local mainReqLevel = ability.Level[mainJobId + 1] or 0;
@@ -247,10 +375,14 @@ function M.GetPlayerAbilities()
                             end
                         end
 
+                        local hj = dbEntry and dbEntry.job;
                         table.insert(abilities, {
                             id = abilityId,
                             name = abilityName,
+                            level = displayLevel,
                             source = source,
+                            jobId = hj,
+                            pinkStarTooltip = universalTwoHour.GetTwoHourPinkTooltipIfApplicable(hj, abilityName),
                         });
                         addedAbilities[abilityId] = true;
                     end
@@ -260,6 +392,13 @@ function M.GetPlayerAbilities()
     end
 
     table.sort(abilities, function(a, b)
+        local ta = universalTwoHour.TwoHourSortRank(a.jobId, a.name);
+        local tb = universalTwoHour.TwoHourSortRank(b.jobId, b.name);
+        if ta ~= tb then return ta < tb; end
+        local fa = sortRankFamiliarFirst(a.name);
+        local fb = sortRankFamiliarFirst(b.name);
+        if fa ~= fb then return fa < fb; end
+        if a.level and b.level and a.level ~= b.level then return a.level < b.level; end
         return a.name < b.name;
     end);
 
@@ -274,34 +413,63 @@ function M.GetPlayerWeaponskills()
     if not player then return {}; end
 
     local resMgr = AshitaCore:GetResourceManager();
+    local wsDb = require('modules.hotbar.database.ws_weapon_types');
     local weaponskills = {};
-    local addedWeaponskills = {};  -- Track by name to avoid duplicates
+    local addedWeaponskills = {};
 
-    -- Scan HasAbility and filter by Type == WeaponSkill (3)
-    for abilityId = 1, 1024 do
+    -- Audit win: iterate the static WS-ability-ID list from actiondb instead of scanning
+    -- all 1024 ability slots. The Type==3 filter is moved into the one-time list build,
+    -- so the per-call loop only has to check HasAbility + dedup.
+    local wsIds = actiondb.GetWeaponSkillAbilityIds();
+    for i = 1, #wsIds do
+        local abilityId = wsIds[i];
         if player:HasAbility(abilityId) then
             local ability = resMgr:GetAbilityById(abilityId);
             if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
-                local abilityType = ability.Type or 0;
-                if abilityType == ABILITY_TYPE.WeaponSkill then
-                    local wsName = ability.Name[1];
-                    if not addedWeaponskills[wsName] then
-                        table.insert(weaponskills, {
-                            id = abilityId,
-                            name = wsName,
-                        });
-                        addedWeaponskills[wsName] = true;
+                local wsName = ability.Name[1];
+                if not addedWeaponskills[wsName] then
+                    local info = wsDb[wsName];
+                    local reqStr = nil;
+                    if info then
+                        reqStr = info.relic and 'Relic Weapon' or ('Skill ' .. tostring(info.skill));
                     end
+                    table.insert(weaponskills, {
+                        id = abilityId,
+                        name = wsName,
+                        reqStr = reqStr,
+                        skill = info and info.skill or 0,
+                        relic = info and info.relic or false,
+                    });
+                    addedWeaponskills[wsName] = true;
                 end
             end
         end
     end
 
     table.sort(weaponskills, function(a, b)
+        if a.relic ~= b.relic then return not a.relic; end
+        if a.skill ~= b.skill then return a.skill < b.skill; end
         return a.name < b.name;
     end);
 
     return weaponskills;
+end
+
+--- Count type-3 abilities the player has (cheap drift detector for new WS without job change).
+local function countLearnedWeaponSkillAbilities(player)
+    if not player then return 0; end
+    local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then return 0; end
+    local c = 0;
+    -- Audit win: same actiondb-driven optimization. The WS-id list already filters by Type == 3
+    -- so the per-call body just needs HasAbility check + counter increment.
+    local wsIds = actiondb.GetWeaponSkillAbilityIds();
+    for i = 1, #wsIds do
+        if player:HasAbility(wsIds[i]) then
+            c = c + 1;
+        end
+    end
+    return c;
 end
 
 --- Get items from all player storage containers
@@ -381,18 +549,58 @@ function M.RefreshCachedLists(dataModule)
     local dataJobId = dataModule and dataModule.jobId or currentJobId;
     local dataSubjobId = dataModule and dataModule.subjobId or currentSubJobId;
 
-    -- Refresh if main job, sub job changed, or cache is empty
-    -- Also refresh if data.jobId differs from cache (pending job change)
-    local jobChanged = cacheJobId ~= currentJobId or cacheSubJobId ~= currentSubJobId;
-    local pendingChange = cacheJobId ~= nil and (cacheJobId ~= dataJobId or cacheSubJobId ~= dataSubjobId);
+    local equipSig = equipmentWs.GetPlayerWeaponskillCacheSignature(player);
+    local fullSig = equipSig .. '|' .. tostring(dataJobId) .. '|' .. tostring(dataSubjobId);
 
-    if jobChanged or pendingChange or not cachedSpells then
+    local nowClock = os.clock();
+    local pendingChange = cacheJobId ~= nil and (cacheJobId ~= dataJobId or cacheSubJobId ~= dataSubjobId);
+    local needRefresh = (fullSig ~= cacheFullSignature)
+        or pendingChange
+        or (not cachedSpells);
+
+    if (not needRefresh) and (nowClock - lastWsCountPollClock >= WS_ABILITY_COUNT_POLL_INTERVAL) then
+        lastWsCountPollClock = nowClock;
+        local wsCountNow = countLearnedWeaponSkillAbilities(player);
+        if wsCountNow ~= lastCachedWsAbilityCount then
+            needRefresh = true;
+        end
+    end
+
+    -- Throttled equip/sync signature poll: catches rare drift if memory state updates without a frame-tied signature change
+    if (not needRefresh) and cacheFullSignature and (nowClock - lastEquipSignaturePollClock >= EQUIP_SIGNATURE_POLL_INTERVAL) then
+        lastEquipSignaturePollClock = nowClock;
+        local equipSigPoll = equipmentWs.GetPlayerWeaponskillCacheSignature(player);
+        local fullSigPoll = equipSigPoll .. '|' .. tostring(dataJobId) .. '|' .. tostring(dataSubjobId);
+        if fullSigPoll ~= cacheFullSignature then
+            needRefresh = true;
+        end
+    end
+
+    if needRefresh then
         cachedSpells = M.GetPlayerSpells();
         cachedAbilities = M.GetPlayerAbilities();
+        -- WS list: trust client HasAbility only; gear/job/sync in signature refreshes cache.
         cachedWeaponskills = M.GetPlayerWeaponskills();
         cachedItems = nil;  -- Clear items cache to refresh on next access
         cacheJobId = currentJobId;
         cacheSubJobId = currentSubJobId;
+        cacheFullSignature = fullSig;
+        lastCachedWsAbilityCount = countLearnedWeaponSkillAbilities(player);
+
+        -- Clear expanded caches on job change so they rebuild with fresh data
+        expandedSpellsCache = nil;
+        expandedAbilitiesCache = nil;
+        expandedWsCache = nil;
+
+        -- Discover any newly learned WS and persist to charSettings
+        if M.DiscoverNewWeaponskills() and SaveCharacterSettingsInternal then
+            SaveCharacterSettingsInternal();
+        end
+
+        local okSr, slotrenderer = pcall(require, 'modules.hotbar.slotrenderer');
+        if okSr and slotrenderer and slotrenderer.ClearAvailabilityCache then
+            slotrenderer.ClearAvailabilityCache();
+        end
     end
 
     -- Only refresh items if cache is empty (expensive operation)
@@ -433,6 +641,13 @@ function M.ClearCache()
     cachedItems = nil;
     cacheJobId = nil;
     cacheSubJobId = nil;
+    cacheFullSignature = nil;
+    lastCachedWsAbilityCount = -1;
+    expandedSpellsCache = nil;
+    expandedAbilitiesCache = nil;
+    expandedWsCache = nil;
+    expandedAbilitiesFilterJobId = nil;
+    expandedSpellsFilterType = nil;
 end
 
 --- Get current cache job ID
@@ -448,15 +663,33 @@ function M.GetCacheSubJobId()
 end
 
 --- Check if an ability name is in the cached abilities list
---- This ensures availability check uses same data as dropdown
+--- Used for `/ja` macro availability: matches the Job Ability dropdown when populated, plus PET_COMMAND_NAMES when learned.
 ---@param abilityName string The ability name to check
 ---@return boolean isAvailable True if ability is in cached list
 function M.IsAbilityInCache(abilityName)
-    if not cachedAbilities then return true; end  -- No cache = assume available
-    for _, ability in ipairs(cachedAbilities) do
-        if ability.name == abilityName then
-            return true;
+    if abilityName == universalTwoHour.ACTION_SENTINEL then
+        abilityName = universalTwoHour.ResolveJaActionName(abilityName);
+        if not abilityName then
+            return false;
         end
+    end
+    if horizonRetailOnlyJa[abilityName] then
+        return false;
+    end
+    -- Ready: honor horizon_abilities pet row (HorizonXI defines Ready for jug pets).
+    if abilityName == 'Ready' and not horizonHasBstReadyPetCommand() then
+        return false;
+    end
+    if cachedAbilities and #cachedAbilities > 0 then
+        for _, ability in ipairs(cachedAbilities) do
+            if ability.name == abilityName then
+                return true;
+            end
+        end
+    end
+    -- Omitted from JA dropdown; `/ja` in macros still uses client HasAbility when the name is a known pet command.
+    if PET_COMMAND_NAMES[abilityName] then
+        return playerHasLearnedNonWsAbilityByName(abilityName);
     end
     return false;
 end
@@ -465,7 +698,9 @@ end
 ---@param wsName string The weaponskill name to check
 ---@return boolean isAvailable True if weaponskill is in cached list
 function M.IsWeaponskillInCache(wsName)
-    if not cachedWeaponskills then return true; end
+    if not cachedWeaponskills or #cachedWeaponskills == 0 then
+        return false;
+    end
     for _, ws in ipairs(cachedWeaponskills) do
         if ws.name == wsName then
             return true;
@@ -473,6 +708,476 @@ function M.IsWeaponskillInCache(wsName)
     end
     return false;
 end
+
+-- ============================================
+-- Per-Character WS Knowledge Cache
+-- ============================================
+
+-- Known WS set: {['Savage Blade']=true, ...}. Populated externally from charSettings.
+local knownWeaponskills = {};
+
+--- Set the known WS table (call from XIUI.lua after loading charSettings)
+function M.SetKnownWeaponskills(tbl)
+    knownWeaponskills = tbl or {};
+end
+
+--- Get the known WS table reference
+function M.GetKnownWeaponskills()
+    return knownWeaponskills;
+end
+
+--- Scan player's current abilities for any new WS and add them to the known set.
+--- Returns true if any new WS were discovered (caller should save charSettings).
+function M.DiscoverNewWeaponskills()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return false; end
+
+    local resMgr = AshitaCore:GetResourceManager();
+    local found = false;
+
+    -- Audit win: same actiondb-driven optimization as GetPlayerWeaponskills.
+    local wsIds = actiondb.GetWeaponSkillAbilityIds();
+    for i = 1, #wsIds do
+        local abilityId = wsIds[i];
+        if player:HasAbility(abilityId) then
+            local ability = resMgr:GetAbilityById(abilityId);
+            if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
+                local wsName = ability.Name[1];
+                if not knownWeaponskills[wsName] then
+                    knownWeaponskills[wsName] = true;
+                    found = true;
+                end
+            end
+        end
+    end
+
+    return found;
+end
+
+-- ============================================
+-- "Show All" Expanded List Builders
+-- ============================================
+
+local expandedSpellsCache = nil;
+local expandedAbilitiesCache = nil;
+local expandedWsCache = nil;
+local expandedCacheJobId = nil;
+local expandedCacheSubJobId = nil;
+local expandedAbilitiesFilterJobId = nil;
+local expandedSpellsFilterType = nil;
+
+local STATUS_HAVE = 'have';
+local STATUS_LEARNABLE = 'learnable';
+local STATUS_UNAVAILABLE = 'unavailable';
+
+local STATUS_SORT = { [STATUS_HAVE] = 1, [STATUS_LEARNABLE] = 2, [STATUS_UNAVAILABLE] = 3 };
+
+--- Get expanded spell list from horizonspells DB with availability status.
+--- When filterMagicType is 'All' or nil, only spells for the current main/sub job are shown.
+--- When a specific type is given, ALL spells of that type are shown regardless of job.
+--- Green = have, Yellow = learnable (right job/level but spell not yet on character), Red = unavailable.
+---@param filterMagicType string|nil Magic type filter ('All', 'WhiteMagic', 'BlackMagic', etc.)
+---@return table Array of {id, name, level, source, type, status, icon_id}
+function M.GetAllSpellsForCurrentJob(filterMagicType)
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return {}; end
+
+    local mainJobId = player:GetMainJob();
+    local mainJobLevel = player:GetMainJobLevel();
+    local subJobId = player:GetSubJob();
+    local subJobLevel = player:GetSubJobLevel();
+
+    local effectiveType = (filterMagicType and filterMagicType ~= 'All') and filterMagicType or 'All';
+
+    -- Self-invalidate when job changes
+    if expandedCacheJobId ~= mainJobId or expandedCacheSubJobId ~= subJobId then
+        expandedSpellsCache = nil;
+        expandedAbilitiesCache = nil;
+        expandedWsCache = nil;
+        expandedCacheJobId = mainJobId;
+        expandedCacheSubJobId = subJobId;
+        expandedSpellsFilterType = nil;
+    end
+    if expandedSpellsFilterType ~= effectiveType then
+        expandedSpellsCache = nil;
+        expandedSpellsFilterType = effectiveType;
+    end
+    if expandedSpellsCache then return expandedSpellsCache; end
+
+    local filterByType = (effectiveType ~= 'All');
+
+    local horizonSpells = require('modules.hotbar.database.horizonspells');
+    local omitList = require('modules.hotbar.database.horizon_spell_omissions');
+    local omitSet = {};
+    for _, name in ipairs(omitList) do omitSet[name] = true; end
+    local spells = {};
+
+    for _, spell in pairs(horizonSpells) do
+        if spell.en and spell.en ~= '' and spell.id and not IsGarbageSpellName(spell.en) then
+            if spell.id >= 896 then goto continue; end
+            if spell.unlearnable then goto continue; end
+            if omitSet[spell.en] then goto continue; end
+
+            if filterByType and spell.type ~= effectiveType then goto continue; end
+
+            local levels = spell.levels;
+            if not levels then goto continue; end
+
+            local mainReq = levels[mainJobId];
+            local subReq = (subJobId and subJobId > 0) and levels[subJobId] or nil;
+            local validMain = mainReq and mainReq > 0 and mainReq < 255;
+            local validSub = subReq and subReq > 0 and subReq < 255;
+
+            if not filterByType and not validMain and not validSub then goto continue; end
+
+            local status;
+            local displayLevel;
+            local source;
+
+            local hasSpell = player:HasSpell(spell.id);
+            local canCastMain = validMain and mainReq <= mainJobLevel;
+            local canCastSub = validSub and subReq <= subJobLevel;
+
+            local reason = nil;
+            if hasSpell and (canCastMain or canCastSub) then
+                status = STATUS_HAVE;
+                displayLevel = canCastMain and mainReq or subReq;
+                source = canCastMain and 'main' or 'sub';
+            elseif (validMain and mainReq <= mainJobLevel) or (validSub and subReq <= subJobLevel) then
+                status = STATUS_LEARNABLE;
+                displayLevel = canCastMain and mainReq or (validSub and subReq or mainReq);
+                source = validMain and 'main' or 'sub';
+                reason = 'Not yet learned';
+            else
+                status = STATUS_UNAVAILABLE;
+                local bestLevel = nil;
+                for _, lv in pairs(levels) do
+                    if lv and lv > 0 and lv < 255 then
+                        if not bestLevel or lv < bestLevel then bestLevel = lv; end
+                    end
+                end
+                displayLevel = (validMain and mainReq) or (validSub and subReq) or bestLevel or 99;
+                source = validMain and 'main' or (validSub and 'sub' or 'other');
+                if source == 'other' then
+                    reason = 'Not available to your current job';
+                else
+                    reason = 'Level too low (requires Lv. ' .. tostring(displayLevel) .. ')';
+                end
+            end
+
+            table.insert(spells, {
+                id = spell.id,
+                name = spell.en,
+                level = displayLevel,
+                source = source,
+                type = spell.type or 'Unknown',
+                status = status,
+                reason = reason,
+                icon_id = spell.icon_id,
+            });
+            ::continue::
+        end
+    end
+
+    table.sort(spells, MakeSpellSortFn(mainJobId));
+
+    expandedSpellsCache = spells;
+    return spells;
+end
+
+--- Get expanded ability list with availability status.
+--- Uses the static horizon_abilities database for reliable job-ability mapping,
+--- cross-referenced with player:HasAbility() for ownership status.
+---@param filterJobId number|nil Specific job ID to show abilities for. 0 or nil = main+sub (default).
+---@return table Array of {id, name, level, source, status}
+function M.GetAllAbilitiesForCurrentJob(filterJobId)
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return {}; end
+
+    local mainJobId = player:GetMainJob();
+    local mainJobLevel = player:GetMainJobLevel();
+    local subJobId = player:GetSubJob();
+    local subJobLevel = player:GetSubJobLevel();
+    local resMgr = AshitaCore:GetResourceManager();
+
+    local effectiveFilter = (filterJobId and filterJobId > 0) and filterJobId or 0;
+
+    if expandedCacheJobId ~= mainJobId or expandedCacheSubJobId ~= subJobId then
+        expandedSpellsCache = nil;
+        expandedAbilitiesCache = nil;
+        expandedWsCache = nil;
+        expandedCacheJobId = mainJobId;
+        expandedCacheSubJobId = subJobId;
+        expandedAbilitiesFilterJobId = nil;
+    end
+    if expandedAbilitiesFilterJobId ~= effectiveFilter then
+        expandedAbilitiesCache = nil;
+        expandedAbilitiesFilterJobId = effectiveFilter;
+    end
+    if expandedAbilitiesCache then return expandedAbilitiesCache; end
+
+    local horizonAbilities = require('modules.hotbar.database.horizon_abilities');
+
+    -- Audit win: previously this function did TWO O(1024) resource-manager scans per
+    -- cache miss (one to build name->id, one to populate playerHas). Both are now driven
+    -- by `actiondb` (lazy session-cached name->id hashmap) + iterating the ~80-entry
+    -- horizon_abilities table instead. Net: ~4096 resource calls collapses to ~160 on
+    -- a cache miss (job change / profile load), with actiondb's one-time hashmap build
+    -- amortized across all callers.
+    local playerHas = {};
+    for abilityName, _ in pairs(horizonAbilities) do
+        local id = actiondb.GetAbilityId(abilityName);
+        if id and id > 0 and player:HasAbility(id) then
+            playerHas[abilityName] = true;
+        end
+    end
+
+    local abilities = {};
+
+    for abilityName, info in pairs(horizonAbilities) do
+        if info.pet then goto continue; end
+
+        local matchesMain = info.job == mainJobId;
+        local matchesSub = subJobId and subJobId > 0 and info.job == subJobId;
+
+        if effectiveFilter > 0 then
+            -- Specific job filter: only show abilities for that job
+            if info.job ~= effectiveFilter then goto continue; end
+        else
+            -- Default: show main + sub job abilities
+            if not matchesMain and not matchesSub then goto continue; end
+        end
+
+        local status;
+        local source;
+        local reason = nil;
+
+        if playerHas[abilityName] then
+            status = STATUS_HAVE;
+            source = matchesMain and 'main' or (matchesSub and 'sub' or 'other');
+        elseif matchesMain and mainJobLevel >= info.level then
+            -- Right job and level met but HasAbility returned false (edge case)
+            status = STATUS_LEARNABLE;
+            source = 'main';
+            reason = 'Should be available — try zoning or checking your abilities menu';
+        elseif matchesSub and subJobLevel >= info.level then
+            status = STATUS_LEARNABLE;
+            source = 'sub';
+            reason = 'Should be available — try zoning or checking your abilities menu';
+        else
+            status = STATUS_UNAVAILABLE;
+            source = matchesMain and 'main' or (matchesSub and 'sub' or 'other');
+            reason = 'Level too low (requires Lv. ' .. tostring(info.level) .. ')';
+        end
+
+        local hj = info.job;
+        table.insert(abilities, {
+            id = actiondb.GetAbilityId(abilityName) or 0,
+            name = abilityName,
+            level = info.level,
+            jobId = hj,
+            source = source,
+            status = status,
+            reason = reason,
+            pinkStarTooltip = universalTwoHour.GetTwoHourPinkTooltipIfApplicable(hj, abilityName),
+        });
+        ::continue::
+    end
+
+    table.sort(abilities, function(a, b)
+        local ta = universalTwoHour.TwoHourSortRank(a.jobId, a.name);
+        local tb = universalTwoHour.TwoHourSortRank(b.jobId, b.name);
+        if ta ~= tb then return ta < tb; end
+        local fa = sortRankFamiliarFirst(a.name);
+        local fb = sortRankFamiliarFirst(b.name);
+        if fa ~= fb then return fa < fb; end
+        local sa = STATUS_SORT[a.status] or 9;
+        local sb = STATUS_SORT[b.status] or 9;
+        if sa ~= sb then return sa < sb; end
+        if a.level ~= b.level then return a.level < b.level; end
+        return a.name < b.name;
+    end);
+
+    expandedAbilitiesCache = abilities;
+    return abilities;
+end
+
+--- Get expanded weaponskill list from static WS lookup with known/unknown status.
+---@param knownWsTable table|nil Per-character set of known WS names (defaults to internal set)
+---@return table Array of {name, weapon, skill, relic, status}
+function M.GetAllWeaponskillsExpanded(knownWsTable)
+    if expandedWsCache then return expandedWsCache; end
+
+    knownWsTable = knownWsTable or knownWeaponskills;
+    local wsDb = require('modules.hotbar.database.ws_weapon_types');
+    local weaponskills = {};
+
+    for wsName, info in pairs(wsDb) do
+        local status = knownWsTable[wsName] and STATUS_HAVE or STATUS_UNAVAILABLE;
+        local reqStr;
+        local reason = nil;
+        if info.relic then
+            reqStr = 'Relic Weapon';
+            if status == STATUS_UNAVAILABLE then
+                reason = 'Requires the relic weapon to be equipped';
+            end
+        else
+            reqStr = 'Skill ' .. tostring(info.skill);
+            if status == STATUS_UNAVAILABLE then
+                reason = 'Not yet learned — use a ' .. info.weapon .. ' in battle (skill Lv. ' .. tostring(info.skill) .. ')';
+            end
+        end
+        table.insert(weaponskills, {
+            name = wsName,
+            weapon = info.weapon,
+            skill = info.skill,
+            relic = info.relic or false,
+            status = status,
+            reqStr = reqStr,
+            reason = reason,
+        });
+    end
+
+    -- Show All: group by weapon type A→Z, then skill requirement low→high (relic last per type), then name.
+    -- Availability color stays on rows; order does not shuffle unknown WS out of weapon clusters.
+    table.sort(weaponskills, function(a, b)
+        if a.weapon ~= b.weapon then return a.weapon < b.weapon; end
+        if a.relic ~= b.relic then return not a.relic; end
+        if a.skill ~= b.skill then return a.skill < b.skill; end
+        return a.name < b.name;
+    end);
+
+    expandedWsCache = weaponskills;
+    return weaponskills;
+end
+
+--- Clear expanded list caches (call on job change, etc.)
+function M.ClearExpandedCaches()
+    expandedSpellsCache = nil;
+    expandedAbilitiesCache = nil;
+    expandedWsCache = nil;
+    expandedCacheJobId = nil;
+    expandedCacheSubJobId = nil;
+    expandedAbilitiesFilterJobId = nil;
+    expandedSpellsFilterType = nil;
+end
+
+-- Internal type names used in horizonspells.lua mapped to display labels
+local MAGIC_TYPE_LABELS = {
+    WhiteMagic    = 'White Magic',
+    BlackMagic    = 'Black Magic',
+    BardSong      = 'Songs',
+    Ninjutsu      = 'Ninjutsu',
+    SummonerPact  = 'Summoning',
+    BlueMagic     = 'Blue Magic',
+    Geomancy      = 'Geomancy',
+    Trust         = 'Trust',
+};
+
+local MAGIC_TYPE_ORDER = {
+    'WhiteMagic', 'BlackMagic', 'BardSong', 'Ninjutsu',
+    'SummonerPact', 'BlueMagic', 'Geomancy', 'Trust',
+};
+
+-- Job ID -> which magic types that job can natively use (sorted alphabetically by label)
+local JOB_MAGIC_TYPES = {
+    [1]  = {},                                                       -- WAR
+    [2]  = {},                                                       -- MNK
+    [3]  = { 'WhiteMagic' },                                         -- WHM
+    [4]  = { 'BlackMagic' },                                         -- BLM
+    [5]  = { 'BlackMagic', 'WhiteMagic' },                           -- RDM
+    [6]  = {},                                                       -- THF
+    [7]  = { 'WhiteMagic' },                                         -- PLD
+    [8]  = { 'BlackMagic' },                                         -- DRK
+    [9]  = {},                                                       -- BST
+    [10] = { 'BardSong', 'WhiteMagic' },                             -- BRD
+    [11] = {},                                                       -- RNG
+    [12] = {},                                                       -- SAM
+    [13] = { 'Ninjutsu' },                                           -- NIN
+    [14] = {},                                                       -- DRG
+    [15] = { 'SummonerPact', 'WhiteMagic' },                         -- SMN
+    [16] = { 'BlueMagic' },                                          -- BLU
+    [17] = {},                                                       -- COR
+    [18] = {},                                                       -- PUP
+    [19] = {},                                                       -- DNC
+    [20] = { 'BlackMagic', 'WhiteMagic' },                           -- SCH
+    [21] = { 'Geomancy' },                                           -- GEO
+    [22] = {},                                                       -- RUN
+};
+
+--- Get the ordered list of magic types for a given job (or current main+sub).
+--- Returns entries like {key='WhiteMagic', label='White Magic'}.
+---@param mainJobId number|nil Main job ID (uses current player if nil)
+---@param subJobId number|nil Sub job ID (uses current player if nil)
+---@return table Array of {key, label} sorted by MAGIC_TYPE_ORDER
+function M.GetMagicTypesForJob(mainJobId, subJobId)
+    if not mainJobId then
+        local player = AshitaCore:GetMemoryManager():GetPlayer();
+        if not player then return {}; end
+        mainJobId = player:GetMainJob();
+        subJobId = player:GetSubJob();
+    end
+
+    local seen = {};
+    local mainTypes = JOB_MAGIC_TYPES[mainJobId] or {};
+    local subTypes = (subJobId and subJobId > 0) and (JOB_MAGIC_TYPES[subJobId] or {}) or {};
+    for _, t in ipairs(mainTypes) do seen[t] = true; end
+    for _, t in ipairs(subTypes) do seen[t] = true; end
+
+    local result = {};
+    for _, key in ipairs(MAGIC_TYPE_ORDER) do
+        if seen[key] then
+            table.insert(result, { key = key, label = MAGIC_TYPE_LABELS[key] });
+        end
+    end
+    return result;
+end
+
+--- Get display label for a magic type key.
+---@param key string Internal type key (e.g. 'WhiteMagic')
+---@return string Display label (e.g. 'White Magic')
+function M.GetMagicTypeLabel(key)
+    return MAGIC_TYPE_LABELS[key] or key;
+end
+
+--- Get all magic type options in canonical order.
+---@return table Array of {key, label}
+function M.GetAllMagicTypes()
+    local result = {};
+    for _, key in ipairs(MAGIC_TYPE_ORDER) do
+        table.insert(result, { key = key, label = MAGIC_TYPE_LABELS[key] });
+    end
+    return result;
+end
+
+--- Get all unique weapon types from the WS lookup.
+---@return table Array of weapon type strings, sorted alphabetically
+function M.GetWeaponTypes()
+    local wsDb = require('modules.hotbar.database.ws_weapon_types');
+    local types = {};
+    local seen = {};
+    for _, info in pairs(wsDb) do
+        if not seen[info.weapon] then
+            seen[info.weapon] = true;
+            table.insert(types, info.weapon);
+        end
+    end
+    table.sort(types);
+    return types;
+end
+
+--- Get BST pet commands from the static database with level-gated availability.
+--- Uses horizon_abilities entries flagged with pet = true.
+---@param playerLevel number The BST job level to check against
+---@return table Array of {name, level, status}
+function M.GetBstPetCommandsExpanded(playerLevel)
+    local petregistry = require('modules.hotbar.petregistry');
+    return petregistry.GetBstPetCommandsExpanded(playerLevel, nil);
+end
+
+M.STATUS_HAVE = STATUS_HAVE;
+M.STATUS_LEARNABLE = STATUS_LEARNABLE;
+M.STATUS_UNAVAILABLE = STATUS_UNAVAILABLE;
 
 -- Export helper for external use
 M.IsGarbageSpellName = IsGarbageSpellName;

--- a/XIUI/modules/hotbar/textures.lua
+++ b/XIUI/modules/hotbar/textures.lua
@@ -51,6 +51,93 @@ local function LoadTextureFromPath(filePath)
     return textureData;
 end
 
+-- Keys: iconname_<lowercase alnum only> — matches "Fire Spirit", "fire spirit", "FireSpirit", "firespirit"
+local ICONNAME_PREFIX = 'iconname_';
+
+local function normalizeSpellIconLookupKey(name)
+    if not name then return ''; end
+    return tostring(name):lower():gsub('[^a-z0-9]', '');
+end
+
+local function storeIconBySpellNameVariants(cache, texture, ...)
+    if not cache or not texture then return; end
+    for i = 1, select('#', ...) do
+        local s = select(i, ...);
+        local k = normalizeSpellIconLookupKey(s);
+        if k ~= '' then
+            cache[ICONNAME_PREFIX .. k] = texture;
+        end
+    end
+end
+
+-- Stems like Sneak_Attack_Icon normalize to sneakattackicon; ability lookups use sneakattack (from "Sneak Attack").
+-- Register the base stem under the ability key when the slot is still free (do not override a plain Sneak_Attack.png).
+local function spellLookupAliasStemFromIconFilenameStem(stem)
+    if not stem or stem == '' then return nil; end
+    return stem:match('^(.+)_[Ii]con$');
+end
+
+local function storeSpellNameLookupAliasIfVacant(cache, texture, nameFragment)
+    if not cache or not texture or not nameFragment or nameFragment == '' then return; end
+    local k = normalizeSpellIconLookupKey(nameFragment);
+    if k == '' or cache[ICONNAME_PREFIX .. k] then return; end
+    cache[ICONNAME_PREFIX .. k] = texture;
+end
+
+-- Optional folders: any .png is loaded and keyed by normalized filename stem (handles Summons/, Summoning/, etc.)
+local function loadPngDirectoryIndexedBySpellName(cache, dir)
+    if not cache or not dir or dir == '' then return; end
+    if not ashita.fs or not ashita.fs.get_directory then return; end
+    local files = ashita.fs.get_directory(dir, '.*%.png$');
+    if not files then return; end
+    for _, file in pairs(files) do
+        local stem = file:match('^(.+)%.[pP][nN][gG]$');
+        if stem then
+            local nk = normalizeSpellIconLookupKey(stem);
+            if nk ~= '' and not cache[ICONNAME_PREFIX .. nk] then
+                local fullPath = dir .. file;
+                local texture = LoadTextureFromPath(fullPath);
+                if texture then
+                    storeIconBySpellNameVariants(cache, texture, stem);
+                    local aliasStem = spellLookupAliasStemFromIconFilenameStem(stem);
+                    if aliasStem then
+                        storeSpellNameLookupAliasIfVacant(cache, texture, aliasStem);
+                    end
+                end
+            end
+        end
+    end
+end
+
+-- Recursively index PNGs for GetIconBySpellName (e.g. assets/hotbar/custom/ffxiv/nin/*.png).
+local function loadPngDirectoryTreeIndexedBySpellName(cache, rootDir, depthLeft)
+    if not cache or not rootDir or rootDir == '' then return; end
+    depthLeft = (depthLeft == nil) and 8 or depthLeft;
+    if depthLeft < 0 then return; end
+    if not ashita.fs or not ashita.fs.get_directory then return; end
+    loadPngDirectoryIndexedBySpellName(cache, rootDir);
+    if depthLeft == 0 then return; end
+    local contents = ashita.fs.get_directory(rootDir, '.*');
+    if not contents then return; end
+    for _, entry in pairs(contents) do
+        if not entry:match('%.') then
+            loadPngDirectoryTreeIndexedBySpellName(cache, rootDir .. entry .. '\\', depthLeft - 1);
+        end
+    end
+end
+
+-- SMN spirit filenames (CamelCase) -> in-game spell names (for /ma "Fire Spirit" …)
+local SMN_FILE_TO_SPELL_NAME = {
+    FireSpirit = 'Fire Spirit',
+    IceSpirit = 'Ice Spirit',
+    AirSpirit = 'Air Spirit',
+    EarthSpirit = 'Earth Spirit',
+    ThunderSpirit = 'Thunder Spirit',
+    WaterSpirit = 'Water Spirit',
+    LightSpirit = 'Light Spirit',
+    DarkSpirit = 'Dark Spirit',
+};
+
 local textures = {};
 
 textures.Initialize = function(self)
@@ -198,11 +285,24 @@ textures.Initialize = function(self)
         local texture = LoadTextureFromPath(fullPath);
         if texture then
             self.Cache[icon.key] = texture;
+            storeIconBySpellNameVariants(self.Cache, texture, icon.file);
+            local spaced = SMN_FILE_TO_SPELL_NAME[icon.file];
+            if spaced then
+                storeIconBySpellNameVariants(self.Cache, texture, spaced);
+            end
         end
     end
 
+    -- Same spell icons may live under Summons/ or Summoning/ with different file naming; all match by normalized name
+    loadPngDirectoryIndexedBySpellName(self.Cache, assetsDirectory .. 'Summons\\');
+    loadPngDirectoryIndexedBySpellName(self.Cache, assetsDirectory .. 'Summoning\\');
+
     -- Load custom icons from hotbar/custom directory
     local customDirectory = string.format('%saddons\\XIUI\\assets\\hotbar\\custom\\', AshitaCore:GetInstallPath());
+
+    -- FFXIV-style per-job folders: register PNGs for name-based lookup (macro /ja badge, GetBindIcon ja/ws/ma).
+    loadPngDirectoryTreeIndexedBySpellName(self.Cache, customDirectory .. 'ffxiv\\', 8);
+    self._ffxivSpellNameIndexLoaded = true;
 
     -- Trust icons
     local trustIcons = {
@@ -347,6 +447,7 @@ textures.Release = function(self)
     if self.Cache then
         self.Cache = nil;
     end
+    self._ffxivSpellNameIndexLoaded = nil;
 end
 
 -- Get texture by filename or key
@@ -355,6 +456,25 @@ textures.Get = function(self, key)
         return nil;
     end
     return self.Cache[key];
+end
+
+--- Resolve a spell/summon icon from assets indexed by normalized English name (any casing/spacing).
+textures.GetIconBySpellName = function(self, spellName)
+    if not spellName or spellName == '' then
+        return nil;
+    end
+    if not self.Cache then
+        return nil;
+    end
+    -- Initialize() skips work when Cache already exists (e.g. addon Lua reload); index custom/ffxiv once on first lookup.
+    if not self._ffxivSpellNameIndexLoaded then
+        local customDirectory = string.format('%saddons\\XIUI\\assets\\hotbar\\custom\\', AshitaCore:GetInstallPath());
+        loadPngDirectoryTreeIndexedBySpellName(self.Cache, customDirectory .. 'ffxiv\\', 8);
+        self._ffxivSpellNameIndexLoaded = true;
+    end
+    local k = normalizeSpellIconLookupKey(spellName);
+    if k == '' then return nil; end
+    return self.Cache[ICONNAME_PREFIX .. k];
 end
 
 -- Get texture path by key (for primitive rendering)


### PR DESCRIPTION
…edup, and custom icon resolution

What changed
- macropalette.lua: Show All toggles and filters (magic type, ability job, WS weapon, pet type). Two-color spell rows (magic-type color + status color). Group headers. Hover reasons on unavailable entries. Ability/BP rows: pink asterisk tooltips for main-job 2-hour (Global macro note) and Astral Flow-only pacts. Copy: duplicate selected macro into editor as a new entry. Locked Global-row handling: Universal 2 Hour macro cannot be deleted or edited through palette duplicate/remove paths. Custom type (+) in popup only; red remove and Rename on the type row; delete confirms macro count; rename modal; delete and rename save paths. Custom grid section header uses Elementals for spirit pets. Move Macro: MoveMacroToPalette API, palette picker popup. RewriteMacroPaletteBindingsInConfig
  + RewriteMacroPaletteBindingsInDraft update all bindings on move. OpenEditorForSlotData accepts opts.bindTargetSlot for double-click-new-macro EFP flow.
- macropalette_macroeditor.lua: New 86 KB closure-factory extension (return function(MP) pattern). SaveMacro syncs dropdown/text buffers into editingMacro before validation so saves match UI state. Main slot icon: implicit refresh on macro text edit no longer forces overwrite; Sync refreshes main icon. JA badge: separate manual vs implicit sync; Sync JA badge clears manual overrides and resolves from /ja line; icon picker marks manual badge on Change. Auto-bind new macro to pendingNewMacroBindTarget slot via data.SetDraftSlotData when set by EFP double-click. Show All combo rows: single InvisibleButton hit target with draw-list text/icons so overlapping widgets do not swallow clicks.
- playerdata.lua: Spell dedup on spell id before building display list removes duplicate rows for spells that appear under multiple magic-type categories. GetPlayerSpells reads unlearnable flags from horizonspells.lua; Show-All-off consistently shows only known/available spells without gaps.
- customiconresolve.lua: New file. Resolves assets/hotbar/custom/*.png by action name (recursive scan with caching). Allows users to drop custom-named PNGs into the custom/ folder and have them appear on matching macro/action slots automatically.
- iconmatch.lua: New file. Fuzzy name-to-icon matcher used by customiconresolve for partial-name and case-insensitive resolution.
- textures.lua: Custom texture resolution layer. custom_icons.maxSize = 0 no-eviction tweak (prevents macro picker stutter from LRU evict+reload on large custom icon sets).

Why
- Large spell/ability lists stay navigable; Copy speeds palette workflows; icon and badge behavior matches user expectations. Custom icon resolution lets users add their own named PNGs to assets/hotbar/custom/ and see them on matching slots without editing Lua. Spell dedup and unlearnable-flag filtering prevent spurious duplicate rows and missing spells in the picker.