### PR TITLE
Profile JSON: whole-profile backup/transfer with export, import, merg…

### DIFF
--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 * XIUI Config Menu - Main Window
 * Entry point for the config menu, handles window rendering and dispatches to module files
 ]]--
@@ -24,16 +24,27 @@ local petbarModule = require('config.petbar');
 local notificationsModule = require('config.notifications');
 local treasurepoolModule = require('config.treasurepool');
 local hotbarModule = require('config.hotbar');
+local crossbarModule = require('config.crossbar');
 local readycheckModule = require('config.readycheck');
 
 local treasurePool = require('modules.treasurepool.init');
 local macropalette = require('modules.hotbar.macropalette');
 local palette = require('modules.hotbar.palette');
+local paletteJson = require('modules.hotbar.palette_json');
 
 local config = {};
 
 -- Track previous config state to detect when config closes
 local wasConfigOpen = false;
+
+-- Lazy: defer closing XIUI Config when Edit Full Palette is open (see config.palettemanager).
+local paletteManagerForCloseDefer = nil;
+local function getPaletteManagerForCloseDefer()
+    if not paletteManagerForCloseDefer then
+        paletteManagerForCloseDefer = require('config.palettemanager');
+    end
+    return paletteManagerForCloseDefer;
+end
 
 -- Track last known config window geometry for smart reposition on open
 local lastConfigPosX, lastConfigPosY = 20, 20;
@@ -114,6 +125,23 @@ local showNewProfilePopup = false;
 local triggerNewProfilePopup = false;
 local triggerDeleteProfilePopup = false;
 local triggerRenameProfilePopup = false;
+local triggerCopyProfilePopup = false;
+-- [1] = include full macroDB when using Copy (DuplicateProfile)
+local copyProfileIncludeMacros = { true };
+
+-- Profile JSON export/import (whole-profile: all palettes + all macros)
+local profileJsonWinOpen = { false };
+local profileJsonMode = 'export'; -- 'export' | 'import'
+local profileJsonBuf = { '' };
+local profileJsonErr = nil;
+local profileJsonInfo = nil;
+local profileJsonExportPart = { 'all' }; -- paletteJson.EXPORT_PART_*
+local profileJsonImportPalettes = { true };
+local profileJsonImportMacros = { true };
+local profileJsonImportMode = { paletteJson.IMPORT_MODE_MERGE }; -- merge | replace (see palette_json)
+local profileJsonImportFiles = {};
+local profileJsonImportSelectedIdx = { -1 };
+local profileJsonImportSelectedName = nil;
 
 -- XIUI Theme Colors (dark + gold accent)
 local gold = {0.957, 0.855, 0.592, 1.0};           -- #F4DA97 - Primary gold accent
@@ -192,12 +220,275 @@ local function PopThemeStyles()
     imgui.PopStyleColor(34);
 end
 
+local function OpenProfileJsonExport()
+    profileJsonMode = 'export';
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+    profileJsonBuf[1] = '';
+    profileJsonExportPart[1] = paletteJson.EXPORT_PART_ALL;
+    profileJsonWinOpen[1] = true;
+end
+
+local function RefreshProfileJsonImportFiles()
+    local files = paletteJson.ListExportFiles();
+    profileJsonImportFiles = files or {};
+    if profileJsonImportSelectedName then
+        profileJsonImportSelectedIdx[1] = -1;
+        for i, n in ipairs(profileJsonImportFiles) do
+            if n == profileJsonImportSelectedName then
+                profileJsonImportSelectedIdx[1] = i - 1;
+                break;
+            end
+        end
+    else
+        profileJsonImportSelectedIdx[1] = -1;
+    end
+end
+
+local function LoadSelectedProfileJsonImportFile()
+    local idx = profileJsonImportSelectedIdx[1];
+    if not idx or idx < 0 then
+        profileJsonErr = 'Pick a file from the list first (or paste JSON below).';
+        return;
+    end
+    local name = profileJsonImportFiles[idx + 1];
+    if not name then
+        profileJsonErr = 'Selected file is no longer present.';
+        return;
+    end
+    local text, err = paletteJson.ReadExportFile(name);
+    if not text then
+        profileJsonErr = err or ('Could not read ' .. name);
+        return;
+    end
+    profileJsonBuf[1] = text;
+    profileJsonErr = nil;
+    profileJsonInfo = 'Loaded ' .. name;
+    profileJsonImportSelectedName = name;
+end
+
+local function OpenProfileJsonImport()
+    profileJsonMode = 'import';
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+    profileJsonBuf[1] = '';
+    profileJsonImportPalettes[1] = true;
+    profileJsonImportMacros[1] = true;
+    profileJsonImportMode[1] = paletteJson.IMPORT_MODE_MERGE;
+    profileJsonImportSelectedName = nil;
+    profileJsonWinOpen[1] = true;
+    RefreshProfileJsonImportFiles();
+end
+
+local function RunProfileJsonExport()
+    local text, err = paletteJson.ExportProfile(profileJsonExportPart[1] or paletteJson.EXPORT_PART_ALL);
+    if not text then
+        profileJsonErr = err or 'Export failed';
+        return;
+    end
+    profileJsonBuf[1] = text;
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+end
+
+local function RunProfileJsonSaveToFile()
+    local baseName = (GetCurrentProfileName and GetCurrentProfileName()) or 'profile';
+    local part = profileJsonExportPart[1] or paletteJson.EXPORT_PART_ALL;
+    baseName = tostring(baseName) .. '_' .. part;
+    local ok, path = paletteJson.SaveTextFile(baseName, profileJsonBuf[1] or '');
+    if ok then
+        profileJsonInfo = path;
+        profileJsonErr = nil;
+    else
+        profileJsonErr = tostring(path);
+    end
+end
+
+local function RunProfileJsonImport()
+    local okImp, errImp = paletteJson.ImportProfile(profileJsonBuf[1] or '', {
+        importPalettes = profileJsonImportPalettes[1],
+        importMacros = profileJsonImportMacros[1],
+        importMode = profileJsonImportMode[1] or paletteJson.IMPORT_MODE_MERGE,
+    });
+    if okImp then
+        profileJsonErr = nil;
+        profileJsonInfo = 'Import applied.';
+        profileJsonWinOpen[1] = false;
+    else
+        profileJsonErr = errImp or 'Import failed';
+    end
+end
+
+local function DrawProfileJsonWindow()
+    if not profileJsonWinOpen[1] then return; end
+
+    PushThemeStyles();
+    imgui.SetNextWindowSize({ 680, 560 }, ImGuiCond_FirstUseEver);
+    local title = (profileJsonMode == 'export') and 'Profile Export (JSON)##xiuiProfJson' or 'Profile Import (JSON)##xiuiProfJson';
+    if imgui.Begin(title, profileJsonWinOpen, ImGuiWindowFlags_NoCollapse) then
+        if profileJsonMode == 'export' then
+            imgui.TextWrapped(
+                'Export this profile\'s palettes and/or macros to a single JSON file. Use it to back up this profile or transfer it to a new character. Entries are pretty-printed with human-readable "_label" tags (job / subjob / palette name), so you can open the file in a text editor, delete the blocks you do not want, save, and then import only the rest.'
+            );
+        else
+            imgui.TextWrapped(
+                'Pick a file from the exports folder, or paste JSON below. Choose Add to existing to merge with this profile, or Replace with file to clear the matching data first so the result matches the export.'
+            );
+        end
+        imgui.Spacing();
+
+        if profileJsonErr then
+            imgui.TextColored({ 1.0, 0.3, 0.3, 1.0 }, profileJsonErr);
+        end
+        if profileJsonInfo then
+            imgui.TextColored({ 0.65, 0.8, 0.65, 1.0 }, profileJsonInfo);
+        end
+        imgui.Separator();
+
+        if profileJsonMode == 'export' then
+            imgui.Text('Include in file:');
+            if imgui.RadioButton('All palettes + macros##pjExAll', profileJsonExportPart[1] == paletteJson.EXPORT_PART_ALL) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_ALL;
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('All palettes only##pjExPal', profileJsonExportPart[1] == paletteJson.EXPORT_PART_PALETTES_ONLY) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_PALETTES_ONLY;
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('All macros only##pjExMac', profileJsonExportPart[1] == paletteJson.EXPORT_PART_MACROS_ONLY) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_MACROS_ONLY;
+            end
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'All palettes + macros: complete profile backup (every keyboard hotbar palette, every crossbar palette, and all macro text).\nAll palettes only: every palette for this profile without macro definitions. Import into a profile that already has the macros.\nAll macros only: the entire macro library without changing any palette layouts.'
+                );
+            end
+
+            imgui.Spacing();
+            if imgui.Button('Generate JSON##pjGen') then
+                RunProfileJsonExport();
+            end
+            imgui.SameLine();
+            if imgui.Button('Save to file##pjSave') then
+                if profileJsonBuf[1] == nil or profileJsonBuf[1] == '' then
+                    RunProfileJsonExport();
+                end
+                if profileJsonBuf[1] ~= nil and profileJsonBuf[1] ~= '' then
+                    RunProfileJsonSaveToFile();
+                end
+            end
+            imgui.SameLine();
+            if imgui.Button('Open exports folder##pjExOpenDir') then
+                paletteJson.OpenExportsDir();
+            end
+            imgui.SameLine();
+            imgui.TextColored({ 0.6, 0.6, 0.65, 1.0 }, 'Files save to config/addons/xiui/exports/.');
+
+            imgui.Spacing();
+            imgui.InputTextMultiline('##profJsonBuf', profileJsonBuf, 200000, { -1, -1 });
+        else
+            if imgui.Checkbox('Import palettes##pjImpPal', profileJsonImportPalettes) then end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Apply keyboard hotbar and crossbar layouts from the file. Add to existing: overlay slot data and merge palette name lists. Replace with file: clear those layouts first, then apply; palette order lists come only from the file.'
+                );
+            end
+            if imgui.Checkbox('Import macros##pjImpMac', profileJsonImportMacros) then end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Add to existing: append macro rows with new IDs and remap palette references. Replace with file: macro library becomes exactly what is in the file (same macro IDs as the export). If you import palettes only and uncheck macros, the file must reference macros that already exist here.'
+                );
+            end
+
+            imgui.Spacing();
+            imgui.Text('Apply mode:');
+            if imgui.RadioButton('Add to existing (merge)##pjModeMerge', profileJsonImportMode[1] == paletteJson.IMPORT_MODE_MERGE) then
+                profileJsonImportMode[1] = paletteJson.IMPORT_MODE_MERGE;
+            end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Overlay the file onto this profile: palette slot data and name lists merge with what you already have; new macro rows get new IDs.'
+                );
+            end
+            if imgui.RadioButton('Replace with file (overwrite)##pjModeReplace', profileJsonImportMode[1] == paletteJson.IMPORT_MODE_REPLACE) then
+                profileJsonImportMode[1] = paletteJson.IMPORT_MODE_REPLACE;
+            end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Before applying: clears hotbar/crossbar layouts for sides present in the file, replaces palette order lists from the file, and replaces the macro library with the file when Import macros is checked. Use this when you want the profile to match the export instead of mixing with old data.'
+                );
+            end
+            if profileJsonImportMode[1] == paletteJson.IMPORT_MODE_REPLACE then
+                imgui.PushStyleColor(ImGuiCol_Text, { 1.0, 0.55, 0.35, 1.0 });
+                if imgui.TextWrapped then
+                    imgui.TextWrapped(
+                        'Replace mode can remove existing bars, combos, palette lists, and macros (for the options you checked) so only the file remains.'
+                    );
+                end
+                imgui.PopStyleColor();
+            end
+
+            imgui.Spacing();
+            imgui.Text('Pick a file from config/addons/xiui/exports/:');
+            imgui.SetNextItemWidth(-220);
+            local fileCount = #profileJsonImportFiles;
+            if fileCount == 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, { 0.7, 0.7, 0.75, 1.0 });
+                -- BeginListBox is not available on all Ashita ImGui builds; use a bordered child instead.
+                imgui.BeginChild('##profJsonFilesEmpty', { -220, 90 }, true);
+                imgui.Text('(No .json files found in the exports folder.)');
+                imgui.EndChild();
+                imgui.PopStyleColor();
+            else
+                if imgui.ListBox and imgui.ListBox('##profJsonFiles', profileJsonImportSelectedIdx, profileJsonImportFiles, fileCount, 5) then
+                    local idx = profileJsonImportSelectedIdx[1];
+                    if idx and idx >= 0 then
+                        profileJsonImportSelectedName = profileJsonImportFiles[idx + 1];
+                    end
+                end
+            end
+            imgui.SameLine();
+            imgui.BeginGroup();
+            if imgui.Button('Load selected##pjLoadFile', { 200, 0 }) then
+                LoadSelectedProfileJsonImportFile();
+            end
+            if imgui.Button('Refresh list##pjRefreshFiles', { 200, 0 }) then
+                RefreshProfileJsonImportFiles();
+                profileJsonInfo = 'Refreshed (' .. #profileJsonImportFiles .. ' file(s)).';
+            end
+            if imgui.Button('Open exports folder##pjOpenDir', { 200, 0 }) then
+                paletteJson.OpenExportsDir();
+            end
+            imgui.EndGroup();
+
+            imgui.Spacing();
+            if imgui.Button('Apply import##pjApply', { 140, 0 }) then
+                RunProfileJsonImport();
+            end
+            imgui.SameLine();
+            imgui.TextColored({ 0.6, 0.6, 0.65, 1.0 }, 'Or paste JSON directly below and Apply.');
+
+            imgui.Spacing();
+            imgui.InputTextMultiline('##profJsonBuf', profileJsonBuf, 200000, { -1, -1 });
+        end
+    end
+    imgui.End();
+    PopThemeStyles();
+end
+
 local function DrawProfilesWindow()
-    if (not showProfilesWindow[1]) then return; end
+    if (not showProfilesWindow[1]) then
+        DrawProfileJsonWindow();
+        return;
+    end
 
     PushThemeStyles();
 
-    imgui.SetNextWindowSize({ 350, 145 }, ImGuiCond_Always);
+    imgui.SetNextWindowSize({ 380, 300 }, ImGuiCond_Always);
     -- Using + for flags as they are typically integers
     if (imgui.Begin("Profiles", showProfilesWindow, ImGuiWindowFlags_NoCollapse + ImGuiWindowFlags_NoResize)) then
 
@@ -221,6 +512,17 @@ local function DrawProfilesWindow()
             imgui.EndCombo();
         end
 
+        if imgui.TextWrapped then
+            imgui.Spacing();
+            imgui.PushStyleColor(ImGuiCol_Text, { 0.55, 0.55, 0.62, 1.0 });
+            imgui.TextWrapped(
+                'Every character that uses this profile name shares the same XIUI data (palettes, macros, layout). '
+                .. 'Use Copy to duplicate the active profile: you can include the full macro library or only layout/appearance. '
+                .. 'To move specific macros, use Export/Import JSON. Empty palette buckets (e.g. Items) are not stored on disk until you add something there.'
+            );
+            imgui.PopStyleColor();
+        end
+
         imgui.Spacing();
         imgui.Spacing();
 
@@ -234,7 +536,8 @@ local function DrawProfilesWindow()
         imgui.SameLine();
 
         if (imgui.Button("Copy")) then
-            DuplicateProfile(currentProfile);
+            copyProfileIncludeMacros[1] = true;
+            triggerCopyProfilePopup = true;
         end
 
         imgui.SameLine();
@@ -282,12 +585,30 @@ local function DrawProfilesWindow()
             imgui.PopStyleColor(3);
         end
 
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
 
+        imgui.Text('Backup / Transfer:');
+        if imgui.ShowHelp then
+            imgui.SameLine();
+            imgui.ShowHelp(
+                'Export or import this entire profile as one JSON file: all keyboard hotbar palettes, all crossbar palettes, and the full macro library for this profile. Use it to back up this profile or move everything onto a new character. You can choose to include palettes, macros, or both on both sides.'
+            );
+        end
+        if imgui.Button('Export JSON##profJsonOpenEx') then
+            OpenProfileJsonExport();
+        end
+        imgui.SameLine();
+        if imgui.Button('Import JSON##profJsonOpenIm') then
+            OpenProfileJsonImport();
+        end
 
         imgui.End();
     end
 
     PopThemeStyles();
+    DrawProfileJsonWindow();
 end
 
 -- Navigation state
@@ -304,8 +625,7 @@ local selectedPetTypeTab = 1;  -- 1 = Avatar, 2 = Charm, 3 = Jug, 4 = Automaton,
 local selectedPetTypeColorTab = 1;  -- Pet type color sub-tab
 local selectedPetBarColorTab = 1;  -- 1 = Pet Bar, 2 = Pet Target (for color settings)
 local selectedHotbarTab = 1;  -- 1 = Bar 1, 2 = Bar 2, etc. (for hotbar settings)
-local selectedModeTab = 'hotbar';  -- 'hotbar' or 'crossbar' (for hotbar/crossbar toggle in 'both' mode)
-local selectedCrossbarTab = 1;  -- 1=L2, 2=R2, 3=L2R2, 4=R2L2, 5=L2x2, 6=R2x2
+local selectedCrossbarTab = 1;  -- 1=Global, 2=L2, â€¦ (for Crossbar category panel)
 
 -- Category definitions
 local categories = {
@@ -323,13 +643,26 @@ local categories = {
     { name = 'notifications', label = 'Notifications' },
     { name = 'treasurePool', label = 'Treasure Pool' },
     { name = 'hotbar', label = 'Hotbar' },
+    { name = 'crossbar', label = 'Crossbar' },
     { name = 'readyCheck', label = 'Ready Check' },
 };
 
 
+-- Index of the Crossbar sidebar category (for palette edit context sync)
+local function GetCrossbarCategoryIndex()
+    for i, c in ipairs(categories) do
+        if c.name == 'crossbar' then
+            return i;
+        end
+    end
+    return nil;
+end
+
 -- Build state object for modules that need tab state
 local function buildState()
     return {
+        selectedCategory = selectedCategory,
+        crossbarCategoryIndex = GetCrossbarCategoryIndex(),
         selectedPartyTab = selectedPartyTab,
         selectedPartyColorTab = selectedPartyColorTab,
         selectedInventoryTab = selectedInventoryTab,
@@ -341,7 +674,6 @@ local function buildState()
         selectedPetTypeTab = selectedPetTypeTab,
         selectedPetTypeColorTab = selectedPetTypeColorTab,
         selectedHotbarTab = selectedHotbarTab,
-        selectedModeTab = selectedModeTab,
         selectedCrossbarTab = selectedCrossbarTab,
         githubTexture = githubTexture,
     };
@@ -356,7 +688,6 @@ local function applySettingsState(newState)
         if newState.selectedPetBarTab then selectedPetBarTab = newState.selectedPetBarTab; end
         if newState.selectedPetTypeTab then selectedPetTypeTab = newState.selectedPetTypeTab; end
         if newState.selectedHotbarTab then selectedHotbarTab = newState.selectedHotbarTab; end
-        if newState.selectedModeTab then selectedModeTab = newState.selectedModeTab; end
         if newState.selectedCrossbarTab then selectedCrossbarTab = newState.selectedCrossbarTab; end
     end
 end
@@ -369,7 +700,6 @@ local function applyColorState(newState)
         if newState.selectedPetBarColorTab then selectedPetBarColorTab = newState.selectedPetBarColorTab; end
         if newState.selectedPetTypeColorTab then selectedPetTypeColorTab = newState.selectedPetTypeColorTab; end
         if newState.selectedHotbarTab then selectedHotbarTab = newState.selectedHotbarTab; end
-        if newState.selectedModeTab then selectedModeTab = newState.selectedModeTab; end
         if newState.selectedCrossbarTab then selectedCrossbarTab = newState.selectedCrossbarTab; end
     end
 end
@@ -433,6 +763,11 @@ end
 
 local function DrawHotbarSettings()
     local newState = hotbarModule.DrawSettings(buildState());
+    applySettingsState(newState);
+end
+
+local function DrawCrossbarSettingsPanel()
+    local newState = crossbarModule.DrawSettings(buildState());
     applySettingsState(newState);
 end
 
@@ -502,6 +837,11 @@ local function DrawHotbarColorSettings()
     applyColorState(newState);
 end
 
+local function DrawCrossbarColorSettingsPanel()
+    local newState = crossbarModule.DrawColorSettings(buildState());
+    applyColorState(newState);
+end
+
 local function DrawReadyCheckColorSettings()
     readycheckModule.DrawColorSettings();
 end
@@ -522,6 +862,7 @@ local settingsDrawFunctions = {
     DrawNotificationsSettings,
     DrawTreasurePoolSettings,
     DrawHotbarSettings,
+    DrawCrossbarSettingsPanel,
     DrawReadyCheckSettings,
 };
 
@@ -540,6 +881,7 @@ local colorSettingsDrawFunctions = {
     DrawNotificationsColorSettings,
     DrawTreasurePoolColorSettings,
     DrawHotbarColorSettings,
+    DrawCrossbarColorSettingsPanel,
     DrawReadyCheckColorSettings,
 };
 
@@ -559,9 +901,13 @@ local function DrawProfilePopups()
         imgui.OpenPopup("Delete Profile");
         triggerDeleteProfilePopup = false;
     end
+    if (triggerCopyProfilePopup) then
+        imgui.OpenPopup("Copy Profile");
+        triggerCopyProfilePopup = false;
+    end
 
     -- New Profile Popup
-    if (imgui.BeginPopupModal("New Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("New Profile")) then
         isModalOpen = true;
         imgui.Text("Create New Profile:");
         imgui.InputText("##NewProfileName", newProfileName, 32);
@@ -584,7 +930,7 @@ local function DrawProfilePopups()
     end
 
     -- Rename Popup
-    if (imgui.BeginPopupModal("Rename Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("Rename Profile")) then
         isModalOpen = true;
         imgui.Text("Rename '" .. GetCurrentProfileName() .. "' to:");
         imgui.InputText("##RenameInput", renameProfileName, 32);
@@ -606,7 +952,7 @@ local function DrawProfilePopups()
     end
 
     -- Delete Confirmation Popup
-    if (imgui.BeginPopupModal("Delete Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("Delete Profile")) then
         isModalOpen = true;
         imgui.Text("Are you sure you want to delete profile:");
         imgui.TextColored({1.0, 0.3, 0.3, 1.0}, profileToDelete);
@@ -624,7 +970,41 @@ local function DrawProfilePopups()
         end
         imgui.EndPopup();
     end
-    
+
+    -- Copy Profile: optional macro library (full clone vs layout-only for another character)
+    if (imgui.BeginPopup("Copy Profile")) then
+        isModalOpen = true;
+        local src = (GetCurrentProfileName and GetCurrentProfileName()) or '';
+        imgui.Text("Create a new profile from:");
+        imgui.TextColored(gold, src);
+        imgui.Spacing();
+        imgui.TextWrapped(
+            'Copy is a full snapshot of the selected profile on disk, except you can start without a macro library. '
+            .. 'Buckets that were never used (e.g. Items / Equipment) are not in the file â€” that is why a clone can show Global/job rows but no separate items bucket until you add some.'
+        );
+        imgui.Spacing();
+        imgui.Checkbox("Include full macro library##copyInclMacros", copyProfileIncludeMacros);
+        if (imgui.ShowHelp) then
+            imgui.SameLine();
+            imgui.ShowHelp(
+                "When checked: all macro palette buckets in this profile (same as a full file copy). When unchecked: empty macro list and custom categories reset; keyboard/crossbar slots that used palette macros are cleared. Spells, abilities, and items on bars are kept. Use Profile â†’ Export/Import JSON to move chosen macros between profiles."
+            );
+        end
+        imgui.Spacing();
+        if (imgui.Button("Create copy##CopyProfileGo", { 120, 0 })) then
+            if (DuplicateProfile and GetCurrentProfileName) then
+                if (DuplicateProfile(GetCurrentProfileName(), { includeMacroLibrary = (copyProfileIncludeMacros[1] == true) })) then
+                    imgui.CloseCurrentPopup();
+                end
+            end
+        end
+        imgui.SameLine();
+        if (imgui.Button("Cancel##CopyProfile", { 120, 0 })) then
+            imgui.CloseCurrentPopup();
+        end
+        imgui.EndPopup();
+    end
+
     return isModalOpen;
 end
 
@@ -634,23 +1014,32 @@ config.DrawWindow = function(us)
     -- Detect when config closes and clear treasure pool preview
     local isConfigOpen = showConfig[1];
     if wasConfigOpen and not isConfigOpen then
-        -- Config just closed - always save profile to persist window positions
-        SaveSettingsToDisk();
-        
-        -- Clear dirty flags if they were set
-        if macropalette.IsHotbarDirty() then
-            macropalette.ClearHotbarDirty();
+        local deferClose = getPaletteManagerForCloseDefer().DeferConfigCloseIfEditFullPaletteOpen();
+        if deferClose then
+            -- Keep XIUI Config open; palette manager shows a confirm popup on the next draw.
+            showConfig[1] = true;
+        else
+            -- Config just closed - always save profile to persist window positions
+            SaveSettingsToDisk();
+
+            -- Clear dirty flags if they were set
+            if macropalette.IsHotbarDirty() then
+                macropalette.ClearHotbarDirty();
+            end
+            if palette.IsPaletteStateDirty() then
+                palette.ClearPaletteStateDirty();
+            end
+            -- Clear preview state and reset settings
+            treasurePool.ClearPreview();
+            gConfig.treasurePoolMiniPreview = false;
+            gConfig.treasurePoolFullPreview = false;
         end
-        if palette.IsPaletteStateDirty() then
-            palette.ClearPaletteStateDirty();
-        end
-        -- Clear preview state and reset settings
-        treasurePool.ClearPreview();
-        gConfig.treasurePoolMiniPreview = false;
-        gConfig.treasurePoolFullPreview = false;
     end
     local configJustOpened = isConfigOpen and not wasConfigOpen;
     wasConfigOpen = isConfigOpen;
+    if configJustOpened then
+        crossbarModule.OnConfigWindowOpened();
+    end
 
     -- Early exit if config window isn't shown (atom0s recommendation)
     -- This prevents unnecessary style pushes and imgui.End() calls when window is hidden
@@ -658,9 +1047,9 @@ config.DrawWindow = function(us)
 
     -- Constrain config window to never exceed the game's render resolution.
     -- Prevents the window from being larger than the screen or lost off-screen on small resolutions.
-    local ioData = imgui.GetIO();
-    local sw = ioData.DisplaySize.x;
-    local sh = ioData.DisplaySize.y;
+    local io = imgui.GetIO();
+    local sw = io.DisplaySize.x;
+    local sh = io.DisplaySize.y;
     if not sw or sw < 1 then return; end
     if not sh or sh < 1 then return; end
 
@@ -690,8 +1079,7 @@ config.DrawWindow = function(us)
             imgui.SetNextWindowPos({ 20, 20 }, ImGuiCond_Always);
         end
     end
-    local configVisible = imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking));
-    if configVisible then
+    if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
         local windowWidth = imgui.GetContentRegionAvail();
         local sidebarWidth = 180;
         local contentWidth = windowWidth - sidebarWidth - 20;
@@ -819,7 +1207,7 @@ config.DrawWindow = function(us)
             showRestoreDefaultsConfirm = false;
         end
 
-        if (imgui.BeginPopupModal("Confirm Reset Settings", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+        if (imgui.BeginPopup("Confirm Reset Settings")) then
             anyModalOpen = true;
             imgui.Text("Are you sure you want to reset all settings to defaults?");
             imgui.Text("This will reset all your customizations including:");
@@ -985,10 +1373,12 @@ config.DrawWindow = function(us)
     end
 
     -- Capture config window geometry while open for smart reposition on next open.
-    -- Two local assignments per frame — negligible cost, but ensures we always have
+    -- Two local assignments per frame â€” negligible cost, but ensures we always have
     -- current values even on addon unload or profile change without an extra frame.
     lastConfigPosX, lastConfigPosY = imgui.GetWindowPos();
     lastConfigSizeW, lastConfigSizeH = imgui.GetWindowSize();
+    -- For other UI (e.g. Crossbar full palette window) to stagger offset from this window without a require() cycle
+    _G._XIUI_CONFIG_LAST_GEOM = { lastConfigPosX, lastConfigPosY, lastConfigSizeW, lastConfigSizeH };
 
     imgui.End();
 
@@ -1023,4 +1413,42 @@ function config.OpenResetSettingsPopup()
     showRestoreDefaultsConfirm = true;
 end
 
+-- Open XIUI config on Crossbar category, Manage Palettes & Crossbar tab (/xiui cpalette)
+-- Used by palette manager modal to close XIUI Config after forcing Edit Full Palette shut.
+function config.SetWindowOpen(isOpen)
+    showConfig[1] = isOpen and true or false;
+end
+
+function config.OpenCrossbarManagePalettes()
+    local idx = GetCrossbarCategoryIndex();
+    if not idx then
+        return false;
+    end
+    selectedCategory = idx;
+    selectedTab = 1;
+    showConfig[1] = true;
+    crossbarModule.OpenCrossbarManagePalettesTab();
+    return true;
+end
+
+-- Toggle: close config if already on Crossbar â†’ Manage Palettes; otherwise open there (/xiui cpalette with no subcommand)
+function config.ToggleCrossbarManagePalettes()
+    local idx = GetCrossbarCategoryIndex();
+    if not idx then
+        return nil;
+    end
+    if showConfig[1] and selectedCategory == idx and selectedTab == 1 then
+        local cross = gConfig and gConfig.hotbarCrossbar;
+        if cross and cross.configUiTab == 2 then
+            showConfig[1] = false;
+            return 'closed';
+        end
+    end
+    if not config.OpenCrossbarManagePalettes() then
+        return nil;
+    end
+    return 'opened';
+end
+
 return config;
+

--- a/XIUI/libs/json.lua
+++ b/XIUI/libs/json.lua
@@ -1,0 +1,366 @@
+--
+-- json.lua
+--
+-- Copyright (c) 2020 rxi
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy of
+-- this software and associated documentation files (the "Software"), to deal in
+-- the Software without restriction, including without limitation the rights to
+-- use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+-- of the Software, and to permit persons to whom the Software is furnished to do
+-- so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+
+local json = { _version = "0.1.2" }
+
+-------------------------------------------------------------------------------
+-- Encode
+-------------------------------------------------------------------------------
+
+local encode
+
+local escape_char_map = {
+ [ "\\" ] = "\\",
+ [ "\"" ] = "\"",
+ [ "\b" ] = "b",
+ [ "\f" ] = "f",
+ [ "\n" ] = "n",
+ [ "\r" ] = "r",
+ [ "\t" ] = "t",
+}
+
+local escape_char_map_inv = { [ "/" ] = "/" }
+for k, v in pairs(escape_char_map) do
+ escape_char_map_inv[v] = k
+end
+
+local function escape_char(c)
+ return "\\" .. (escape_char_map[c] or string.format("u%04x", c:byte()))
+end
+
+local function encode_nil(val)
+ return "null"
+end
+
+local function encode_table(val, stack)
+ local res = {}
+ stack = stack or {}
+
+ -- Circular reference?
+ if stack[val] then error("circular reference") end
+
+ stack[val] = true
+
+ if rawget(val, 1) ~= nil or next(val) == nil then
+ -- Treat as array -- check keys are valid and it is not sparse
+ local n = 0
+ for k in pairs(val) do
+ if type(k) ~= "number" then
+ error("invalid table: mixed or invalid key types")
+ end
+ n = n + 1
+ end
+ if n ~= #val then
+ error("invalid table: sparse array")
+ end
+ -- Encode
+ for i, v in ipairs(val) do
+ table.insert(res, encode(v, stack))
+ end
+ stack[val] = nil
+ return "[" .. table.concat(res, ",") .. "]"
+
+ else
+ -- Treat as an object
+ for k, v in pairs(val) do
+ if type(k) ~= "string" then
+ error("invalid table: mixed or invalid key types")
+ end
+ table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+ end
+ stack[val] = nil
+ return "{" .. table.concat(res, ",") .. "}"
+ end
+end
+
+local function encode_string(val)
+ return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+local function encode_number(val)
+ -- Check for NaN, -inf and inf
+ if val ~= val or val <= -math.huge or val >= math.huge then
+ error("unexpected number value '" .. tostring(val) .. "'")
+ end
+ return string.format("%.14g", val)
+end
+
+local type_func_map = {
+ [ "nil" ] = encode_nil,
+ [ "table" ] = encode_table,
+ [ "string" ] = encode_string,
+ [ "number" ] = encode_number,
+ [ "boolean" ] = tostring,
+}
+
+encode = function(val, stack)
+ local t = type(val)
+ local f = type_func_map[t]
+ if f then
+ return f(val, stack)
+ end
+ error("unexpected type '" .. t .. "'")
+end
+
+function json.encode(val)
+ return ( encode(val) )
+end
+
+-------------------------------------------------------------------------------
+-- Decode
+-------------------------------------------------------------------------------
+
+local parse
+
+local function create_set(...)
+ local res = {}
+ for i = 1, select("#", ...) do
+ res[ select(i, ...) ] = true
+ end
+ return res
+end
+
+local space_chars = create_set(" ", "\t", "\r", "\n")
+local delim_chars = create_set(" ", "\t", "\r", "\n", "]", "}", ",")
+local escape_chars = create_set("\\", "/", '"', "b", "f", "n", "r", "t", "u")
+local literals = create_set("true", "false", "null")
+
+local literal_map = {
+ [ "true" ] = true,
+ [ "false" ] = false,
+ [ "null" ] = nil,
+}
+
+local function next_char(str, idx, set, negate)
+ for i = idx, #str do
+ if set[str:sub(i, i)] ~= negate then
+ return i
+ end
+ end
+ return #str + 1
+end
+
+local function decode_error(str, idx, msg)
+ local line_count = 1
+ local col_count = 1
+ for i = 1, idx - 1 do
+ col_count = col_count + 1
+ if str:sub(i, i) == "\n" then
+ line_count = line_count + 1
+ col_count = 1
+ end
+ end
+ error( string.format("%s at line %d col %d", msg, line_count, col_count) )
+end
+
+local function codepoint_to_utf8(n)
+ -- http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-appendixa
+ local f = math.floor
+ if n <= 0x7f then
+ return string.char(n)
+ elseif n <= 0x7ff then
+ return string.char(f(n / 64) + 192, n % 64 + 128)
+ elseif n <= 0xffff then
+ return string.char(f(n / 4096) + 224, f(n % 4096 / 64) + 128, n % 64 + 128)
+ elseif n <= 0x10ffff then
+ return string.char(f(n / 262144) + 240, f(n % 262144 / 4096) + 128,
+ f(n % 4096 / 64) + 128, n % 64 + 128)
+ end
+ error( string.format("invalid unicode codepoint '%x'", n) )
+end
+
+local function parse_unicode_escape(s)
+ local n1 = tonumber( s:sub(1, 4), 16 )
+ local n2 = tonumber( s:sub(7, 10), 16 )
+ -- Surrogate pair?
+ if n2 then
+ return codepoint_to_utf8((n1 - 0xd800) * 0x400 + (n2 - 0xdc00) + 0x10000)
+ else
+ return codepoint_to_utf8(n1)
+ end
+end
+
+local function parse_string(str, i)
+ local res = ""
+ local j = i + 1
+ local k = j
+
+ while j <= #str do
+ local x = str:byte(j)
+
+ if x < 32 then
+ decode_error(str, j, "control character in string")
+
+ elseif x == 92 then -- `\`: Escape
+ res = res .. str:sub(k, j - 1)
+ j = j + 1
+ local c = str:sub(j, j)
+ if c == "u" then
+ local hex = str:match("^[dD][89aAbB]%x%x\\u%x%x%x%x", j + 1)
+ or str:match("^%x%x%x%x", j + 1)
+ or decode_error(str, j - 1, "invalid unicode escape in string")
+ res = res .. parse_unicode_escape(hex)
+ j = j + #hex
+ else
+ if not escape_chars[c] then
+ decode_error(str, j - 1, "invalid escape char '" .. c .. "' in string")
+ end
+ res = res .. escape_char_map_inv[c]
+ end
+ k = j + 1
+
+ elseif x == 34 then -- `"`: End of string
+ res = res .. str:sub(k, j - 1)
+ return res, j + 1
+ end
+
+ j = j + 1
+ end
+
+ decode_error(str, i, "expected closing quote for string")
+end
+
+local function parse_number(str, i)
+ local x = next_char(str, i, delim_chars)
+ local s = str:sub(i, x - 1)
+ local n = tonumber(s)
+ if not n then
+ decode_error(str, i, "invalid number '" .. s .. "'")
+ end
+ return n, x
+end
+
+local function parse_literal(str, i)
+ local x = next_char(str, i, delim_chars)
+ local word = str:sub(i, x - 1)
+ if not literals[word] then
+ decode_error(str, i, "invalid literal '" .. word .. "'")
+ end
+ return literal_map[word], x
+end
+
+local function parse_array(str, i)
+ local res = {}
+ local n = 1
+ i = i + 1
+ while 1 do
+ local x
+ i = next_char(str, i, space_chars, true)
+ -- Empty / end of array?
+ if str:sub(i, i) == "]" then
+ i = i + 1
+ break
+ end
+ -- Read token
+ x, i = parse(str, i)
+ res[n] = x
+ n = n + 1
+ -- Next token
+ i = next_char(str, i, space_chars, true)
+ local chr = str:sub(i, i)
+ i = i + 1
+ if chr == "]" then break end
+ if chr ~= "," then decode_error(str, i, "expected ']' or ','") end
+ end
+ return res, i
+end
+
+local function parse_object(str, i)
+ local res = {}
+ i = i + 1
+ while 1 do
+ local key, val
+ i = next_char(str, i, space_chars, true)
+ -- Empty / end of object?
+ if str:sub(i, i) == "}" then
+ i = i + 1
+ break
+ end
+ -- Read key
+ if str:sub(i, i) ~= '"' then
+ decode_error(str, i, "expected string for key")
+ end
+ key, i = parse(str, i)
+ -- Read ':' delimiter
+ i = next_char(str, i, space_chars, true)
+ if str:sub(i, i) ~= ":" then
+ decode_error(str, i, "expected ':' after key")
+ end
+ i = next_char(str, i + 1, space_chars, true)
+ -- Read value
+ val, i = parse(str, i)
+ -- Set
+ res[key] = val
+ -- Next token
+ i = next_char(str, i, space_chars, true)
+ local chr = str:sub(i, i)
+ i = i + 1
+ if chr == "}" then break end
+ if chr ~= "," then decode_error(str, i, "expected '}' or ','") end
+ end
+ return res, i
+end
+
+local char_func_map = {
+ [ '"' ] = parse_string,
+ [ "0" ] = parse_number,
+ [ "1" ] = parse_number,
+ [ "2" ] = parse_number,
+ [ "3" ] = parse_number,
+ [ "4" ] = parse_number,
+ [ "5" ] = parse_number,
+ [ "6" ] = parse_number,
+ [ "7" ] = parse_number,
+ [ "8" ] = parse_number,
+ [ "9" ] = parse_number,
+ [ "-" ] = parse_number,
+ [ "t" ] = parse_literal,
+ [ "f" ] = parse_literal,
+ [ "n" ] = parse_literal,
+ [ "[" ] = parse_array,
+ [ "{" ] = parse_object,
+}
+
+parse = function(str, idx)
+ local chr = str:sub(idx, idx)
+ local f = char_func_map[chr]
+ if f then
+ return f(str, idx)
+ end
+ decode_error(str, idx, "unexpected character '" .. chr .. "'")
+end
+
+function json.decode(str)
+ if type(str) ~= "string" then
+ error("expected argument of type string, got " .. type(str))
+ end
+ local res, idx = parse(str, next_char(str, 1, space_chars, true))
+ idx = next_char(str, idx, space_chars, true)
+ if idx <= #str then
+ decode_error(str, idx, "trailing garbage")
+ end
+ return res
+end
+
+return json

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -35,6 +35,7 @@
 
 require('common');
 require('handlers.helpers');
+local gameState = require('core.gamestate');
 local dragdrop = require('libs.dragdrop');
 local imtext = require('libs.imtext');
 
@@ -75,6 +76,17 @@ M.visible = true;
 -- Track hotbar enable/disable state for transitions
 local wasHotbarEnabled = nil;
 
+-- Crossbar controller "Disable XI Macros" is shared with Hotbar -> Disable XI Macros (hotbarGlobal.disableMacroBars).
+-- Wrapper exists so the call sites read as crossbar-specific intent.
+local function GetCrossbarDisableXiMacrosEffective()
+    local hg = gConfig and gConfig.hotbarGlobal;
+    return hg and hg.disableMacroBars == true;
+end
+
+-- Palette change dedup: SetActivePalette / SetActivePaletteForCombo fire one callback per bar (1-6)
+-- or per combo mode (6x). Without deduping, display/slot cache clears run 6x per logical palette change.
+local lastPaletteVisualRefreshSig = nil;
+
 -- True if any hotbar bar or crossbar combo-mode has petAware enabled.
 -- Used to short-circuit the pet-change callback's cache wipes when no
 -- bar would actually rebind its slots in response.
@@ -113,6 +125,11 @@ function M.Initialize(settings)
 
     -- Initialize data module (sets player job)
     data.Initialize();
+    -- Migrate any legacy non-pet-aware storage keys + invalidate cache after migration.
+    if data.MigratePetAwareSlotStorageKeys then
+        data.MigratePetAwareSlotStorageKeys();
+    end
+    data.InvalidateStorageKeyCache();
 
     -- Validate palettes on reload (not just on job change packets)
     -- Helper function to validate palettes once job is ready
@@ -121,7 +138,14 @@ function M.Initialize(settings)
         local maxAttempts = 20;
 
         if data.SetPlayerJob() then
-            palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+            -- Honor pending "profile loaded before job was readable" (char select / logout)
+            -- so the default crossbar palette scope applies on first job-ready frame.
+            local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+                and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+                or nil;
+            palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+                applyDefaultCrossbarScope = pending,
+            });
             macropalette.SyncToCurrentJob();
             display.ClearIconCache();
             slotrenderer.ClearAllCache();
@@ -138,7 +162,12 @@ function M.Initialize(settings)
     end
 
     if data.jobId then
-        palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+        local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+            and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+            or nil;
+        palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+            applyDefaultCrossbarScope = pending,
+        });
     else
         -- Job not ready yet, start retry loop
         ashita.tasks.once(0.3, function()
@@ -177,16 +206,28 @@ function M.Initialize(settings)
         macropalette.ClearPetCommandsCache();
     end);
 
-    -- Register palette change callback to clear caches
+    -- Register palette change callback to clear caches.
+    -- Dedupe identical logical palette switches: SetActivePalette / SetActivePaletteForCombo
+    -- fire one callback per bar (1-6) or per combo mode (6x), so a single user palette change
+    -- triggers 6+ identical cache flushes if unguarded.
+    -- For no-op refreshes (same name -> same name, e.g. JSON import) include barIdentifier so
+    -- every bar/combo still runs; otherwise only the first callback fires and the UI stays blank.
     palette.OnPaletteChanged(function(barIdentifier, oldPaletteName, newPaletteName)
-        -- Invalidate storage key cache (palette change affects storage keys)
+        local sig;
+        if oldPaletteName == newPaletteName then
+            sig = tostring(barIdentifier) .. '\0' .. tostring(oldPaletteName) .. '\0' .. tostring(newPaletteName);
+        else
+            sig = tostring(oldPaletteName) .. '\0' .. tostring(newPaletteName);
+        end
+        if sig == lastPaletteVisualRefreshSig then
+            return;
+        end
+        lastPaletteVisualRefreshSig = sig;
         data.InvalidateStorageKeyCache();
-        -- Clear crossbar icon cache when any palette changes (hotbar or crossbar)
+        display.ClearIconCache();
         if crossbarInitialized then
             crossbar.ClearIconCache();
         end
-        -- Clear ONLY slot rendering cache (not availability/MP/item caches)
-        -- OPTIMIZED: Selective invalidation avoids unnecessary recalculation cascade
         slotrenderer.ClearSlotRenderingCache();
     end);
 
@@ -204,11 +245,10 @@ function M.Initialize(settings)
     end
     -- If checkbox is OFF, macrofix is already applied by initialize_patches()
 
-    -- Initialize crossbar if mode includes crossbar
-    -- Defensive: validate gConfig.hotbarCrossbar is a table before accessing
+    -- Initialize crossbar when enabled (independent flag, not mode-based).
+    -- Defensive: validate gConfig.hotbarCrossbar is a table before accessing.
     local crossbarConfig = gConfig and type(gConfig.hotbarCrossbar) == 'table' and gConfig.hotbarCrossbar or nil;
-    local crossbarMode = crossbarConfig and crossbarConfig.mode or 'hotbar';
-    local crossbarNeeded = crossbarMode == 'crossbar' or crossbarMode == 'both';
+    local crossbarNeeded = gConfig and gConfig.crossbarEnabled ~= false;
     if crossbarNeeded and crossbarConfig then
         crossbar.Initialize(crossbarConfig, gAdjustedSettings.crossbarSettings);
         
@@ -231,8 +271,8 @@ function M.Initialize(settings)
         controller.SetSlotActivateCallback(function(comboMode, slotIndex)
             crossbar.ActivateSlot(comboMode, slotIndex);
         end);
-        -- Set controller blocking enabled state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Set controller blocking enabled state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
         crossbarInitialized = true;
     end
 
@@ -271,9 +311,8 @@ function M.UpdateVisuals(settings)
         macrosLib.set_controller_hold_to_show(holdToShow);
     end
 
-    -- Handle crossbar enable/disable based on mode
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    local crossbarNeeded = crossbarMode == 'crossbar' or crossbarMode == 'both';
+    -- Handle crossbar enable/disable (independent flag, not mode-based)
+    local crossbarNeeded = gConfig and gConfig.crossbarEnabled ~= false;
 
     if crossbarNeeded and not crossbarInitialized then
         -- Initialize crossbar when newly needed
@@ -290,8 +329,8 @@ function M.UpdateVisuals(settings)
         controller.SetSlotActivateCallback(function(comboMode, slotIndex)
             crossbar.ActivateSlot(comboMode, slotIndex);
         end);
-        -- Set controller blocking enabled state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Set controller blocking enabled state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
         crossbarInitialized = true;
     elseif not crossbarNeeded and crossbarInitialized then
         -- Cleanup crossbar when no longer needed
@@ -312,8 +351,8 @@ function M.UpdateVisuals(settings)
             customMapping = gConfig.hotbarCrossbar.customControllerMappings.dinput;
         end
         controller.SetControllerScheme(gConfig.hotbarCrossbar.controllerScheme, customMapping);
-        -- Update controller blocking state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Update controller blocking state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
     end
 
     -- Update state tracking for hotbar enable/disable
@@ -339,38 +378,50 @@ function M.DrawWindow(settings)
         texturesInitialized = true;
     end
 
-    if gConfig and gConfig.hotbarEnabled == false then
-        display.HideWindow();
-        if crossbarInitialized then
-            crossbar.SetHidden(true);
-        end
-        return;
-    end
+    -- Hotbar and crossbar are independent; either, both, or neither can be on. Menu-hide
+    -- is evaluated here per-system so keyboard hotbars and the crossbar can have different
+    -- hideOnMenuFocus behaviors (they previously shared `hotbarHideOnMenuFocus`).
+    local menuOpen = gameState.IsMenuOpen();
+    local hideKbOnMenu = gConfig.hotbarHideOnMenuFocus == true;
+    local hideXbOnMenu = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.crossbarHideOnMenuFocus == true;
+    local showHotbar = gConfig
+        and gConfig.hotbarEnabled ~= false
+        and not (menuOpen and hideKbOnMenu);
+    local showCrossbar = gConfig
+        and gConfig.crossbarEnabled ~= false
+        and not (menuOpen and hideXbOnMenu);
 
-    -- Determine what to draw based on mode
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    local showHotbar = crossbarMode == 'hotbar' or crossbarMode == 'both';
-    local showCrossbar = crossbarMode == 'crossbar' or crossbarMode == 'both';
-
-    -- Draw hotbar if mode includes it
+    -- Draw keyboard hotbars when enabled
     if showHotbar then
         display.DrawWindow(settings);
     else
         display.HideWindow();
     end
 
-    -- Draw crossbar if mode includes it
+    -- Draw crossbar when enabled
     if showCrossbar and crossbarInitialized then
         crossbar.DrawWindow(gConfig.hotbarCrossbar, gAdjustedSettings.crossbarSettings);
     elseif crossbarInitialized then
         crossbar.SetHidden(true);
     end
 
-    -- Always draw macro palette and keybind modal (regardless of mode)
+    -- Always draw macro palette and keybind modal (regardless of enabled state)
     macropalette.DrawPalette();
     hotbarConfig.DrawKeybindModal();
 
-    -- Render drag preview (must be called at end of frame, after all drop zones)
+    -- Drop previews / deferred overlaps happen in M.FinalizeFrame() — XIUI.lua calls it
+    -- after palettemanager.Draw so the floating palette can win when its DropZone overlaps
+    -- the HUD crossbar / Edit Full Palette preview.
+end
+
+-- Called by XIUI.lua at the very end of d3d_present, after palettemanager.Draw().
+-- Resolves overlapping DropZone hits via FlushDeferredDrops (highest dropPriority wins)
+-- and then renders the drag preview overlay.
+function M.FinalizeFrame()
+    if not M.initialized then return; end
+
+    -- Resolve overlapping DropZones (HUD crossbar vs. Edit Full Palette preview, etc.)
+    dragdrop.FlushDeferredDrops();
     dragdrop.Render();
 
     -- Handle slot dragged outside (remove the action)
@@ -381,9 +432,13 @@ function M.DrawWindow(settings)
                 -- Standard hotbar slot was dragged outside - clear it
                 macropalette.ClearSlot(lastPayload.barIndex, lastPayload.slotIndex);
             elseif lastPayload.type == 'crossbar_slot' then
-                -- Crossbar slot was dragged outside - clear it
-                data.ClearCrossbarSlotData(lastPayload.comboMode, lastPayload.slotIndex);
-                -- Clear icon cache for this slot (targeted - fast)
+                -- Crossbar slot dragged outside: distinguish a draft slot (Edit Full Palette
+                -- editing buffer) from a live HUD slot so we don't blow away the wrong store.
+                if lastPayload.paletteEditStorageKey and data.ClearDraftSlotData then
+                    data.ClearDraftSlotData(lastPayload.comboMode, lastPayload.slotIndex);
+                else
+                    data.ClearCrossbarSlotData(lastPayload.comboMode, lastPayload.slotIndex);
+                end
                 if crossbarInitialized then
                     crossbar.ClearIconCacheForSlot(lastPayload.comboMode, lastPayload.slotIndex);
                 end
@@ -437,6 +492,12 @@ function M.HandleZonePacket()
     petpalette.ClearPetState();
     -- Clear availability cache since player state is invalid during zone
     slotrenderer.ClearAvailabilityCache();
+    -- Universal 2hr glow state can hold a stale subtarget arm across zones.
+    -- Defensive require: module may not be merged yet in intermediate states.
+    local okU, uth = pcall(require, 'modules.hotbar.universal_two_hour');
+    if okU and uth and uth.ResetUniversalTwoHourSubtargetGlowArm then
+        uth.ResetUniversalTwoHourSubtargetGlowArm();
+    end
 end
 
 function M.HandleJobChangePacket(e)
@@ -445,9 +506,26 @@ function M.HandleJobChangePacket(e)
         local maxAttempts = 20;
 
         if data.SetPlayerJob() then
-            -- Job successfully read - proceed with refresh
+            -- Job successfully read - proceed with refresh.
+            -- Reset universal 2hr subtarget glow arm; it can carry stale state across job change.
+            local okU, uth = pcall(require, 'modules.hotbar.universal_two_hour');
+            if okU and uth and uth.ResetUniversalTwoHourSubtargetGlowArm then
+                uth.ResetUniversalTwoHourSubtargetGlowArm();
+            end
             macropalette.SyncToCurrentJob();
-            palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+            -- Universal 2hr global row mirrors the current job's 2hr ability; resync after job change.
+            local okMg, macroGlobalDefaults = pcall(require, 'modules.hotbar.macro_global_defaults');
+            if okMg and macroGlobalDefaults and macroGlobalDefaults.SyncUniversalTwoHourGlobalRow and gConfig then
+                macroGlobalDefaults.SyncUniversalTwoHourGlobalRow(gConfig);
+            end
+            -- Honor pending "profile loaded before job was readable" (char select / logout) so
+            -- Default Palette Type on Profile Load applies on first job-ready frame.
+            local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+                and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+                or nil;
+            palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+                applyDefaultCrossbarScope = pending,
+            });
             display.ClearIconCache();
             actions.ClearNoIconCache();
             if crossbarInitialized then
@@ -524,10 +602,8 @@ function M.HandleKey(event)
 end
 
 function M.HandleXInputState(e)
+    -- Controller events go through crossbar regardless of keyboard hotbar enable state.
     if not crossbarInitialized then return; end
-    if gConfig and gConfig.hotbarEnabled == false then return; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return; end
     controller.HandleXInputState(e);
 end
 
@@ -535,9 +611,6 @@ end
 -- Returns true if the button should be blocked
 function M.HandleXInputButton(e)
     if not crossbarInitialized then return false; end
-    if gConfig and gConfig.hotbarEnabled == false then return false; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return false; end
     return controller.HandleXInputButton(e);
 end
 
@@ -545,18 +618,12 @@ end
 -- Returns true if the button should be blocked
 function M.HandleDInputButton(e)
     if not crossbarInitialized then return false; end
-    if gConfig and gConfig.hotbarEnabled == false then return false; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return false; end
     return controller.HandleDInputButton(e);
 end
 
 -- Handle DirectInput state event (for D-pad POV)
 function M.HandleDInputState(e)
     if not crossbarInitialized then return; end
-    if gConfig and gConfig.hotbarEnabled == false then return; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return; end
     controller.HandleDInputState(e);
 end
 

--- a/XIUI/modules/hotbar/palette.lua
+++ b/XIUI/modules/hotbar/palette.lua
@@ -27,6 +27,8 @@ local M = {};
 
 M.DEFAULT_PALETTE_NAME = 'Default';  -- Name for auto-created palettes
 M.PALETTE_KEY_PREFIX = 'palette:';
+-- All-jobs crossbar palettes (slotActions key prefix: global:palette:{name})
+M.UNIVERSAL_CROSSBAR_PREFIX = 'global:palette:';
 
 -- Deferred save state for palette selection changes
 -- Instead of saving immediately, track dirty state and save at natural pause points
@@ -45,9 +47,42 @@ local state = {
     -- NOTE: Crossbar can have 0 palettes and use default slots
     crossbarActivePalette = nil,
 
+    -- All-jobs universal crossbar sets (enableUniversalCrossbarPalettes in config)
+    crossbarPaletteScope = 'job', -- 'job' | 'universal'
+    crossbarActiveUniversalPalette = nil,
+
+    -- Job-scope crossbar: which storage tier is active — 0 = Job-wide (all subjobs), N = that subjob only
+    -- Only meaningful when the character has a support job (live subjob ~= 0)
+    crossbarActiveStorageSubjob = nil,
+
+    -- /xiui cpal preview of another job's named palette (off-job). Cleared on cycle, commit, scope/job change.
+    crossbarCliPreview = nil, -- { jobId, storageSubjob, paletteName }
+
+    -- /xiui cpal return-to-origin anchors (set on first cpal switch per scope, cleared on R1 double-tap return or job change)
+    cpalJobAnchor = nil,        -- { name, storageSubjob, jobId }
+    cpalUniversalAnchor = nil,  -- string palette name
+
     -- Callbacks for palette change events
     onPaletteChangedCallbacks = {},
 };
+
+-- Pending: profile/gConfig was swapped before player job was readable (addon startup). Consumed by hotbar init.
+local pendingApplyDefaultCrossbarScopeFromProfile = false;
+
+function M.NotifyProfileSettingsLoaded()
+    pendingApplyDefaultCrossbarScopeFromProfile = true;
+end
+
+function M.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+    if pendingApplyDefaultCrossbarScopeFromProfile then
+        pendingApplyDefaultCrossbarScopeFromProfile = false;
+        return true;
+    end
+    return false;
+end
+
+-- After hotbarCrossbar exists: seed one blank Job [J] Default palette per job (1–22) without touching live active palette.
+local crossbarBlankDefaultsSeeded = false;
 
 -- ============================================
 -- Performance: Palette List Cache
@@ -67,6 +102,64 @@ local function InvalidatePaletteListCache()
     paletteListCache = {};
     crossbarPaletteListCache = {};
 end
+
+-- Prefer the palette that was next in list after delete (below), else above (typical "stay nearby" UX)
+local function PickNeighborPaletteName(orderedList, deletedName)
+    if not orderedList or not deletedName then
+        return nil;
+    end
+    local idx = nil;
+    for i, n in ipairs(orderedList) do
+        if n == deletedName then
+            idx = i;
+            break;
+        end
+    end
+    if not idx then
+        return nil;
+    end
+    if orderedList[idx + 1] then
+        return orderedList[idx + 1];
+    end
+    if orderedList[idx - 1] then
+        return orderedList[idx - 1];
+    end
+    return nil;
+end
+
+-- Token for GetCrossbarAvailablePalettes when live subjob ~= 0: tier + palette name (names cannot contain ':')
+local CROSSBAR_ENTRY_SEP = '\1';
+
+function M.EncodeCrossbarEntryToken(storageSubjob, name)
+    return tostring(storageSubjob or 0) .. CROSSBAR_ENTRY_SEP .. (name or '');
+end
+
+-- Returns storageSubjob, name or nil, plainToken if not an encoded entry
+function M.DecodeCrossbarEntryToken(token)
+    if not token or type(token) ~= 'string' then
+        return nil, nil;
+    end
+    local st, name = token:match('^(%d+)' .. CROSSBAR_ENTRY_SEP .. '(.+)$');
+    if st then
+        return tonumber(st), name;
+    end
+    return nil, token;
+end
+
+-- Display suffix: Job-wide vs Subjob-specific tier (not Global [G], which is separate scope)
+function M.FormatCrossbarTierSuffixLabel(storageSubjob, liveSubjobId)
+    local live = liveSubjobId or 0;
+    if live == 0 then
+        return ' (J)';
+    end
+    if (storageSubjob or 0) == 0 then
+        return ' (J)';
+    end
+    return ' (SJ)';
+end
+
+-- Crossbar combo modes (single list for callbacks / universal scope)
+local CROSSBAR_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
 
 -- ============================================
 -- Config Structure Helpers
@@ -278,6 +371,108 @@ local function IsValidPaletteName(name)
     return true;
 end
 
+-- Key for hotbar RB-cycle exclude map: matches palette order when using shared fallback (subjob 0)
+local function GetEffectiveHotbarPaletteMetaKey(jobId, subjobId)
+    local jid = jobId or 1;
+    local sj = subjobId or 0;
+    if sj ~= 0 and M.IsUsingFallbackPalettes(jid, sj) then
+        return BuildJobSubjobKey(jid, 0);
+    end
+    return BuildJobSubjobKey(jid, sj);
+end
+
+local function PrunePaletteExcludeSubtable(root, key)
+    if not root or not root[key] then
+        return;
+    end
+    local empty = true;
+    for _ in pairs(root[key]) do
+        empty = false;
+        break;
+    end
+    if empty then
+        root[key] = nil;
+    end
+end
+
+-- When true, palette is included in RB+D-pad / keyboard palette cycling for hotbars
+function M.IsHotbarPaletteInRbCycle(jobId, subjobId, paletteName)
+    if not paletteName then
+        return true;
+    end
+    local key = GetEffectiveHotbarPaletteMetaKey(jobId, subjobId);
+    local t = gConfig and gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[key];
+    if t and t[paletteName] then
+        return false;
+    end
+    return true;
+end
+
+function M.SetHotbarPaletteInRbCycle(jobId, subjobId, paletteName, inCycle)
+    if not paletteName or not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    if not EnsureHotbarConfigExists() then
+        return false, 'Config unavailable';
+    end
+    if not gConfig.hotbar.paletteExcludeFromCycle then
+        gConfig.hotbar.paletteExcludeFromCycle = {};
+    end
+    local key = GetEffectiveHotbarPaletteMetaKey(jobId, subjobId);
+    if not gConfig.hotbar.paletteExcludeFromCycle[key] then
+        gConfig.hotbar.paletteExcludeFromCycle[key] = {};
+    end
+    local ex = gConfig.hotbar.paletteExcludeFromCycle[key];
+    if inCycle then
+        ex[paletteName] = nil;
+        PrunePaletteExcludeSubtable(gConfig.hotbar.paletteExcludeFromCycle, key);
+    else
+        ex[paletteName] = true;
+    end
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Job crossbar (non-universal): per storage tier orderKey job:tier
+function M.IsCrossbarPaletteInRbCycle(jobId, tierStorageSubjob, paletteName)
+    if not paletteName then
+        return true;
+    end
+    local key = BuildJobSubjobKey(jobId or 1, tierStorageSubjob or 0);
+    local cbs = gConfig.hotbarCrossbar;
+    local t = cbs and cbs.crossbarPaletteExcludeFromCycle and cbs.crossbarPaletteExcludeFromCycle[key];
+    if t and t[paletteName] then
+        return false;
+    end
+    return true;
+end
+
+function M.SetCrossbarPaletteInRbCycle(jobId, tierStorageSubjob, paletteName, inCycle)
+    if not paletteName or not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    local cbs = gConfig.hotbarCrossbar;
+    if not cbs then
+        return false, 'Crossbar settings not found';
+    end
+    if not cbs.crossbarPaletteExcludeFromCycle then
+        cbs.crossbarPaletteExcludeFromCycle = {};
+    end
+    local key = BuildJobSubjobKey(jobId or 1, tierStorageSubjob or 0);
+    if not cbs.crossbarPaletteExcludeFromCycle[key] then
+        cbs.crossbarPaletteExcludeFromCycle[key] = {};
+    end
+    local ex = cbs.crossbarPaletteExcludeFromCycle[key];
+    if inCycle then
+        ex[paletteName] = nil;
+        PrunePaletteExcludeSubtable(cbs.crossbarPaletteExcludeFromCycle, key);
+    else
+        ex[paletteName] = true;
+    end
+    SaveSettingsToDisk();
+    return true;
+end
+
 -- ============================================
 -- Palette Key Generation
 -- ============================================
@@ -311,17 +506,7 @@ function M.BuildSharedPaletteStorageKey(jobId, paletteName)
     return M.BuildPaletteStorageKey(jobId, 0, paletteName);
 end
 
--- DEPRECATED: Old format - kept for backwards compatibility during migration
--- Build full storage key for a palette using old format (includes subjob)
--- baseKey: '{jobId}:{subjobId}' format
--- paletteName: palette name or nil for default slot data
-function M.BuildStorageKey(baseKey, paletteName)
-    local suffix = M.GetPaletteKeySuffix(paletteName);
-    if not suffix then
-        return baseKey;
-    end
-    return string.format('%s:%s', baseKey, suffix);
-end
+-- REMOVED: BuildStorageKey — was deprecated, no callers remain. Use BuildPaletteStorageKey instead.
 
 -- Parse a storage key to extract palette name
 -- Returns nil if no palette suffix (default slots)
@@ -554,9 +739,15 @@ end
 function M.CyclePalette(barIndex, direction, jobId, subjobId)
     direction = direction or 1;
 
-    local palettes = M.GetAvailablePalettes(barIndex, jobId, subjobId);
+    local all = M.GetAvailablePalettes(barIndex, jobId, subjobId);
+    local palettes = {};
+    for _, name in ipairs(all) do
+        if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+            table.insert(palettes, name);
+        end
+    end
     if #palettes <= 1 then
-        return nil;  -- No palettes to cycle (0 or 1 palette)
+        return nil;  -- No palettes to cycle (0 or 1 in RB cycle list)
     end
 
     local currentName = state.activePalette;
@@ -724,6 +915,7 @@ function M.DeletePalette(barIndex, paletteName, jobId, subjobId)
     if #availablePalettes <= 1 then
         return false, 'Cannot delete the last palette';
     end
+    local neighborName = PickNeighborPaletteName(availablePalettes, paletteName);
 
     -- Find the storage key (could be subjob-specific or shared)
     local storageKey = FindPaletteStorageKey(1, paletteName, normalizedJobId, normalizedSubjobId);
@@ -767,17 +959,40 @@ function M.DeletePalette(barIndex, paletteName, jobId, subjobId)
         end
     end
 
+    if gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[orderKey] then
+        gConfig.hotbar.paletteExcludeFromCycle[orderKey][paletteName] = nil;
+        PrunePaletteExcludeSubtable(gConfig.hotbar.paletteExcludeFromCycle, orderKey);
+    end
+
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
 
-    -- If this was the active palette, switch to the first available palette
+    -- If this was the active palette, switch to a nearby palette in the old order (below, else above)
     if state.activePalette == paletteName then
-        -- Get updated list after deletion
         local remainingPalettes = M.GetAvailablePalettes(barIndex, normalizedJobId, normalizedSubjobId);
-        local newActive = remainingPalettes[1];  -- First palette becomes active
-        M.SetActivePalette(1, newActive, normalizedJobId, normalizedSubjobId);
+        local newActive = nil;
+        if neighborName then
+            for _, n in ipairs(remainingPalettes) do
+                if n == neighborName then
+                    newActive = n;
+                    break;
+                end
+            end
+        end
+        if not newActive and #remainingPalettes > 0 then
+            newActive = remainingPalettes[1];
+        end
+        if newActive then
+            local changed = M.SetActivePalette(1, newActive, normalizedJobId, normalizedSubjobId);
+            if not changed then
+                for i = 1, 6 do
+                    M.FirePaletteChangedCallbacks(i, newActive, newActive);
+                end
+            end
+        end
     end
 
+    InvalidateAllVisualCachesAfterPaletteListMutation();
     SaveSettingsToDisk();
     return true;
 end
@@ -852,6 +1067,14 @@ function M.RenamePalette(barIndex, oldName, newName, jobId, subjobId)
         end
     end
 
+    if gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[orderKey] then
+        local ex = gConfig.hotbar.paletteExcludeFromCycle[orderKey];
+        if ex[oldName] then
+            ex[oldName] = nil;
+            ex[newName] = true;
+        end
+    end
+
     -- Update active palette if this was active
     if state.activePalette == oldName then
         state.activePalette = newName;
@@ -887,20 +1110,18 @@ function M.MovePalette(barIndex, paletteName, direction, jobId, subjobId)
     end
     local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
 
-    -- Ensure paletteOrder exists and is populated
     if not gConfig.hotbar then
         gConfig.hotbar = {};
     end
     if not gConfig.hotbar.paletteOrder then
         gConfig.hotbar.paletteOrder = {};
     end
-    if not gConfig.hotbar.paletteOrder[orderKey] then
-        -- Initialize paletteOrder from current available palettes
-        gConfig.hotbar.paletteOrder[orderKey] = {};
-        local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-        for _, name in ipairs(available) do
-            table.insert(gConfig.hotbar.paletteOrder[orderKey], name);
-        end
+
+    -- Match the merged list used by the Palette Manager / cycling (stored order can omit new palettes)
+    local canonical = M.GetAvailablePalettes(barIndex, normalizedJobId, normalizedSubjobId);
+    gConfig.hotbar.paletteOrder[orderKey] = {};
+    for _, name in ipairs(canonical) do
+        table.insert(gConfig.hotbar.paletteOrder[orderKey], name);
     end
 
     local order = gConfig.hotbar.paletteOrder[orderKey];
@@ -969,17 +1190,26 @@ function M.SetPaletteOrder(barIndex, palettes, jobId, subjobId)
     return true;
 end
 
--- Get the index of a palette in the order (1-based) (GLOBAL)
--- barIndex param kept for backwards compatibility but ignored
--- subjobId param kept for backwards compatibility but ignored
--- Returns the index, or nil if not found
+-- Ordered palette names included in RB / keyboard cycling (excludes "Inactive" in Palette Manager).
+function M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId)
+    local out = {};
+    for _, name in ipairs(M.GetAvailablePalettes(barIndex, jobId, subjobId)) do
+        if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+            table.insert(out, name);
+        end
+    end
+    return out;
+end
+
+-- Get the index of a palette within RB-cycle order only (1-based) (GLOBAL)
+-- Returns nil if the palette is not in the cycle list (e.g. marked Inactive).
 function M.GetPaletteIndex(barIndex, paletteName, jobId, subjobId)
     if not paletteName then
         return nil;
     end
 
-    local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-    for i, name in ipairs(available) do
+    local cycle = M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId);
+    for i, name in ipairs(cycle) do
         if name == paletteName then
             return i;
         end
@@ -987,12 +1217,9 @@ function M.GetPaletteIndex(barIndex, paletteName, jobId, subjobId)
     return nil;
 end
 
--- Get the total number of palettes (GLOBAL)
--- barIndex param kept for backwards compatibility but ignored
--- subjobId param kept for backwards compatibility but ignored
+-- Count of palettes that participate in RB / keyboard cycling (not total defined palettes).
 function M.GetPaletteCount(barIndex, jobId, subjobId)
-    local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-    return #available;
+    return #M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId);
 end
 
 -- ============================================
@@ -1038,12 +1265,79 @@ function M.FirePaletteChangedCallbacks(barIndex, oldPalette, newPalette)
     end
 end
 
+-- SetActive* skips callbacks when name (and tier) match current state, but storage may still
+-- have changed (e.g. same palette name on another tier, or recreated empty Default).
+local function FireCrossbarComboRefreshNoop(displayName)
+    if not displayName then
+        return;
+    end
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, displayName, displayName);
+    end
+end
+
+-- Palette OnPaletteChanged only clears slotrenderer rendering cache + crossbar icons; hotbar also uses
+-- display-layer icon cache. After delete + redirect, force a full flush so binds resolve to the new storage key.
+local function InvalidateAllVisualCachesAfterPaletteListMutation()
+    local ok, dataMod = pcall(require, 'modules.hotbar.data');
+    if ok and dataMod and dataMod.InvalidateStorageKeyCache then
+        dataMod.InvalidateStorageKeyCache();
+    end
+    local ok2, sr = pcall(require, 'modules.hotbar.slotrenderer');
+    if ok2 and sr and sr.ClearAllCache then
+        sr.ClearAllCache();
+    end
+    pcall(function()
+        local disp = require('modules.hotbar.display');
+        if disp.ClearIconCache then
+            disp.ClearIconCache();
+        end
+    end);
+    pcall(function()
+        local xb = require('modules.hotbar.crossbar');
+        if xb.ClearIconCache then
+            xb.ClearIconCache();
+        end
+    end);
+end
+
+--- Re-run palette validation (active names vs lists) then fire a no-op palette change per bar/combo so
+--- hotbar/crossbar UIs reload binds from gConfig (JSON import changes data under the same palette name).
+function M.RefreshActivePaletteVisualsAfterExternalEdit()
+    local okData, dataMod = pcall(require, 'modules.hotbar.data');
+    if okData and dataMod and dataMod.jobId then
+        pcall(function()
+            M.ValidatePalettesForJob(dataMod.jobId, dataMod.subjobId or 0, { applyDefaultCrossbarScope = false });
+        end);
+    end
+    local hotbarName = state.activePalette;
+    if hotbarName then
+        for i = 1, 6 do
+            M.FirePaletteChangedCallbacks(i, hotbarName, hotbarName);
+        end
+    end
+    if state.crossbarActivePalette then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            M.FirePaletteChangedCallbacks('crossbar:' .. mode, state.crossbarActivePalette, state.crossbarActivePalette);
+        end
+    end
+    if state.crossbarActiveUniversalPalette then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            M.FirePaletteChangedCallbacks('crossbar:' .. mode, state.crossbarActiveUniversalPalette, state.crossbarActiveUniversalPalette);
+        end
+    end
+end
+
+--- Called after tools import or replace slot data outside normal palette APIs (e.g. JSON import).
+function M.InvalidateCachesAfterExternalSlotMutation()
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    M.RefreshActivePaletteVisualsAfterExternalEdit();
+end
+
 -- ============================================
 -- Crossbar Palette Management
 -- ============================================
-
--- Crossbar combo modes for iteration
-local CROSSBAR_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
 
 -- Helper: Scan crossbar for palettes matching a pattern prefix
 -- Returns: table of { [paletteName] = true }
@@ -1069,17 +1363,81 @@ local function ScanCrossbarForPalettes(patternPrefix)
     return existingPalettes;
 end
 
--- Get all available palette names for crossbar only
--- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
--- Fallback: If no subjob-specific palettes exist, falls back to shared palettes (subjob 0)
--- Returns: { 'Stuns', 'Heals', ... } - palettes available ONLY for crossbar (empty if none defined)
--- Crossbar palettes are SEPARATE from hotbar palettes
--- OPTIMIZED: Results are cached with TTL
+-- Build ordered list of crossbar palette rows for a job + live subjob context (no Either/Or hiding).
+-- storageSubjob 0 = Job-wide [J]; storageSubjob == subjobId (when ~=0) = Subjob-only [SJ] entries.
+local function BuildCrossbarMergedRowsInternal(jobId, subjobId)
+    local jid = jobId or 1;
+    local sj = subjobId or 0;
+    local rows = {};
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+
+    local function orderedNamesForTier(tierSj, existingSet)
+        local orderKey = BuildJobSubjobKey(jid, tierSj);
+        local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+            and crossbarSettings.crossbarPaletteOrder[orderKey];
+        local out = {};
+        local seen = {};
+        if storedOrder then
+            for _, paletteName in ipairs(storedOrder) do
+                if existingSet[paletteName] and not seen[paletteName] then
+                    seen[paletteName] = true;
+                    table.insert(out, paletteName);
+                end
+            end
+        end
+        local remaining = {};
+        for paletteName, _ in pairs(existingSet) do
+            if not seen[paletteName] then
+                table.insert(remaining, paletteName);
+            end
+        end
+        table.sort(remaining);
+        for _, paletteName in ipairs(remaining) do
+            table.insert(out, paletteName);
+        end
+        return out;
+    end
+
+    if sj == 0 then
+        local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+        local set0 = ScanCrossbarForPalettes(pattern0);
+        for _, n in ipairs(orderedNamesForTier(0, set0)) do
+            table.insert(rows, { name = n, storageSubjob = 0 });
+        end
+        return rows;
+    end
+
+    local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+    local set0 = ScanCrossbarForPalettes(pattern0);
+    local seen = {};
+    for _, n in ipairs(orderedNamesForTier(0, set0)) do
+        seen[n] = true;
+        table.insert(rows, { name = n, storageSubjob = 0 });
+    end
+
+    local subPattern = string.format('%d:%d:%s', jid, sj, M.PALETTE_KEY_PREFIX);
+    local setS = ScanCrossbarForPalettes(subPattern);
+    local extraSet = {};
+    for name, _ in pairs(setS) do
+        if not seen[name] then
+            extraSet[name] = true;
+        end
+    end
+    for _, n in ipairs(orderedNamesForTier(sj, extraSet)) do
+        table.insert(rows, { name = n, storageSubjob = sj });
+    end
+
+    return rows;
+end
+
+-- Get all available crossbar entries for the current job/subjob context.
+-- When live subjob is 0: returns plain palette names (Job [J] tier only).
+-- When live subjob ~= 0: returns encoded tokens 'storageSubjob' .. sep .. 'name' so Job + Subjob tiers stay distinct.
+-- Crossbar palettes are SEPARATE from hotbar palettes. OPTIMIZED: cached with TTL.
 function M.GetCrossbarAvailablePalettes(jobId, subjobId)
     local normalizedJobId = jobId or 1;
     local normalizedSubjobId = subjobId or 0;
 
-    -- Check cache first
     local cacheKey = BuildPaletteCacheKey(normalizedJobId, normalizedSubjobId);
     local cached = crossbarPaletteListCache[cacheKey];
     local now = os.clock();
@@ -1088,162 +1446,757 @@ function M.GetCrossbarAvailablePalettes(jobId, subjobId)
     end
 
     local palettes = {};
-
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
     if not crossbarSettings or not crossbarSettings.slotActions then
         crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
         return palettes;
     end
 
-    -- Check subjob-specific palettes first: '{jobId}:{subjobId}:palette:{name}'
-    local subjobPattern = string.format('%d:%d:%s', normalizedJobId, normalizedSubjobId, M.PALETTE_KEY_PREFIX);
-    local existingPalettes = ScanCrossbarForPalettes(subjobPattern);
-
-    -- Count subjob-specific palettes
-    local subjobPaletteCount = 0;
-    for _ in pairs(existingPalettes) do
-        subjobPaletteCount = subjobPaletteCount + 1;
-    end
-
-    -- Fallback to shared palettes (subjob 0) if no subjob-specific palettes exist
-    local usingFallback = false;
-    if subjobPaletteCount == 0 and normalizedSubjobId ~= 0 then
-        local sharedPattern = string.format('%d:0:%s', normalizedJobId, M.PALETTE_KEY_PREFIX);
-        existingPalettes = ScanCrossbarForPalettes(sharedPattern);
-        usingFallback = true;
-    end
-
-    -- Get the stored palette order (keyed by job:subjob or fallback to job:0)
-    local orderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
-    local storedOrder = crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[orderKey];
-
-    -- If using fallback, also check for shared order
-    if not storedOrder and usingFallback then
-        local sharedOrderKey = BuildJobSubjobKey(normalizedJobId, 0);
-        storedOrder = crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[sharedOrderKey];
-    end
-
-    -- Build ordered result: first add palettes from storedOrder that exist
-    local seen = {};
-    if storedOrder then
-        for _, paletteName in ipairs(storedOrder) do
-            if existingPalettes[paletteName] and not seen[paletteName] then
-                seen[paletteName] = true;
-                table.insert(palettes, paletteName);
-            end
+    if normalizedSubjobId == 0 then
+        local rows = BuildCrossbarMergedRowsInternal(normalizedJobId, 0);
+        for _, r in ipairs(rows) do
+            table.insert(palettes, r.name);
+        end
+    else
+        local rows = BuildCrossbarMergedRowsInternal(normalizedJobId, normalizedSubjobId);
+        for _, r in ipairs(rows) do
+            table.insert(palettes, M.EncodeCrossbarEntryToken(r.storageSubjob, r.name));
         end
     end
 
-    -- Collect any remaining palettes not in the stored order
+    crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
+    return palettes;
+end
+
+-- Rows for Manage / embedded Palette Manager (and cycle order): Job [J] then Subjob [SJ]-only names.
+function M.GetCrossbarManagePaletteRows(jobId, subjobId)
+    return BuildCrossbarMergedRowsInternal(jobId or 1, subjobId or 0);
+end
+
+-- SJ-only palette names in the same order as (SJ) rows in Manage: job:sj:palette:* names that are NOT
+-- also on job:0:palette:* for the same main job (excludes empty duplicate SJ buckets that shadow [J] names).
+function M.GetCrossbarSjOnlyPaletteNamesOrdered(jobId, liveSubjobId)
+    local jid = jobId or 1;
+    local sj = liveSubjobId or 0;
+    if sj == 0 then
+        return {};
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+    local set0 = ScanCrossbarForPalettes(pattern0);
+    local jNames = {};
+    for name, _ in pairs(set0) do
+        jNames[name] = true;
+    end
+    local subPattern = string.format('%d:%d:%s', jid, sj, M.PALETTE_KEY_PREFIX);
+    local setS = ScanCrossbarForPalettes(subPattern);
+    local extraSet = {};
+    for name, _ in pairs(setS) do
+        if not jNames[name] then
+            extraSet[name] = true;
+        end
+    end
+    local orderKey = BuildJobSubjobKey(jid, sj);
+    local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+        and crossbarSettings.crossbarPaletteOrder[orderKey];
+    local out = {};
+    local seen = {};
+    if storedOrder then
+        for _, paletteName in ipairs(storedOrder) do
+            if extraSet[paletteName] and not seen[paletteName] then
+                seen[paletteName] = true;
+                table.insert(out, paletteName);
+            end
+        end
+    end
     local remaining = {};
-    for paletteName, _ in pairs(existingPalettes) do
+    for paletteName, _ in pairs(extraSet) do
         if not seen[paletteName] then
             table.insert(remaining, paletteName);
         end
     end
-
-    -- Sort remaining palettes alphabetically and append
     table.sort(remaining);
     for _, paletteName in ipairs(remaining) do
-        table.insert(palettes, paletteName);
+        table.insert(out, paletteName);
     end
-
-    -- Cache the result
-    crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
-
-    return palettes;
+    return out;
 end
 
--- Check if crossbar palettes are using fallback (shared) mode
--- Returns true if using shared palettes because no subjob-specific ones exist
-function M.IsUsingCrossbarFallbackPalettes(jobId, subjobId)
-    local normalizedJobId = jobId or 1;
-    local normalizedSubjobId = subjobId or 0;
-
-    if normalizedSubjobId == 0 then
-        return false;  -- Already using shared palettes
-    end
-
+-- Ordered palette names for a single storage tier (used when reordering within that tier)
+function M.GetCrossbarPaletteNamesForOrderTier(jobId, tierSubjob)
+    local jid = jobId or 1;
+    local tier = tierSubjob or 0;
+    local pattern = string.format('%d:%d:%s', jid, tier, M.PALETTE_KEY_PREFIX);
+    local existing = ScanCrossbarForPalettes(pattern);
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
-    if not crossbarSettings or not crossbarSettings.slotActions then
-        return true;  -- No settings, would use fallback
-    end
-
-    -- Check for subjob-specific palettes
-    local subjobPattern = string.format('%d:%d:%s', normalizedJobId, normalizedSubjobId, M.PALETTE_KEY_PREFIX);
-    for storageKey, _ in pairs(crossbarSettings.slotActions) do
-        if type(storageKey) == 'string' and storageKey:find(subjobPattern, 1, true) == 1 then
-            return false;  -- Found at least one subjob-specific palette
-        end
-    end
-
-    return true;  -- Using fallback
-end
-
--- Unified fallback check for both hotbar and crossbar
--- paletteType: 'hotbar' or 'crossbar'
-function M.IsUsingFallback(jobId, subjobId, paletteType)
-    if subjobId == 0 then return false; end
-    if paletteType == 'crossbar' then
-        return M.IsUsingCrossbarFallbackPalettes(jobId, subjobId);
-    else
-        return M.IsUsingFallbackPalettes(jobId, subjobId);
-    end
-end
-
--- DEPRECATED: GetAllAvailablePalettes - kept for backwards compatibility
--- Now just returns hotbar palettes since crossbar has its own separate palettes
-function M.GetAllAvailablePalettes(jobId, subjobId)
-    local palettes = {};
+    local orderKey = BuildJobSubjobKey(jid, tier);
+    local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+        and crossbarSettings.crossbarPaletteOrder[orderKey];
+    local out = {};
     local seen = {};
-
-    -- Scan all 6 hotbar bars only (NOT crossbar - they are separate now)
-    for barIndex = 1, 6 do
-        local barPalettes = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-        for _, paletteName in ipairs(barPalettes) do
-            if not seen[paletteName] then
+    if storedOrder then
+        for _, paletteName in ipairs(storedOrder) do
+            if existing[paletteName] and not seen[paletteName] then
                 seen[paletteName] = true;
-                table.insert(palettes, paletteName);
+                table.insert(out, paletteName);
             end
         end
     end
-
-    return palettes;
+    local remaining = {};
+    for paletteName, _ in pairs(existing) do
+        if not seen[paletteName] then
+            table.insert(remaining, paletteName);
+        end
+    end
+    table.sort(remaining);
+    for _, paletteName in ipairs(remaining) do
+        table.insert(out, paletteName);
+    end
+    return out;
 end
 
--- Get active palette name for crossbar (GLOBAL - single palette for all combo modes)
+-- ============================================
+-- Universal (all-jobs) crossbar palettes
+-- Storage key: global:palette:{name} in hotbarCrossbar.slotActions
+-- Pet overlays never apply to these keys (handled in data.lua).
+-- ============================================
+
+function M.BuildUniversalCrossbarStorageKey(paletteName)
+    if not paletteName or paletteName == '' then
+        return nil;
+    end
+    return M.UNIVERSAL_CROSSBAR_PREFIX .. paletteName;
+end
+
+local function ScanUniversalCrossbarPaletteNames()
+    local existing = {};
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return existing;
+    end
+    local prefix = M.UNIVERSAL_CROSSBAR_PREFIX;
+    for storageKey, _ in pairs(crossbarSettings.slotActions) do
+        if type(storageKey) == 'string' and storageKey:sub(1, #prefix) == prefix then
+            local name = storageKey:sub(#prefix + 1);
+            if name and name ~= '' then
+                existing[name] = true;
+            end
+        end
+    end
+    return existing;
+end
+
+--- Ordered list of all universal crossbar palette names (for UI).
+function M.GetUniversalCrossbarPaletteNamesOrdered()
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return {};
+    end
+    local existing = ScanUniversalCrossbarPaletteNames();
+    local ordered = {};
+    local seen = {};
+    local orderList = crossbarSettings.universalCrossbarPaletteOrder;
+    if orderList then
+        for _, name in ipairs(orderList) do
+            if existing[name] and not seen[name] then
+                seen[name] = true;
+                table.insert(ordered, name);
+            end
+        end
+    end
+    local rest = {};
+    for name, _ in pairs(existing) do
+        if not seen[name] then
+            table.insert(rest, name);
+        end
+    end
+    table.sort(rest);
+    for _, name in ipairs(rest) do
+        table.insert(ordered, name);
+    end
+    return ordered;
+end
+
+function M.GetUniversalPaletteIncludeInCycle(name)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local meta = crossbarSettings and crossbarSettings.crossbarUniversalPaletteMeta;
+    if not meta or not meta[name] then
+        return true;
+    end
+    if meta[name].includeInCycle == false then
+        return false;
+    end
+    return true;
+end
+
+function M.SetUniversalPaletteIncludeInCycle(name, includeInCycle)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false;
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta = {};
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta[name] then
+        crossbarSettings.crossbarUniversalPaletteMeta[name] = {};
+    end
+    crossbarSettings.crossbarUniversalPaletteMeta[name].includeInCycle = includeInCycle and true or false;
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Palettes RB+D-pad cycles when scope is universal (respects includeInCycle).
+function M.GetUniversalCrossbarPalettesForCycle()
+    local all = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local out = {};
+    for _, name in ipairs(all) do
+        if M.GetUniversalPaletteIncludeInCycle(name) then
+            table.insert(out, name);
+        end
+    end
+    return out;
+end
+
+function M.CreateUniversalCrossbarPalette(paletteName)
+    if not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local key = M.BuildUniversalCrossbarStorageKey(paletteName);
+    if crossbarSettings.slotActions[key] then
+        return false, 'Palette already exists';
+    end
+    crossbarSettings.slotActions[key] = {};
+    if not crossbarSettings.universalCrossbarPaletteOrder then
+        crossbarSettings.universalCrossbarPaletteOrder = {};
+    end
+    table.insert(crossbarSettings.universalCrossbarPaletteOrder, paletteName);
+    if not crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta = {};
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta[paletteName] then
+        crossbarSettings.crossbarUniversalPaletteMeta[paletteName] = { includeInCycle = true };
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.EnsureUniversalCrossbarDefaultExists()
+    local names = M.GetUniversalCrossbarPaletteNamesOrdered();
+    if #names > 0 then
+        return names[1];
+    end
+    local ok = M.CreateUniversalCrossbarPalette(M.DEFAULT_PALETTE_NAME);
+    if ok == true then
+        return M.DEFAULT_PALETTE_NAME;
+    end
+    return nil;
+end
+
+function M.DeleteUniversalCrossbarPalette(paletteName)
+    if not paletteName or paletteName == '' then
+        return false, 'No palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return false, 'Not found';
+    end
+    local key = M.BuildUniversalCrossbarStorageKey(paletteName);
+    if not crossbarSettings.slotActions[key] then
+        return false, 'Palette not found';
+    end
+    local orderedBefore = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local neighborName = PickNeighborPaletteName(orderedBefore, paletteName);
+    crossbarSettings.slotActions[key] = nil;
+    if crossbarSettings.universalCrossbarPaletteOrder then
+        for i, n in ipairs(crossbarSettings.universalCrossbarPaletteOrder) do
+            if n == paletteName then
+                table.remove(crossbarSettings.universalCrossbarPaletteOrder, i);
+                break;
+            end
+        end
+    end
+    if crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta[paletteName] = nil;
+    end
+    M.EnsureUniversalCrossbarDefaultExists();
+    if state.crossbarActiveUniversalPalette == paletteName then
+        local rest = M.GetUniversalCrossbarPaletteNamesOrdered();
+        local pickName = nil;
+        if neighborName then
+            for _, n in ipairs(rest) do
+                if n == neighborName then
+                    pickName = n;
+                    break;
+                end
+            end
+        end
+        if not pickName and #rest > 0 then
+            pickName = rest[1];
+        end
+        if pickName then
+            local changed = M.SetActiveUniversalCrossbarPalette(pickName);
+            if not changed then
+                FireCrossbarComboRefreshNoop(pickName);
+            end
+        end
+    end
+    if crossbarSettings.comboModeSettings then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            local ms = crossbarSettings.comboModeSettings[mode];
+            if ms and ms.universalOverridePalette == paletteName then
+                ms.universalOverridePalette = nil;
+            end
+        end
+    end
+    if crossbarSettings.namedPaletteComboModeSettings then
+        for _, perPal in pairs(crossbarSettings.namedPaletteComboModeSettings) do
+            if type(perPal) == 'table' then
+                for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+                    local o = perPal[mode];
+                    if o and o.universalOverridePalette == paletteName then
+                        o.universalOverridePalette = nil;
+                    end
+                end
+            end
+        end
+    end
+    if crossbarSettings.segmentOverrides then
+        for jid, modes in pairs(crossbarSettings.segmentOverrides) do
+            if type(modes) == 'table' then
+                for mode, seg in pairs(modes) do
+                    if type(seg) == 'table' and seg.scope == 'global' and seg.globalPalette == paletteName then
+                        modes[mode] = nil;
+                    end
+                end
+                if next(modes) == nil then
+                    crossbarSettings.segmentOverrides[jid] = nil;
+                end
+            end
+        end
+        if next(crossbarSettings.segmentOverrides) == nil then
+            crossbarSettings.segmentOverrides = nil;
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.RenameUniversalCrossbarPalette(oldName, newName)
+    if not oldName or oldName == '' then
+        return false, 'No palette name';
+    end
+    if not newName or newName == '' then
+        return false, 'No new name';
+    end
+    if oldName == newName then
+        return false, 'New name is the same as the old name';
+    end
+    if not IsValidPaletteName(newName) then
+        return false, 'Invalid new palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return false, 'Crossbar settings not found';
+    end
+    local oldKey = M.BuildUniversalCrossbarStorageKey(oldName);
+    local newKey = M.BuildUniversalCrossbarStorageKey(newName);
+    if not crossbarSettings.slotActions[oldKey] then
+        return false, 'Palette not found';
+    end
+    if crossbarSettings.slotActions[newKey] then
+        return false, 'A palette with that name already exists';
+    end
+    crossbarSettings.slotActions[newKey] = crossbarSettings.slotActions[oldKey];
+    crossbarSettings.slotActions[oldKey] = nil;
+    if crossbarSettings.universalCrossbarPaletteOrder then
+        for i, n in ipairs(crossbarSettings.universalCrossbarPaletteOrder) do
+            if n == oldName then
+                crossbarSettings.universalCrossbarPaletteOrder[i] = newName;
+                break;
+            end
+        end
+    end
+    if crossbarSettings.crossbarUniversalPaletteMeta then
+        if crossbarSettings.crossbarUniversalPaletteMeta[oldName] then
+            crossbarSettings.crossbarUniversalPaletteMeta[newName] = crossbarSettings.crossbarUniversalPaletteMeta[oldName];
+            crossbarSettings.crossbarUniversalPaletteMeta[oldName] = nil;
+        end
+    end
+    if state.crossbarActiveUniversalPalette == oldName then
+        state.crossbarActiveUniversalPalette = newName;
+    end
+    if crossbarSettings.comboModeSettings then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            local ms = crossbarSettings.comboModeSettings[mode];
+            if ms and ms.universalOverridePalette == oldName then
+                ms.universalOverridePalette = newName;
+            end
+        end
+    end
+    if crossbarSettings.namedPaletteComboModeSettings then
+        for _, perPal in pairs(crossbarSettings.namedPaletteComboModeSettings) do
+            if type(perPal) == 'table' then
+                for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+                    local o = perPal[mode];
+                    if o and o.universalOverridePalette == oldName then
+                        o.universalOverridePalette = newName;
+                    end
+                end
+            end
+        end
+    end
+    if crossbarSettings.segmentOverrides then
+        for _, modes in pairs(crossbarSettings.segmentOverrides) do
+            if type(modes) == 'table' then
+                for _, seg in pairs(modes) do
+                    if type(seg) == 'table' and seg.scope == 'global' and seg.globalPalette == oldName then
+                        seg.globalPalette = newName;
+                    end
+                end
+            end
+        end
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Reorder Global [G] crossbar palettes (same list as GetUniversalCrossbarPaletteNamesOrdered).
+function M.MoveUniversalCrossbarPalette(paletteName, direction)
+    if not paletteName or paletteName == '' then
+        return false, 'No palette specified';
+    end
+    if direction ~= -1 and direction ~= 1 then
+        return false, 'Invalid direction';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    local ordered = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local currentIndex = nil;
+    for i, name in ipairs(ordered) do
+        if name == paletteName then
+            currentIndex = i;
+            break;
+        end
+    end
+    if not currentIndex then
+        return false, 'Palette not found in order';
+    end
+    local newIndex = currentIndex + direction;
+    if newIndex < 1 or newIndex > #ordered then
+        return false, 'Cannot move palette further';
+    end
+    ordered[currentIndex], ordered[newIndex] = ordered[newIndex], ordered[currentIndex];
+    crossbarSettings.universalCrossbarPaletteOrder = {};
+    for _, n in ipairs(ordered) do
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, n);
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Deep-copy one Global [G] palette's slot data to a new or existing palette name.
+function M.CopyUniversalCrossbarPalette(sourceName, destName, overwriteExisting)
+    if not sourceName or sourceName == '' then
+        return false, 'No palette specified';
+    end
+    local dest = destName or sourceName;
+    if not IsValidPaletteName(dest) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local sourceKey = M.BuildUniversalCrossbarStorageKey(sourceName);
+    local destKey = M.BuildUniversalCrossbarStorageKey(dest);
+    if not crossbarSettings.slotActions[sourceKey] then
+        return false, 'Source palette not found';
+    end
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    local copiedData = {};
+    for comboMode, modeData in pairs(sourceData) do
+        if type(modeData) == 'table' then
+            copiedData[comboMode] = {};
+            for slotIdx, slotData in pairs(modeData) do
+                if type(slotData) == 'table' then
+                    copiedData[comboMode][slotIdx] = {};
+                    for k, v in pairs(slotData) do
+                        copiedData[comboMode][slotIdx][k] = v;
+                    end
+                else
+                    copiedData[comboMode][slotIdx] = slotData;
+                end
+            end
+        else
+            copiedData[comboMode] = modeData;
+        end
+    end
+    crossbarSettings.slotActions[destKey] = copiedData;
+    if not destExists then
+        if not crossbarSettings.universalCrossbarPaletteOrder then
+            crossbarSettings.universalCrossbarPaletteOrder = {};
+        end
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, dest);
+        if not crossbarSettings.crossbarUniversalPaletteMeta then
+            crossbarSettings.crossbarUniversalPaletteMeta = {};
+        end
+        if not crossbarSettings.crossbarUniversalPaletteMeta[dest] then
+            crossbarSettings.crossbarUniversalPaletteMeta[dest] = { includeInCycle = true };
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.GetCrossbarPaletteScope()
+    return state.crossbarPaletteScope or 'job';
+end
+
+--- Temporary /xiui cpal summon of another job's palette (job storage only). See data.GetCrossbarStorageKeyForCombo.
+function M.GetCrossbarCliPreview()
+    return state.crossbarCliPreview;
+end
+
+function M.ClearCrossbarCliPreview()
+    if not state.crossbarCliPreview then
+        return;
+    end
+    state.crossbarCliPreview = nil;
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, nil);
+    end
+end
+
+function M.SetCrossbarCliPreview(jobId, storageSubjob, paletteName)
+    state.crossbarCliPreview = {
+        jobId = jobId,
+        storageSubjob = storageSubjob or 0,
+        paletteName = paletteName,
+    };
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, paletteName);
+    end
+end
+
+function M.SetCrossbarPaletteScope(scope)
+    if scope ~= 'job' and scope ~= 'universal' then
+        return false;
+    end
+    if state.crossbarPaletteScope == scope then
+        return false;
+    end
+    state.crossbarPaletteScope = scope;
+    state.crossbarCliPreview = nil;
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, nil);
+    end
+    return true;
+end
+
+local lastCrossbarScopeToggleClock = 0;
+
+function M.ToggleCrossbarPaletteScope()
+    local now = os.clock();
+    if now - lastCrossbarScopeToggleClock < 0.25 then
+        return false;
+    end
+    lastCrossbarScopeToggleClock = now;
+    local nextScope = (state.crossbarPaletteScope == 'universal') and 'job' or 'universal';
+    return M.SetCrossbarPaletteScope(nextScope);
+end
+
+function M.GetActiveUniversalCrossbarPalette()
+    return state.crossbarActiveUniversalPalette;
+end
+
+function M.SetActiveUniversalCrossbarPalette(paletteName)
+    state.crossbarCliPreview = nil;
+    local old = state.crossbarActiveUniversalPalette;
+    if old == paletteName then
+        return false;
+    end
+    state.crossbarActiveUniversalPalette = paletteName;
+    state.crossbarPaletteScope = 'universal';
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, old, paletteName);
+    end
+    return true;
+end
+
+-- Unified fallback check: crossbar never uses fallback (both J and SJ tiers are visible).
+function M.IsUsingFallback(jobId, subjobId, paletteType)
+    if subjobId == 0 then return false; end
+    if paletteType == 'crossbar' then
+        return false;
+    end
+    return M.IsUsingFallbackPalettes(jobId, subjobId);
+end
+
+-- Get active palette name for crossbar (job-tier or universal-tier depending on scope)
 -- comboMode param kept for backwards compatibility but ignored
 -- Returns nil if no palette (using default slots)
 function M.GetActivePaletteForCombo(comboMode)
+    if state.crossbarPaletteScope == 'universal' then
+        return state.crossbarActiveUniversalPalette;
+    end
     return state.crossbarActivePalette;
 end
 
--- Get active palette display name for crossbar (GLOBAL)
+-- Get active palette display name for crossbar
 -- comboMode param kept for backwards compatibility but ignored
 -- Returns nil if no palette is active
 function M.GetActivePaletteDisplayNameForCombo(comboMode)
+    if state.crossbarPaletteScope == 'universal' then
+        return state.crossbarActiveUniversalPalette;
+    end
     return state.crossbarActivePalette;
 end
 
--- Set active palette for crossbar (GLOBAL - affects all combo modes)
+-- Set active palette for crossbar (job / job+subjob tier — affects all combo modes)
 -- comboMode param kept for backwards compatibility but ignored
 -- paletteName: name to activate, or nil to clear
-function M.SetActivePaletteForCombo(comboMode, paletteName)
+-- storageSubjob: 0 = Job [J] tier; live subjob id = Subjob [SJ] tier (omit/nil = infer from merged list later)
+function M.SetActivePaletteForCombo(comboMode, paletteName, storageSubjob)
+    state.crossbarCliPreview = nil;
     local oldPalette = state.crossbarActivePalette;
+    local oldScope = state.crossbarPaletteScope;
+    local oldSt = state.crossbarActiveStorageSubjob;
 
-    -- Skip if no change
-    if oldPalette == paletteName then
+    state.crossbarPaletteScope = 'job';
+    state.crossbarActivePalette = paletteName;
+    if storageSubjob ~= nil then
+        state.crossbarActiveStorageSubjob = storageSubjob;
+    elseif paletteName == nil or oldPalette ~= paletteName then
+        state.crossbarActiveStorageSubjob = nil;
+    end
+
+    if oldPalette == paletteName and oldScope == 'job' and oldSt == state.crossbarActiveStorageSubjob then
         return false;
     end
 
-    state.crossbarActivePalette = paletteName;
-
-    -- Fire callbacks for all combo modes (they all share the same palette now)
     for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
         M.FirePaletteChangedCallbacks('crossbar:' .. mode, oldPalette, paletteName);
     end
 
     return true;
+end
+
+-- Persisted / current Job-scope storage tier (nil = infer from merged list by name)
+function M.GetCrossbarActiveStorageSubjob()
+    return state.crossbarActiveStorageSubjob;
+end
+
+-- ── /xiui cpal return-to-origin anchor API ──────────────────────────────────
+
+-- Save the job-scope anchor only if one isn't already set.
+-- Call this BEFORE switching the active palette via a cpal command.
+function M.SetCpalJobAnchorIfUnset(currentName, currentStorageSubjob, currentJobId)
+    if state.cpalJobAnchor ~= nil then return; end
+    state.cpalJobAnchor = {
+        name           = currentName,
+        storageSubjob  = currentStorageSubjob or 0,
+        jobId          = currentJobId,
+    };
+end
+
+-- Save the universal/global-scope anchor only if one isn't already set.
+function M.SetCpalUniversalAnchorIfUnset(currentName)
+    if state.cpalUniversalAnchor ~= nil then return; end
+    state.cpalUniversalAnchor = currentName;
+end
+
+-- Return the anchor for the given scope ('job' or 'universal').
+-- For job scope, lazily validates the anchor against the current live job; clears and returns nil if stale.
+function M.GetCpalAnchor(scope)
+    if scope == 'universal' then
+        return state.cpalUniversalAnchor;
+    end
+    local a = state.cpalJobAnchor;
+    if not a then return nil; end
+    local ok, datamod = pcall(require, 'modules.hotbar.data');
+    if ok and datamod and datamod.jobId and a.jobId ~= datamod.jobId then
+        state.cpalJobAnchor = nil;
+        return nil;
+    end
+    return a;
+end
+
+-- Clear the anchor for the given scope without restoring.
+function M.ClearCpalAnchor(scope)
+    if scope == 'universal' then
+        state.cpalUniversalAnchor = nil;
+    else
+        state.cpalJobAnchor = nil;
+    end
+end
+
+-- Restore the anchor for the given scope: switches the active palette back to the saved value
+-- and then clears the anchor.
+function M.RestoreCpalAnchor(scope)
+    if scope == 'universal' then
+        local a = state.cpalUniversalAnchor;
+        if a then
+            state.cpalUniversalAnchor = nil;
+            M.SetActiveUniversalCrossbarPalette(a);
+        end
+    else
+        local a = state.cpalJobAnchor;
+        if a then
+            state.cpalJobAnchor = nil;
+            M.SetActivePaletteForCombo(nil, a.name, a.storageSubjob);
+        end
+    end
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Storage tier for slot key resolution when [J] scope (not Global [G])
+function M.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, liveSubjobId)
+    local lj = liveSubjobId or 0;
+    if lj == 0 then
+        return 0;
+    end
+    local st = state.crossbarActiveStorageSubjob;
+    if st ~= nil then
+        return st;
+    end
+    if state.crossbarActivePalette then
+        local rows = M.GetCrossbarManagePaletteRows(jobId, lj);
+        for _, r in ipairs(rows) do
+            if r.name == state.crossbarActivePalette then
+                return r.storageSubjob;
+            end
+        end
+    end
+    return 0;
 end
 
 -- Clear active palette for crossbar (uses default slot data)
@@ -1252,46 +2205,76 @@ function M.ClearActivePaletteForCombo(comboMode)
     return M.SetActivePaletteForCombo(comboMode, nil);
 end
 
--- Cycle through palettes for crossbar (GLOBAL - affects all combo modes)
+-- Cycle through palettes for crossbar (job tier or all-jobs universal tier)
 -- comboMode param kept for backwards compatibility but ignored
 -- direction: 1 for next, -1 for previous
 function M.CyclePaletteForCombo(comboMode, direction, jobId, subjobId)
     direction = direction or 1;
 
-    -- Use crossbar-only palette list (separate from hotbar)
-    local palettes = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    if #palettes == 0 then
-        return nil, false;  -- No palettes defined, second return = no palettes exist
-    end
+    M.ClearCrossbarCliPreview();
 
-    if #palettes == 1 then
-        -- Only one palette, just make sure it's active
-        M.SetActivePaletteForCombo(comboMode, palettes[1]);
-        return palettes[1], true;
-    end
-
-    local currentName = state.crossbarActivePalette;
-    local currentIndex = 1;  -- Default to first palette
-
-    -- Find current palette index
-    if currentName then
-        for i, name in ipairs(palettes) do
-            if name == currentName then
-                currentIndex = i;
-                break;
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes and state.crossbarPaletteScope == 'universal' then
+        local palettes = M.GetUniversalCrossbarPalettesForCycle();
+        if #palettes == 0 then
+            return nil, false;
+        end
+        if #palettes == 1 then
+            M.SetActiveUniversalCrossbarPalette(palettes[1]);
+            return palettes[1], true;
+        end
+        local currentName = state.crossbarActiveUniversalPalette;
+        local currentIndex = 1;
+        if currentName then
+            for i, name in ipairs(palettes) do
+                if name == currentName then
+                    currentIndex = i;
+                    break;
+                end
             end
+        end
+        local newIndex = currentIndex + direction;
+        if newIndex < 1 then newIndex = #palettes; end
+        if newIndex > #palettes then newIndex = 1; end
+        local newPalette = palettes[newIndex];
+        M.SetActiveUniversalCrossbarPalette(newPalette);
+        return newPalette, true;
+    end
+
+    local rowsAll = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local rows = {};
+    for _, r in ipairs(rowsAll) do
+        if M.IsCrossbarPaletteInRbCycle(jobId, r.storageSubjob, r.name) then
+            table.insert(rows, r);
+        end
+    end
+    if #rows == 0 then
+        return nil, false;
+    end
+
+    local currentIndex = 1;
+    for i, r in ipairs(rows) do
+        if r.name == state.crossbarActivePalette
+            and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == r.storageSubjob) then
+            currentIndex = i;
+            break;
         end
     end
 
-    -- Calculate new index with wrap-around (1..#palettes only, no "empty" state)
+    if #rows == 1 then
+        local r = rows[1];
+        M.SetActivePaletteForCombo(comboMode, r.name, r.storageSubjob);
+        return r.name, true;
+    end
+
     local newIndex = currentIndex + direction;
-    if newIndex < 1 then newIndex = #palettes; end
-    if newIndex > #palettes then newIndex = 1; end
+    if newIndex < 1 then newIndex = #rows; end
+    if newIndex > #rows then newIndex = 1; end
 
-    local newPalette = palettes[newIndex];
-    M.SetActivePaletteForCombo(comboMode, newPalette);
+    local pick = rows[newIndex];
+    M.SetActivePaletteForCombo(comboMode, pick.name, pick.storageSubjob);
 
-    return newPalette, true;  -- Second return = palettes exist
+    return pick.name, true;
 end
 
 -- Get the palette key suffix for crossbar (GLOBAL - same for all combo modes)
@@ -1304,8 +2287,9 @@ end
 
 -- Create a new palette for crossbar (stores in crossbar slotActions)
 -- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
+-- skipSave: when true, caller batches SaveSettingsToDisk (e.g. multi-job seed)
 -- Returns true on success, false with error message on failure
-function M.CreateCrossbarPalette(paletteName, jobId, subjobId)
+function M.CreateCrossbarPalette(paletteName, jobId, subjobId, skipSave)
     if not IsValidPaletteName(paletteName) then
         return false, 'Invalid palette name';
     end
@@ -1347,42 +2331,38 @@ function M.CreateCrossbarPalette(paletteName, jobId, subjobId)
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
 
-    SaveSettingsToDisk();
+    if not skipSave then
+        SaveSettingsToDisk();
+    end
     return true;
 end
 
 -- Ensure at least one crossbar palette exists for a job
--- Creates a "Default" palette if none exist
--- Returns the name of the first available palette
+-- Creates a "Default" palette at Job [J] tier if none exist
+-- Does not change the live active crossbar palette (config must not flip in-game scope)
+-- Returns the name of the first palette in merged order for this context
 function M.EnsureCrossbarDefaultPaletteExists(jobId, subjobId)
     local normalizedJobId = jobId or 1;
+    local sj = subjobId or 0;
 
-    -- Check if any palettes exist for this job
-    local availablePalettes = M.GetCrossbarAvailablePalettes(normalizedJobId, subjobId);
+    local rows = M.GetCrossbarManagePaletteRows(normalizedJobId, sj);
 
-    if #availablePalettes == 0 then
-        -- No palettes exist, create the default one at subjob 0 (shared)
-        -- This ensures imported data at subjob 0 isn't shadowed by empty subjob-specific palettes
+    if #rows == 0 then
         local success, err = M.CreateCrossbarPalette(M.DEFAULT_PALETTE_NAME, normalizedJobId, 0);
         if success then
-            -- Auto-activate the new palette
-            M.SetActivePaletteForCombo('L2', M.DEFAULT_PALETTE_NAME);
             return M.DEFAULT_PALETTE_NAME;
-        else
-            -- If "Default" already exists somehow, try numbered names
-            for i = 1, 99 do
-                local name = 'Palette ' .. i;
-                success, err = M.CreateCrossbarPalette(name, normalizedJobId, 0);
-                if success then
-                    M.SetActivePaletteForCombo('L2', name);
-                    return name;
-                end
+        end
+        for i = 1, 99 do
+            local name = 'Palette ' .. i;
+            success, err = M.CreateCrossbarPalette(name, normalizedJobId, 0);
+            if success then
+                return name;
             end
         end
-        return nil;  -- Failed to create
+        return nil;
     end
 
-    return availablePalettes[1];  -- Return first existing palette
+    return rows[1].name;
 end
 
 -- Helper: Find the actual crossbar storage key for a palette
@@ -1415,6 +2395,51 @@ local function FindCrossbarPaletteStorageKey(paletteName, jobId, subjobId)
     return nil;
 end
 
+-- If a Job [J] shared storage tier (tier 0) has zero palettes, create one blank Default (or Palette N).
+-- Subjob [SJ] tiers may be empty; gameplay falls back to shared job palettes.
+local function EnsureCrossbarStorageTierHasDefaultPalette(jobId, storageTier, skipSave)
+    local jid = jobId or 1;
+    local tier = storageTier or 0;
+    if #M.GetCrossbarPaletteNamesForOrderTier(jid, tier) > 0 then
+        return;
+    end
+    local ok, err = M.CreateCrossbarPalette(M.DEFAULT_PALETTE_NAME, jid, tier, skipSave);
+    if ok then
+        return;
+    end
+    for i = 1, 99 do
+        ok, err = M.CreateCrossbarPalette('Palette ' .. i, jid, tier, skipSave);
+        if ok then
+            return;
+        end
+    end
+end
+
+local CROSSBAR_JOB_SEED_MAX = 22;
+
+local function MaybeSeedBlankCrossbarDefaultPalettesForAllJobs()
+    if crossbarBlankDefaultsSeeded then
+        return;
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return;
+    end
+    crossbarBlankDefaultsSeeded = true;
+
+    local any = false;
+    for jid = 1, CROSSBAR_JOB_SEED_MAX do
+        if #M.GetCrossbarManagePaletteRows(jid, 0) == 0 then
+            EnsureCrossbarStorageTierHasDefaultPalette(jid, 0, true);
+            any = true;
+        end
+    end
+    if any then
+        InvalidatePaletteListCache();
+        SaveSettingsToDisk();
+    end
+end
+
 -- Delete a crossbar palette
 -- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
 -- Returns true on success, false with error message on failure
@@ -1437,8 +2462,18 @@ function M.DeleteCrossbarPalette(paletteName, jobId, subjobId)
         return false, 'Palette not found';
     end
 
+    local keyJobId, keySubjobId = storageKey:match('^(%d+):(%d+):');
+    local jidOrder = (keyJobId and tonumber(keyJobId)) or normalizedJobId;
+    local tierForOrder = (keySubjobId and tonumber(keySubjobId)) or normalizedSubjobId;
+    local orderedBefore = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, tierForOrder);
+    local neighborName = PickNeighborPaletteName(orderedBefore, paletteName);
+
     -- Delete the palette
     crossbarSettings.slotActions[storageKey] = nil;
+
+    if crossbarSettings.namedPaletteComboModeSettings then
+        crossbarSettings.namedPaletteComboModeSettings[storageKey] = nil;
+    end
 
     -- Determine which order key to use based on the storage key found
     local orderKey;
@@ -1459,13 +2494,52 @@ function M.DeleteCrossbarPalette(paletteName, jobId, subjobId)
         end
     end
 
-    -- If the GLOBAL crossbar palette was this palette, clear it
-    if state.crossbarActivePalette == paletteName then
-        state.crossbarActivePalette = nil;
+    if crossbarSettings.crossbarPaletteExcludeFromCycle and crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey] then
+        crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey][paletteName] = nil;
+        PrunePaletteExcludeSubtable(crossbarSettings.crossbarPaletteExcludeFromCycle, orderKey);
+    end
+
+    -- Only auto-fill Job [J] shared tier; SJ tiers can remain empty.
+    if tierForOrder == 0 then
+        EnsureCrossbarStorageTierHasDefaultPalette(jidOrder, tierForOrder);
+    end
+
+    if state.crossbarActivePalette == paletteName
+        and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == tierForOrder) then
+        local rest = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, tierForOrder);
+        local pickName = nil;
+        local pickTier = tierForOrder;
+        if neighborName then
+            for _, n in ipairs(rest) do
+                if n == neighborName then
+                    pickName = n;
+                    break;
+                end
+            end
+        end
+        if not pickName and #rest > 0 then
+            pickName = rest[1];
+        end
+        -- Last SJ palette removed: move active selection to Job [J] shared tier.
+        if not pickName and tierForOrder ~= 0 then
+            EnsureCrossbarStorageTierHasDefaultPalette(jidOrder, 0, true);
+            local jrest = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, 0);
+            if #jrest > 0 then
+                pickName = jrest[1];
+                pickTier = 0;
+            end
+        end
+        if pickName then
+            local changed = M.SetActivePaletteForCombo('L2', pickName, pickTier);
+            if not changed then
+                FireCrossbarComboRefreshNoop(pickName);
+            end
+        end
     end
 
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
 
     SaveSettingsToDisk();
     return true;
@@ -1518,6 +2592,14 @@ function M.RenameCrossbarPalette(oldName, newName, jobId, subjobId)
     crossbarSettings.slotActions[newStorageKey] = crossbarSettings.slotActions[oldStorageKey];
     crossbarSettings.slotActions[oldStorageKey] = nil;
 
+    if crossbarSettings.namedPaletteComboModeSettings then
+        local np = crossbarSettings.namedPaletteComboModeSettings;
+        if np[oldStorageKey] then
+            np[newStorageKey] = np[oldStorageKey];
+            np[oldStorageKey] = nil;
+        end
+    end
+
     -- Update crossbarPaletteOrder
     local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
     if crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[orderKey] then
@@ -1529,8 +2611,16 @@ function M.RenameCrossbarPalette(oldName, newName, jobId, subjobId)
         end
     end
 
-    -- Update GLOBAL crossbar active palette if this was the active one
-    if state.crossbarActivePalette == oldName then
+    if crossbarSettings.crossbarPaletteExcludeFromCycle and crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey] then
+        local ex = crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey];
+        if ex[oldName] then
+            ex[oldName] = nil;
+            ex[newName] = true;
+        end
+    end
+
+    if state.crossbarActivePalette == oldName
+        and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == effectiveSubjobId) then
         state.crossbarActivePalette = newName;
     end
 
@@ -1562,24 +2652,18 @@ function M.MoveCrossbarPalette(paletteName, direction, jobId, subjobId)
     local normalizedJobId = jobId or 1;
     local normalizedSubjobId = subjobId or 0;
 
-    -- If using fallback palettes, modify the shared order (subjob 0) instead
-    local effectiveSubjobId = normalizedSubjobId;
-    if normalizedSubjobId ~= 0 and M.IsUsingCrossbarFallbackPalettes(normalizedJobId, normalizedSubjobId) then
-        effectiveSubjobId = 0;
-    end
-    local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
+    -- subjobId is the storage tier for this palette (0 = Job [J], N = Subjob [SJ])
+    local orderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
 
-    -- Ensure crossbarPaletteOrder exists and is populated
     if not crossbarSettings.crossbarPaletteOrder then
         crossbarSettings.crossbarPaletteOrder = {};
     end
-    if not crossbarSettings.crossbarPaletteOrder[orderKey] then
-        -- Initialize crossbarPaletteOrder from current available palettes
-        crossbarSettings.crossbarPaletteOrder[orderKey] = {};
-        local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-        for _, name in ipairs(available) do
-            table.insert(crossbarSettings.crossbarPaletteOrder[orderKey], name);
-        end
+
+    -- Same merged order the UI lists (raw crossbarPaletteOrder can be stale or missing names)
+    local canonical = M.GetCrossbarPaletteNamesForOrderTier(normalizedJobId, normalizedSubjobId);
+    crossbarSettings.crossbarPaletteOrder[orderKey] = {};
+    for _, name in ipairs(canonical) do
+        table.insert(crossbarSettings.crossbarPaletteOrder[orderKey], name);
     end
 
     local order = crossbarSettings.crossbarPaletteOrder[orderKey];
@@ -1614,41 +2698,67 @@ function M.MoveCrossbarPalette(paletteName, direction, jobId, subjobId)
     return true;
 end
 
--- Check if a specific crossbar palette exists
-function M.CrossbarPaletteExists(paletteName, jobId, subjobId)
+-- Check if a specific crossbar palette exists (optional storage tier: 0 = Job [J], else Subjob [SJ])
+function M.CrossbarPaletteExists(paletteName, jobId, subjobId, storageTier)
     if not paletteName then
         return false;
     end
 
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    for _, name in ipairs(available) do
-        if name == paletteName then
+    local rows = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    for _, r in ipairs(rows) do
+        if r.name == paletteName and (storageTier == nil or r.storageSubjob == storageTier) then
             return true;
         end
     end
     return false;
 end
 
--- Get the index of a crossbar palette in the order list
--- Returns nil if palette not found
-function M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId)
+-- Crossbar rows that participate in RB+D-pad cycling (excludes Inactive in Palette Manager).
+function M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId)
+    local out = {};
+    for _, r in ipairs(M.GetCrossbarManagePaletteRows(jobId, subjobId)) do
+        if M.IsCrossbarPaletteInRbCycle(jobId, r.storageSubjob, r.name) then
+            table.insert(out, r);
+        end
+    end
+    return out;
+end
+
+-- Index in RB-cycle order only (1-based). Nil if palette is inactive or not found.
+function M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId, storageTier)
     if not paletteName then
         return nil;
     end
 
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    for i, name in ipairs(available) do
-        if name == paletteName then
+    local rows = M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+    for i, r in ipairs(rows) do
+        if r.name == paletteName and (storageTier == nil or r.storageSubjob == storageTier) then
             return i;
         end
     end
     return nil;
 end
 
--- Get the total number of crossbar palettes
 function M.GetCrossbarPaletteCount(jobId, subjobId)
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    return #available;
+    return #M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+end
+
+--- Index and total for the on-screen palette label (RB cycle): universal [G] uses universal cycle; job [J] uses job rows.
+function M.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId)
+    if not paletteName then
+        return nil, nil;
+    end
+    if M.GetCrossbarPaletteScope() == 'universal' then
+        local cycle = M.GetUniversalCrossbarPalettesForCycle();
+        local total = #cycle;
+        for i, n in ipairs(cycle) do
+            if n == paletteName then
+                return i, total;
+            end
+        end
+        return nil, (total > 0) and total or nil;
+    end
+    return M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId), M.GetCrossbarPaletteCount(jobId, subjobId);
 end
 
 -- ============================================
@@ -1657,8 +2767,9 @@ end
 
 -- Validate active palettes against current job's available palettes
 -- Ensures at least one palette exists, and auto-selects the first palette if none is active
--- Should be called on job change
-function M.ValidatePalettesForJob(jobId, subjobId)
+-- opts.applyDefaultCrossbarScope: only pass true when loading/reloading a profile (see XIUI xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad).
+-- Zone/job packets and leveling must not flip scope — user toggles L1+R1 for that session.
+function M.ValidatePalettesForJob(jobId, subjobId, opts)
     -- Ensure gConfig.hotbar structure exists before any palette operations
     if not EnsureHotbarConfigExists() then
         print('[XIUI palette] Warning: gConfig not available, skipping palette validation');
@@ -1669,6 +2780,9 @@ function M.ValidatePalettesForJob(jobId, subjobId)
     if NeedsPaletteMigration() then
         RunPaletteMigration();
     end
+
+    -- Blank Default crossbar palette per job (no live palette activation; avoids config/job clicks)
+    MaybeSeedBlankCrossbarDefaultPalettesForAllJobs();
 
     -- Ensure at least one palette exists for this job
     local firstPalette = M.EnsureDefaultPaletteExists(jobId, subjobId);
@@ -1683,56 +2797,59 @@ function M.ValidatePalettesForJob(jobId, subjobId)
     -- Try to restore saved palette state for this job:subjob
     local savedPalette = LoadPaletteState(jobId, subjobId);
 
-    -- Check if current hotbar palette is valid
+    -- First palette that participates in RB / keyboard cycling (Palette Manager "Active")
+    local function firstHotbarPaletteInCycle()
+        for _, name in ipairs(availablePalettes) do
+            if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+                return name;
+            end
+        end
+        if #availablePalettes > 0 then
+            return availablePalettes[1];
+        end
+        return firstPalette;
+    end
+
+    local function savedHotbarPaletteIfInCycle(name)
+        if not name then
+            return nil;
+        end
+        for _, n in ipairs(availablePalettes) do
+            if n == name and M.IsHotbarPaletteInRbCycle(jobId, subjobId, n) then
+                return name;
+            end
+        end
+        return nil;
+    end
+
+    -- Hotbar: do not keep a palette marked Inactive as the active palette after load / job change
+    local oldHotbarPalette = state.activePalette;
+    local desiredHotbar = nil;
     if state.activePalette then
-        local found = false;
+        local exists = false;
         for _, name in ipairs(availablePalettes) do
             if name == state.activePalette then
-                found = true;
+                exists = true;
                 break;
             end
         end
-        if not found then
-            -- Palette doesn't exist for this job, try saved state or use first available
-            local oldPalette = state.activePalette;
-            local newPalette = nil;
-
-            -- Check if saved palette exists for this job
-            if savedPalette then
-                for _, name in ipairs(availablePalettes) do
-                    if name == savedPalette then
-                        newPalette = savedPalette;
-                        break;
-                    end
-                end
-            end
-
-            state.activePalette = newPalette or firstPalette;
-            -- Fire callbacks for all bars
-            for i = 1, 6 do
-                M.FirePaletteChangedCallbacks(i, oldPalette, state.activePalette);
-            end
+        if exists and M.IsHotbarPaletteInRbCycle(jobId, subjobId, state.activePalette) then
+            desiredHotbar = state.activePalette;
+        else
+            desiredHotbar = savedHotbarPaletteIfInCycle(savedPalette) or firstHotbarPaletteInCycle();
         end
     else
-        -- No palette active, try saved state or select the first one
-        local newPalette = nil;
+        desiredHotbar = savedHotbarPaletteIfInCycle(savedPalette) or firstHotbarPaletteInCycle();
+    end
 
-        -- Check if saved palette exists for this job
-        if savedPalette then
-            for _, name in ipairs(availablePalettes) do
-                if name == savedPalette then
-                    newPalette = savedPalette;
-                    break;
-                end
-            end
-        end
-
-        state.activePalette = newPalette or firstPalette;
-        -- Fire callbacks for all bars
+    if oldHotbarPalette ~= desiredHotbar then
+        state.activePalette = desiredHotbar;
         for i = 1, 6 do
-            M.FirePaletteChangedCallbacks(i, nil, state.activePalette);
+            M.FirePaletteChangedCallbacks(i, oldHotbarPalette, desiredHotbar);
         end
     end
+
+    SavePaletteState(jobId, subjobId);
 
     -- Ensure at least one crossbar palette exists for this job
     local firstCrossbarPalette = M.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
@@ -1740,32 +2857,103 @@ function M.ValidatePalettesForJob(jobId, subjobId)
         print('[XIUI palette] Warning: Failed to create default crossbar palette for job ' .. tostring(jobId));
     end
 
-    -- Get available crossbar palettes
-    local availableCrossbarPalettes = M.GetCrossbarAvailablePalettes(jobId, subjobId);
+    -- Merge factory crossbar defaults into gConfig so keys like defaultCrossbarPaletteScope and
+    -- enableUniversalCrossbarPalettes always resolve (older/partial profiles omit nested fields).
+    if not gConfig.hotbarCrossbar then
+        gConfig.hotbarCrossbar = {};
+    end
+    local factories = require('core.settings.factories');
+    DeepMergeWithDefaults(gConfig.hotbarCrossbar, factories.createCrossbarDefaults());
 
-    -- Check if current crossbar palette is valid
-    if state.crossbarActivePalette then
-        local found = false;
-        for _, name in ipairs(availableCrossbarPalettes) do
-            if name == state.crossbarActivePalette then
-                found = true;
-                break;
+    local function ProfileDefaultWantsUniversalCrossbar(cs)
+        local v = cs and cs.defaultCrossbarPaletteScope;
+        if type(v) ~= 'string' then
+            return false;
+        end
+        local l = (v:lower():match('^%s*(.-)%s*$')) or '';
+        return l == 'universal' or l == 'global';
+    end
+
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    local firstUniversal = nil;
+    -- Apply Job vs Global [G] scope from profile before reconciling [J] tier palettes so callbacks see correct scope.
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes then
+        firstUniversal = M.EnsureUniversalCrossbarDefaultExists();
+        if opts and opts.applyDefaultCrossbarScope == true then
+            pendingApplyDefaultCrossbarScopeFromProfile = false;
+            if ProfileDefaultWantsUniversalCrossbar(crossbarSettings) then
+                state.crossbarPaletteScope = 'universal';
+            else
+                state.crossbarPaletteScope = 'job';
             end
         end
-        if not found then
-            -- Palette doesn't exist for this job, use first available
+        if state.crossbarActiveUniversalPalette then
+            local ulist = M.GetUniversalCrossbarPaletteNamesOrdered();
+            local ufound = false;
+            for _, n in ipairs(ulist) do
+                if n == state.crossbarActiveUniversalPalette then
+                    ufound = true;
+                    break;
+                end
+            end
+            if not ufound then
+                local cyc = M.GetUniversalCrossbarPalettesForCycle();
+                state.crossbarActiveUniversalPalette = (cyc[1] or firstUniversal);
+            end
+        elseif firstUniversal and state.crossbarPaletteScope == 'universal' then
+            state.crossbarActiveUniversalPalette = firstUniversal;
+        end
+    elseif crossbarSettings then
+        -- Feature explicitly disabled in profile — scope must be job tier only.
+        state.crossbarPaletteScope = 'job';
+    end
+
+    local crossbarRowsAll = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local crossbarRowsCycle = M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+
+    local function pickFirstCrossbarRowInCycle()
+        if #crossbarRowsCycle > 0 then
+            return crossbarRowsCycle[1];
+        end
+        if #crossbarRowsAll > 0 then
+            return crossbarRowsAll[1];
+        end
+        return nil;
+    end
+
+    if state.crossbarActivePalette then
+        local matchRow = nil;
+        for _, r in ipairs(crossbarRowsAll) do
+            if r.name == state.crossbarActivePalette then
+                if state.crossbarActiveStorageSubjob == nil then
+                    state.crossbarActiveStorageSubjob = r.storageSubjob;
+                end
+                if r.storageSubjob == state.crossbarActiveStorageSubjob then
+                    matchRow = r;
+                    break;
+                end
+            end
+        end
+        local ok = matchRow and M.IsCrossbarPaletteInRbCycle(jobId, matchRow.storageSubjob, matchRow.name);
+        if not ok then
             local oldPalette = state.crossbarActivePalette;
-            state.crossbarActivePalette = firstCrossbarPalette;
-            -- Fire callbacks for all combo modes
+            local pick = pickFirstCrossbarRowInCycle();
+            if pick then
+                state.crossbarActivePalette = pick.name;
+                state.crossbarActiveStorageSubjob = pick.storageSubjob;
+            elseif firstCrossbarPalette then
+                state.crossbarActivePalette = firstCrossbarPalette;
+                state.crossbarActiveStorageSubjob = 0;
+            end
             for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
                 M.FirePaletteChangedCallbacks('crossbar:' .. mode, oldPalette, state.crossbarActivePalette);
             end
         end
     else
-        -- No crossbar palette active, select the first one
-        if firstCrossbarPalette then
-            state.crossbarActivePalette = firstCrossbarPalette;
-            -- Fire callbacks for all combo modes
+        local pick = pickFirstCrossbarRowInCycle();
+        if pick then
+            state.crossbarActivePalette = pick.name;
+            state.crossbarActiveStorageSubjob = pick.storageSubjob;
             for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
                 M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, state.crossbarActivePalette);
             end
@@ -1777,6 +2965,9 @@ end
 function M.Reset()
     state.activePalette = nil;
     state.crossbarActivePalette = nil;
+    state.crossbarActiveStorageSubjob = nil;
+    state.crossbarPaletteScope = 'job';
+    state.crossbarActiveUniversalPalette = nil;
 end
 
 -- Get state for persistence (if needed)
@@ -1784,6 +2975,9 @@ function M.GetState()
     return {
         activePalette = state.activePalette,
         crossbarActivePalette = state.crossbarActivePalette,
+        crossbarActiveStorageSubjob = state.crossbarActiveStorageSubjob,
+        crossbarPaletteScope = state.crossbarPaletteScope,
+        crossbarActiveUniversalPalette = state.crossbarActiveUniversalPalette,
     };
 end
 
@@ -1792,6 +2986,11 @@ function M.RestoreState(savedState)
     if savedState then
         state.activePalette = savedState.activePalette;
         state.crossbarActivePalette = savedState.crossbarActivePalette;
+        state.crossbarActiveStorageSubjob = savedState.crossbarActiveStorageSubjob;
+        if savedState.crossbarPaletteScope == 'job' or savedState.crossbarPaletteScope == 'universal' then
+            state.crossbarPaletteScope = savedState.crossbarPaletteScope;
+        end
+        state.crossbarActiveUniversalPalette = savedState.crossbarActiveUniversalPalette;
     end
 end
 
@@ -1800,8 +2999,9 @@ end
 -- ============================================
 
 -- Copy a hotbar palette to a different job:subjob combination
--- Returns true on success, false with error message on failure
-function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName)
+-- newName: destination palette name (nil = same as source name)
+-- overwriteExisting: if true, replace data on an existing destination palette (slot actions / macros on all 6 bars)
+function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName, overwriteExisting)
     if not paletteName then
         return false, 'No palette specified';
     end
@@ -1820,13 +3020,23 @@ function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId
     -- Build destination storage key
     local destKey = M.BuildPaletteStorageKey(toJobId, toSubjobId, destName);
 
-    -- Check if destination already exists
+    local destExists = false;
     for barIdx = 1, 6 do
         local configKey = 'hotbarBar' .. barIdx;
         local barSettings = gConfig and gConfig[configKey];
         if barSettings and barSettings.slotActions and barSettings.slotActions[destKey] then
+            destExists = true;
+            break;
+        end
+    end
+
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
             return false, 'Palette already exists at destination';
         end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
     end
 
     -- Copy palette data to all bars
@@ -1858,26 +3068,29 @@ function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId
         end
     end
 
-    -- Add to destination's palette order
-    local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
-    if not gConfig.hotbar then
-        gConfig.hotbar = {};
+    -- Add to destination's palette order (new palette only)
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
+        if not gConfig.hotbar then
+            gConfig.hotbar = {};
+        end
+        if not gConfig.hotbar.paletteOrder then
+            gConfig.hotbar.paletteOrder = {};
+        end
+        if not gConfig.hotbar.paletteOrder[destOrderKey] then
+            gConfig.hotbar.paletteOrder[destOrderKey] = {};
+        end
+        table.insert(gConfig.hotbar.paletteOrder[destOrderKey], destName);
     end
-    if not gConfig.hotbar.paletteOrder then
-        gConfig.hotbar.paletteOrder = {};
-    end
-    if not gConfig.hotbar.paletteOrder[destOrderKey] then
-        gConfig.hotbar.paletteOrder[destOrderKey] = {};
-    end
-    table.insert(gConfig.hotbar.paletteOrder[destOrderKey], destName);
 
+    InvalidatePaletteListCache();
     SaveSettingsToDisk();
     return true;
 end
 
 -- Copy a crossbar palette to a different job:subjob combination
--- Returns true on success, false with error message on failure
-function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName)
+-- overwriteExisting: replace slot data on an existing destination palette
+function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName, overwriteExisting)
     if not paletteName then
         return false, 'No palette specified';
     end
@@ -1901,9 +3114,14 @@ function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, to
     -- Build destination storage key
     local destKey = M.BuildPaletteStorageKey(toJobId, toSubjobId, destName);
 
-    -- Check if destination already exists
-    if crossbarSettings.slotActions and crossbarSettings.slotActions[destKey] then
-        return false, 'Palette already exists at destination';
+    local destExists = crossbarSettings.slotActions and crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
     end
 
     -- Ensure slotActions structure
@@ -1937,16 +3155,166 @@ function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, to
         crossbarSettings.slotActions[destKey] = {};
     end
 
-    -- Add to destination's palette order
-    local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
-    if not crossbarSettings.crossbarPaletteOrder then
-        crossbarSettings.crossbarPaletteOrder = {};
+    -- Add to destination's palette order (new palette only)
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
+        if not crossbarSettings.crossbarPaletteOrder then
+            crossbarSettings.crossbarPaletteOrder = {};
+        end
+        if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
+            crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
+        end
+        table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], destName);
     end
-    if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
-        crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
-    end
-    table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], destName);
 
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Copy a Job [J]/Subjob-tier crossbar palette into the Global [G] (all-jobs universal) namespace.
+function M.CopyCrossbarPaletteToUniversal(paletteName, fromJobId, fromSubjobId, destName, overwriteExisting)
+    if not paletteName then
+        return false, 'No palette specified';
+    end
+    local outName = destName or paletteName;
+    if not IsValidPaletteName(outName) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    local sourceKey = FindCrossbarPaletteStorageKey(paletteName, fromJobId, fromSubjobId);
+    if not sourceKey then
+        return false, 'Source palette not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local destKey = M.BuildUniversalCrossbarStorageKey(outName);
+    if not destKey then
+        return false, 'Invalid destination key';
+    end
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    if sourceData then
+        local copiedData = {};
+        for comboMode, modeData in pairs(sourceData) do
+            if type(modeData) == 'table' then
+                copiedData[comboMode] = {};
+                for slotIdx, slotData in pairs(modeData) do
+                    if type(slotData) == 'table' then
+                        copiedData[comboMode][slotIdx] = {};
+                        for k, v in pairs(slotData) do
+                            copiedData[comboMode][slotIdx][k] = v;
+                        end
+                    else
+                        copiedData[comboMode][slotIdx] = slotData;
+                    end
+                end
+            else
+                copiedData[comboMode] = modeData;
+            end
+        end
+        crossbarSettings.slotActions[destKey] = copiedData;
+    else
+        crossbarSettings.slotActions[destKey] = {};
+    end
+    if not destExists then
+        if not crossbarSettings.universalCrossbarPaletteOrder then
+            crossbarSettings.universalCrossbarPaletteOrder = {};
+        end
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, outName);
+        if not crossbarSettings.crossbarUniversalPaletteMeta then
+            crossbarSettings.crossbarUniversalPaletteMeta = {};
+        end
+        if not crossbarSettings.crossbarUniversalPaletteMeta[outName] then
+            crossbarSettings.crossbarUniversalPaletteMeta[outName] = { includeInCycle = true };
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Copy a Global [G] universal crossbar palette into a Job [J]/Subjob-tier palette.
+function M.CopyUniversalCrossbarPaletteToJob(sourceName, destName, toJobId, toSubjobId, overwriteExisting)
+    if not sourceName or sourceName == '' then
+        return false, 'No palette specified';
+    end
+    local outName = destName or sourceName;
+    if not IsValidPaletteName(outName) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local sourceKey = M.BuildUniversalCrossbarStorageKey(sourceName);
+    if not crossbarSettings.slotActions[sourceKey] then
+        return false, 'Source palette not found';
+    end
+    local normalizedJobId = toJobId or 1;
+    local normalizedSubjobId = toSubjobId or 0;
+    local destKey = M.BuildPaletteStorageKey(normalizedJobId, normalizedSubjobId, outName);
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    if sourceData then
+        local copiedData = {};
+        for comboMode, modeData in pairs(sourceData) do
+            if type(modeData) == 'table' then
+                copiedData[comboMode] = {};
+                for slotIdx, slotData in pairs(modeData) do
+                    if type(slotData) == 'table' then
+                        copiedData[comboMode][slotIdx] = {};
+                        for k, v in pairs(slotData) do
+                            copiedData[comboMode][slotIdx][k] = v;
+                        end
+                    else
+                        copiedData[comboMode][slotIdx] = slotData;
+                    end
+                end
+            else
+                copiedData[comboMode] = modeData;
+            end
+        end
+        crossbarSettings.slotActions[destKey] = copiedData;
+    else
+        crossbarSettings.slotActions[destKey] = {};
+    end
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
+        if not crossbarSettings.crossbarPaletteOrder then
+            crossbarSettings.crossbarPaletteOrder = {};
+        end
+        if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
+            crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
+        end
+        table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], outName);
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
     SaveSettingsToDisk();
     return true;
 end

--- a/XIUI/modules/hotbar/palette_json.lua
+++ b/XIUI/modules/hotbar/palette_json.lua
@@ -1,0 +1,1069 @@
+--[[
+* XIUI — JSON export/import for an entire profile: palettes (keyboard hotbar + crossbar) and macro library.
+* Format: xiuiExportVersion 1, kind xiui_profile.
+* One file = one profile snapshot. Import options let you apply palettes, macros, or both.
+]]--
+
+require('common');
+
+local json = require('libs.json');
+local jobs = require('libs.jobs');
+local palette = require('modules.hotbar.palette');
+local data = require('modules.hotbar.data');
+local sharedMacroStore = require('core.shared_macro_store');
+
+local M = {};
+
+local EXPORT_VERSION = 1;
+M.KIND_PROFILE = 'xiui_profile';
+
+local UNIVERSAL_CROSSBAR_PREFIX = 'global:palette:';
+local PALETTE_KEY_PREFIX = 'palette:';
+
+local function jobAbbr(jobId)
+    if not jobId or jobId == 0 then return 'NONE'; end
+    return jobs[jobId] or ('Job' .. tostring(jobId));
+end
+
+--- parseHotbarStorageKey("1:2:palette:Foo") -> 1, 2, "Foo"
+local function parseHotbarStorageKey(sk)
+    local j, s, name = sk:match('^(%d+):(%d+):' .. PALETTE_KEY_PREFIX .. '(.+)$');
+    if j then
+        return tonumber(j), tonumber(s), name;
+    end
+    return nil, nil, nil;
+end
+
+--- parseCrossbarStorageKey(sk) -> scope ("global"|"job"|"other"), jobId, subjobId, name
+local function parseCrossbarStorageKey(sk)
+    if sk:sub(1, #UNIVERSAL_CROSSBAR_PREFIX) == UNIVERSAL_CROSSBAR_PREFIX then
+        return 'global', nil, nil, sk:sub(#UNIVERSAL_CROSSBAR_PREFIX + 1);
+    end
+    local j, s, name = parseHotbarStorageKey(sk);
+    if j then
+        return 'job', j, s, name;
+    end
+    return 'other', nil, nil, nil;
+end
+
+local function formatHotbarPaletteLabel(sk)
+    local j, s, name = parseHotbarStorageKey(sk);
+    if j then
+        return string.format('Keyboard hotbar palette — %s/%s — "%s"',
+            jobAbbr(j), jobAbbr(s), name);
+    end
+    return 'Keyboard hotbar palette — ' .. sk;
+end
+
+local function formatCrossbarPaletteLabel(sk)
+    local scope, j, s, name = parseCrossbarStorageKey(sk);
+    if scope == 'global' then
+        return string.format('Crossbar palette — Global [G] — "%s"', name or sk);
+    elseif scope == 'job' then
+        return string.format('Crossbar palette — Job [J] — %s/%s — "%s"',
+            jobAbbr(j), jobAbbr(s), name);
+    end
+    return 'Crossbar palette — ' .. sk;
+end
+
+local function formatMacroBucketLabel(ks)
+    if ks == 'global' then
+        return 'Global macros (all jobs)';
+    end
+    if ks == 'items' then
+        return 'Macros — Items (gear / consumables, all jobs)';
+    end
+    if ks == 'equipment' then
+        return 'Macros — Equipment (all jobs)';
+    end
+    if ks == 'xiui' then
+        return 'Macros — XIUI Commands (slash shortcuts, all jobs)';
+    end
+    if type(ks) == 'string' and ks:sub(1, 8) == 'custom:' and gConfig and gConfig.macroCustomCategories then
+        for _, e in ipairs(gConfig.macroCustomCategories) do
+            if e.key == ks then
+                return string.format('Macros — %s (custom category)', e.label or ks);
+            end
+        end
+    end
+    local n = tonumber(ks);
+    if n then
+        return string.format('Macros — %s (job id %d)', jobAbbr(n), n);
+    end
+    local j, kind, id = ks:match('^(%d+):([^:]+):(.+)$');
+    if j and kind then
+        return string.format('Macros — %s %s overlay "%s"', jobAbbr(tonumber(j)), kind, id);
+    end
+    return 'Macros — ' .. ks;
+end
+
+M.EXPORT_PART_ALL = 'all';
+M.EXPORT_PART_PALETTES_ONLY = 'palettes_only';
+M.EXPORT_PART_MACROS_ONLY = 'macros_only';
+
+--- Import behavior: merge appends macros and merges palette lists; replace clears matching data first so the profile matches the file.
+M.IMPORT_MODE_MERGE = 'merge';
+M.IMPORT_MODE_REPLACE = 'replace';
+
+--- Match handlers/tbar_migration.StorageKeyToMacroPaletteKey (macroDB bucket key).
+local function macroKeyFromStorageKey(storageKey)
+    if storageKey == 'global' then
+        return 'global';
+    end
+    local jobIdPalette, _paletteName = storageKey:match('^(%d+):palette:(.+)$');
+    if jobIdPalette then
+        return tonumber(jobIdPalette);
+    end
+    local jobIdPet, petType, petKey = storageKey:match('^(%d+):%d+:([^:]+):(.+)$');
+    if jobIdPet and (petType == 'avatar' or petType == 'spirit') then
+        return string.format('%s:%s:%s', jobIdPet, petType, petKey);
+    end
+    local baseJobId = storageKey:match('^(%d+)');
+    if baseJobId then
+        return tonumber(baseJobId);
+    end
+    return 'global';
+end
+
+local function macroKeyToString(k)
+    if k == nil then
+        return '';
+    end
+    return tostring(k);
+end
+
+local function macroKeyFromString(s)
+    if s == nil or s == '' then
+        return nil;
+    end
+    if s == 'global' then
+        return 'global';
+    end
+    if s == 'items' then
+        return 'items';
+    end
+    if s == 'equipment' then
+        return 'equipment';
+    end
+    if s == 'xiui' then
+        return 'xiui';
+    end
+    local n = tonumber(s);
+    if n then
+        return n;
+    end
+    return s;
+end
+
+local function deepCopy(v)
+    if type(v) ~= 'table' then
+        return v;
+    end
+    local t = {};
+    for k, x in pairs(v) do
+        t[k] = deepCopy(x);
+    end
+    return t;
+end
+
+--- rxi json requires non-sparse arrays / string object keys.
+local function encodeSlotMap(slotMap)
+    if type(slotMap) ~= 'table' then
+        return {};
+    end
+    local out = {};
+    for slotIdx, slot in pairs(slotMap) do
+        if type(slot) == 'table' then
+            out[tostring(slotIdx)] = deepCopy(slot);
+        end
+    end
+    return out;
+end
+
+local function decodeSlotMap(slotMap)
+    if type(slotMap) ~= 'table' then
+        return {};
+    end
+    local out = {};
+    for slotIdx, slot in pairs(slotMap) do
+        local nk = tonumber(slotIdx) or slotIdx;
+        out[nk] = slot;
+    end
+    return out;
+end
+
+-- =============================================================================
+-- Export profile
+-- =============================================================================
+
+--- Encode every hotbar palette into { storageKey -> { _label, _jobId, _subjobId, _paletteName, bars = { "1".."6" } } }.
+local function encodeAllHotbarPalettes()
+    local palettes = {};
+    if not gConfig then return palettes; end
+    local keys = {};
+    for bar = 1, 6 do
+        local cfg = gConfig['hotbarBar' .. bar];
+        if cfg and cfg.slotActions then
+            for sk, _ in pairs(cfg.slotActions) do
+                keys[sk] = true;
+            end
+        end
+    end
+    for sk, _ in pairs(keys) do
+        local bars = {};
+        for bar = 1, 6 do
+            local cfg = gConfig['hotbarBar' .. bar];
+            local smap = cfg and cfg.slotActions and cfg.slotActions[sk];
+            -- Only emit bars that actually have bound slots; importer tolerates missing bar keys and this keeps the file readable.
+            if type(smap) == 'table' and next(smap) ~= nil then
+                bars[tostring(bar)] = encodeSlotMap(smap);
+            end
+        end
+        local j, s, name = parseHotbarStorageKey(sk);
+        palettes[sk] = {
+            _label = formatHotbarPaletteLabel(sk),
+            _jobId = j,
+            _jobName = j and jobAbbr(j) or nil,
+            _subjobId = s,
+            _subjobName = s and jobAbbr(s) or nil,
+            _paletteName = name,
+            bars = bars,
+        };
+    end
+    return palettes;
+end
+
+--- Encode every crossbar palette into { storageKey -> { _label, _scope, ..., slotActions = { comboMode -> slotMap } } }.
+local function encodeAllCrossbarPalettes()
+    local palettes = {};
+    local hc = gConfig and gConfig.hotbarCrossbar;
+    if not hc or not hc.slotActions then
+        return palettes;
+    end
+    for sk, root in pairs(hc.slotActions) do
+        if type(root) == 'table' then
+            local encodedRoot = {};
+            for comboMode, modeData in pairs(root) do
+                if type(modeData) == 'table' then
+                    encodedRoot[comboMode] = encodeSlotMap(modeData);
+                end
+            end
+            local scope, j, s, name = parseCrossbarStorageKey(sk);
+            palettes[sk] = {
+                _label = formatCrossbarPaletteLabel(sk),
+                _scope = scope,
+                _jobId = j,
+                _jobName = j and jobAbbr(j) or nil,
+                _subjobId = s,
+                _subjobName = s and jobAbbr(s) or nil,
+                _paletteName = name,
+                slotActions = encodedRoot,
+            };
+        end
+    end
+    return palettes;
+end
+
+local function encodeAllMacros()
+    local out = {};
+    local labels = {};
+    if not gConfig or not gConfig.macroDB then
+        return out;
+    end
+    for mk, bucket in pairs(gConfig.macroDB) do
+        if type(bucket) == 'table' then
+            local ks = macroKeyToString(mk);
+            if ks ~= '' then
+                local list = {};
+                for _, m in ipairs(bucket) do
+                    if type(m) == 'table' then
+                        table.insert(list, deepCopy(m));
+                    end
+                end
+                out[ks] = list;
+                labels[ks] = formatMacroBucketLabel(ks);
+            end
+        end
+    end
+    if next(labels) ~= nil then
+        out._labels = labels;
+        out._readme = 'Bucket keys: "global" = shared across jobs; "items" / "equipment" = all-jobs buckets; "xiui" = XIUI slash shortcuts; "custom:N" = user-defined categories; a plain number = that job id (1=WAR, 2=MNK, ...); "<jobId>:avatar:<id>" or "<jobId>:spirit:<id>" = pet-specific overlays. See _labels for human-readable names. To remove a macro bucket from this import, delete its key (and the matching _labels entry).';
+    end
+    return out;
+end
+
+local function encodeHotbarPaletteOrder()
+    local order = gConfig and gConfig.hotbar and gConfig.hotbar.paletteOrder;
+    if type(order) ~= 'table' then return {}; end
+    local out = {};
+    for k, list in pairs(order) do
+        if type(list) == 'table' then
+            out[tostring(k)] = deepCopy(list);
+        end
+    end
+    return out;
+end
+
+local function encodeCrossbarPaletteOrders()
+    local hc = gConfig and gConfig.hotbarCrossbar;
+    local jobOrder = {};
+    if hc and type(hc.crossbarPaletteOrder) == 'table' then
+        for k, list in pairs(hc.crossbarPaletteOrder) do
+            if type(list) == 'table' then
+                jobOrder[tostring(k)] = deepCopy(list);
+            end
+        end
+    end
+    local univ = {};
+    if hc and type(hc.universalCrossbarPaletteOrder) == 'table' then
+        for _, n in ipairs(hc.universalCrossbarPaletteOrder) do
+            table.insert(univ, n);
+        end
+    end
+    return jobOrder, univ;
+end
+
+-- =============================================================================
+-- Pretty encoder
+-- Emits human-readable, stable-ordered JSON so users can manually edit the file
+-- (delete specific palette entries they do not want to import, etc.). Keys beginning
+-- with "_" are annotations and come first inside every object; they are ignored by
+-- ImportProfile. Numeric-looking keys sort numerically so slot indices line up.
+-- =============================================================================
+
+local function prettyEncode(v)
+    local function recur(val, depth)
+        local pad = string.rep('  ', depth);
+        local padIn = string.rep('  ', depth + 1);
+        if type(val) ~= 'table' then
+            return json.encode(val);
+        end
+        if next(val) == nil then
+            return '[]';
+        end
+        local isArr = rawget(val, 1) ~= nil;
+        if isArr then
+            local n = 0;
+            for k in pairs(val) do
+                if type(k) ~= 'number' then isArr = false; break; end
+                n = n + 1;
+            end
+            if isArr and n ~= #val then isArr = false; end
+        end
+        if isArr then
+            local parts = {};
+            for _, x in ipairs(val) do
+                table.insert(parts, padIn .. recur(x, depth + 1));
+            end
+            return '[\n' .. table.concat(parts, ',\n') .. '\n' .. pad .. ']';
+        end
+        local keys = {};
+        for k in pairs(val) do table.insert(keys, k); end
+        table.sort(keys, function(a, b)
+            local sa, sb = tostring(a), tostring(b);
+            local ua = sa:sub(1, 1) == '_';
+            local ub = sb:sub(1, 1) == '_';
+            if ua ~= ub then return ua; end
+            local na, nb = tonumber(sa), tonumber(sb);
+            if na and nb then return na < nb; end
+            return sa < sb;
+        end);
+        local parts = {};
+        for _, k in ipairs(keys) do
+            local kk = json.encode(tostring(k));
+            table.insert(parts, padIn .. kk .. ': ' .. recur(val[k], depth + 1));
+        end
+        return '{\n' .. table.concat(parts, ',\n') .. '\n' .. pad .. '}';
+    end
+    return recur(v, 0);
+end
+
+local function currentTimestamp()
+    if os and os.date then
+        return os.date('%Y-%m-%d %H:%M:%S');
+    end
+    return '';
+end
+
+local function partHuman(part)
+    if part == M.EXPORT_PART_PALETTES_ONLY then
+        return 'all palettes only';
+    elseif part == M.EXPORT_PART_MACROS_ONLY then
+        return 'all macros only';
+    end
+    return 'all palettes + macros';
+end
+
+--- Export the whole profile. exportPart:
+---   EXPORT_PART_ALL           -> palettes + macros
+---   EXPORT_PART_PALETTES_ONLY -> palettes (hotbar + crossbar) only
+---   EXPORT_PART_MACROS_ONLY   -> macros only
+---
+--- Output is pretty-printed JSON with _label/_readme annotations so users can
+--- manually edit the file (e.g. delete palettes or macro buckets they do not
+--- want to import into a new character). Keys starting with "_" are ignored on
+--- import; delete them or leave them alone either way.
+function M.ExportProfile(exportPart)
+    if not gConfig then
+        return nil, 'No config';
+    end
+    exportPart = exportPart or M.EXPORT_PART_ALL;
+
+    local profileName;
+    if GetCurrentProfileName then
+        local okN, n = pcall(GetCurrentProfileName);
+        if okN and type(n) == 'string' then profileName = n; end
+    end
+
+    local payload = {
+        _readme = 'XIUI profile export. You can edit this file before importing: delete entries from "hotbarPalettes.bars", "crossbarPalettes.slotActions", or "macros" to leave them out, then import as usual. Every "_" key (including _label, _readme, _exportedAt, _jobId, _jobName, etc.) is purely for humans and is ignored by the importer. Keep the canonical fields (xiuiExportVersion, kind, exportPart, bars, slotActions, macros).',
+        _exportedAt = currentTimestamp(),
+        _exportPart = partHuman(exportPart),
+        _profileName = profileName,
+        xiuiExportVersion = EXPORT_VERSION,
+        kind = M.KIND_PROFILE,
+        exportPart = exportPart,
+    };
+
+    if exportPart ~= M.EXPORT_PART_MACROS_ONLY then
+        local hotbarPalettes = encodeAllHotbarPalettes();
+        local crossbarPalettes = encodeAllCrossbarPalettes();
+        local hbOrder = encodeHotbarPaletteOrder();
+        local xbJobOrder, xbUnivOrder = encodeCrossbarPaletteOrders();
+        payload.hotbarPalettes = {
+            _label = 'Keyboard hotbar palettes (six bars per palette; keys look like "<jobId>:<subjobId>:palette:<name>"). Delete a key under "bars" to skip that palette on import.',
+            paletteOrder = hbOrder,
+            bars = hotbarPalettes,
+        };
+        payload.crossbarPalettes = {
+            _label = 'Controller crossbar palettes (L2/R2 combo grids). Keys are "global:palette:<name>" for Global [G] palettes shared across jobs, or "<jobId>:<subjobId>:palette:<name>" for Job [J] palettes. Delete a key under "slotActions" to skip that palette on import.',
+            crossbarPaletteOrder = xbJobOrder,
+            universalCrossbarPaletteOrder = xbUnivOrder,
+            slotActions = crossbarPalettes,
+        };
+    end
+
+    if exportPart ~= M.EXPORT_PART_PALETTES_ONLY then
+        payload.macros = encodeAllMacros();
+        if gConfig.macroCustomCategories and next(gConfig.macroCustomCategories) ~= nil then
+            payload.macroCustomCategories = deepCopy(gConfig.macroCustomCategories);
+        end
+        if gConfig.macroCustomNextSeq and gConfig.macroCustomNextSeq > 1 then
+            payload.macroCustomNextSeq = gConfig.macroCustomNextSeq;
+        end
+        if gConfig.macroXiuiDefaultsSeeded ~= nil then
+            payload.macroXiuiDefaultsSeeded = gConfig.macroXiuiDefaultsSeeded;
+        end
+        if gConfig.macroGlobalUniversalTwoHourSeeded ~= nil then
+            payload.macroGlobalUniversalTwoHourSeeded = gConfig.macroGlobalUniversalTwoHourSeeded;
+        end
+    end
+
+    local ok, result = pcall(prettyEncode, payload);
+    if not ok then
+        return nil, tostring(result);
+    end
+    return result;
+end
+
+-- =============================================================================
+-- Import profile
+-- =============================================================================
+
+--- Annotation keys (leading underscore) are written by ExportProfile so humans can
+--- read / edit the file. They must never affect import.
+local function isAnnotationKey(k)
+    return type(k) == 'string' and k:sub(1, 1) == '_';
+end
+
+local function nextMacroIdInBucket(bucket)
+    local maxId = 0;
+    if type(bucket) == 'table' then
+        for _, m in ipairs(bucket) do
+            if m and m.id and m.id > maxId then
+                maxId = m.id;
+            end
+        end
+    end
+    return maxId;
+end
+
+--- Append imported macro rows into destination buckets with fresh IDs.
+--- Returns idMaps: idMaps[srcBucketKeyStr][oldId] = newId.
+local function importMacrosAppend(macrosObj)
+    if not gConfig then
+        return nil, 'No config';
+    end
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    local idMaps = {};
+    for srcKs, list in pairs(macrosObj or {}) do
+        if not isAnnotationKey(srcKs) and type(list) == 'table' then
+            local destKey = macroKeyFromString(srcKs);
+            if destKey ~= nil then
+                local destBucket = gConfig.macroDB[destKey];
+                if not destBucket then
+                    gConfig.macroDB[destKey] = {};
+                    destBucket = gConfig.macroDB[destKey];
+                end
+                local maxId = nextMacroIdInBucket(destBucket);
+                if (gConfig.macroStorageScope or 'profile') == 'shared' and sharedMacroStore.GetMaxMacroIdInFrozenProfileBucket then
+                    local fmax = sharedMacroStore.GetMaxMacroIdInFrozenProfileBucket(destKey);
+                    if fmax > maxId then
+                        maxId = fmax;
+                    end
+                end
+                idMaps[srcKs] = idMaps[srcKs] or {};
+                for _, m in ipairs(list) do
+                    if type(m) == 'table' and m.id then
+                        maxId = maxId + 1;
+                        local copy = deepCopy(m);
+                        local oldId = copy.id;
+                        copy.id = maxId;
+                        table.insert(destBucket, copy);
+                        idMaps[srcKs][oldId] = maxId;
+                    end
+                end
+            end
+        end
+    end
+    return idMaps;
+end
+
+--- Load macros from JSON into an empty macroDB, preserving macro ids from the file (no remapping).
+--- Caller must clear gConfig.macroDB before calling when doing a full replace.
+local function importMacrosReplace(macrosObj)
+    if not gConfig then
+        return;
+    end
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    for srcKs, list in pairs(macrosObj or {}) do
+        if not isAnnotationKey(srcKs) and type(list) == 'table' then
+            local destKey = macroKeyFromString(srcKs);
+            if destKey ~= nil then
+                gConfig.macroDB[destKey] = {};
+                local destBucket = gConfig.macroDB[destKey];
+                for _, m in ipairs(list) do
+                    if type(m) == 'table' then
+                        table.insert(destBucket, deepCopy(m));
+                    end
+                end
+            end
+        end
+    end
+end
+
+local function clearHotbarSlotLayoutsOnly()
+    if not gConfig then return; end
+    for bar = 1, 6 do
+        local cfg = gConfig['hotbarBar' .. bar];
+        if cfg then
+            cfg.slotActions = {};
+        end
+    end
+end
+
+local function clearCrossbarSlotLayoutsOnly()
+    if gConfig and gConfig.hotbarCrossbar then
+        gConfig.hotbarCrossbar.slotActions = {};
+    end
+end
+
+local function macroExistsInBucket(bucketKey, macroId)
+    if not gConfig or not gConfig.macroDB or not macroId then
+        return false;
+    end
+    local db = gConfig.macroDB[bucketKey];
+    if type(db) ~= 'table' then return false; end
+    for _, m in ipairs(db) do
+        if m and m.id == macroId then return true; end
+    end
+    return false;
+end
+
+local K_MACRO_BIND_P = 'macroBindProfile';
+local K_MACRO_BIND_S = 'macroBindShared';
+
+--- Validate that every macroRef in the imported palettes already resolves in the destination's macroDB.
+--- Used when palette import is requested without macro import.
+local function validatePaletteMacroRefs(hotbarPalettesTbl, crossbarPalettesTbl)
+    local function checkArm(arm, defMk, where)
+        if type(arm) ~= 'table' or not arm.macroRef then return nil; end
+        local mpk = arm.macroPaletteKey or defMk;
+        if not macroExistsInBucket(mpk, arm.macroRef) then
+            return string.format(
+                'Destination is missing macro id %s (bucket %s) referenced by %s. Import macros too, or choose a full export.',
+                tostring(arm.macroRef), macroKeyToString(mpk), where);
+        end
+        return nil;
+    end
+
+    local function check(slot, defMk, where)
+        if type(slot) ~= 'table' then return nil; end
+        local e = checkArm(slot[K_MACRO_BIND_P], defMk, where);
+        if e then return e; end
+        e = checkArm(slot[K_MACRO_BIND_S], defMk, where);
+        if e then return e; end
+        return checkArm(slot, defMk, where);
+    end
+
+    if type(hotbarPalettesTbl) == 'table' then
+        for sk, entry in pairs(hotbarPalettesTbl) do
+            if not isAnnotationKey(sk) then
+                local defMk = macroKeyFromStorageKey(sk);
+                local bars = entry and entry.bars;
+                if type(bars) == 'table' then
+                    for barIdx = 1, 6 do
+                        local smap = decodeSlotMap(bars[tostring(barIdx)] or {});
+                        for _, slot in pairs(smap) do
+                            local err = check(slot, defMk, string.format('hotbar bar %d of "%s"', barIdx, sk));
+                            if err then return false, err; end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    if type(crossbarPalettesTbl) == 'table' then
+        for sk, entry in pairs(crossbarPalettesTbl) do
+            if not isAnnotationKey(sk) then
+                local defMk = macroKeyFromStorageKey(sk);
+                local root = entry and entry.slotActions;
+                if type(root) == 'table' then
+                    for comboMode, modeData in pairs(root) do
+                        if not isAnnotationKey(comboMode) and type(modeData) == 'table' then
+                            for _, slot in pairs(modeData) do
+                                if type(slot) == 'table' then
+                                    local err = check(slot, defMk, string.format('crossbar "%s"', sk));
+                                    if err then return false, err; end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return true;
+end
+
+local function remapMacroArm(arm, defMk, idMaps)
+    if type(arm) ~= 'table' or not arm.macroRef then return; end
+    local srcKs = macroKeyToString(arm.macroPaletteKey);
+    if srcKs == '' then
+        srcKs = macroKeyToString(defMk);
+    end
+    local map = idMaps and idMaps[srcKs];
+    if map and map[arm.macroRef] then
+        arm.macroRef = map[arm.macroRef];
+        arm.macroPaletteKey = defMk;
+    end
+end
+
+local function remapSlotMacroRefs(slot, defMk, idMaps)
+    if type(slot) ~= 'table' then return; end
+    remapMacroArm(slot[K_MACRO_BIND_P], defMk, idMaps);
+    remapMacroArm(slot[K_MACRO_BIND_S], defMk, idMaps);
+    if slot[K_MACRO_BIND_P] or slot[K_MACRO_BIND_S] then return; end
+    remapMacroArm(slot, defMk, idMaps);
+end
+
+--- Write imported hotbar palettes into gConfig.hotbarBar1..6.slotActions by storage key.
+--- idMaps may be nil (no macro import).
+local function applyHotbarPalettes(hotbarPalettesTbl, idMaps)
+    if type(hotbarPalettesTbl) ~= 'table' then return; end
+    for sk, entry in pairs(hotbarPalettesTbl) do
+        if not isAnnotationKey(sk) then
+            local defMk = macroKeyFromStorageKey(sk);
+            local bars = entry and entry.bars;
+            if type(bars) == 'table' then
+                for barIdx = 1, 6 do
+                    local cfgKey = 'hotbarBar' .. barIdx;
+                    local cfg = gConfig[cfgKey];
+                    if not cfg then
+                        gConfig[cfgKey] = {};
+                        cfg = gConfig[cfgKey];
+                    end
+                    if not cfg.slotActions then
+                        cfg.slotActions = {};
+                    end
+                    local slotMap = decodeSlotMap(bars[tostring(barIdx)] or {});
+                    if idMaps then
+                        for _, slot in pairs(slotMap) do
+                            remapSlotMacroRefs(slot, defMk, idMaps);
+                        end
+                    end
+                    cfg.slotActions[sk] = slotMap;
+                end
+            end
+        end
+    end
+end
+
+--- Write imported crossbar palettes into gConfig.hotbarCrossbar.slotActions by storage key.
+local function applyCrossbarPalettes(crossbarPalettesTbl, idMaps)
+    if type(crossbarPalettesTbl) ~= 'table' then return; end
+    local hc = gConfig.hotbarCrossbar;
+    if not hc then
+        gConfig.hotbarCrossbar = {};
+        hc = gConfig.hotbarCrossbar;
+    end
+    if not hc.slotActions then
+        hc.slotActions = {};
+    end
+    for sk, entry in pairs(crossbarPalettesTbl) do
+        if not isAnnotationKey(sk) then
+            local defMk = macroKeyFromStorageKey(sk);
+            local root = entry and entry.slotActions;
+            local newRoot = {};
+            if type(root) == 'table' then
+                for comboMode, modeData in pairs(root) do
+                    if not isAnnotationKey(comboMode) and type(modeData) == 'table' then
+                        local slotMap = decodeSlotMap(modeData);
+                        if idMaps then
+                            for _, slot in pairs(slotMap) do
+                                remapSlotMacroRefs(slot, defMk, idMaps);
+                            end
+                        end
+                        newRoot[comboMode] = slotMap;
+                    end
+                end
+            end
+            hc.slotActions[sk] = newRoot;
+        end
+    end
+end
+
+--- Merge a list of names into an existing order list, preserving existing entries first.
+local function mergeOrderList(existing, incoming)
+    existing = existing or {};
+    local seen = {};
+    for _, n in ipairs(existing) do seen[n] = true; end
+    for _, n in ipairs(incoming or {}) do
+        if not seen[n] then
+            table.insert(existing, n);
+            seen[n] = true;
+        end
+    end
+    return existing;
+end
+
+--- Apply hotbar paletteOrder. replace=true overwrites the destination dict entirely; replace=false merges per key.
+local function applyHotbarPaletteOrder(orderTbl, replace)
+    if type(orderTbl) ~= 'table' then return; end
+    if not gConfig.hotbar then gConfig.hotbar = {}; end
+    if replace then
+        local newOrder = {};
+        for k, list in pairs(orderTbl) do
+            if not isAnnotationKey(k) and type(list) == 'table' then
+                newOrder[k] = deepCopy(list);
+            end
+        end
+        gConfig.hotbar.paletteOrder = newOrder;
+        return;
+    end
+    if not gConfig.hotbar.paletteOrder then gConfig.hotbar.paletteOrder = {}; end
+    for k, list in pairs(orderTbl) do
+        if not isAnnotationKey(k) and type(list) == 'table' then
+            gConfig.hotbar.paletteOrder[k] = mergeOrderList(gConfig.hotbar.paletteOrder[k], list);
+        end
+    end
+end
+
+--- Apply crossbar palette order dicts. replace=true overwrites destination lists; replace=false merges.
+local function applyCrossbarPaletteOrders(jobOrder, univOrder, replace)
+    local hc = gConfig.hotbarCrossbar;
+    if not hc then
+        gConfig.hotbarCrossbar = {};
+        hc = gConfig.hotbarCrossbar;
+    end
+    if type(jobOrder) == 'table' then
+        if replace then
+            local newJob = {};
+            for k, list in pairs(jobOrder) do
+                if not isAnnotationKey(k) and type(list) == 'table' then
+                    newJob[k] = deepCopy(list);
+                end
+            end
+            hc.crossbarPaletteOrder = newJob;
+        else
+            if not hc.crossbarPaletteOrder then hc.crossbarPaletteOrder = {}; end
+            for k, list in pairs(jobOrder) do
+                if not isAnnotationKey(k) and type(list) == 'table' then
+                    hc.crossbarPaletteOrder[k] = mergeOrderList(hc.crossbarPaletteOrder[k], list);
+                end
+            end
+        end
+    end
+    if type(univOrder) == 'table' then
+        if replace then
+            hc.universalCrossbarPaletteOrder = deepCopy(univOrder);
+        else
+            hc.universalCrossbarPaletteOrder = mergeOrderList(hc.universalCrossbarPaletteOrder, univOrder);
+        end
+    end
+end
+
+--- Return true if any non-annotation key is present in the table.
+local function hasRealKey(tbl)
+    if type(tbl) ~= 'table' then return false; end
+    for k, _ in pairs(tbl) do
+        if not isAnnotationKey(k) then return true; end
+    end
+    return false;
+end
+
+local function hasHotbarPalettes(decoded)
+    local hp = decoded.hotbarPalettes;
+    return hp and hasRealKey(hp.bars);
+end
+
+local function hasCrossbarPalettes(decoded)
+    local cp = decoded.crossbarPalettes;
+    return cp and hasRealKey(cp.slotActions);
+end
+
+local function hasMacroPayload(decoded)
+    return hasRealKey(decoded.macros);
+end
+
+--- Import a whole-profile JSON.
+--- opts.importPalettes (default true)
+--- opts.importMacros   (default true)
+--- opts.importMode     (default IMPORT_MODE_MERGE):
+---   MERGE: append macros with new ids (remap palette refs); merge palette name lists; overlay slot data per key.
+---   REPLACE: clear imported sides first — macros become exactly the file’s buckets (ids preserved); hotbar/crossbar
+---            slot layouts for sides present in the file are cleared then filled; palette order lists for those
+---            sides are replaced from the file (not merged).
+--- When importing palettes without macros (merge or replace), the destination must already have every referenced macro id.
+function M.ImportProfile(jsonStr, opts)
+    opts = opts or {};
+    local importPalettes = opts.importPalettes ~= false;
+    local importMacros = opts.importMacros ~= false;
+    local importMode = opts.importMode or M.IMPORT_MODE_MERGE;
+    local replace = (importMode == M.IMPORT_MODE_REPLACE);
+    if not importPalettes and not importMacros then
+        return false, 'Select at least one: palettes or macros.';
+    end
+    if not gConfig then
+        return false, 'No config';
+    end
+
+    local ok, res = pcall(json.decode, jsonStr);
+    if not ok then
+        return false, 'Invalid JSON: ' .. tostring(res);
+    end
+    local decoded = res;
+    if decoded.xiuiExportVersion ~= EXPORT_VERSION or decoded.kind ~= M.KIND_PROFILE then
+        return false,
+            'Not an XIUI profile export (wrong version or kind). Re-export from a recent version.';
+    end
+
+    local hasHotbar = hasHotbarPalettes(decoded);
+    local hasCrossbar = hasCrossbarPalettes(decoded);
+    local hasPalettesAny = hasHotbar or hasCrossbar;
+    local hasMacros = hasMacroPayload(decoded);
+
+    if not hasPalettesAny and not hasMacros then
+        return false, 'JSON has no palettes and no macros.';
+    end
+    -- If the user asked for both but the file only has one side, quietly drop the missing side instead of erroring.
+    if importPalettes and not hasPalettesAny then
+        if not importMacros then
+            return false, 'JSON has no palettes. Choose a file that includes palettes, or check Import macros.';
+        end
+        importPalettes = false;
+    end
+    if importMacros and not hasMacros then
+        if not importPalettes then
+            return false, 'JSON has no macros. Choose a file that includes macros, or check Import palettes.';
+        end
+        importMacros = false;
+    end
+
+    local hotbarPalettesTbl = hasHotbar and decoded.hotbarPalettes.bars or nil;
+    local crossbarPalettesTbl = hasCrossbar and decoded.crossbarPalettes.slotActions or nil;
+
+    local idMaps;
+    if importMacros then
+        if replace then
+            gConfig.macroDB = {};
+            importMacrosReplace(decoded.macros or {});
+        else
+            local maps, ierr = importMacrosAppend(decoded.macros or {});
+            if not maps then
+                return false, ierr or 'Macro import failed';
+            end
+            idMaps = maps;
+        end
+        if replace then
+            if type(decoded.macroCustomCategories) == 'table' then
+                gConfig.macroCustomCategories = deepCopy(decoded.macroCustomCategories);
+            else
+                gConfig.macroCustomCategories = {};
+            end
+        elseif type(decoded.macroCustomCategories) == 'table' then
+            gConfig.macroCustomCategories = gConfig.macroCustomCategories or {};
+            local have = {};
+            for _, e in ipairs(gConfig.macroCustomCategories) do
+                if e and e.key then
+                    have[e.key] = true;
+                end
+            end
+            for _, e in ipairs(decoded.macroCustomCategories) do
+                if type(e) == 'table' and e.key and not have[e.key] then
+                    table.insert(gConfig.macroCustomCategories, deepCopy(e));
+                    have[e.key] = true;
+                end
+            end
+        end
+        if decoded.macroCustomNextSeq and type(decoded.macroCustomNextSeq) == 'number' then
+            if replace then
+                gConfig.macroCustomNextSeq = decoded.macroCustomNextSeq;
+            else
+                gConfig.macroCustomNextSeq = math.max(tonumber(gConfig.macroCustomNextSeq) or 1, decoded.macroCustomNextSeq);
+            end
+        elseif replace then
+            gConfig.macroCustomNextSeq = 1;
+        end
+        if replace then
+            if decoded.macroXiuiDefaultsSeeded ~= nil then
+                gConfig.macroXiuiDefaultsSeeded = decoded.macroXiuiDefaultsSeeded;
+            else
+                gConfig.macroXiuiDefaultsSeeded = false;
+            end
+            if decoded.macroGlobalUniversalTwoHourSeeded ~= nil then
+                gConfig.macroGlobalUniversalTwoHourSeeded = decoded.macroGlobalUniversalTwoHourSeeded;
+            else
+                gConfig.macroGlobalUniversalTwoHourSeeded = false;
+            end
+        end
+    end
+
+    if importPalettes then
+        if replace then
+            if hasHotbar then
+                clearHotbarSlotLayoutsOnly();
+            end
+            if hasCrossbar then
+                clearCrossbarSlotLayoutsOnly();
+            end
+        end
+        if not importMacros then
+            local okV, errV = validatePaletteMacroRefs(hotbarPalettesTbl, crossbarPalettesTbl);
+            if not okV then
+                return false, errV;
+            end
+        end
+        applyHotbarPalettes(hotbarPalettesTbl, idMaps);
+        applyCrossbarPalettes(crossbarPalettesTbl, idMaps);
+        if hasHotbar then
+            applyHotbarPaletteOrder(decoded.hotbarPalettes.paletteOrder, replace);
+        end
+        if hasCrossbar then
+            applyCrossbarPaletteOrders(
+                decoded.crossbarPalettes.crossbarPaletteOrder,
+                decoded.crossbarPalettes.universalCrossbarPaletteOrder,
+                replace
+            );
+        end
+    end
+
+    if importMacros and gConfig then
+        local okM, mgd = pcall(require, 'modules.hotbar.macro_global_defaults');
+        if okM and mgd and mgd.SyncUniversalTwoHourGlobalRow then
+            mgd.SyncUniversalTwoHourGlobalRow(gConfig, { persist = false });
+        end
+    end
+
+    data.MarkMacroLookupDirty();
+    palette.InvalidateCachesAfterExternalSlotMutation();
+    if importMacros and gConfig and (gConfig.macroStorageScope or 'profile') == 'shared' then
+        sharedMacroStore.MarkSharedLibraryDirty();
+    end
+    if SaveSettingsToDisk then
+        SaveSettingsToDisk();
+    end
+    return true;
+end
+
+-- =============================================================================
+-- Disk helpers
+-- =============================================================================
+
+--- Absolute path of the exports directory (creates it on first access).
+function M.GetExportsDir()
+    local dir = AshitaCore:GetInstallPath() .. 'config\\addons\\xiui\\exports\\';
+    if ashita.fs and not ashita.fs.exists(dir) then
+        ashita.fs.create_directory(dir);
+    end
+    return dir;
+end
+
+--- Open the exports folder in Windows Explorer. Returns true on success.
+function M.OpenExportsDir()
+    local dir = M.GetExportsDir();
+    os.execute('explorer "' .. dir .. '"');
+    return true, dir;
+end
+
+--- Return a sorted list of *.json filenames in the exports folder.
+--- Ashita filters use regex (see profile_manager / config.hotbar), not Lua patterns:
+--- use '.*\\.json$' (literal dot before json), not '.*%.json$'.
+function M.ListExportFiles()
+    local dir = M.GetExportsDir();
+    local files = {};
+    local jsonPattern = '.*\\.json$';
+    if ashita.fs then
+        local found;
+        -- Prefer get_directory — same API as SyncProfilesWithDisk / frame PNG scan.
+        if ashita.fs.get_directory then
+            found = ashita.fs.get_directory(dir, jsonPattern);
+        end
+        if found == nil and ashita.fs.get_dir then
+            found = ashita.fs.get_dir(dir, jsonPattern, true);
+        end
+        if type(found) == 'table' then
+            for _, name in ipairs(found) do
+                table.insert(files, name);
+            end
+        end
+    end
+    table.sort(files);
+    return files, dir;
+end
+
+--- Read the full contents of an export file (filename relative to the exports dir).
+function M.ReadExportFile(filename)
+    if not filename or filename == '' then
+        return nil, 'No file';
+    end
+    local path = M.GetExportsDir() .. filename;
+    local f = io.open(path, 'r');
+    if not f then
+        return nil, 'Could not open ' .. path;
+    end
+    local text = f:read('*a');
+    f:close();
+    return text, path;
+end
+
+--- Write UTF-8 text under Ashita config/addons/xiui/exports/ (creates folder).
+function M.SaveTextFile(baseName, text)
+    local dir = M.GetExportsDir();
+    local safe = (baseName or 'xiui'):gsub('[^%w%-%_]', '_');
+    local path = dir .. safe .. '_' .. os.time() .. '.json';
+    local f = io.open(path, 'w');
+    if not f then
+        return false, path;
+    end
+    f:write(text or '');
+    f:close();
+    return true, path;
+end
+
+return M;


### PR DESCRIPTION
…e, and post-import refresh

What changed
- palette_json.lua: New 40 KB module. Whole-profile JSON export/import (xiuiExportVersion 1, kind xiui_profile). Exports all keyboard palettes, all crossbar palettes, and the full macro library in one annotated JSON file. Merge vs replace import; file list + paste input; exports folder helpers. Post-import hooks call InvalidateCachesAfterExternalSlotMutation and RefreshActivePaletteVisualsAfterExternalEdit so the active bar refreshes immediately.
- libs/json.lua: rxi's json.lua (MIT). JSON encode/decode used by palette_json.
- palette.lua: InvalidateCachesAfterExternalSlotMutation; RefreshActivePaletteVisualsAfterExternalEdit after external edits (e.g. import). ValidatePalettesForJob merges factory crossbar defaults into gConfig.hotbarCrossbar before reading enableUniversal/defaultCrossbarPaletteScope.
- init.lua: OnPaletteChanged dedupe includes bar/combo id for same-name refreshes so every bar reloads after import.
- config.lua: Profiles window Backup/Transfer (export/import modal), larger Profiles window size, merge/replace and import toggles.

Why
- Before: no structured way to move an entire character's bars and macros between copies or accounts. After: one JSON file per profile for full backup or migration. Import refreshes the visible UI immediately without requiring a manual palette switch or relog.