### PR TITLE
Crossbar core: visual cutoff fix, WindowPadding, shared expanded bar,…

### DIFF
--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -274,7 +274,7 @@ end
 function M.createHotbarGlobalDefaults()
     return T{
         -- Game UI patches
-        disableMacroBars = false,  -- Disable native XI macros (macro bar display + controller macro blocking)
+        disableMacroBars = false,  -- Keyboard: hide native macro bar UI + block Ctrl/Alt+number macro keys (controller blocking is Crossbar → Disable XI Macros)
         controllerHoldToShow = true,  -- Controller triggers use hold-to-show (like macrofix addon) instead of tap-to-toggle
 
         -- Blocked game keys - array of key definitions that should be blocked from reaching the game
@@ -292,6 +292,10 @@ function M.createHotbarGlobalDefaults()
         -- Palette cycling controller (RB + Dpad)
         paletteCycleControllerEnabled = true,  -- Enable controller palette cycling
         hotbarPaletteCycleButton = 'R1',       -- 'R1' or 'L1' for hotbar cycling
+
+        logPaletteName = true,                 -- Log palette name when cycling keyboard hotbars
+        logPaletteNameCrossbar = true,         -- Log palette name when cycling via controller (crossbar)
+        logPaletteNameCrossbarCycleHint = true, -- Second CLI line: RB+D-pad return hint after job preview
 
         -- Visual settings
         slotSize = 48,          -- Slot size in pixels
@@ -333,7 +337,7 @@ function M.createHotbarGlobalDefaults()
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -350,7 +354,16 @@ function M.createHotbarGlobalDefaults()
         skillchainIconScale = 1.0,              -- Scale multiplier for icon (0.5-2.0)
         skillchainIconOffsetX = 0,              -- X offset in pixels
         skillchainIconOffsetY = 0,              -- Y offset in pixels
-    
+
+        -- Magic Burst highlight settings. Window opens IMMEDIATELY when a SC closes and runs
+        -- for 7.0s (matches retail's MB cutoff at the back end while front-loading the visual
+        -- cue). Highlights spell / magical pact rage / /ma-or-/pet macro slots whose element
+        -- matches one of the SC's burstable elements. Uses the same corner icon as the
+        -- skillchain highlight (the SC's name asset) but in the bottom-left corner with a
+        -- cyan-blue border to keep the two highlights visually distinct.
+        magicBurstHighlightEnabled = true,      -- Show MB highlight on element-matching spell slots
+        magicBurstHighlightColor = 0xFF44D4FF,  -- Cyan-blue (ARGB) — distinct from gold SC border
+
         -- Cooldown timer settings
         recastTimerFontSize = 11,               -- Font size for cooldown timer display
         recastTimerFontColor = 0xFFFFFFFF,      -- Color for cooldown timer text
@@ -372,6 +385,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Pet-aware toggle (when true, hotbar can have different palettes per pet for SMN/BST/DRG/PUP)
         petAware = false,
         showPetIndicator = true,  -- Show indicator dot when petAware is enabled
+        -- When set: array of type tokens 'avatars'|'elementals'|'beasts'|'wyvern'|'puppet' (legacy 'summons' = avatars+elementals). nil = all.
+        petPalettePetKeys = nil,
 
         -- Layout settings (always per-bar)
         enabled = true,
@@ -420,7 +435,7 @@ function M.createHotbarBarDefaults(overrides)
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -443,6 +458,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Structure: paletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Palettes are displayed in this order; missing palettes are appended alphabetically
         paletteOrder = {},
+        -- paletteExcludeFromCycle[orderKey][paletteName] = true skips palette for RB / keyboard cycling only
+        paletteExcludeFromCycle = {},
     };
     if overrides then
         for k, v in pairs(overrides) do
@@ -460,22 +477,51 @@ end
 -- The crossbar provides 4 combo modes: L2, R2, L2+R2, R2+L2 (32 total slots)
 function M.createCrossbarDefaults()
     return T{
-        -- Layout mode: 'hotbar', 'crossbar', or 'both'
-        mode = 'hotbar',
+        -- Show controller crossbar UI (mirrors gConfig.crossbarEnabled; kept for migration)
+        showCrossbar = true,
+
+        -- Hide crossbar when game menu open (independent from Hotbar → Hide When Menu Open)
+        crossbarHideOnMenuFocus = false,
+
+        -- Disable crossbar input while a game menu is open (keeps it visible but blocks trigger macros)
+        crossbarDisableInMenu = true,
+
+        -- Config UI: which main section is active (1=Controller, 2=Manage palettes, 3=Global visuals)
+        configUiTab = 1,
+        -- 'universal' = editing [G] all-jobs sets; 'job' = editing palettes for configEditJobId
+        configFocus = 'job',
+        configEditJobId = nil,   -- nil = use live main job from data when in job focus
+        configEditSubjobId = nil,
 
         -- Job-specific toggle (when true, actions are stored per-job; when false, actions are shared across all jobs)
         jobSpecific = true,
 
-        -- Per-combo-mode settings (pet-aware is per-combo, palettes are GLOBAL)
-        -- NOTE: activePalette was removed - crossbar palettes are now global (see palette.lua state.crossbarActivePalette)
+        -- All-jobs universal crossbar palettes (storage: global:palette:{name} in slotActions)
+        enableUniversalCrossbarPalettes = false,
+        -- 'job' = job/subjob named palettes; 'universal' = all-jobs sets (toggle L1+R1 when enabled)
+        defaultCrossbarPaletteScope = 'job',
+        -- Per-palette: includeInCycle = false hides palette from RB+D-pad when scope is universal
+        crossbarUniversalPaletteMeta = {},
+        universalCrossbarPaletteOrder = {},
+
+        -- Per-segment: petAware, optional per-segment petPalettePetKeys, universalOverridePalette = all-jobs palette name. Default pet types: petPalettePetKeys on parent.
         comboModeSettings = {
-            L2 = { petAware = false },
-            R2 = { petAware = false },
-            L2R2 = { petAware = false },
-            R2L2 = { petAware = false },
-            L2x2 = { petAware = false },
-            R2x2 = { petAware = false },
+            L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
         },
+        -- Optional per named [J] palette: comboMode -> { petAware?, universalOverridePalette? } (nil field = inherit Crossbar defaults)
+        namedPaletteComboModeSettings = {},
+
+        -- Crossbar [J] only: which pet families (avatars/elementals/beasts/wyvern/puppet) use pet hotbar storage; nil = all. Not per named palette.
+        petPalettePetKeys = nil,
+
+        -- Per main job id (string key): effective combo mode -> { scope = 'jobShared' | 'global', globalPalette = name? }
+        -- Primary L2/R2 are not used. Resolves slot data to jobsegment:{jobId}:{mode} or global:palette:{name}.
+        segmentOverrides = {},
 
         -- Layout
         slotSize = 40,              -- Slot size in pixels
@@ -495,7 +541,8 @@ function M.createCrossbarDefaults()
         slotBackgroundColor = 0x55000000,
         slotOpacity = 1.0,                  -- Opacity multiplier for slot.png (0.0-1.0)
         activeSlotHighlight = 0x44FFFFFF,   -- Highlight color when trigger held
-        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side
+        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side (expanded / non-trigger dim)
+        inactiveSideWhileTriggerDim = 0.15, -- Dim for the non-active half while L2 or R2 is held
 
         -- Display mode
         displayMode = 'normal',             -- 'normal' or 'activeOnly'
@@ -511,6 +558,8 @@ function M.createCrossbarDefaults()
         buttonIconGapH = 8,                 -- Horizontal spacing between center icons
         buttonIconGapV = 2,                 -- Vertical spacing between center icons
         buttonIconPosition = 'corner',      -- 'corner' or 'replace_keybind'
+        -- Job icon set for palette UI (Manage Palettes strip + in-game palette scope icon when Job [J])
+        paletteJobIconTheme = 'Classic',     -- 'Classic', 'FFXI', 'FFXIV-1' (under assets/jobs/)
         controllerTheme = 'Xbox',           -- 'PlayStation', 'Xbox', or 'Nintendo' button icons
         controllerScheme = 'xbox',          -- Controller profile: 'xbox', 'dualsense', 'switchpro', 'dinput'
         triggerIconScale = 0.8,             -- Scale for L2/R2 trigger icons (base 49x28)
@@ -545,10 +594,14 @@ function M.createCrossbarDefaults()
         comboTextOffsetY = 0,               -- Y offset for combo text position
 
         -- Palette name display (shows current palette and index, e.g., "Stuns (2/5)")
-        showPaletteName = false,            -- Toggle to show palette name
+        showPaletteName = false,            -- Toggle to show palette name text below crossbar
+        showPaletteScopeIcon = true,        -- Job / Global scope icon above divider; nil in saved config = legacy (follow showPaletteName)
         paletteNameFontSize = 10,           -- Font size for palette name
         paletteNameOffsetX = 0,             -- X offset for position
         paletteNameOffsetY = 0,             -- Y offset for position
+        -- Job / Global palette scope icon above center divider
+        paletteScopeIconOffsetY = 12,       -- Vertical lift (px); higher = icon moves up
+        paletteScopeIconSize = 22,          -- Icon width/height (px); legacy profiles fall back to font-based size if unset
 
         -- Expanded crossbar (L2+R2 combos)
         enableExpandedCrossbar = true,      -- Enable L2+R2 and R2+L2 combos
@@ -557,6 +610,12 @@ function M.createCrossbarDefaults()
         -- Double-tap crossbar (tap trigger twice quickly)
         enableDoubleTap = false,            -- Enable L2x2 and R2x2 double-tap modes
         doubleTapWindow = 0.3,              -- Time window for double-tap detection (seconds)
+
+        -- Double-tap preview windows (always-visible overlays showing L2x2 / R2x2 bars)
+        showDoubleTapPreview    = false,     -- Show floating preview windows for double-tap bars
+        doubleTapPreviewScale   = 0.60,     -- Preview scale relative to main crossbar (0.3–1.0)
+        doubleTapPreviewOpacity = 1.0,      -- Preview opacity multiplier (0.2–1.0; dims with trigger)
+        doubleTapPreviewLocked  = false,    -- Lock preview positions independently of the main crossbar
 
         -- Analog trigger thresholds (0-255 normalized range)
         -- Used by Xbox (XInput) and PlayStation (DirectInput with signed->unsigned conversion)
@@ -587,6 +646,8 @@ function M.createCrossbarDefaults()
         -- Structure: crossbarPaletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Note: Crossbar palettes are independent from hotbar palettes
         crossbarPaletteOrder = {},
+        -- Same shape as paletteExcludeFromCycle on hotbar; per job:storage-tier key
+        crossbarPaletteExcludeFromCycle = {},
     };
 end
 

--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -5,6 +5,8 @@
 
 local M = {};
 local profileManager = require('core.profile_manager');
+local macroXiuiDefaults = require('modules.hotbar.macro_xiui_defaults');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
 
 -- Migrate settings from HXUI to XIUI (one-time migration for users upgrading from HXUI)
 -- IMPORTANT: This must be called BEFORE settings.load() so that copied files are picked up
@@ -607,6 +609,20 @@ function M.MigrateIndividualSettings(gConfig, defaults)
             if petType.tpFontSize == nil then petType.tpFontSize = oldVitalsFontSize; end
         end
     end
+
+    if gConfig.petBarResizeAnchor == nil then
+        local wantsBottom = false;
+        for _, pt in ipairs(petTypeTables) do
+            if pt and pt.alignBottom then
+                wantsBottom = true;
+                break;
+            end
+        end
+        gConfig.petBarResizeAnchor = wantsBottom and 'bottom' or 'top';
+    end
+    if gConfig.petTargetSnapAnchor == 'top' and type(gConfig.petTargetSnapOffsetX) == 'number' and gConfig.petTargetSnapOffsetX >= 100 then
+        gConfig.petTargetSnapOffsetX = 0;
+    end
 end
 
 -- Migrate flat castCost* settings to nested castCost table
@@ -1053,7 +1069,116 @@ end
 
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
+-- Split legacy hotbarCrossbar.mode ('hotbar'|'crossbar'|'both') into separate visibility flags
+function M.MigrateCrossbarModuleFlags(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.crossbarEnabled == nil then
+        if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.showCrossbar ~= nil then
+            gConfig.crossbarEnabled = gConfig.hotbarCrossbar.showCrossbar;
+        else
+            gConfig.crossbarEnabled = true;
+        end
+    end
+    local hg = gConfig.hotbarGlobal;
+    if hg and hg.logPaletteNameCrossbar == nil then
+        hg.logPaletteNameCrossbar = hg.logPaletteName;
+    end
+    if hg and hg.logPaletteNameCrossbarCycleHint == nil then
+        hg.logPaletteNameCrossbarCycleHint = true;
+    end
+end
+
+function M.MigrateHotbarCrossbarLayoutFlags(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local m = gConfig.hotbarCrossbar.mode;
+    if m ~= nil then
+        if m == 'hotbar' then
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = false;
+        elseif m == 'crossbar' then
+            gConfig.hotbarShowKeyboardBars = false;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        else
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        end
+        gConfig.hotbarCrossbar.mode = nil;
+    end
+    if gConfig.hotbarShowKeyboardBars == nil then
+        gConfig.hotbarShowKeyboardBars = true;
+    end
+    if gConfig.hotbarCrossbar.showCrossbar == nil then
+        gConfig.hotbarCrossbar.showCrossbar = true;
+    end
+end
+
+-- Fold legacy hotbarShowKeyboardBars into hotbarEnabled (same intent as Hotbar → Enabled today).
+function M.MigrateHotbarShowKeyboardBarsRemoval(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.hotbarShowKeyboardBars == false and gConfig.hotbarEnabled ~= false then
+        gConfig.hotbarEnabled = false;
+    end
+    gConfig.hotbarShowKeyboardBars = nil;
+end
+
+-- Drop deprecated keys from profiles saved during older builds (macros/skillchain are hotbarGlobal only now).
+function M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local xb = gConfig.hotbarCrossbar;
+    xb.crossbarDisableXiMacros = nil;
+    xb.skillchainHighlightEnabled = nil;
+    xb.skillchainHighlightColor = nil;
+    xb.skillchainIconScale = nil;
+    xb.skillchainIconOffsetX = nil;
+    xb.skillchainIconOffsetY = nil;
+end
+
+function M.MigrateMacroGlobalUniversalTwoHour(gConfig)
+    if not gConfig then
+        return;
+    end
+    macroGlobalDefaults.SeedUniversalTwoHourIfNeeded(gConfig);
+end
+
+function M.MigrateMacroXiuiDefaults(gConfig)
+    if not gConfig then
+        return;
+    end
+    local inserted = macroXiuiDefaults.SeedIfNeeded(gConfig);
+    if inserted then
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if ok and hotbarData and hotbarData.MarkMacroLookupDirty then
+            hotbarData.MarkMacroLookupDirty();
+        end
+    end
+end
+
 function M.RunStructureMigrations(gConfig, defaults)
+    -- Run before anything touches macroDB: coalesce "4" vs 4 and dedupe macro ids (fixes wrong macro on hotbar / drag)
+    if gConfig then
+        local ok, data = pcall(require, 'modules.hotbar.data');
+        if ok and data and data.EnsureMacroDatabaseCoherence then
+            data.EnsureMacroDatabaseCoherence(gConfig);
+        end
+    end
+    M.MigrateCrossbarModuleFlags(gConfig);
+    M.MigrateHotbarCrossbarLayoutFlags(gConfig);
+    M.MigrateHotbarShowKeyboardBarsRemoval(gConfig);
+    M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig);
+    if gConfig then
+        local ok, hbData = pcall(require, 'modules.hotbar.data');
+        if ok and hbData and hbData.MigrateSlotDualMacroBindings then
+            hbData.MigrateSlotDualMacroBindings(gConfig);
+        end
+    end
     M.MigratePartyListLayoutSettings(gConfig, defaults);
     M.MigratePerPartySettings(gConfig, defaults);
     M.MigratePerPetTypeSettings(gConfig, defaults);
@@ -1067,6 +1192,8 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
     M.MigrateSlotMacroRefs(gConfig);
+    M.MigrateMacroXiuiDefaults(gConfig);
+    M.MigrateMacroGlobalUniversalTwoHour(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -63,10 +63,31 @@ function M.createUserSettingsDefaults()
         treasurePoolExpanded = false,         -- Expanded view (false = collapsed)
 
         -- Hotbar settings (global)
-        hotbarEnabled = true,                 -- Show hotbar module
-        -- Lock movement: when true, disables drag/drop and slot swapping for hotbar bars
+        hotbarEnabled = true,                 -- Show hotbar module (keyboard strips when enabled; use Crossbar category for controller UI)
+
+        crossbarEnabled = true,               -- Load controller crossbar (L2/R2 UI); independent from keyboard hotbars
+        -- Lock movement: when true, disables drag/drop and slot swapping for keyboard hotbars only
         hotbarLockMovement = false,
+        -- Lock crossbar: when true, disables drag/drop/slot moves and window drag for controller crossbar
+        crossbarLockMovement = false,
         hotbarPreview = false,                -- Show preview with test data
+
+        -- Macro palette editor: icon auto-source + custom/ subfolder (persists per profile)
+        macroEditorIconPrefs = {
+            iconAutoSource = 'all',   -- 'all' | 'spells' | 'items' | 'custom'
+            customIconFolder = 'all', -- 'all' or a top-level folder name under assets/hotbar/custom/
+        },
+
+        -- Macro palette: custom dropdown categories (keys "custom:N" under macroDB)
+        macroCustomCategories = T{},
+        macroCustomNextSeq = 1,
+        -- When false, empty "xiui" macro bucket gets default /xiui slash shortcuts once (see macro_xiui_defaults.lua)
+        macroXiuiDefaultsSeeded = false,
+        -- When false, Global bucket may receive default "Universal 2 Hour" macro once (see macro_global_defaults.lua)
+        macroGlobalUniversalTwoHourSeeded = false,
+
+        -- "profile" = macros in this profile's lua only; "shared" = one global library (SharedMacros.lua) for all characters using Shared.
+        macroStorageScope = 'profile',
 
         -- Global hotbar visual settings (used when bar's useGlobalSettings = true)
         hotbarGlobal = factories.createHotbarGlobalDefaults(),
@@ -665,6 +686,7 @@ function M.createUserSettingsDefaults()
         petBarScaleY = 1.0,
         petBarHideDuringEvents = true,
         petBarPreview = true,
+        petBarResizeAnchor = 'top',              -- Pet bar resize: 'top' or 'bottom' fixed edge when height changes
         petBarPreviewType = 2, -- Avatar (SMN)
         petBarShowDistance = true,
         petBarShowTarget = true,
@@ -792,10 +814,14 @@ function M.createUserSettingsDefaults()
         petTargetDistanceOffsetY = 44,
 
         -- Pet Target snap to petbar (positions pet target directly below petbar)
-        petTargetSnapToPetBar = true,        -- When enabled, pet target snaps below petbar
-        petTargetSnapAnchor = 'bottom',      -- 'bottom' = offset from bottom of pet bar, 'top' = offset from top (static when buffs change height)
+        petTargetSnapToPetBar = true,        -- When enabled, pet target snaps relative to pet bar geometry
+        petTargetSnapAnchor = 'bottom',      -- bottom: pet target window below pet bar; top: above pet bar
         petTargetSnapOffsetX = 0,            -- Horizontal offset from petbar position
         petTargetSnapOffsetY = 16,           -- Vertical offset below petbar (accounts for background border)
+        -- Extra pixels between Pet Target bottom and pet bar top when snap anchor is Top (0 = use offset Y only)
+        petTargetSnapTopGap = 5,
+        -- Last measured PetBarTarget window height (top snap only); avoids first-frame placement jump after load
+        petTargetSnapCachedHeight = nil,
 
         -- Per-pet-type settings (Avatar, Charm, Jug, Automaton, Wyvern each have independent visual settings)
         petBarAvatar = factories.createPetBarTypeDefaults(),

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -17,13 +17,35 @@ local dragdrop = require('libs.dragdrop');
 local data = require('modules.hotbar.data');
 local actions = require('modules.hotbar.actions');
 local textures = require('modules.hotbar.textures');
+-- TextureManager is used for the palette scope icon overlay (job icon / infinity for universal palettes).
+local TextureManager = require('libs.texturemanager');
 local controller = require('modules.hotbar.controller');
 local recast = require('modules.hotbar.recast');
 local slotrenderer = require('modules.hotbar.slotrenderer');
+-- playerdata caches the player's known abilities + weaponskills; `IsActionAvailable` falls
+-- back to "unavailable" when the caches are empty. Keyboard hotbars warm these from their
+-- own DrawWindow, but crossbar-only setups (`hotbarEnabled=false, crossbarEnabled=true`)
+-- never touched playerdata before — every JA/WS slot then read as unavailable (grayed +
+-- "X") even on jobs that knew the abilities. We now refresh once per frame from crossbar
+-- DrawWindow as well; the refresh is signature-gated internally (job/level/equip diff) so
+-- the steady-state cost is a few cache reads, not a full re-scan.
+local playerdata = require('modules.hotbar.playerdata');
 local animation = require('libs.animation');
 local skillchain = require('modules.hotbar.skillchain');
+-- macroparse extracts the primary line + JA badge type from a /ws or /pet macro body, so we can
+-- predict skillchain icons on macro slots whose first line is a weapon skill or blood pact.
+-- Display.lua does the same thing for keyboard hotbars; without it, crossbar macro slots whose
+-- primary line is /ws or /pet would never light up even though firing the macro IS the WS/pact.
+local macroparse = require('modules.hotbar.macroparse');
 local targetLib = require('libs.target');
 local palette = require('modules.hotbar.palette');
+-- Used to dim the crossbar when a blocking game menu is open AND `crossbarDisableInMenu`
+-- is enabled, so the player can see at a glance that controller input is paused.
+local gamestate = require('core.gamestate');
+-- macropalette is required only for the palette-editor drop handlers (effective palette key
+-- + macro source store). Required at module scope here (mirrors Ferris); if a future
+-- circular dependency creeps in this can be flipped to a lazy `require` inside the closures.
+local macropalette = require('modules.hotbar.macropalette');
 
 local M = {};
 
@@ -75,6 +97,13 @@ end
 
 local SLOTS_PER_SIDE = 8;
 local COMBO_MODES = controller.COMBO_MODES;
+-- Full enumeration of combo-mode storage keys (used by the Edit Full Palette editor and the
+-- pet-tab filter). 'Shared' is the chord-fallback for sharedExpanded layouts where both
+-- L2+R2 and R2+L2 collapse to one set.
+local ALL_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', 'Shared' };
+-- Naming prefix on resource maps + IDs used by the Edit Full Palette draft layer so its
+-- ImGui drop zones / animation keys never collide with the live HUD's 'crossbar_*' set.
+local PAL_ED_PREFIX = 'PalEd_';
 
 -- ============================================
 -- Layout Calculation Functions
@@ -277,7 +306,14 @@ local function GetCachedCrossbarIcon(comboMode, slotIndex, slotData)
 end
 
 -- Clear crossbar icon cache
+-- iconCache rows hold the only Lua ref to D3D textures returned by actions.GetBindIcon
+-- (LoadTextureFromPath wires a gc_safe_release finalizer). Wiping mid-frame — e.g. palette
+-- deletion fires InvalidateAllVisualCachesAfterPaletteListMutation while the crossbar
+-- DrawWindow is still building this frame's ImGui draw list — lets Lua GC finalize the COM
+-- texture while AddImage still references it (CTD on Ashita 4.16). DeferRelease holds the
+-- old table alive until FlushPendingReleases runs at the top of the next d3d_present.
 local function ClearCrossbarIconCache()
+    TextureManager.DeferRelease(iconCache);
     iconCache = {};
 end
 
@@ -286,6 +322,10 @@ local function ClearCrossbarIconCacheForSlot(comboMode, slotIndex)
     -- Use effective combo mode for cache key (Shared when shared expanded bar is enabled)
     comboMode = data.GetEffectiveComboModeForStorage and data.GetEffectiveComboModeForStorage(comboMode) or comboMode;
     if iconCache[comboMode] then
+        local oldRow = iconCache[comboMode][slotIndex];
+        if oldRow ~= nil then
+            TextureManager.DeferRelease(oldRow);
+        end
         iconCache[comboMode][slotIndex] = nil;
     end
 end
@@ -328,6 +368,16 @@ local state = {
         progress = 1.0,
         wasHidden = false,
     },
+
+    -- useSharedExpandedBar bookkeeping. The shared-center layout collapses the bar to one
+    -- diamond width and forces the X anchor to screen-center every frame; without these the
+    -- normal X anchor would either get persisted as the centered narrow value (chord persists
+    -- across a save) or snap back to the leftmost saved position on chord exit. The two-step
+    -- handoff is: while in chord we stash the last "wide" window X here, then on the first
+    -- frame that exits chord we re-anchor to that stashed X so the bar returns where the
+    -- user actually placed it (rather than wherever the centered narrow bar happened to land).
+    lastWideCrossbarWindowX = nil,
+    wasSharedCenterChordLayout = false,
 };
 
 -- ============================================
@@ -376,12 +426,24 @@ end
 -- ============================================
 
 -- Determine which combo modes to display on left/right based on active combo
--- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'both', or nil)
-local function GetDisplayModes(activeCombo)
+-- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'center', 'both', or nil)
+-- When useSharedExpandedBar is enabled and the user holds a chord (L2+R2 / R2+L2), expandedSide
+-- becomes 'center': only the left column is drawn (using the 'Shared' storage key), the window
+-- shrinks to one diamond width, and DrawWindow re-centers it to screen X (a single 8-slot strip
+-- centered like the FFXIV controller bar) rather than the two-diamond wide layout.
+local function GetDisplayModes(activeCombo, settings)
+    settings = settings or (gConfig and gConfig.hotbarCrossbar);
+    local useSharedExp = settings and settings.useSharedExpandedBar == true;
     if activeCombo == COMBO_MODES.L2_THEN_R2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: L2 first, then R2 -> show L2R2 on left side only, right side dimmed (shows R2)
         return 'L2R2', 'R2', true, 'left';
     elseif activeCombo == COMBO_MODES.R2_THEN_L2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: R2 first, then L2 -> show R2L2 on right side only, left side dimmed (shows L2)
         return 'L2', 'R2L2', true, 'right';
     elseif activeCombo == 'Shared' then
@@ -585,6 +647,69 @@ local function GetSlotPositionInWindow(side, slotIndex, windowX, windowY, settin
 end
 
 -- ============================================
+-- Window-decor padding (slot-top vs window-top accounting)
+-- ============================================
+-- ImGui clips anything we draw OUTSIDE the window's content rect. The crossbar paints a
+-- lot of decoration above the slot grid (L2/R2 trigger icons, combo text, R1 cpal-anchor
+-- pulse, palette-modifier refresh glyph) and below it (palette name, action labels). To
+-- keep all of that inside the window's draw region we open the ImGui window taller than
+-- the slot grid by CROSSBAR_WINDOW_TOP_DECOR_PAD on top and `GetCrossbarWindowBottomPad`
+-- on the bottom, then offset the window-top so the SLOT GRID still lands at the user's
+-- saved (or default) Y. `state.windowY` continues to mean "slot grid top" everywhere
+-- else in this module, which lets the rest of the layout code stay unchanged.
+local CROSSBAR_WINDOW_TOP_DECOR_PAD = 80;
+
+local function GetCrossbarWindowBottomPad(settings)
+    settings = settings or {};
+    local pad = 10;
+    if settings.showActionLabels then
+        pad = pad + (settings.labelFontSize or 10) + 6 + math.max(0, tonumber(settings.actionLabelOffsetY) or 0);
+    end
+    pad = pad + math.floor(((settings.mpCostFontSize or 10) + (settings.quantityFontSize or 10)) * 0.15 + 0.5);
+    return math.min(72, math.max(10, pad));
+end
+
+-- Profile stores SLOT TOP Y (`gConfig.windowPositions.Crossbar.y`), not window-top. When
+-- we apply a saved position we subtract the decor pad so the slot grid lands where the
+-- user originally placed it. The `appliedPositions` flag keeps ImGui's drag from being
+-- overridden every frame (ImGuiCond_Always otherwise).
+local function ApplyCrossbarWindowPositionOnce()
+    if not gConfig or not gConfig.windowPositions or not gConfig.windowPositions['Crossbar'] then
+        return false;
+    end
+    if not gConfig.appliedPositions then
+        gConfig.appliedPositions = {};
+    end
+    if gConfig.appliedPositions['Crossbar'] then
+        return false;
+    end
+    local pos = gConfig.windowPositions['Crossbar'];
+    imgui.SetNextWindowPos({ pos.x, pos.y - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    gConfig.appliedPositions['Crossbar'] = true;
+    return true;
+end
+
+-- Save SLOT TOP Y, not window-top, so the saved coordinate stays meaningful even if the
+-- decor pad changes between releases (or a future patch adds more decoration above the
+-- slot grid). Skips writes when nothing changed to avoid table churn / unnecessary disk
+-- saves on every frame.
+local function SaveCrossbarWindowSlotTopPosition()
+    if not gConfig then return; end
+    local wx, wy = imgui.GetWindowPos();
+    if not gConfig.windowPositions then
+        gConfig.windowPositions = {};
+    end
+    local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+    local saved = gConfig.windowPositions['Crossbar'];
+    if not saved then
+        gConfig.windowPositions['Crossbar'] = { x = wx, y = slotTopY };
+    elseif saved.x ~= wx or saved.y ~= slotTopY then
+        saved.x = wx;
+        saved.y = slotTopY;
+    end
+end
+
+-- ============================================
 -- Initialization
 -- ============================================
 
@@ -671,12 +796,147 @@ end
 -- animOpacity: 0-1 for animation fade (default 1.0)
 -- yOffset: Y offset in pixels for animation (default 0)
 -- skillchainName: (optional) Skillchain name for WS slots
-local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName)
+-- Reusable cbInteraction sub-tables built lazily for palette-editor slots so the editor and
+-- the live crossbar each get their own slotInteraction set (different idPrefix/buttonId/
+-- dropZoneId — palette editor uses 'paled_*'; live crossbar uses 'crossbar_*'). Keeping
+-- them separate also lets the slotrenderer drop-zone-lock semantics treat them differently
+-- (paled_* are never locked; crossbar_* respect crossbarLockMovement).
+local cbInteractionPalEd = {};
+
+local function GetCbInteractionPaletteEditor(comboMode, slotIndex)
+    if not cbInteractionPalEd[comboMode] then cbInteractionPalEd[comboMode] = {}; end
+    local cached = cbInteractionPalEd[comboMode][slotIndex];
+    if cached then return cached; end
+
+    local entry = {
+        buttonId = string.format('##paled_%s_%d', comboMode, slotIndex),
+        dropZoneId = string.format('paled_%s_%d', comboMode, slotIndex),
+        pressKey = 'paled_' .. comboMode .. '_' .. slotIndex,
+        onDrop = function(payload)
+            -- Palette-editor drops go through the draft layer; Apply Draft promotes them to live.
+            -- All branches normalize through the overlay (draft falls back to live) and finalize
+            -- before writing so dual-arm macros swap correctly and empty results clear properly.
+            if payload.type == 'macro' then
+                if payload.data and payload.data.macroPaletteKey == nil then
+                    if macropalette.GetEffectivePaletteType then
+                        payload.data.macroPaletteKey = macropalette.GetEffectivePaletteType();
+                    else
+                        payload.data.macroPaletteKey = data.jobId or 1;
+                    end
+                end
+                if payload.data and macropalette.GetMacroSourceTagForDrops
+                    and payload.data.macroSourceStore == nil then
+                    payload.data.macroSourceStore = macropalette.GetMacroSourceTagForDrops();
+                end
+                local arm = {};
+                for k, v in pairs(payload.data) do arm[k] = v; end
+                if arm.macroRef == nil and payload.data.id then
+                    arm.macroRef = payload.data.id;
+                end
+                local existingRaw = data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex);
+                local existing = data.NormalizeCrossbarSlotRawForSwap(existingRaw);
+                local store = arm.macroSourceStore
+                    or (macropalette.GetMacroSourceTagForDrops and macropalette.GetMacroSourceTagForDrops())
+                    or 'profile';
+                local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                data.SetDraftSlotData(comboMode, slotIndex, built);
+            elseif payload.type == 'crossbar_slot' then
+                -- Always read source/target from overlay at drop time; payload.data was captured
+                -- at drag start and can alias stale tables after earlier moves in the same session.
+                local srcCombo = payload.comboMode;
+                local srcSlot = payload.slotIndex;
+                if srcCombo == comboMode and srcSlot == slotIndex then return; end
+                if data.BeginDraftUndoGroup then data.BeginDraftUndoGroup(); end
+                local srcRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(srcCombo, srcSlot));
+                local tgtRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+                local newTgt, newSrc = data.SwapActiveMacroArmsInPlace(srcRaw, tgtRaw);
+                local fT = data.FinalizeCrossbarRawSlotForStorage(newTgt);
+                local fS = data.FinalizeCrossbarRawSlotForStorage(newSrc);
+                if fT == nil then
+                    data.ClearDraftSlotData(comboMode, slotIndex);
+                else
+                    data.SetDraftSlotData(comboMode, slotIndex, fT);
+                end
+                if fS == nil then
+                    data.ClearDraftSlotData(srcCombo, srcSlot);
+                else
+                    data.SetDraftSlotData(srcCombo, srcSlot, fS);
+                end
+                if data.EndDraftUndoGroup then data.EndDraftUndoGroup(); end
+                -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+                -- the icon cache clear above is the only refresh needed for the source slot.
+                ClearCrossbarIconCacheForSlot(srcCombo, srcSlot);
+            elseif payload.type == 'slot' then
+                if payload.data then
+                    local c = data.FinalizeCrossbarRawSlotForStorage(data.CopyTable(payload.data));
+                    if c == nil then
+                        data.ClearDraftSlotData(comboMode, slotIndex);
+                    else
+                        data.SetDraftSlotData(comboMode, slotIndex, c);
+                    end
+                end
+            end
+            -- Visual refresh for the target slot (matches live-HUD drop behaviour).
+            -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+            -- the icon cache clear is the only refresh needed (the bind hash on next frame
+            -- naturally re-derives slot draw state — see ClearSlotIconCache notes in macropalette).
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        getDragData = function()
+            -- Use overlay (draft falling back to live) so dragging a slot that hasn't been
+            -- touched in this edit session still carries its persisted data. Reading draft-only
+            -- here would drag nil and the drop handler would clear the target slot.
+            local raw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+            return {
+                type = 'crossbar_slot',
+                comboMode = comboMode,
+                slotIndex = slotIndex,
+                data = raw,
+            };
+        end,
+        onRightClick = function()
+            data.ClearDraftSlotData(comboMode, slotIndex);
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        -- Double-click in Edit Full Palette opens the macro editor for the slot's draft
+        -- content. For empty slots that resolves to nil and macropalette.OpenEditorForSlotData
+        -- starts a fresh "creating new" session seeded with the active palette type's defaults.
+        -- The (comboMode, slotIndex) carried in the pending edit lets palettemanager auto-bind
+        -- the new macro to this slot after Save (see config/palettemanager.lua consume site).
+        -- We funnel through data.SetPendingPaletteSlotEdit so the editor opens on the NEXT
+        -- frame (consumed by config/palettemanager.lua after slots draw); opening it directly
+        -- inside this click handler would put a modal inside the hotbar's draw pass and skip
+        -- the macropalette draw-order assumptions.
+        onDoubleClick = function()
+            local slotData = data.GetDraftSlotData
+                and data.GetDraftSlotData(comboMode, slotIndex)
+                or nil;
+            data.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex);
+        end,
+    };
+    cbInteractionPalEd[comboMode][slotIndex] = entry;
+    return entry;
+end
+
+-- Palette-editor empty-slot panel tint (matches the Edit Full Palette row fill in palettemanager.lua).
+-- Lighter than the live crossbar's 0x55000000 so slot outlines read clearly against the editor row.
+local PAL_ED_EMPTY_SLOT_BG = 0xFF8E96AC;
+
+local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName, activeCombo, editorClipRect, magicBurstName)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
-    -- Get pre-created interaction closures and IDs
-    local interaction = GetCbInteraction(comboMode, slotIndex);
+    -- Edit Full Palette state: when active, this slot belongs to the editor's draft layer
+    -- rather than the live crossbar. palSk is the storage-key the editor is targeting; the
+    -- draft layer is separate per-key (so editing one palette doesn't touch the live binding).
+    local palSk = data.GetCrossbarPaletteEditSessionKey and data.GetCrossbarPaletteEditSessionKey();
+    local isEditor = palSk ~= nil;
+
+    -- Get pre-created interaction closures and IDs. Editor and live get different prefixes so
+    -- the slotrenderer drop-zone-lock policy can distinguish them (paled_* are never locked).
+    local interaction = isEditor
+        and GetCbInteractionPaletteEditor(comboMode, slotIndex)
+        or GetCbInteraction(comboMode, slotIndex);
 
     -- Apply Y offset for animation
     local drawY = y + yOffset;
@@ -687,8 +947,14 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
         iconPressScale = animation.getPressScale(interaction.pressKey, isPressed and isActive);
     end
 
-    -- Get slot data
-    local slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    -- Slot data source: editor reads from the draft layer (synced from live at session start
+    -- via data.SyncDraftSlotFromLive); live crossbar always reads the persisted binding.
+    local slotData;
+    if isEditor then
+        slotData = data.GetDraftSlotData and data.GetDraftSlotData(comboMode, slotIndex) or nil;
+    else
+        slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    end
 
     -- Get icon + cached abbreviation for this action (cached - only rebuilds when bind changes)
     local icon, cachedAbbr, cachedAbbrW = GetCachedCrossbarIcon(comboMode, slotIndex, slotData);
@@ -696,6 +962,33 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     -- Global UI scale (slotSize/x/y come in already scaled; we apply gs here to
     -- font sizes and pixel offsets that come straight from settings).
     local gs = (gConfig and gConfig.globalScale) or 1.0;
+
+    -- Diamond position: 1=Top, 2=Right, 3=Bottom, 4=Left (slots 5-8 map via -4 for face buttons).
+    -- Top-slot labels placed below would overlap the bottom slot's MP/quantity text, so the
+    -- editor (and any caller that asks for labels) flips them above for the top position.
+    local posIndex = (slotIndex <= 4) and slotIndex or (slotIndex - 4);
+    local labelAboveSlot = (posIndex == 1);
+
+    -- Dim policy. Live crossbar: inactive sides get a softer dim; when a trigger is held the
+    -- non-active half dims much harder so the active set pops. Editor: nothing is "inactive".
+    local dimFactor = 1.0;
+    if not isEditor and not isActive then
+        if activeCombo and activeCombo ~= COMBO_MODES.NONE then
+            dimFactor = settings.inactiveSideWhileTriggerDim;
+            if dimFactor == nil then dimFactor = 0.15; end
+        else
+            dimFactor = settings.inactiveSlotDim or 0.5;
+        end
+    end
+
+    -- Editor background: lighter tint behind empty editor slots so slot borders pop on the
+    -- panel row; filled editor slots use the user's normal background.
+    local slotBgColor = settings.slotBackgroundColor or 0x55000000;
+    local slotOpacity = settings.slotOpacity or 1.0;
+    if isEditor and not slotData then
+        slotBgColor = PAL_ED_EMPTY_SLOT_BG;
+        slotOpacity = 1.0;
+    end
 
     -- Update reusable params table in-place
     local p = cbParams;
@@ -707,28 +1000,30 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.cachedAbbrW = cachedAbbrW;
     p.bind = slotData;
     p.icon = icon;
-    p.slotBgColor = settings.slotBackgroundColor or 0x55000000;
-    p.slotOpacity = settings.slotOpacity or 1.0;
-    p.dimFactor = isActive and 1.0 or (settings.inactiveSlotDim or 0.5);
+    p.slotBgColor = slotBgColor;
+    p.slotOpacity = slotOpacity;
+    p.dimFactor = dimFactor;
     p.animOpacity = animOpacity;
     p.isPressed = isPressed and isActive;
     p.iconPressScale = iconPressScale;
-    p.showMpCost = settings.showMpCost ~= false;
+    p.showMpCost = isEditor and false or (settings.showMpCost ~= false);
     p.mpCostFontSize = (settings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = settings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = settings.mpCostNoMpColor or 0xFFFF4444;
     p.mpCostOffsetX = (settings.mpCostOffsetX or 0) * gs;
     p.mpCostOffsetY = (settings.mpCostOffsetY or 0) * gs;
-    p.showQuantity = settings.showQuantity ~= false;
+    p.showQuantity = isEditor and false or (settings.showQuantity ~= false);
     p.showStackQuantity = settings.showStackQuantity == true;
     p.quantityFontSize = (settings.quantityFontSize or 10) * gs;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
     p.quantityOffsetX = (settings.quantityOffsetX or 0) * gs;
     p.quantityOffsetY = (settings.quantityOffsetY or 0) * gs;
-    p.showLabel = settings.showActionLabels or false;
+    -- Editor: always show labels (on-slot abbrev with hover popup); live crossbar respects the user setting.
+    p.showLabel = isEditor and true or (settings.showActionLabels or false);
     p.labelText = slotData and (slotData.displayName or slotData.action or '') or '';
-    p.labelOffsetX = (settings.actionLabelOffsetX or 0) * gs;
-    p.labelOffsetY = ((settings.actionLabelOffsetY or 0) + 2) * gs;
+    p.labelOffsetX = isEditor and 0 or ((settings.actionLabelOffsetX or 0) * gs);
+    p.labelOffsetY = isEditor and 0 or (((settings.actionLabelOffsetY or 0) + 2) * gs);
+    p.labelAboveSlot = labelAboveSlot;
     p.labelFontSize = (settings.labelFontSize or 10) * gs;
     p.recastTimerFontSize = (settings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = settings.recastTimerFontColor or 0xFFFFFFFF;
@@ -744,10 +1039,29 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.dragType = 'crossbar_slot';
     p.getDragData = interaction.getDragData;
     p.onRightClick = interaction.onRightClick;
+    -- Editor slots: double-click opens the macro editor (empty slot = new macro seeded
+    -- with palette defaults, filled slot = edit existing). Live crossbar slots leave
+    -- onDoubleClick nil so single-click executes the action immediately.
+    p.onDoubleClick = isEditor and interaction.onDoubleClick or nil;
+    -- Editor slots don't have a "live" action to execute; suppressing the single-click
+    -- action is what enables the click-tracking pipeline in slotrenderer to detect a
+    -- second click and dispatch onDoubleClick. Live HUD keeps the default behavior.
+    p.suppressActionOnClick = isEditor and true or false;
     p.showTooltip = true;
-    -- Skillchain highlight
-    p.skillchainName = skillchainName;
+    -- Editor-only params consumed by slotrenderer Pass 2 (clip culling + on-slot multi-line label).
+    p.editorClipRect = editorClipRect;
+    p.editorMinimalView = isEditor;
+    p.labelForeground = isEditor;
+    -- Editor drops should win against the live crossbar zone underneath when the editor preview
+    -- overlaps the HUD (FlushDeferredDrops resolves overlaps by highest priority).
+    p.dropPriority = isEditor and 10 or nil;
+    -- Skillchain highlight (only on live crossbar; editor preview suppresses it).
+    p.skillchainName = (not isEditor) and skillchainName or nil;
     p.skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44;
+    -- Magic Burst highlight — same suppression rules as skillchain (editor preview has no
+    -- live target so the prediction would be meaningless / misleading there).
+    p.magicBurstName = (not isEditor) and magicBurstName or nil;
+    p.magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF;
 
     -- Render slot using shared renderer (handles ALL rendering and interactions)
     slotrenderer.DrawSlot(p);
@@ -879,8 +1193,125 @@ local function DrawTriggerIcons(activeCombo, l2GroupX, r2GroupX, groupY, groupWi
                 {0, 0}, {1, 1},
                 tintColor
             );
+
+            -- R1 return indicator: rendered above R2 when the user has set a "cpal" anchor
+            -- (via `/xiui cpal <Job>`). Pulses to draw the eye toward the return-to-anchor
+            -- shortcut. Per-scope so anchors don't leak across universal vs job-scoped views.
+            local scope = palette.GetCrossbarPaletteScope();
+            local anchor = palette.GetCpalAnchor and palette.GetCpalAnchor(scope);
+            if anchor then
+                local r1Texture = textures:GetControllerIcon('R1');
+                if r1Texture and r1Texture.image then
+                    local r1Ptr = tonumber(ffi.cast('uint32_t', r1Texture.image));
+                    if r1Ptr then
+                        local r1Width = baseIconWidth;
+                        local r1Height = baseIconHeight;
+                        local r1IconX = r2GroupX + (groupWidth / 2) - (r1Width / 2);
+                        local r1IconY = r2IconY - r1Height - 4;
+
+                        -- ~2.5 Hz size pulse (peak +30%) keeps the indicator visible without
+                        -- being distracting. Sin → abs so the icon "breathes" symmetrically.
+                        local pulse = math.abs(math.sin(os.clock() * 2.5));
+                        local sizeScale = 1.0 + 0.30 * pulse;
+                        local sw = r1Width * sizeScale;
+                        local sh = r1Height * sizeScale;
+                        local sx = r1IconX + r1Width * 0.5 - sw * 0.5;
+                        local sy = r1IconY + r1Height * 0.5 - sh * 0.5;
+
+                        -- Pill-shaped dark backdrop spans the icon + "x2" text so they read
+                        -- as a single legend regardless of the underlying scene.
+                        local textGap, textEstW, pad = 3, 14, 4;
+                        drawList:AddRectFilled(
+                            { r1IconX - pad, r1IconY - pad },
+                            { r1IconX + r1Width + textGap + textEstW + pad, r1IconY + r1Height + pad },
+                            0x99000000, 5
+                        );
+
+                        drawList:AddImage(r1Ptr, { sx, sy }, { sx + sw, sy + sh }, { 0, 0 }, { 1, 1 }, 0xFFFFFFFF);
+                        -- Gold ARGB: A=FF R=FF G=C8 B=32 → ImGui's GetColorU32 byte order is 0xAABBGGRR
+                        drawList:AddText(
+                            { r1IconX + r1Width + textGap, r1IconY + r1Height * 0.5 - 6 },
+                            0xFF32C8FF,
+                            'x2'
+                        );
+                    end
+                end
+            end
         end
     end
+end
+
+-- Shared expanded bar (useSharedExpandedBar): the L2+R2 / R2+L2 chord collapses both diamonds
+-- into a single centered 8-slot strip, so DrawTriggerIcons can't position L2 over the left group
+-- and R2 over the (now-absent) right group. This variant renders an "L2 + R2" chord glyph centred
+-- on the single visible diamond: both icons inline with a small "+" between them, tinted brighter
+-- when their trigger is part of the active combo. Same draw list as DrawTriggerIcons so the chord
+-- glyph layers with the same z-order as the regular trigger labels.
+local function DrawTriggerIconsSharedExpandedCenter(activeCombo, groupLeftX, groupY, groupWidth, settings, drawList)
+    if not settings.showTriggerLabels then return; end
+    if not drawList then return; end
+
+    local baseScale = settings.triggerIconScale or 1.0;
+    local iw = 49 * baseScale;
+    local ih = 28 * baseScale;
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    -- chordTight: pull the +/glyphs closer together as the icons shrink so the legend stays compact
+    -- (matches the spacing the editor's shared-chord glyph uses in DrawPaletteEditorL2R2TriggerGlyphs).
+    local chordTight = math.max(0.5, 0.65 * baseScale);
+    local cx = groupLeftX + groupWidth * 0.5;
+    local cy = groupY - ih * 0.5;
+
+    -- Both triggers participate in any chord / double-tap involving them, so animate accordingly.
+    local l2Active = activeCombo == COMBO_MODES.L2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.L2_DOUBLE;
+    local r2Active = activeCombo == COMBO_MODES.R2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.R2_DOUBLE;
+    if activeCombo == COMBO_MODES.NONE then
+        l2Active = false;
+        r2Active = false;
+    end
+
+    local l2PressScale = 1.0;
+    local r2PressScale = 1.0;
+    if settings.enablePressScale ~= false then
+        l2PressScale = animation.getPressScale('trigger_L2', l2Active);
+        r2PressScale = animation.getPressScale('trigger_R2', r2Active);
+    end
+
+    -- Measure the "+" once so the chord can be centered as a single unit (icon + plus + icon).
+    -- Fallback dims 10x14 keep layout sensible on builds where imgui.CalcTextSize isn't bound.
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImageScaled(texName, ix, iy, w, h, tintColor)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        drawList:AddImage(p, { ix, iy }, { ix + w, iy + h }, { 0, 0 }, { 1, 1 }, tintColor);
+    end
+
+    local ptw, pth = plusSize();
+    local lw = iw * l2PressScale;
+    local lh = ih * l2PressScale;
+    local rw = iw * r2PressScale;
+    local rh = ih * r2PressScale;
+    local total = lw + chordTight + ptw + chordTight + rw;
+    local leftX = cx - total * 0.5;
+    local l2Tint = l2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    local r2Tint = r2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    drawImageScaled('L2', leftX, cy - lh * 0.5, lw, lh, l2Tint);
+    drawList:AddText({ leftX + lw + chordTight, cy - pth * 0.5 }, textCol, '+');
+    drawImageScaled('R2', leftX + lw + chordTight + ptw + chordTight, cy - rh * 0.5, rw, rh, r2Tint);
 end
 
 -- Draw combo text in center for complex combos (L2R2, R2L2, L2x2, R2x2) or edit mode
@@ -934,7 +1365,13 @@ local function DrawComboText(activeCombo, centerX, topY, settings)
     end
 end
 
--- Draw palette name below crossbar (e.g., "Stuns (2/5)")
+-- Draw palette name below crossbar (e.g., "Stuns (2/5)"). The index/total count is
+-- restricted to ENABLED palettes (RB-cycle filtered) and is hidden entirely when there
+-- is only one cycleable palette (a 1/1 badge is just noise). For universal [G] scope,
+-- routes through GetCrossbarPaletteLabelIndexAndTotal which uses the universal cycle list
+-- instead of the per-job rows. (Lookup is microseconds at typical 1-10 palette counts; a
+-- per-frame label cache was tried and reverted because it could go stale on PaletteManager
+-- CRUD without a roster-version invalidation hook.)
 local function DrawPaletteName(centerX, bottomY, settings)
     if not settings.showPaletteName then return; end
 
@@ -943,10 +1380,14 @@ local function DrawPaletteName(centerX, bottomY, settings)
 
     local jobId = data.jobId or 1;
     local subjobId = data.subjobId or 0;
-    local index = palette.GetCrossbarPaletteIndex(paletteName, jobId, subjobId) or 1;
-    local total = palette.GetCrossbarPaletteCount(jobId, subjobId) or 1;
+    local index, total = palette.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId);
 
-    local displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    local displayText;
+    if index and total and total > 1 then
+        displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    else
+        displayText = paletteName;
+    end
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local fontSize = (settings.paletteNameFontSize or 10) * gs;
     local offsetX = (settings.paletteNameOffsetX or 0) * gs;
@@ -961,8 +1402,97 @@ local function DrawPaletteName(centerX, bottomY, settings)
     end
 end
 
--- Helper to draw just the left side
-local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- ============================================
+-- Palette scope icon (above the center divider)
+-- Shows the infinity glyph for Global/universal palettes, or the job icon for job-scoped.
+-- Lazily caches the infinity texture; the job-icon TextureManager has its own cache.
+-- ============================================
+local cachedInfinityPaletteTex = nil;
+
+local function GetInfinityPaletteIconTexture()
+    if cachedInfinityPaletteTex and cachedInfinityPaletteTex.image then
+        return cachedInfinityPaletteTex;
+    end
+    cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not cachedInfinityPaletteTex or not cachedInfinityPaletteTex.image then
+        cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    return cachedInfinityPaletteTex;
+end
+
+local function GetPaletteJobIconThemeFromSettings(settings)
+    local t = settings and settings.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+
+-- When showPaletteScopeIcon is nil (legacy profiles), the scope icon follows showPaletteName;
+-- explicit true/false overrides. Keeps the icon visible by default for existing users without
+-- forcing them through the settings menu after the upgrade.
+local function ShouldShowPaletteScopeIcon(settings)
+    if not settings then return false; end
+    if settings.showPaletteScopeIcon == false then return false; end
+    if settings.showPaletteScopeIcon == true then return true; end
+    return settings.showPaletteName == true;
+end
+
+-- Draws the scope marker (infinity for Global / universal, job icon otherwise) centred just
+-- above the divider. Only fires when a palette is actually active for the L2 group.
+local function DrawPaletteScopeIconAboveDivider(dividerX, dividerTopY, settings, drawList)
+    if not ShouldShowPaletteScopeIcon(settings) or not drawList then return; end
+
+    local paletteName = palette.GetActivePaletteForCombo('L2');
+    if not paletteName then return; end
+
+    local jobId = data.jobId or 1;
+    local iconTex;
+    if palette.GetCrossbarPaletteScope() == 'universal' then
+        iconTex = GetInfinityPaletteIconTexture();
+    else
+        iconTex = TextureManager.getJobIcon(jobId, GetPaletteJobIconThemeFromSettings(settings));
+    end
+
+    if not iconTex or not iconTex.image then return; end
+
+    local iconPtr = tonumber(ffi.cast('uint32_t', iconTex.image));
+    if not iconPtr then return; end
+
+    -- Size: explicit slider override (8..64 px) or auto-derive from palette-name font size.
+    local iconSize;
+    local explicitSize = tonumber(settings.paletteScopeIconSize);
+    if explicitSize and explicitSize > 0 then
+        iconSize = math.floor(math.max(8, math.min(64, explicitSize)) + 0.5);
+    else
+        local fontSize = settings.paletteNameFontSize or 10;
+        iconSize = math.max(12, math.min(22, math.floor(fontSize * 1.45)));
+        iconSize = math.floor(iconSize * 1.50 + 0.5);
+    end
+    local gapAboveLine = 3;
+    local scopeLiftY = tonumber(settings.paletteScopeIconOffsetY) or 6;
+    -- Clearance above the L2 / R2 combo-text strip at the top of the window.
+    local clearanceAboveComboText = 6;
+    -- Horizontally align with palette-name X offset so the icon stacks with the name.
+    local iconCenterX = dividerX + (settings.paletteNameOffsetX or 0);
+    local iconTopY = dividerTopY - gapAboveLine - iconSize - scopeLiftY - clearanceAboveComboText;
+    local leftX = iconCenterX - iconSize / 2;
+
+    drawList:AddImage(
+        iconPtr,
+        { leftX, iconTopY },
+        { leftX + iconSize, iconTopY + iconSize },
+        { 0, 0 },
+        { 1, 1 },
+        imgui.GetColorU32({ 1, 1, 1, 1 })
+    );
+end
+
+-- Helper to draw just the left side. `activeCombo` is threaded through so DrawSlot's dim
+-- policy can apply Ferris's "stronger dim on the inactive half while a trigger is held"
+-- behavior (settings.inactiveSideWhileTriggerDim, default 0.15) — without it the inactive
+-- half just gets settings.inactiveSlotDim (default 0.5) like 1.7.5/early-1.8.0.
+local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -970,15 +1500,40 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('L2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- Resolve slotData ONCE per slot so both prediction paths (skillchain + magic burst)
+        -- share the same fetch; previously the SC path re-fetched per branch. Cheap either
+        -- way, but cleaner now that two features need the same row.
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
+        -- Skillchain prediction: matches display.lua's coverage so the crossbar lights up the
+        -- same WS / Blood Pact / macro slots the keyboard hotbar does. Bloodpact slots use the
+        -- separate name->attributes map in skillchain.lua (bloodPactResonationMap); macro slots
+        -- run through macroparse to extract the primary /ws or /pet line and then route to the
+        -- matching predictor. Without the pet/macro branches, SMN ability slots and any /pet or
+        -- /ws macro would never get a skillchain icon overlay on the crossbar.
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        -- Magic Burst prediction: spells / magical pact rages / /ma|/pet-primary macros. The
+        -- single GetMagicBurstForSlot call internally routes by actionType + (for macros) the
+        -- macroparse primary line — mirrors the dispatch pattern used by display.lua.
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -989,8 +1544,9 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     end
 end
 
--- Helper to draw just the right side
-local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- Helper to draw just the right side. See DrawLeftSide above for the rationale on the
+-- trailing activeCombo / magicBurstEnabled parameters.
+local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -998,15 +1554,29 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('R2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- See DrawLeftSide for slotData / SC / MB routing rationale (identical logic).
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -1017,17 +1587,260 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     end
 end
 
--- Helper to draw a complete bar set (both sides) - used for non-animated drawing
+-- Helper to draw a complete bar set (both sides) - used for non-animated drawing.
+-- activeCombo flows from M.DrawWindow down to DrawSlot for the trigger-held dim policy.
 local function DrawBarSet(leftMode, rightMode, leftGroupX, leftGroupY, rightGroupX, rightGroupY,
                           slotSize, settings, leftActive, rightActive, pressedSlot,
-                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
-    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
-    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
+                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
+    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+end
+
+-- ============================================
+-- Double-Tap Preview Windows
+-- ============================================
+-- Reference floating windows that mirror the L2x2 / R2x2 bars at user-configurable scale
+-- and opacity. Rendered as independent ImGui windows AFTER the main crossbar so they have
+-- their own position/draw list (no shared primitives, no z-fighting). Drawn non-interactive
+-- (suppressActionOnClick) — the previews are visual reference only; actual slot activation
+-- still routes through the main bar's controller path.
+
+-- Return a shallow copy of settings with all layout-affecting fields scaled. Preserves the
+-- caller's settings unchanged so the main bar keeps its own layout numbers.
+--
+-- Result is cached on a (settings ref, scale, layout-key signature) tuple — the full
+-- shallow-copy is the dominant cost when the preview is on (8 slots × 2 windows × scaled
+-- settings every frame). Invalidates only when the caller passes a new settings table OR
+-- changes one of the geometry/scale inputs. This avoids the per-frame table-copy churn
+-- without going stale on slider drags (signature changes immediately).
+local previewSettingsCache = {
+    settingsRef = nil,
+    scale       = nil,
+    signature   = nil,
+    result      = nil,
+};
+
+local function MakePreviewSettings(settings, scale)
+    -- Cheap signature: only the fields MakePreviewSettings actually reads. Keep this in
+    -- sync with the scaled fields below — additions need a sig entry or the cache goes stale.
+    local sig = string.format('%s|%s|%s|%s|%s|%s|%s|%s|%s',
+        tostring(settings.slotSize), tostring(settings.slotGapV), tostring(settings.slotGapH),
+        tostring(settings.diamondSpacing), tostring(settings.groupSpacing),
+        tostring(settings.buttonIconSize), tostring(settings.buttonIconGapH), tostring(settings.buttonIconGapV),
+        tostring(settings.triggerIconScale));
+
+    if previewSettingsCache.settingsRef == settings
+        and previewSettingsCache.scale == scale
+        and previewSettingsCache.signature == sig then
+        return previewSettingsCache.result;
+    end
+
+    local s = {};
+    for k, v in pairs(settings) do s[k] = v; end
+    s.slotSize       = math.max(8, math.floor((settings.slotSize       or 40) * scale));
+    s.slotGapV       = math.max(1, math.floor((settings.slotGapV       or 2)  * scale));
+    s.slotGapH       = math.max(1, math.floor((settings.slotGapH       or 2)  * scale));
+    s.diamondSpacing = math.max(2, math.floor((settings.diamondSpacing or 16) * scale));
+    s.groupSpacing   = math.max(4, math.floor((settings.groupSpacing   or 24) * scale));
+    s.buttonIconSize = math.max(4, math.floor((settings.buttonIconSize or 24) * scale));
+    s.buttonIconGapH = math.max(1, math.floor((settings.buttonIconGapH or 2)  * scale));
+    s.buttonIconGapV = math.max(1, math.floor((settings.buttonIconGapV or 2)  * scale));
+    s.triggerIconScale = (settings.triggerIconScale or 1.0) * scale;
+
+    previewSettingsCache.settingsRef = settings;
+    previewSettingsCache.scale       = scale;
+    previewSettingsCache.signature   = sig;
+    previewSettingsCache.result      = s;
+    return s;
+end
+
+-- Draw one side of a double-tap preview using ImGui-only rendering (non-interactive).
+-- winX/winY    : top-left of the preview ImGui window (slot grid origin).
+-- side         : always 'L2' for single-group preview windows (slots start at window left).
+-- mode         : crossbar storage mode string ('L2x2', 'R2x2', 'L2', 'R2', etc.) whose slots to render.
+-- baseOp       : base opacity for the slot backgrounds (NOT dimmed) so frames stay visible.
+-- dimFactor    : 0-1 multiplier applied to icon/text rendering (mirrors main bar dim policy).
+-- targetServerId / skillchainEnabled / magicBurstEnabled: same per-slot SC/MB resolution
+--                inputs used by the main DrawLeftSide/DrawRightSide path. Letting the preview
+--                share them keeps the highlight calculus identical between live and preview
+--                (a slot that lights up on the live bar lights up on its preview).
+local function DrawPreviewSide(winX, winY, windowKey, side, mode, ps, baseOp, dimFactor, drawList, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize  = ps.slotSize or 40;
+    local contentOp = baseOp * dimFactor;
+
+    -- Slot background (flat rounded rect). slotrenderer's built-in bg path requires a D3D
+    -- slot primitive (we have none in preview), so paint it manually with baseOp so the
+    -- frame stays visible while icons dim with contentOp.
+    local bgArgb = ps.slotBackgroundColor or 0x55000000;
+    local bgA_raw = bit.rshift(bit.band(bgArgb, 0xFF000000), 24) / 255;
+    local bgA = math.max(bgA_raw, 0.55) * baseOp;
+    local bgR = bit.rshift(bit.band(bgArgb, 0x00FF0000), 16) / 255;
+    local bgG = bit.rshift(bit.band(bgArgb, 0x0000FF00), 8) / 255;
+    local bgB = bit.band(bgArgb, 0x000000FF) / 255;
+    local cornerR = math.max(4, math.min(10, math.floor(slotSize * 0.125 + 0.5)));
+    local bgU32 = imgui.GetColorU32({ bgR, bgG, bgB, bgA });
+
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        local slotX, slotY = GetSlotPositionInWindow(side, slotIndex, winX, winY, ps);
+
+        if drawList then
+            drawList:AddRectFilled({ slotX, slotY }, { slotX + slotSize, slotY + slotSize }, bgU32, cornerR);
+        end
+
+        local slotData = data.GetCrossbarSlotData(mode, slotIndex);
+        local icon = GetCachedCrossbarIcon(mode, slotIndex, slotData);
+
+        -- Per-slot skillchain + magic burst resolution — identical dispatch to DrawLeftSide
+        -- so a slot that highlights on the live crossbar highlights on its preview window
+        -- too. Without this the preview would silently omit both borders, hiding useful
+        -- "you could chain/MB from the other bar" cues exactly when the player is deciding
+        -- whether to commit to a double-tap.
+        local slotSkillchainName = nil;
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
+                slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
+            end
+        end
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+
+        slotrenderer.DrawSlot({
+            x    = slotX,
+            y    = slotY,
+            size = slotSize,
+            windowName = windowKey,
+            bind = slotData,
+            icon = icon,
+            slotBgColor = 0x00000000,
+            slotOpacity = 1.0,
+            dimFactor   = 1.0,
+            animOpacity = contentOp,
+            isPressed   = false,
+            iconPressScale = 1.0,
+            -- MP cost + quantity are intentionally OFF on the double-tap preview regardless of
+            -- the user's main-bar settings: the preview is a transient "what's on the other
+            -- bar" overlay, not an action-resolution surface, so a player glancing at it just
+            -- wants the icon + cooldown to decide if the next press is worth it. Showing MP /
+            -- charges duplicates the info on the live bar and crowds an already-small preview.
+            -- Cooldowns are kept (recastTimer* + flashCooldownUnder5) — they ARE useful here
+            -- because the preview's whole purpose is "should I commit to this bar".
+            showMpCost = false,
+            showQuantity = false,
+            showLabel = false,
+            recastTimerFontSize   = ps.recastTimerFontSize or 11,
+            recastTimerFontColor  = ps.recastTimerFontColor or 0xFFFFFFFF,
+            flashCooldownUnder5   = ps.flashCooldownUnder5 or false,
+            useHHMMCooldownFormat = ps.useHHMMCooldownFormat or false,
+            -- Skillchain + Magic Burst highlights. Colors fall back to the live-bar defaults
+            -- so the preview matches the main bar without requiring its own settings keys.
+            skillchainName  = slotSkillchainName,
+            skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44,
+            magicBurstName  = slotMagicBurstName,
+            magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF,
+            buttonId              = string.format('##dtprev_%s_%s_%d', windowKey, mode, slotIndex),
+            suppressActionOnClick = true,
+            forceImGuiIcon        = true,
+            drawCornerTextForeground = true,
+        });
+    end
+
+    if drawList and ps.showButtonIcons and contentOp > 0.05 then
+        DrawDiamondCenterIconsImGui('dpad', winX, winY, ps, true, drawList, contentOp);
+        DrawDiamondCenterIconsImGui('face', winX, winY, ps, true, drawList, contentOp);
+    end
+end
+
+-- Draw one double-tap preview window (L2x2 or R2x2 reference).
+-- windowKey : unique ImGui window name and persisted-position key.
+-- mode      : crossbar storage mode for the 8 slots displayed (e.g. 'L2x2', 'R2x2', 'L2', 'R2').
+-- ps        : scaled settings table (from MakePreviewSettings).
+-- baseOp    : base opacity (user slider * visibilityOpacity).
+-- dimFactor : 0-1 content dim (1.0 = at rest, inactiveSideWhileTriggerDim while any trigger held).
+-- settings  : raw crossbar settings (used for doubleTapPreviewLocked move-anchor gating).
+local function DrawDoubleTapPreviewWindow(windowKey, mode, ps, baseOp, dimFactor, activeCombo, settings, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize = ps.slotSize or 40;
+    local gw, gh = CalculateGroupDimensions(slotSize, ps.slotGapV or 2, ps.slotGapH or 2, ps.diamondSpacing or 16);
+    local totalW = gw;
+    local totalH = gh;
+
+    local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+    if savedPos then
+        imgui.SetNextWindowPos({savedPos.x, savedPos.y}, ImGuiCond_Always);
+    else
+        imgui.SetNextWindowPos({200, 200}, ImGuiCond_FirstUseEver);
+    end
+    imgui.SetNextWindowSize({totalW, totalH}, ImGuiCond_Always);
+
+    -- Preview windows intentionally omit NoBringToFrontOnFocus so they stay layered above the
+    -- main crossbar (which has that flag set). NoMove + the move anchor below gives us
+    -- explicit positioning control without ImGui drifting the window on focus.
+    local flags = bit.bor(
+        ImGuiWindowFlags_NoDecoration,
+        ImGuiWindowFlags_NoResize,
+        ImGuiWindowFlags_NoFocusOnAppearing,
+        ImGuiWindowFlags_NoNav,
+        ImGuiWindowFlags_NoBackground,
+        ImGuiWindowFlags_NoDocking,
+        ImGuiWindowFlags_NoMove
+    );
+
+    -- Zero window padding so the draw list clip rect matches the window bounds exactly.
+    -- Without this the default 8 px padding clips slots at the left/right edges (same fix
+    -- that landed for the main crossbar window in the previous smoke-test pass).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+    local didBegin = imgui.Begin(windowKey, true, flags);
+    imgui.PopStyleVar();
+
+    if didBegin then
+        local wX, wY = imgui.GetWindowPos();
+        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+        if savedPos == nil then
+            gConfig.windowPositions[windowKey] = {x = wX, y = wY};
+        end
+
+        local dl = imgui.GetWindowDrawList();
+        DrawPreviewSide(wX, wY, windowKey, 'L2', mode, ps, baseOp, dimFactor, dl, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled);
+    end
+    imgui.End();
+
+    -- Move anchor: independent lock so previews can be repositioned without unlocking the
+    -- main crossbar (and vice versa).
+    local previewLocked = settings and settings.doubleTapPreviewLocked;
+    if not previewLocked then
+        local pos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+        local anchorX = pos and pos.x or 200;
+        local anchorY = pos and pos.y or 200;
+        local newX, newY = drawing.DrawMoveAnchor(windowKey, anchorX, anchorY, {
+            anchorSide  = 'top',
+            windowWidth = totalW,
+        });
+        if newX ~= nil then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[windowKey] = {x = newX, y = newY};
+        end
+    end
 end
 
 -- Main draw function
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
+
+    -- Warm playerdata caches even when keyboard hotbars are disabled. Cheap on cache hit
+    -- (signature compare against job/level/equip ids), only does the heavy ability/WS scan
+    -- when the signature changes. See the require-site comment for the user-visible bug
+    -- this prevents (all JA/WS slots reading as unavailable on crossbar-only setups).
+    playerdata.RefreshCachedLists(data);
 
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local slotSize = (settings.slotSize or 48) * gs;
@@ -1037,34 +1850,12 @@ function M.DrawWindow(settings, moduleSettings)
     local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate dimensions using layout functions
-    local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local fullWidth, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local width = fullWidth;
 
-    -- Window flags (dummy window for positioning, like hotbar display.lua)
-    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
-
-    local windowName = 'Crossbar';
-    local defaultX, defaultY = GetDefaultPosition(settings);
-
-    -- Check if anchor is currently being dragged - if so, force position
-    local anchorDragging = drawing.IsAnchorDragging(windowName);
-    
-    if anchorDragging then
-        -- Use state position directly during drag for immediate response
-        imgui.SetNextWindowPos({state.windowX, state.windowY}, ImGuiCond_Always);
-    else
-        -- Apply saved position (once) or default
-        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-
-        if hasSaved then
-            ApplyWindowPosition(windowName);
-        else
-            imgui.SetNextWindowPos({defaultX, defaultY}, ImGuiCond_FirstUseEver);
-        end
-    end
-    
-    imgui.SetNextWindowSize({width, height}, ImGuiCond_Always);
-
-    -- Get current combo mode and pressed slot from controller
+    -- Get current combo mode and pressed slot from controller. Resolved BEFORE the window
+    -- size/position calls so the useSharedExpandedBar branch can shrink the window to a single
+    -- diamond and re-center it (a chord with useSharedExp on collapses to one 8-slot strip).
     local activeCombo = controller.GetActiveCombo();
     local pressedSlot = controller.GetPressedSlot();
 
@@ -1075,6 +1866,75 @@ function M.DrawWindow(settings, moduleSettings)
         activeCombo = editBar;
         pressedSlot = nil;  -- Don't show pressed state in edit mode
     end
+
+    -- Determine which bar set to display based on active combo. expandedSide == 'center' is
+    -- the useSharedExpandedBar branch (chord collapses both diamonds into one centered strip).
+    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo, settings);
+
+    -- useSharedExpandedBar special layout: shrink window to one diamond, re-center on screen X,
+    -- skip the right group draw + center divider/scope icon (they have no meaning when there's
+    -- only one diamond visible). Outside of chord, behaves identically to the standard 2-diamond
+    -- layout. exitingChordCenter catches the FIRST frame after the user releases the chord: we
+    -- restore the stashed wide-bar X so SaveCrossbarWindowSlotTopPosition doesn't persist the
+    -- narrow centered value.
+    local hideRightForSharedCenter = (isExpanded and expandedSide == 'center');
+    if hideRightForSharedCenter then
+        width = groupWidth;
+    end
+    local exitingChordCenter = state.wasSharedCenterChordLayout and (not hideRightForSharedCenter);
+
+    -- Window flags (dummy window for positioning, like hotbar display.lua)
+    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
+
+    local windowName = 'Crossbar';
+    local defaultX, defaultY = GetDefaultPosition(settings);
+
+    local function storedCrossbarPosY()
+        local posY = defaultY;
+        local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowName];
+        if savedPos and savedPos.y ~= nil then
+            posY = savedPos.y;
+        elseif state.windowY ~= nil then
+            posY = state.windowY;
+        end
+        return posY;
+    end
+
+    -- Check if anchor is currently being dragged - if so, force position
+    local anchorDragging = drawing.IsAnchorDragging(windowName);
+
+    -- state.windowX / state.windowY track the SLOT GRID origin. ImGui's window must open
+    -- CROSSBAR_WINDOW_TOP_DECOR_PAD pixels higher so the decoration above the slots
+    -- (L2/R2 triggers, combo text, R1 cpal-anchor pulse) stays inside the window's
+    -- content rect and doesn't get clipped.
+    if anchorDragging then
+        -- Use state position directly during drag for immediate response
+        imgui.SetNextWindowPos({ state.windowX, state.windowY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif hideRightForSharedCenter then
+        -- Shared-center chord: force X to screen-center each frame so the narrow window reads as
+        -- the FFXIV-style single 8-slot strip (Y persists from the last wide-bar position).
+        local io = imgui.GetIO();
+        local screenW = (io and io.DisplaySize and io.DisplaySize.x) or 1920;
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ (screenW - width) * 0.5, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif exitingChordCenter and state.lastWideCrossbarWindowX ~= nil then
+        -- First frame after chord release: re-anchor to the wide-bar X we stashed before the
+        -- chord, otherwise the user-visible position would briefly snap to the centered narrow X.
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ state.lastWideCrossbarWindowX, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    else
+        -- Apply saved position (once, slot-top -> window-top offset handled inside) or default
+        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+
+        if hasSaved then
+            ApplyCrossbarWindowPositionOnce();
+        else
+            imgui.SetNextWindowPos({ defaultX, defaultY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_FirstUseEver);
+        end
+    end
+
+    local bottomPad = GetCrossbarWindowBottomPad(settings);
+    imgui.SetNextWindowSize({ width, height + CROSSBAR_WINDOW_TOP_DECOR_PAD + bottomPad }, ImGuiCond_Always);
 
     -- Determine visibility for activeOnly display mode
     local leftVisible, rightVisible, crossbarVisible = GetVisibilityState(activeCombo, settings, isEditMode);
@@ -1100,8 +1960,14 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
-    -- Determine which bar set to display based on active combo
-    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo);
+    -- Menu-open dim: when a blocking game menu is open and the user has "Disable Crossbar
+    -- While In Menu" enabled, controller.lua already stops routing input — we additionally
+    -- dim everything the crossbar draws so it visually reads as "paused" rather than just
+    -- silently unresponsive. visibilityOpacity propagates into every slot via the per-slot
+    -- animOpacity param plus the background / border / trigger / divider alpha scales below.
+    if gamestate.IsMenuOpen() and settings.crossbarDisableInMenu ~= false then
+        visibilityOpacity = visibilityOpacity * 0.35;
+    end
 
     -- Check if animations are disabled - if so, force complete any in-progress animation
     if settings.enableTransitionAnimations == false and state.animation.active then
@@ -1143,7 +2009,11 @@ function M.DrawWindow(settings, moduleSettings)
     local leftActive, rightActive;
     if isExpanded then
         -- In expanded mode, only the expanded side is active, other side is dimmed
-        if expandedSide == 'left' then
+        if expandedSide == 'center' then
+            -- useSharedExpandedBar: only the left column is drawn (no right group exists this frame)
+            leftActive = true;
+            rightActive = false;
+        elseif expandedSide == 'left' then
             leftActive = true;
             rightActive = false;
         elseif expandedSide == 'right' then
@@ -1171,10 +2041,13 @@ function M.DrawWindow(settings, moduleSettings)
     -- Get draw list for ImGui-based rendering (behind config when open)
     local drawList = GetUIDrawList();
 
-    -- Get target server ID for skillchain prediction (cached for all slots)
+    -- Get target server ID for skillchain / magic burst prediction (cached for all slots).
+    -- Both features key off the same target so a single resolve+cache covers everything; the
+    -- per-slot SC and MB calls are no-ops when their respective enable flags are off.
     local targetServerId = nil;
     local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
-    if skillchainEnabled then
+    local magicBurstEnabled = gConfig.hotbarGlobal.magicBurstHighlightEnabled ~= false;
+    if skillchainEnabled or magicBurstEnabled then
         local mainTargetIdx = targetLib.GetTargets();
         if mainTargetIdx and mainTargetIdx ~= 0 then
             local targetEntity = GetEntity(mainTargetIdx);
@@ -1184,15 +2057,48 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
+    -- Zero out WindowPadding so the leftmost and rightmost diamond slots (which sit flush
+    -- against the window's content rect) aren't clipped by ImGui's default 8px padding.
+    -- Without this the left/right slots of each diamond render partially off-window and
+    -- their button hitboxes get pushed inward (slot interactions become unreliable).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
     -- Begin ImGui window - ALL slot rendering happens inside to enable interactions
     if imgui.Begin('Crossbar', true, windowFlags) then
-        -- Save position if moved (profile support)
-        SaveWindowPosition('Crossbar');
+        -- Save SLOT-TOP position if moved (decor-pad-aware; profile coordinate stays the
+        -- slot grid top so the saved value is meaningful even if decor pad changes later).
+        -- During the shared-center chord the X is force-centered each frame, so we MUST NOT
+        -- let SaveCrossbarWindowSlotTopPosition persist that narrow centered X — only sync Y.
+        if hideRightForSharedCenter then
+            if gConfig.windowPositions and gConfig.windowPositions[windowName] then
+                local wx, wy = imgui.GetWindowPos();
+                local s = gConfig.windowPositions[windowName];
+                local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+                if s.y ~= slotTopY then
+                    s.y = slotTopY;
+                end
+                -- Track the centered window X for free (used by lastWideCrossbarWindowX restore)
+                if s.x ~= wx then
+                    s.x = wx;
+                end
+            end
+        else
+            SaveCrossbarWindowSlotTopPosition();
+        end
         windowPosX, windowPosY = imgui.GetWindowPos();
 
-        -- Update stored position
+        -- Update stored position. state.windowY = slot grid top (window top + decor pad);
+        -- the rest of the layout code references state.windowY as the slot origin.
         state.windowX = windowPosX;
-        state.windowY = windowPosY;
+        state.windowY = windowPosY + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+
+        -- Stash the wide-bar X so that when the user releases the chord we can restore it
+        -- (otherwise the narrow centered X from this frame would be the "last" saved X).
+        if not hideRightForSharedCenter then
+            state.lastWideCrossbarWindowX = windowPosX;
+        end
+        -- Remember the layout for the NEXT frame so exitingChordCenter (above) can detect
+        -- the chord-release transition and re-anchor X.
+        state.wasSharedCenterChordLayout = hideRightForSharedCenter;
 
         -- Recalculate group positions with updated window position
         leftGroupX = state.windowX;
@@ -1244,35 +2150,36 @@ function M.DrawWindow(settings, moduleSettings)
                     -- Left side changed - animate it
                     if outOpacity > 0.01 then
                         DrawLeftSide(state.animation.fromLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Left side didn't change - draw at full opacity (with visibility fade)
                     DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
 
-            -- Draw RIGHT side (skip in activeOnly mode if not visible)
-            if not isActiveOnlyMode or rightVisible then
+            -- Draw RIGHT side (skip in activeOnly mode if not visible, or whenever the chord
+            -- collapsed both groups into a single centered strip — there is no right group).
+            if (not hideRightForSharedCenter) and (not isActiveOnlyMode or rightVisible) then
                 if state.animation.rightChanged then
                     -- Right side changed - animate it
                     if outOpacity > 0.01 then
                         DrawRightSide(state.animation.fromRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Right side didn't change - draw at full opacity (with visibility fade)
                     DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
         else
@@ -1281,12 +2188,16 @@ function M.DrawWindow(settings, moduleSettings)
                 -- ActiveOnly mode: draw only visible sides with visibility fade
                 if leftVisible then
                     DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
-                if rightVisible then
+                if (not hideRightForSharedCenter) and rightVisible then
                     DrawRightSide(state.currentRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
+            elseif hideRightForSharedCenter then
+                -- Shared-center chord: render only the (now-Shared) left column as one centered strip.
+                DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
+                    leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
             else
                 -- Normal mode: draw both sides at full opacity
                 DrawBarSet(
@@ -1295,17 +2206,21 @@ function M.DrawWindow(settings, moduleSettings)
                     slotSize, settings,
                     leftActive, rightActive,
                     pressedSlot, leftShowPressed, rightShowPressed,
-                    1.0, drawList, 0, targetServerId, skillchainEnabled
+                    1.0, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled
                 );
             end
         end
 
         imgui.End();
     end
+    -- Pop the WindowPadding style we pushed before Begin. Has to be unconditional (must match
+    -- the push even when Begin returns false / window is collapsed).
+    imgui.PopStyleVar();
 
-    -- Draw move anchor (only visible when config is open)
-    -- Only show when crossbar movement is NOT locked (uses global lock setting)
-    local crossbarLocked = gConfig and gConfig.hotbarLockMovement;
+    -- Draw move anchor (only visible when config is open).
+    -- Uses the crossbar-specific lock so Hotbar's lock toggle doesn't accidentally freeze
+    -- the crossbar (fixes the issue where Lock Crossbar was tied to Hotbar's setting).
+    local crossbarLocked = gConfig and gConfig.crossbarLockMovement;
     if not crossbarLocked then
         -- Use same window name as ImGui window so positions are shared
         local anchorNewX, anchorNewY = drawing.DrawMoveAnchor('Crossbar', state.windowX, state.windowY);
@@ -1323,22 +2238,36 @@ function M.DrawWindow(settings, moduleSettings)
     local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
     local showCenterElements = not isActiveOnlyMode;
 
-    -- Draw center divider (optional, hidden in activeOnly mode)
-    if settings.showDivider and drawList and showCenterElements then
-        local dividerX = state.windowX + groupWidth + (groupSpacing / 2);
-        local dividerY1 = state.windowY + 10;
-        local dividerY2 = state.windowY + height - 10;
+    -- Center decor (divider line, scope icon, combo text, palette name): all hidden in
+    -- activeOnly mode since that layout collapses to a single side and the divider has no meaning.
+    -- Shared-center chord layout: centerX is the middle of the (now single-diamond) window so the
+    -- scope icon / combo text / palette name still sit over the visible bar. The DIVIDER itself
+    -- is suppressed in chord since there's no longer a left/right split to divide.
+    local centerX;
+    if hideRightForSharedCenter then
+        centerX = state.windowX + width * 0.5;
+    else
+        centerX = state.windowX + groupWidth + (groupSpacing / 2);
+    end
+    local dividerTopY = state.windowY + 10;
 
+    if settings.showDivider and drawList and showCenterElements and (not hideRightForSharedCenter) then
+        local dividerY2 = state.windowY + height - 10;
         drawList:AddLine(
-            { dividerX, dividerY1 },
-            { dividerX, dividerY2 },
+            { centerX, dividerTopY },
+            { centerX, dividerY2 },
             imgui.GetColorU32({ 1, 1, 1, 0.3 }),
             2
         );
     end
 
+    -- Palette scope icon (infinity for Global / job icon for job-scoped) — drawn above the
+    -- divider's top endpoint. Same drawList as the divider so z-order is consistent.
+    if showCenterElements and drawList then
+        DrawPaletteScopeIconAboveDivider(centerX, dividerTopY, settings, drawList);
+    end
+
     -- Draw combo text in center for complex combos (hidden in activeOnly mode)
-    local centerX = state.windowX + groupWidth + (groupSpacing / 2);
     local topY = state.windowY - 4;  -- Above the window
     if showCenterElements then
         DrawComboText(activeCombo, centerX, topY, settings);
@@ -1350,9 +2279,15 @@ function M.DrawWindow(settings, moduleSettings)
         DrawPaletteName(centerX, bottomY, settings);
     end
 
-    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode)
+    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode). The shared-center
+    -- chord uses a different glyph (L2 + R2 chord centred on the single visible diamond) since
+    -- there's no left-vs-right group to position labels against.
     if drawList and showCenterElements then
-        DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        if hideRightForSharedCenter then
+            DrawTriggerIconsSharedExpandedCenter(activeCombo, leftGroupX, leftGroupY, groupWidth, settings, drawList);
+        else
+            DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        end
     end
 
     -- Draw palette modifier indicator (refresh icon when modifier key is held)
@@ -1380,6 +2315,41 @@ function M.DrawWindow(settings, moduleSettings)
                 );
             end
         end
+    end
+
+    -- Double-tap preview windows. Drawn AFTER the main crossbar so they end up in
+    -- separate ImGui windows with their own draw list / position, layered above the main
+    -- bar. Gated on both `enableDoubleTap` (the L2x2/R2x2 modes have to be enabled at all)
+    -- and `showDoubleTapPreview` (the per-feature visibility toggle). When the active combo
+    -- IS the matching double-tap, the preview swaps to the BASE L2/R2 slots as a reference
+    -- — the main bar is already showing the double-tap content.
+    if settings.enableDoubleTap and settings.showDoubleTapPreview then
+        local scale  = settings.doubleTapPreviewScale  or 0.60;
+        local baseOp = (settings.doubleTapPreviewOpacity or 1.0) * visibilityOpacity;
+        -- Skip the preview render path entirely when nothing would be visible (menu dim or
+        -- activeOnly hide). Saves the 16-slot DrawSlot + ImGui begin/end overhead per frame.
+        if baseOp <= 0.02 then return; end
+        local dimFact = settings.inactiveSideWhileTriggerDim;
+        if dimFact == nil then dimFact = 0.15; end
+        local ps = MakePreviewSettings(settings, scale);
+
+        local isL2xActive = (activeCombo == COMBO_MODES.L2_DOUBLE);
+        local isR2xActive = (activeCombo == COMBO_MODES.R2_DOUBLE);
+        local anyTriggerHeld = (activeCombo ~= COMBO_MODES.NONE);
+        local previewDim = anyTriggerHeld and dimFact or 1.0;
+
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewL2x2',
+            isL2xActive and 'L2' or 'L2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewR2x2',
+            isR2xActive and 'R2' or 'R2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
     end
 end
 
@@ -1467,6 +2437,11 @@ end
 -- Clear icon cache (call when job changes)
 function M.ClearIconCache()
     ClearCrossbarIconCache();
+    -- Mirror the wipe to actions.lua's negative-result cache so "no icon" decisions
+    -- pinned from a previous state don't survive into the new job/palette context.
+    if actions and actions.ClearNoIconCache then
+        actions.ClearNoIconCache();
+    end
 end
 
 -- Clear icon cache for a specific slot (call on targeted slot updates)
@@ -1487,6 +2462,187 @@ function M.ResetPositions()
     if gConfig.appliedPositions then
         gConfig.appliedPositions['Crossbar'] = nil;
     end
+end
+
+-- ============================================
+-- Edit Full Palette (called from config/palettemanager.lua's ImGui window)
+-- ============================================
+-- The editor draws a static representation of a crossbar row using the SAME DrawSlot path
+-- as the live HUD, so layout (diamond geometry, slot size, label position, MP/quantity)
+-- always matches what the user actually plays with. The editor differs from the HUD in:
+--   * Slot data is read from the draft layer (data.GetDraftSlotData) not the live binding.
+--   * MP / quantity / cooldown text are suppressed (showMpCost=false, showQuantity=false).
+--   * The action name renders ON the slot (labelForeground + editorMinimalView).
+--   * Drop zones use 'paled_*' IDs with dropPriority=10 so they win against the HUD zones
+--     underneath when the editor window overlaps the live crossbar.
+--   * Optional editorClipRect culls slots scrolled off the editor panel.
+-- These are all set by the local DrawSlot wrapper above; the public functions here just
+-- iterate the 8 slots of each diamond and call DrawSlot once per slot.
+
+-- Shared palette-editor slot row. Either or both of modeLeft (L2 group) and modeRight
+-- (R2 group) may be set; pass nil on a side to omit it (Pets tab filter renders single-sided rows).
+local function DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    if not state.initialized then return; end
+    if not modeLeft and not modeRight then return; end
+    local editorClipRect;
+    if clipMinX and clipMinY and clipMaxX and clipMaxY then
+        editorClipRect = { clipMinX, clipMinY, clipMaxX, clipMaxY };
+    end
+    local slotSize = settings.slotSize or 48;
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        if modeLeft then
+            local sx, sy = GetSlotPositionInWindow('L2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeLeft, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+        if modeRight then
+            local sx, sy = GetSlotPositionInWindow('R2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeRight, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+    end
+end
+
+function M.DrawPaletteEditorL2R2Row(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+function M.DrawPaletteEditorSingleRow(screenOriginX, screenOriginY, settings, modeOnly, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeOnly, nil, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+-- Trigger glyphs raised above the editor's slot cluster. glyphMode:
+--   'primary'     — L2 | R2 (one glyph per side, gap between d-pad and face).
+--   'doubleTap'   — L2 + "x2", R2 + "x2".
+--   'chordCombo'  — Left: L2+R2, Right: R2+L2 (with text "+" between).
+--   'sharedChord' — Single L2+R2 glyph centred over the shared diamond.
+-- Optional sides = { l=bool, r=bool } (default both true) — used by Pets-tab single-sided rows.
+function M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, glyphMode, sides)
+    local dl = imgui.GetWindowDrawList();
+    if not dl then return; end
+    glyphMode = glyphMode or 'primary';
+    local sl = (not sides or sides.l ~= false);
+    local sr = (not sides or sides.r ~= false);
+    local totalW, _, groupW, ghgt = GetCrossbarDimensions(settings);
+    local gs = totalW - 2 * groupW;
+    local slotSize = settings.slotSize or 48;
+    local scale = (settings.triggerIconScale or 1.0) * math.max(0.42, math.min(1.1, slotSize / 48));
+    local iw = 49 * scale;
+    local ih = 28 * scale;
+    local yLift = 35;
+    local cy = screenOriginY + ghgt * 0.5 - yLift;
+    local tint = imgui.GetColorU32({ 1, 1, 1, 0.88 });
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    local chordTight = math.max(0.5, 0.65 * scale);
+    local doubleTapImgGap = math.max(1, 2 * scale);
+
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImage(texName, ix, iy)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+    end
+
+    local function drawComboAtCenter(cx, firstTex, secondTex)
+        local ptw, pth = plusSize();
+        local gL, gR = chordTight, chordTight;
+        local total = iw + gL + ptw + gR + iw;
+        local leftX = cx - total * 0.5;
+        drawImage(firstTex, leftX, cy - ih * 0.5);
+        dl:AddText({ leftX + iw + gL, cy - pth * 0.5 }, textCol, '+');
+        drawImage(secondTex, leftX + iw + gL + ptw + gR, cy - ih * 0.5);
+    end
+
+    if glyphMode == 'sharedChord' then
+        drawComboAtCenter(screenOriginX + groupW * 0.5, 'L2', 'R2');
+        return;
+    end
+
+    if glyphMode == 'chordCombo' then
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then drawComboAtCenter(l2cx, 'L2', 'R2'); end
+        if sr then drawComboAtCenter(r2cx, 'R2', 'L2'); end
+        return;
+    end
+
+    if glyphMode == 'doubleTap' then
+        local x2Str = 'x2';
+        local tw, th = 18, 16;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize(x2Str);
+            if type(ts) == 'table' then
+                tw = ts[1] or ts.x or tw;
+                th = ts[2] or ts.y or th;
+            end
+        end
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then
+            local l2Tex = textures:GetControllerIcon('L2');
+            if l2Tex and l2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', l2Tex.image));
+                if p and p ~= 0 then
+                    local ix = l2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        if sr then
+            local r2Tex = textures:GetControllerIcon('R2');
+            if r2Tex and r2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', r2Tex.image));
+                if p and p ~= 0 then
+                    local ix = r2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        return;
+    end
+
+    -- primary
+    local l2cx = screenOriginX + groupW * 0.5;
+    local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+    if sl then drawImage('L2', l2cx - iw * 0.5, cy - ih * 0.5); end
+    if sr then drawImage('R2', r2cx - iw * 0.5, cy - ih * 0.5); end
+end
+
+-- Convenience wrapper used by the Shared (chord-fallback) row.
+function M.DrawPaletteEditorSharedChordTriggerGlyphs(screenOriginX, screenOriginY, settings)
+    M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, 'sharedChord');
+end
+
+-- Exposed so palettemanager.lua can size the editor row to match the live HUD dimensions
+-- without duplicating the math (slot size, gaps, diamond spacing, etc. all flow through here).
+function M.GetEditorCrossbarRowDimensions(settings)
+    return GetCrossbarDimensions(settings);
+end
+
+-- Legacy GDI hook (kept as a no-op for API compatibility with `palettemanager.lua`).
+-- Pre-1.8.0 this hid the persistent D3D/GDI primitives backing the editor's slot row when
+-- the editor window was not currently drawing. Under 1.8.0's imtext architecture there are
+-- no persistent objects to hide — un-emitted draw calls simply don't render. The function
+-- is retained so callers don't break and so the contract is documented; consider removing
+-- once palettemanager.lua's six call sites are updated.
+function M.HidePaletteEditorPrimitives()
 end
 
 return M;

--- a/XIUI/modules/hotbar/palette.lua
+++ b/XIUI/modules/hotbar/palette.lua
@@ -27,6 +27,8 @@ local M = {};
 
 M.DEFAULT_PALETTE_NAME = 'Default';  -- Name for auto-created palettes
 M.PALETTE_KEY_PREFIX = 'palette:';
+-- All-jobs crossbar palettes (slotActions key prefix: global:palette:{name})
+M.UNIVERSAL_CROSSBAR_PREFIX = 'global:palette:';
 
 -- Deferred save state for palette selection changes
 -- Instead of saving immediately, track dirty state and save at natural pause points
@@ -45,9 +47,42 @@ local state = {
     -- NOTE: Crossbar can have 0 palettes and use default slots
     crossbarActivePalette = nil,
 
+    -- All-jobs universal crossbar sets (enableUniversalCrossbarPalettes in config)
+    crossbarPaletteScope = 'job', -- 'job' | 'universal'
+    crossbarActiveUniversalPalette = nil,
+
+    -- Job-scope crossbar: which storage tier is active — 0 = Job-wide (all subjobs), N = that subjob only
+    -- Only meaningful when the character has a support job (live subjob ~= 0)
+    crossbarActiveStorageSubjob = nil,
+
+    -- /xiui cpal preview of another job's named palette (off-job). Cleared on cycle, commit, scope/job change.
+    crossbarCliPreview = nil, -- { jobId, storageSubjob, paletteName }
+
+    -- /xiui cpal return-to-origin anchors (set on first cpal switch per scope, cleared on R1 double-tap return or job change)
+    cpalJobAnchor = nil,        -- { name, storageSubjob, jobId }
+    cpalUniversalAnchor = nil,  -- string palette name
+
     -- Callbacks for palette change events
     onPaletteChangedCallbacks = {},
 };
+
+-- Pending: profile/gConfig was swapped before player job was readable (addon startup). Consumed by hotbar init.
+local pendingApplyDefaultCrossbarScopeFromProfile = false;
+
+function M.NotifyProfileSettingsLoaded()
+    pendingApplyDefaultCrossbarScopeFromProfile = true;
+end
+
+function M.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+    if pendingApplyDefaultCrossbarScopeFromProfile then
+        pendingApplyDefaultCrossbarScopeFromProfile = false;
+        return true;
+    end
+    return false;
+end
+
+-- After hotbarCrossbar exists: seed one blank Job [J] Default palette per job (1–22) without touching live active palette.
+local crossbarBlankDefaultsSeeded = false;
 
 -- ============================================
 -- Performance: Palette List Cache
@@ -67,6 +102,64 @@ local function InvalidatePaletteListCache()
     paletteListCache = {};
     crossbarPaletteListCache = {};
 end
+
+-- Prefer the palette that was next in list after delete (below), else above (typical "stay nearby" UX)
+local function PickNeighborPaletteName(orderedList, deletedName)
+    if not orderedList or not deletedName then
+        return nil;
+    end
+    local idx = nil;
+    for i, n in ipairs(orderedList) do
+        if n == deletedName then
+            idx = i;
+            break;
+        end
+    end
+    if not idx then
+        return nil;
+    end
+    if orderedList[idx + 1] then
+        return orderedList[idx + 1];
+    end
+    if orderedList[idx - 1] then
+        return orderedList[idx - 1];
+    end
+    return nil;
+end
+
+-- Token for GetCrossbarAvailablePalettes when live subjob ~= 0: tier + palette name (names cannot contain ':')
+local CROSSBAR_ENTRY_SEP = '\1';
+
+function M.EncodeCrossbarEntryToken(storageSubjob, name)
+    return tostring(storageSubjob or 0) .. CROSSBAR_ENTRY_SEP .. (name or '');
+end
+
+-- Returns storageSubjob, name or nil, plainToken if not an encoded entry
+function M.DecodeCrossbarEntryToken(token)
+    if not token or type(token) ~= 'string' then
+        return nil, nil;
+    end
+    local st, name = token:match('^(%d+)' .. CROSSBAR_ENTRY_SEP .. '(.+)$');
+    if st then
+        return tonumber(st), name;
+    end
+    return nil, token;
+end
+
+-- Display suffix: Job-wide vs Subjob-specific tier (not Global [G], which is separate scope)
+function M.FormatCrossbarTierSuffixLabel(storageSubjob, liveSubjobId)
+    local live = liveSubjobId or 0;
+    if live == 0 then
+        return ' (J)';
+    end
+    if (storageSubjob or 0) == 0 then
+        return ' (J)';
+    end
+    return ' (SJ)';
+end
+
+-- Crossbar combo modes (single list for callbacks / universal scope)
+local CROSSBAR_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
 
 -- ============================================
 -- Config Structure Helpers
@@ -278,6 +371,108 @@ local function IsValidPaletteName(name)
     return true;
 end
 
+-- Key for hotbar RB-cycle exclude map: matches palette order when using shared fallback (subjob 0)
+local function GetEffectiveHotbarPaletteMetaKey(jobId, subjobId)
+    local jid = jobId or 1;
+    local sj = subjobId or 0;
+    if sj ~= 0 and M.IsUsingFallbackPalettes(jid, sj) then
+        return BuildJobSubjobKey(jid, 0);
+    end
+    return BuildJobSubjobKey(jid, sj);
+end
+
+local function PrunePaletteExcludeSubtable(root, key)
+    if not root or not root[key] then
+        return;
+    end
+    local empty = true;
+    for _ in pairs(root[key]) do
+        empty = false;
+        break;
+    end
+    if empty then
+        root[key] = nil;
+    end
+end
+
+-- When true, palette is included in RB+D-pad / keyboard palette cycling for hotbars
+function M.IsHotbarPaletteInRbCycle(jobId, subjobId, paletteName)
+    if not paletteName then
+        return true;
+    end
+    local key = GetEffectiveHotbarPaletteMetaKey(jobId, subjobId);
+    local t = gConfig and gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[key];
+    if t and t[paletteName] then
+        return false;
+    end
+    return true;
+end
+
+function M.SetHotbarPaletteInRbCycle(jobId, subjobId, paletteName, inCycle)
+    if not paletteName or not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    if not EnsureHotbarConfigExists() then
+        return false, 'Config unavailable';
+    end
+    if not gConfig.hotbar.paletteExcludeFromCycle then
+        gConfig.hotbar.paletteExcludeFromCycle = {};
+    end
+    local key = GetEffectiveHotbarPaletteMetaKey(jobId, subjobId);
+    if not gConfig.hotbar.paletteExcludeFromCycle[key] then
+        gConfig.hotbar.paletteExcludeFromCycle[key] = {};
+    end
+    local ex = gConfig.hotbar.paletteExcludeFromCycle[key];
+    if inCycle then
+        ex[paletteName] = nil;
+        PrunePaletteExcludeSubtable(gConfig.hotbar.paletteExcludeFromCycle, key);
+    else
+        ex[paletteName] = true;
+    end
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Job crossbar (non-universal): per storage tier orderKey job:tier
+function M.IsCrossbarPaletteInRbCycle(jobId, tierStorageSubjob, paletteName)
+    if not paletteName then
+        return true;
+    end
+    local key = BuildJobSubjobKey(jobId or 1, tierStorageSubjob or 0);
+    local cbs = gConfig.hotbarCrossbar;
+    local t = cbs and cbs.crossbarPaletteExcludeFromCycle and cbs.crossbarPaletteExcludeFromCycle[key];
+    if t and t[paletteName] then
+        return false;
+    end
+    return true;
+end
+
+function M.SetCrossbarPaletteInRbCycle(jobId, tierStorageSubjob, paletteName, inCycle)
+    if not paletteName or not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    local cbs = gConfig.hotbarCrossbar;
+    if not cbs then
+        return false, 'Crossbar settings not found';
+    end
+    if not cbs.crossbarPaletteExcludeFromCycle then
+        cbs.crossbarPaletteExcludeFromCycle = {};
+    end
+    local key = BuildJobSubjobKey(jobId or 1, tierStorageSubjob or 0);
+    if not cbs.crossbarPaletteExcludeFromCycle[key] then
+        cbs.crossbarPaletteExcludeFromCycle[key] = {};
+    end
+    local ex = cbs.crossbarPaletteExcludeFromCycle[key];
+    if inCycle then
+        ex[paletteName] = nil;
+        PrunePaletteExcludeSubtable(cbs.crossbarPaletteExcludeFromCycle, key);
+    else
+        ex[paletteName] = true;
+    end
+    SaveSettingsToDisk();
+    return true;
+end
+
 -- ============================================
 -- Palette Key Generation
 -- ============================================
@@ -311,17 +506,7 @@ function M.BuildSharedPaletteStorageKey(jobId, paletteName)
     return M.BuildPaletteStorageKey(jobId, 0, paletteName);
 end
 
--- DEPRECATED: Old format - kept for backwards compatibility during migration
--- Build full storage key for a palette using old format (includes subjob)
--- baseKey: '{jobId}:{subjobId}' format
--- paletteName: palette name or nil for default slot data
-function M.BuildStorageKey(baseKey, paletteName)
-    local suffix = M.GetPaletteKeySuffix(paletteName);
-    if not suffix then
-        return baseKey;
-    end
-    return string.format('%s:%s', baseKey, suffix);
-end
+-- REMOVED: BuildStorageKey — was deprecated, no callers remain. Use BuildPaletteStorageKey instead.
 
 -- Parse a storage key to extract palette name
 -- Returns nil if no palette suffix (default slots)
@@ -554,9 +739,15 @@ end
 function M.CyclePalette(barIndex, direction, jobId, subjobId)
     direction = direction or 1;
 
-    local palettes = M.GetAvailablePalettes(barIndex, jobId, subjobId);
+    local all = M.GetAvailablePalettes(barIndex, jobId, subjobId);
+    local palettes = {};
+    for _, name in ipairs(all) do
+        if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+            table.insert(palettes, name);
+        end
+    end
     if #palettes <= 1 then
-        return nil;  -- No palettes to cycle (0 or 1 palette)
+        return nil;  -- No palettes to cycle (0 or 1 in RB cycle list)
     end
 
     local currentName = state.activePalette;
@@ -724,6 +915,7 @@ function M.DeletePalette(barIndex, paletteName, jobId, subjobId)
     if #availablePalettes <= 1 then
         return false, 'Cannot delete the last palette';
     end
+    local neighborName = PickNeighborPaletteName(availablePalettes, paletteName);
 
     -- Find the storage key (could be subjob-specific or shared)
     local storageKey = FindPaletteStorageKey(1, paletteName, normalizedJobId, normalizedSubjobId);
@@ -767,17 +959,40 @@ function M.DeletePalette(barIndex, paletteName, jobId, subjobId)
         end
     end
 
+    if gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[orderKey] then
+        gConfig.hotbar.paletteExcludeFromCycle[orderKey][paletteName] = nil;
+        PrunePaletteExcludeSubtable(gConfig.hotbar.paletteExcludeFromCycle, orderKey);
+    end
+
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
 
-    -- If this was the active palette, switch to the first available palette
+    -- If this was the active palette, switch to a nearby palette in the old order (below, else above)
     if state.activePalette == paletteName then
-        -- Get updated list after deletion
         local remainingPalettes = M.GetAvailablePalettes(barIndex, normalizedJobId, normalizedSubjobId);
-        local newActive = remainingPalettes[1];  -- First palette becomes active
-        M.SetActivePalette(1, newActive, normalizedJobId, normalizedSubjobId);
+        local newActive = nil;
+        if neighborName then
+            for _, n in ipairs(remainingPalettes) do
+                if n == neighborName then
+                    newActive = n;
+                    break;
+                end
+            end
+        end
+        if not newActive and #remainingPalettes > 0 then
+            newActive = remainingPalettes[1];
+        end
+        if newActive then
+            local changed = M.SetActivePalette(1, newActive, normalizedJobId, normalizedSubjobId);
+            if not changed then
+                for i = 1, 6 do
+                    M.FirePaletteChangedCallbacks(i, newActive, newActive);
+                end
+            end
+        end
     end
 
+    InvalidateAllVisualCachesAfterPaletteListMutation();
     SaveSettingsToDisk();
     return true;
 end
@@ -852,6 +1067,14 @@ function M.RenamePalette(barIndex, oldName, newName, jobId, subjobId)
         end
     end
 
+    if gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[orderKey] then
+        local ex = gConfig.hotbar.paletteExcludeFromCycle[orderKey];
+        if ex[oldName] then
+            ex[oldName] = nil;
+            ex[newName] = true;
+        end
+    end
+
     -- Update active palette if this was active
     if state.activePalette == oldName then
         state.activePalette = newName;
@@ -887,20 +1110,18 @@ function M.MovePalette(barIndex, paletteName, direction, jobId, subjobId)
     end
     local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
 
-    -- Ensure paletteOrder exists and is populated
     if not gConfig.hotbar then
         gConfig.hotbar = {};
     end
     if not gConfig.hotbar.paletteOrder then
         gConfig.hotbar.paletteOrder = {};
     end
-    if not gConfig.hotbar.paletteOrder[orderKey] then
-        -- Initialize paletteOrder from current available palettes
-        gConfig.hotbar.paletteOrder[orderKey] = {};
-        local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-        for _, name in ipairs(available) do
-            table.insert(gConfig.hotbar.paletteOrder[orderKey], name);
-        end
+
+    -- Match the merged list used by the Palette Manager / cycling (stored order can omit new palettes)
+    local canonical = M.GetAvailablePalettes(barIndex, normalizedJobId, normalizedSubjobId);
+    gConfig.hotbar.paletteOrder[orderKey] = {};
+    for _, name in ipairs(canonical) do
+        table.insert(gConfig.hotbar.paletteOrder[orderKey], name);
     end
 
     local order = gConfig.hotbar.paletteOrder[orderKey];
@@ -969,17 +1190,26 @@ function M.SetPaletteOrder(barIndex, palettes, jobId, subjobId)
     return true;
 end
 
--- Get the index of a palette in the order (1-based) (GLOBAL)
--- barIndex param kept for backwards compatibility but ignored
--- subjobId param kept for backwards compatibility but ignored
--- Returns the index, or nil if not found
+-- Ordered palette names included in RB / keyboard cycling (excludes "Inactive" in Palette Manager).
+function M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId)
+    local out = {};
+    for _, name in ipairs(M.GetAvailablePalettes(barIndex, jobId, subjobId)) do
+        if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+            table.insert(out, name);
+        end
+    end
+    return out;
+end
+
+-- Get the index of a palette within RB-cycle order only (1-based) (GLOBAL)
+-- Returns nil if the palette is not in the cycle list (e.g. marked Inactive).
 function M.GetPaletteIndex(barIndex, paletteName, jobId, subjobId)
     if not paletteName then
         return nil;
     end
 
-    local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-    for i, name in ipairs(available) do
+    local cycle = M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId);
+    for i, name in ipairs(cycle) do
         if name == paletteName then
             return i;
         end
@@ -987,12 +1217,9 @@ function M.GetPaletteIndex(barIndex, paletteName, jobId, subjobId)
     return nil;
 end
 
--- Get the total number of palettes (GLOBAL)
--- barIndex param kept for backwards compatibility but ignored
--- subjobId param kept for backwards compatibility but ignored
+-- Count of palettes that participate in RB / keyboard cycling (not total defined palettes).
 function M.GetPaletteCount(barIndex, jobId, subjobId)
-    local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-    return #available;
+    return #M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId);
 end
 
 -- ============================================
@@ -1038,12 +1265,79 @@ function M.FirePaletteChangedCallbacks(barIndex, oldPalette, newPalette)
     end
 end
 
+-- SetActive* skips callbacks when name (and tier) match current state, but storage may still
+-- have changed (e.g. same palette name on another tier, or recreated empty Default).
+local function FireCrossbarComboRefreshNoop(displayName)
+    if not displayName then
+        return;
+    end
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, displayName, displayName);
+    end
+end
+
+-- Palette OnPaletteChanged only clears slotrenderer rendering cache + crossbar icons; hotbar also uses
+-- display-layer icon cache. After delete + redirect, force a full flush so binds resolve to the new storage key.
+local function InvalidateAllVisualCachesAfterPaletteListMutation()
+    local ok, dataMod = pcall(require, 'modules.hotbar.data');
+    if ok and dataMod and dataMod.InvalidateStorageKeyCache then
+        dataMod.InvalidateStorageKeyCache();
+    end
+    local ok2, sr = pcall(require, 'modules.hotbar.slotrenderer');
+    if ok2 and sr and sr.ClearAllCache then
+        sr.ClearAllCache();
+    end
+    pcall(function()
+        local disp = require('modules.hotbar.display');
+        if disp.ClearIconCache then
+            disp.ClearIconCache();
+        end
+    end);
+    pcall(function()
+        local xb = require('modules.hotbar.crossbar');
+        if xb.ClearIconCache then
+            xb.ClearIconCache();
+        end
+    end);
+end
+
+--- Re-run palette validation (active names vs lists) then fire a no-op palette change per bar/combo so
+--- hotbar/crossbar UIs reload binds from gConfig (JSON import changes data under the same palette name).
+function M.RefreshActivePaletteVisualsAfterExternalEdit()
+    local okData, dataMod = pcall(require, 'modules.hotbar.data');
+    if okData and dataMod and dataMod.jobId then
+        pcall(function()
+            M.ValidatePalettesForJob(dataMod.jobId, dataMod.subjobId or 0, { applyDefaultCrossbarScope = false });
+        end);
+    end
+    local hotbarName = state.activePalette;
+    if hotbarName then
+        for i = 1, 6 do
+            M.FirePaletteChangedCallbacks(i, hotbarName, hotbarName);
+        end
+    end
+    if state.crossbarActivePalette then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            M.FirePaletteChangedCallbacks('crossbar:' .. mode, state.crossbarActivePalette, state.crossbarActivePalette);
+        end
+    end
+    if state.crossbarActiveUniversalPalette then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            M.FirePaletteChangedCallbacks('crossbar:' .. mode, state.crossbarActiveUniversalPalette, state.crossbarActiveUniversalPalette);
+        end
+    end
+end
+
+--- Called after tools import or replace slot data outside normal palette APIs (e.g. JSON import).
+function M.InvalidateCachesAfterExternalSlotMutation()
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    M.RefreshActivePaletteVisualsAfterExternalEdit();
+end
+
 -- ============================================
 -- Crossbar Palette Management
 -- ============================================
-
--- Crossbar combo modes for iteration
-local CROSSBAR_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
 
 -- Helper: Scan crossbar for palettes matching a pattern prefix
 -- Returns: table of { [paletteName] = true }
@@ -1069,17 +1363,81 @@ local function ScanCrossbarForPalettes(patternPrefix)
     return existingPalettes;
 end
 
--- Get all available palette names for crossbar only
--- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
--- Fallback: If no subjob-specific palettes exist, falls back to shared palettes (subjob 0)
--- Returns: { 'Stuns', 'Heals', ... } - palettes available ONLY for crossbar (empty if none defined)
--- Crossbar palettes are SEPARATE from hotbar palettes
--- OPTIMIZED: Results are cached with TTL
+-- Build ordered list of crossbar palette rows for a job + live subjob context (no Either/Or hiding).
+-- storageSubjob 0 = Job-wide [J]; storageSubjob == subjobId (when ~=0) = Subjob-only [SJ] entries.
+local function BuildCrossbarMergedRowsInternal(jobId, subjobId)
+    local jid = jobId or 1;
+    local sj = subjobId or 0;
+    local rows = {};
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+
+    local function orderedNamesForTier(tierSj, existingSet)
+        local orderKey = BuildJobSubjobKey(jid, tierSj);
+        local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+            and crossbarSettings.crossbarPaletteOrder[orderKey];
+        local out = {};
+        local seen = {};
+        if storedOrder then
+            for _, paletteName in ipairs(storedOrder) do
+                if existingSet[paletteName] and not seen[paletteName] then
+                    seen[paletteName] = true;
+                    table.insert(out, paletteName);
+                end
+            end
+        end
+        local remaining = {};
+        for paletteName, _ in pairs(existingSet) do
+            if not seen[paletteName] then
+                table.insert(remaining, paletteName);
+            end
+        end
+        table.sort(remaining);
+        for _, paletteName in ipairs(remaining) do
+            table.insert(out, paletteName);
+        end
+        return out;
+    end
+
+    if sj == 0 then
+        local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+        local set0 = ScanCrossbarForPalettes(pattern0);
+        for _, n in ipairs(orderedNamesForTier(0, set0)) do
+            table.insert(rows, { name = n, storageSubjob = 0 });
+        end
+        return rows;
+    end
+
+    local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+    local set0 = ScanCrossbarForPalettes(pattern0);
+    local seen = {};
+    for _, n in ipairs(orderedNamesForTier(0, set0)) do
+        seen[n] = true;
+        table.insert(rows, { name = n, storageSubjob = 0 });
+    end
+
+    local subPattern = string.format('%d:%d:%s', jid, sj, M.PALETTE_KEY_PREFIX);
+    local setS = ScanCrossbarForPalettes(subPattern);
+    local extraSet = {};
+    for name, _ in pairs(setS) do
+        if not seen[name] then
+            extraSet[name] = true;
+        end
+    end
+    for _, n in ipairs(orderedNamesForTier(sj, extraSet)) do
+        table.insert(rows, { name = n, storageSubjob = sj });
+    end
+
+    return rows;
+end
+
+-- Get all available crossbar entries for the current job/subjob context.
+-- When live subjob is 0: returns plain palette names (Job [J] tier only).
+-- When live subjob ~= 0: returns encoded tokens 'storageSubjob' .. sep .. 'name' so Job + Subjob tiers stay distinct.
+-- Crossbar palettes are SEPARATE from hotbar palettes. OPTIMIZED: cached with TTL.
 function M.GetCrossbarAvailablePalettes(jobId, subjobId)
     local normalizedJobId = jobId or 1;
     local normalizedSubjobId = subjobId or 0;
 
-    -- Check cache first
     local cacheKey = BuildPaletteCacheKey(normalizedJobId, normalizedSubjobId);
     local cached = crossbarPaletteListCache[cacheKey];
     local now = os.clock();
@@ -1088,162 +1446,757 @@ function M.GetCrossbarAvailablePalettes(jobId, subjobId)
     end
 
     local palettes = {};
-
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
     if not crossbarSettings or not crossbarSettings.slotActions then
         crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
         return palettes;
     end
 
-    -- Check subjob-specific palettes first: '{jobId}:{subjobId}:palette:{name}'
-    local subjobPattern = string.format('%d:%d:%s', normalizedJobId, normalizedSubjobId, M.PALETTE_KEY_PREFIX);
-    local existingPalettes = ScanCrossbarForPalettes(subjobPattern);
-
-    -- Count subjob-specific palettes
-    local subjobPaletteCount = 0;
-    for _ in pairs(existingPalettes) do
-        subjobPaletteCount = subjobPaletteCount + 1;
-    end
-
-    -- Fallback to shared palettes (subjob 0) if no subjob-specific palettes exist
-    local usingFallback = false;
-    if subjobPaletteCount == 0 and normalizedSubjobId ~= 0 then
-        local sharedPattern = string.format('%d:0:%s', normalizedJobId, M.PALETTE_KEY_PREFIX);
-        existingPalettes = ScanCrossbarForPalettes(sharedPattern);
-        usingFallback = true;
-    end
-
-    -- Get the stored palette order (keyed by job:subjob or fallback to job:0)
-    local orderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
-    local storedOrder = crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[orderKey];
-
-    -- If using fallback, also check for shared order
-    if not storedOrder and usingFallback then
-        local sharedOrderKey = BuildJobSubjobKey(normalizedJobId, 0);
-        storedOrder = crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[sharedOrderKey];
-    end
-
-    -- Build ordered result: first add palettes from storedOrder that exist
-    local seen = {};
-    if storedOrder then
-        for _, paletteName in ipairs(storedOrder) do
-            if existingPalettes[paletteName] and not seen[paletteName] then
-                seen[paletteName] = true;
-                table.insert(palettes, paletteName);
-            end
+    if normalizedSubjobId == 0 then
+        local rows = BuildCrossbarMergedRowsInternal(normalizedJobId, 0);
+        for _, r in ipairs(rows) do
+            table.insert(palettes, r.name);
+        end
+    else
+        local rows = BuildCrossbarMergedRowsInternal(normalizedJobId, normalizedSubjobId);
+        for _, r in ipairs(rows) do
+            table.insert(palettes, M.EncodeCrossbarEntryToken(r.storageSubjob, r.name));
         end
     end
 
-    -- Collect any remaining palettes not in the stored order
+    crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
+    return palettes;
+end
+
+-- Rows for Manage / embedded Palette Manager (and cycle order): Job [J] then Subjob [SJ]-only names.
+function M.GetCrossbarManagePaletteRows(jobId, subjobId)
+    return BuildCrossbarMergedRowsInternal(jobId or 1, subjobId or 0);
+end
+
+-- SJ-only palette names in the same order as (SJ) rows in Manage: job:sj:palette:* names that are NOT
+-- also on job:0:palette:* for the same main job (excludes empty duplicate SJ buckets that shadow [J] names).
+function M.GetCrossbarSjOnlyPaletteNamesOrdered(jobId, liveSubjobId)
+    local jid = jobId or 1;
+    local sj = liveSubjobId or 0;
+    if sj == 0 then
+        return {};
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+    local set0 = ScanCrossbarForPalettes(pattern0);
+    local jNames = {};
+    for name, _ in pairs(set0) do
+        jNames[name] = true;
+    end
+    local subPattern = string.format('%d:%d:%s', jid, sj, M.PALETTE_KEY_PREFIX);
+    local setS = ScanCrossbarForPalettes(subPattern);
+    local extraSet = {};
+    for name, _ in pairs(setS) do
+        if not jNames[name] then
+            extraSet[name] = true;
+        end
+    end
+    local orderKey = BuildJobSubjobKey(jid, sj);
+    local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+        and crossbarSettings.crossbarPaletteOrder[orderKey];
+    local out = {};
+    local seen = {};
+    if storedOrder then
+        for _, paletteName in ipairs(storedOrder) do
+            if extraSet[paletteName] and not seen[paletteName] then
+                seen[paletteName] = true;
+                table.insert(out, paletteName);
+            end
+        end
+    end
     local remaining = {};
-    for paletteName, _ in pairs(existingPalettes) do
+    for paletteName, _ in pairs(extraSet) do
         if not seen[paletteName] then
             table.insert(remaining, paletteName);
         end
     end
-
-    -- Sort remaining palettes alphabetically and append
     table.sort(remaining);
     for _, paletteName in ipairs(remaining) do
-        table.insert(palettes, paletteName);
+        table.insert(out, paletteName);
     end
-
-    -- Cache the result
-    crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
-
-    return palettes;
+    return out;
 end
 
--- Check if crossbar palettes are using fallback (shared) mode
--- Returns true if using shared palettes because no subjob-specific ones exist
-function M.IsUsingCrossbarFallbackPalettes(jobId, subjobId)
-    local normalizedJobId = jobId or 1;
-    local normalizedSubjobId = subjobId or 0;
-
-    if normalizedSubjobId == 0 then
-        return false;  -- Already using shared palettes
-    end
-
+-- Ordered palette names for a single storage tier (used when reordering within that tier)
+function M.GetCrossbarPaletteNamesForOrderTier(jobId, tierSubjob)
+    local jid = jobId or 1;
+    local tier = tierSubjob or 0;
+    local pattern = string.format('%d:%d:%s', jid, tier, M.PALETTE_KEY_PREFIX);
+    local existing = ScanCrossbarForPalettes(pattern);
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
-    if not crossbarSettings or not crossbarSettings.slotActions then
-        return true;  -- No settings, would use fallback
-    end
-
-    -- Check for subjob-specific palettes
-    local subjobPattern = string.format('%d:%d:%s', normalizedJobId, normalizedSubjobId, M.PALETTE_KEY_PREFIX);
-    for storageKey, _ in pairs(crossbarSettings.slotActions) do
-        if type(storageKey) == 'string' and storageKey:find(subjobPattern, 1, true) == 1 then
-            return false;  -- Found at least one subjob-specific palette
-        end
-    end
-
-    return true;  -- Using fallback
-end
-
--- Unified fallback check for both hotbar and crossbar
--- paletteType: 'hotbar' or 'crossbar'
-function M.IsUsingFallback(jobId, subjobId, paletteType)
-    if subjobId == 0 then return false; end
-    if paletteType == 'crossbar' then
-        return M.IsUsingCrossbarFallbackPalettes(jobId, subjobId);
-    else
-        return M.IsUsingFallbackPalettes(jobId, subjobId);
-    end
-end
-
--- DEPRECATED: GetAllAvailablePalettes - kept for backwards compatibility
--- Now just returns hotbar palettes since crossbar has its own separate palettes
-function M.GetAllAvailablePalettes(jobId, subjobId)
-    local palettes = {};
+    local orderKey = BuildJobSubjobKey(jid, tier);
+    local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+        and crossbarSettings.crossbarPaletteOrder[orderKey];
+    local out = {};
     local seen = {};
-
-    -- Scan all 6 hotbar bars only (NOT crossbar - they are separate now)
-    for barIndex = 1, 6 do
-        local barPalettes = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-        for _, paletteName in ipairs(barPalettes) do
-            if not seen[paletteName] then
+    if storedOrder then
+        for _, paletteName in ipairs(storedOrder) do
+            if existing[paletteName] and not seen[paletteName] then
                 seen[paletteName] = true;
-                table.insert(palettes, paletteName);
+                table.insert(out, paletteName);
             end
         end
     end
-
-    return palettes;
+    local remaining = {};
+    for paletteName, _ in pairs(existing) do
+        if not seen[paletteName] then
+            table.insert(remaining, paletteName);
+        end
+    end
+    table.sort(remaining);
+    for _, paletteName in ipairs(remaining) do
+        table.insert(out, paletteName);
+    end
+    return out;
 end
 
--- Get active palette name for crossbar (GLOBAL - single palette for all combo modes)
+-- ============================================
+-- Universal (all-jobs) crossbar palettes
+-- Storage key: global:palette:{name} in hotbarCrossbar.slotActions
+-- Pet overlays never apply to these keys (handled in data.lua).
+-- ============================================
+
+function M.BuildUniversalCrossbarStorageKey(paletteName)
+    if not paletteName or paletteName == '' then
+        return nil;
+    end
+    return M.UNIVERSAL_CROSSBAR_PREFIX .. paletteName;
+end
+
+local function ScanUniversalCrossbarPaletteNames()
+    local existing = {};
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return existing;
+    end
+    local prefix = M.UNIVERSAL_CROSSBAR_PREFIX;
+    for storageKey, _ in pairs(crossbarSettings.slotActions) do
+        if type(storageKey) == 'string' and storageKey:sub(1, #prefix) == prefix then
+            local name = storageKey:sub(#prefix + 1);
+            if name and name ~= '' then
+                existing[name] = true;
+            end
+        end
+    end
+    return existing;
+end
+
+--- Ordered list of all universal crossbar palette names (for UI).
+function M.GetUniversalCrossbarPaletteNamesOrdered()
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return {};
+    end
+    local existing = ScanUniversalCrossbarPaletteNames();
+    local ordered = {};
+    local seen = {};
+    local orderList = crossbarSettings.universalCrossbarPaletteOrder;
+    if orderList then
+        for _, name in ipairs(orderList) do
+            if existing[name] and not seen[name] then
+                seen[name] = true;
+                table.insert(ordered, name);
+            end
+        end
+    end
+    local rest = {};
+    for name, _ in pairs(existing) do
+        if not seen[name] then
+            table.insert(rest, name);
+        end
+    end
+    table.sort(rest);
+    for _, name in ipairs(rest) do
+        table.insert(ordered, name);
+    end
+    return ordered;
+end
+
+function M.GetUniversalPaletteIncludeInCycle(name)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local meta = crossbarSettings and crossbarSettings.crossbarUniversalPaletteMeta;
+    if not meta or not meta[name] then
+        return true;
+    end
+    if meta[name].includeInCycle == false then
+        return false;
+    end
+    return true;
+end
+
+function M.SetUniversalPaletteIncludeInCycle(name, includeInCycle)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false;
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta = {};
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta[name] then
+        crossbarSettings.crossbarUniversalPaletteMeta[name] = {};
+    end
+    crossbarSettings.crossbarUniversalPaletteMeta[name].includeInCycle = includeInCycle and true or false;
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Palettes RB+D-pad cycles when scope is universal (respects includeInCycle).
+function M.GetUniversalCrossbarPalettesForCycle()
+    local all = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local out = {};
+    for _, name in ipairs(all) do
+        if M.GetUniversalPaletteIncludeInCycle(name) then
+            table.insert(out, name);
+        end
+    end
+    return out;
+end
+
+function M.CreateUniversalCrossbarPalette(paletteName)
+    if not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local key = M.BuildUniversalCrossbarStorageKey(paletteName);
+    if crossbarSettings.slotActions[key] then
+        return false, 'Palette already exists';
+    end
+    crossbarSettings.slotActions[key] = {};
+    if not crossbarSettings.universalCrossbarPaletteOrder then
+        crossbarSettings.universalCrossbarPaletteOrder = {};
+    end
+    table.insert(crossbarSettings.universalCrossbarPaletteOrder, paletteName);
+    if not crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta = {};
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta[paletteName] then
+        crossbarSettings.crossbarUniversalPaletteMeta[paletteName] = { includeInCycle = true };
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.EnsureUniversalCrossbarDefaultExists()
+    local names = M.GetUniversalCrossbarPaletteNamesOrdered();
+    if #names > 0 then
+        return names[1];
+    end
+    local ok = M.CreateUniversalCrossbarPalette(M.DEFAULT_PALETTE_NAME);
+    if ok == true then
+        return M.DEFAULT_PALETTE_NAME;
+    end
+    return nil;
+end
+
+function M.DeleteUniversalCrossbarPalette(paletteName)
+    if not paletteName or paletteName == '' then
+        return false, 'No palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return false, 'Not found';
+    end
+    local key = M.BuildUniversalCrossbarStorageKey(paletteName);
+    if not crossbarSettings.slotActions[key] then
+        return false, 'Palette not found';
+    end
+    local orderedBefore = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local neighborName = PickNeighborPaletteName(orderedBefore, paletteName);
+    crossbarSettings.slotActions[key] = nil;
+    if crossbarSettings.universalCrossbarPaletteOrder then
+        for i, n in ipairs(crossbarSettings.universalCrossbarPaletteOrder) do
+            if n == paletteName then
+                table.remove(crossbarSettings.universalCrossbarPaletteOrder, i);
+                break;
+            end
+        end
+    end
+    if crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta[paletteName] = nil;
+    end
+    M.EnsureUniversalCrossbarDefaultExists();
+    if state.crossbarActiveUniversalPalette == paletteName then
+        local rest = M.GetUniversalCrossbarPaletteNamesOrdered();
+        local pickName = nil;
+        if neighborName then
+            for _, n in ipairs(rest) do
+                if n == neighborName then
+                    pickName = n;
+                    break;
+                end
+            end
+        end
+        if not pickName and #rest > 0 then
+            pickName = rest[1];
+        end
+        if pickName then
+            local changed = M.SetActiveUniversalCrossbarPalette(pickName);
+            if not changed then
+                FireCrossbarComboRefreshNoop(pickName);
+            end
+        end
+    end
+    if crossbarSettings.comboModeSettings then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            local ms = crossbarSettings.comboModeSettings[mode];
+            if ms and ms.universalOverridePalette == paletteName then
+                ms.universalOverridePalette = nil;
+            end
+        end
+    end
+    if crossbarSettings.namedPaletteComboModeSettings then
+        for _, perPal in pairs(crossbarSettings.namedPaletteComboModeSettings) do
+            if type(perPal) == 'table' then
+                for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+                    local o = perPal[mode];
+                    if o and o.universalOverridePalette == paletteName then
+                        o.universalOverridePalette = nil;
+                    end
+                end
+            end
+        end
+    end
+    if crossbarSettings.segmentOverrides then
+        for jid, modes in pairs(crossbarSettings.segmentOverrides) do
+            if type(modes) == 'table' then
+                for mode, seg in pairs(modes) do
+                    if type(seg) == 'table' and seg.scope == 'global' and seg.globalPalette == paletteName then
+                        modes[mode] = nil;
+                    end
+                end
+                if next(modes) == nil then
+                    crossbarSettings.segmentOverrides[jid] = nil;
+                end
+            end
+        end
+        if next(crossbarSettings.segmentOverrides) == nil then
+            crossbarSettings.segmentOverrides = nil;
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.RenameUniversalCrossbarPalette(oldName, newName)
+    if not oldName or oldName == '' then
+        return false, 'No palette name';
+    end
+    if not newName or newName == '' then
+        return false, 'No new name';
+    end
+    if oldName == newName then
+        return false, 'New name is the same as the old name';
+    end
+    if not IsValidPaletteName(newName) then
+        return false, 'Invalid new palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return false, 'Crossbar settings not found';
+    end
+    local oldKey = M.BuildUniversalCrossbarStorageKey(oldName);
+    local newKey = M.BuildUniversalCrossbarStorageKey(newName);
+    if not crossbarSettings.slotActions[oldKey] then
+        return false, 'Palette not found';
+    end
+    if crossbarSettings.slotActions[newKey] then
+        return false, 'A palette with that name already exists';
+    end
+    crossbarSettings.slotActions[newKey] = crossbarSettings.slotActions[oldKey];
+    crossbarSettings.slotActions[oldKey] = nil;
+    if crossbarSettings.universalCrossbarPaletteOrder then
+        for i, n in ipairs(crossbarSettings.universalCrossbarPaletteOrder) do
+            if n == oldName then
+                crossbarSettings.universalCrossbarPaletteOrder[i] = newName;
+                break;
+            end
+        end
+    end
+    if crossbarSettings.crossbarUniversalPaletteMeta then
+        if crossbarSettings.crossbarUniversalPaletteMeta[oldName] then
+            crossbarSettings.crossbarUniversalPaletteMeta[newName] = crossbarSettings.crossbarUniversalPaletteMeta[oldName];
+            crossbarSettings.crossbarUniversalPaletteMeta[oldName] = nil;
+        end
+    end
+    if state.crossbarActiveUniversalPalette == oldName then
+        state.crossbarActiveUniversalPalette = newName;
+    end
+    if crossbarSettings.comboModeSettings then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            local ms = crossbarSettings.comboModeSettings[mode];
+            if ms and ms.universalOverridePalette == oldName then
+                ms.universalOverridePalette = newName;
+            end
+        end
+    end
+    if crossbarSettings.namedPaletteComboModeSettings then
+        for _, perPal in pairs(crossbarSettings.namedPaletteComboModeSettings) do
+            if type(perPal) == 'table' then
+                for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+                    local o = perPal[mode];
+                    if o and o.universalOverridePalette == oldName then
+                        o.universalOverridePalette = newName;
+                    end
+                end
+            end
+        end
+    end
+    if crossbarSettings.segmentOverrides then
+        for _, modes in pairs(crossbarSettings.segmentOverrides) do
+            if type(modes) == 'table' then
+                for _, seg in pairs(modes) do
+                    if type(seg) == 'table' and seg.scope == 'global' and seg.globalPalette == oldName then
+                        seg.globalPalette = newName;
+                    end
+                end
+            end
+        end
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Reorder Global [G] crossbar palettes (same list as GetUniversalCrossbarPaletteNamesOrdered).
+function M.MoveUniversalCrossbarPalette(paletteName, direction)
+    if not paletteName or paletteName == '' then
+        return false, 'No palette specified';
+    end
+    if direction ~= -1 and direction ~= 1 then
+        return false, 'Invalid direction';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    local ordered = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local currentIndex = nil;
+    for i, name in ipairs(ordered) do
+        if name == paletteName then
+            currentIndex = i;
+            break;
+        end
+    end
+    if not currentIndex then
+        return false, 'Palette not found in order';
+    end
+    local newIndex = currentIndex + direction;
+    if newIndex < 1 or newIndex > #ordered then
+        return false, 'Cannot move palette further';
+    end
+    ordered[currentIndex], ordered[newIndex] = ordered[newIndex], ordered[currentIndex];
+    crossbarSettings.universalCrossbarPaletteOrder = {};
+    for _, n in ipairs(ordered) do
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, n);
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Deep-copy one Global [G] palette's slot data to a new or existing palette name.
+function M.CopyUniversalCrossbarPalette(sourceName, destName, overwriteExisting)
+    if not sourceName or sourceName == '' then
+        return false, 'No palette specified';
+    end
+    local dest = destName or sourceName;
+    if not IsValidPaletteName(dest) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local sourceKey = M.BuildUniversalCrossbarStorageKey(sourceName);
+    local destKey = M.BuildUniversalCrossbarStorageKey(dest);
+    if not crossbarSettings.slotActions[sourceKey] then
+        return false, 'Source palette not found';
+    end
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    local copiedData = {};
+    for comboMode, modeData in pairs(sourceData) do
+        if type(modeData) == 'table' then
+            copiedData[comboMode] = {};
+            for slotIdx, slotData in pairs(modeData) do
+                if type(slotData) == 'table' then
+                    copiedData[comboMode][slotIdx] = {};
+                    for k, v in pairs(slotData) do
+                        copiedData[comboMode][slotIdx][k] = v;
+                    end
+                else
+                    copiedData[comboMode][slotIdx] = slotData;
+                end
+            end
+        else
+            copiedData[comboMode] = modeData;
+        end
+    end
+    crossbarSettings.slotActions[destKey] = copiedData;
+    if not destExists then
+        if not crossbarSettings.universalCrossbarPaletteOrder then
+            crossbarSettings.universalCrossbarPaletteOrder = {};
+        end
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, dest);
+        if not crossbarSettings.crossbarUniversalPaletteMeta then
+            crossbarSettings.crossbarUniversalPaletteMeta = {};
+        end
+        if not crossbarSettings.crossbarUniversalPaletteMeta[dest] then
+            crossbarSettings.crossbarUniversalPaletteMeta[dest] = { includeInCycle = true };
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.GetCrossbarPaletteScope()
+    return state.crossbarPaletteScope or 'job';
+end
+
+--- Temporary /xiui cpal summon of another job's palette (job storage only). See data.GetCrossbarStorageKeyForCombo.
+function M.GetCrossbarCliPreview()
+    return state.crossbarCliPreview;
+end
+
+function M.ClearCrossbarCliPreview()
+    if not state.crossbarCliPreview then
+        return;
+    end
+    state.crossbarCliPreview = nil;
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, nil);
+    end
+end
+
+function M.SetCrossbarCliPreview(jobId, storageSubjob, paletteName)
+    state.crossbarCliPreview = {
+        jobId = jobId,
+        storageSubjob = storageSubjob or 0,
+        paletteName = paletteName,
+    };
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, paletteName);
+    end
+end
+
+function M.SetCrossbarPaletteScope(scope)
+    if scope ~= 'job' and scope ~= 'universal' then
+        return false;
+    end
+    if state.crossbarPaletteScope == scope then
+        return false;
+    end
+    state.crossbarPaletteScope = scope;
+    state.crossbarCliPreview = nil;
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, nil);
+    end
+    return true;
+end
+
+local lastCrossbarScopeToggleClock = 0;
+
+function M.ToggleCrossbarPaletteScope()
+    local now = os.clock();
+    if now - lastCrossbarScopeToggleClock < 0.25 then
+        return false;
+    end
+    lastCrossbarScopeToggleClock = now;
+    local nextScope = (state.crossbarPaletteScope == 'universal') and 'job' or 'universal';
+    return M.SetCrossbarPaletteScope(nextScope);
+end
+
+function M.GetActiveUniversalCrossbarPalette()
+    return state.crossbarActiveUniversalPalette;
+end
+
+function M.SetActiveUniversalCrossbarPalette(paletteName)
+    state.crossbarCliPreview = nil;
+    local old = state.crossbarActiveUniversalPalette;
+    if old == paletteName then
+        return false;
+    end
+    state.crossbarActiveUniversalPalette = paletteName;
+    state.crossbarPaletteScope = 'universal';
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, old, paletteName);
+    end
+    return true;
+end
+
+-- Unified fallback check: crossbar never uses fallback (both J and SJ tiers are visible).
+function M.IsUsingFallback(jobId, subjobId, paletteType)
+    if subjobId == 0 then return false; end
+    if paletteType == 'crossbar' then
+        return false;
+    end
+    return M.IsUsingFallbackPalettes(jobId, subjobId);
+end
+
+-- Get active palette name for crossbar (job-tier or universal-tier depending on scope)
 -- comboMode param kept for backwards compatibility but ignored
 -- Returns nil if no palette (using default slots)
 function M.GetActivePaletteForCombo(comboMode)
+    if state.crossbarPaletteScope == 'universal' then
+        return state.crossbarActiveUniversalPalette;
+    end
     return state.crossbarActivePalette;
 end
 
--- Get active palette display name for crossbar (GLOBAL)
+-- Get active palette display name for crossbar
 -- comboMode param kept for backwards compatibility but ignored
 -- Returns nil if no palette is active
 function M.GetActivePaletteDisplayNameForCombo(comboMode)
+    if state.crossbarPaletteScope == 'universal' then
+        return state.crossbarActiveUniversalPalette;
+    end
     return state.crossbarActivePalette;
 end
 
--- Set active palette for crossbar (GLOBAL - affects all combo modes)
+-- Set active palette for crossbar (job / job+subjob tier — affects all combo modes)
 -- comboMode param kept for backwards compatibility but ignored
 -- paletteName: name to activate, or nil to clear
-function M.SetActivePaletteForCombo(comboMode, paletteName)
+-- storageSubjob: 0 = Job [J] tier; live subjob id = Subjob [SJ] tier (omit/nil = infer from merged list later)
+function M.SetActivePaletteForCombo(comboMode, paletteName, storageSubjob)
+    state.crossbarCliPreview = nil;
     local oldPalette = state.crossbarActivePalette;
+    local oldScope = state.crossbarPaletteScope;
+    local oldSt = state.crossbarActiveStorageSubjob;
 
-    -- Skip if no change
-    if oldPalette == paletteName then
+    state.crossbarPaletteScope = 'job';
+    state.crossbarActivePalette = paletteName;
+    if storageSubjob ~= nil then
+        state.crossbarActiveStorageSubjob = storageSubjob;
+    elseif paletteName == nil or oldPalette ~= paletteName then
+        state.crossbarActiveStorageSubjob = nil;
+    end
+
+    if oldPalette == paletteName and oldScope == 'job' and oldSt == state.crossbarActiveStorageSubjob then
         return false;
     end
 
-    state.crossbarActivePalette = paletteName;
-
-    -- Fire callbacks for all combo modes (they all share the same palette now)
     for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
         M.FirePaletteChangedCallbacks('crossbar:' .. mode, oldPalette, paletteName);
     end
 
     return true;
+end
+
+-- Persisted / current Job-scope storage tier (nil = infer from merged list by name)
+function M.GetCrossbarActiveStorageSubjob()
+    return state.crossbarActiveStorageSubjob;
+end
+
+-- ── /xiui cpal return-to-origin anchor API ──────────────────────────────────
+
+-- Save the job-scope anchor only if one isn't already set.
+-- Call this BEFORE switching the active palette via a cpal command.
+function M.SetCpalJobAnchorIfUnset(currentName, currentStorageSubjob, currentJobId)
+    if state.cpalJobAnchor ~= nil then return; end
+    state.cpalJobAnchor = {
+        name           = currentName,
+        storageSubjob  = currentStorageSubjob or 0,
+        jobId          = currentJobId,
+    };
+end
+
+-- Save the universal/global-scope anchor only if one isn't already set.
+function M.SetCpalUniversalAnchorIfUnset(currentName)
+    if state.cpalUniversalAnchor ~= nil then return; end
+    state.cpalUniversalAnchor = currentName;
+end
+
+-- Return the anchor for the given scope ('job' or 'universal').
+-- For job scope, lazily validates the anchor against the current live job; clears and returns nil if stale.
+function M.GetCpalAnchor(scope)
+    if scope == 'universal' then
+        return state.cpalUniversalAnchor;
+    end
+    local a = state.cpalJobAnchor;
+    if not a then return nil; end
+    local ok, datamod = pcall(require, 'modules.hotbar.data');
+    if ok and datamod and datamod.jobId and a.jobId ~= datamod.jobId then
+        state.cpalJobAnchor = nil;
+        return nil;
+    end
+    return a;
+end
+
+-- Clear the anchor for the given scope without restoring.
+function M.ClearCpalAnchor(scope)
+    if scope == 'universal' then
+        state.cpalUniversalAnchor = nil;
+    else
+        state.cpalJobAnchor = nil;
+    end
+end
+
+-- Restore the anchor for the given scope: switches the active palette back to the saved value
+-- and then clears the anchor.
+function M.RestoreCpalAnchor(scope)
+    if scope == 'universal' then
+        local a = state.cpalUniversalAnchor;
+        if a then
+            state.cpalUniversalAnchor = nil;
+            M.SetActiveUniversalCrossbarPalette(a);
+        end
+    else
+        local a = state.cpalJobAnchor;
+        if a then
+            state.cpalJobAnchor = nil;
+            M.SetActivePaletteForCombo(nil, a.name, a.storageSubjob);
+        end
+    end
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Storage tier for slot key resolution when [J] scope (not Global [G])
+function M.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, liveSubjobId)
+    local lj = liveSubjobId or 0;
+    if lj == 0 then
+        return 0;
+    end
+    local st = state.crossbarActiveStorageSubjob;
+    if st ~= nil then
+        return st;
+    end
+    if state.crossbarActivePalette then
+        local rows = M.GetCrossbarManagePaletteRows(jobId, lj);
+        for _, r in ipairs(rows) do
+            if r.name == state.crossbarActivePalette then
+                return r.storageSubjob;
+            end
+        end
+    end
+    return 0;
 end
 
 -- Clear active palette for crossbar (uses default slot data)
@@ -1252,46 +2205,76 @@ function M.ClearActivePaletteForCombo(comboMode)
     return M.SetActivePaletteForCombo(comboMode, nil);
 end
 
--- Cycle through palettes for crossbar (GLOBAL - affects all combo modes)
+-- Cycle through palettes for crossbar (job tier or all-jobs universal tier)
 -- comboMode param kept for backwards compatibility but ignored
 -- direction: 1 for next, -1 for previous
 function M.CyclePaletteForCombo(comboMode, direction, jobId, subjobId)
     direction = direction or 1;
 
-    -- Use crossbar-only palette list (separate from hotbar)
-    local palettes = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    if #palettes == 0 then
-        return nil, false;  -- No palettes defined, second return = no palettes exist
-    end
+    M.ClearCrossbarCliPreview();
 
-    if #palettes == 1 then
-        -- Only one palette, just make sure it's active
-        M.SetActivePaletteForCombo(comboMode, palettes[1]);
-        return palettes[1], true;
-    end
-
-    local currentName = state.crossbarActivePalette;
-    local currentIndex = 1;  -- Default to first palette
-
-    -- Find current palette index
-    if currentName then
-        for i, name in ipairs(palettes) do
-            if name == currentName then
-                currentIndex = i;
-                break;
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes and state.crossbarPaletteScope == 'universal' then
+        local palettes = M.GetUniversalCrossbarPalettesForCycle();
+        if #palettes == 0 then
+            return nil, false;
+        end
+        if #palettes == 1 then
+            M.SetActiveUniversalCrossbarPalette(palettes[1]);
+            return palettes[1], true;
+        end
+        local currentName = state.crossbarActiveUniversalPalette;
+        local currentIndex = 1;
+        if currentName then
+            for i, name in ipairs(palettes) do
+                if name == currentName then
+                    currentIndex = i;
+                    break;
+                end
             end
+        end
+        local newIndex = currentIndex + direction;
+        if newIndex < 1 then newIndex = #palettes; end
+        if newIndex > #palettes then newIndex = 1; end
+        local newPalette = palettes[newIndex];
+        M.SetActiveUniversalCrossbarPalette(newPalette);
+        return newPalette, true;
+    end
+
+    local rowsAll = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local rows = {};
+    for _, r in ipairs(rowsAll) do
+        if M.IsCrossbarPaletteInRbCycle(jobId, r.storageSubjob, r.name) then
+            table.insert(rows, r);
+        end
+    end
+    if #rows == 0 then
+        return nil, false;
+    end
+
+    local currentIndex = 1;
+    for i, r in ipairs(rows) do
+        if r.name == state.crossbarActivePalette
+            and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == r.storageSubjob) then
+            currentIndex = i;
+            break;
         end
     end
 
-    -- Calculate new index with wrap-around (1..#palettes only, no "empty" state)
+    if #rows == 1 then
+        local r = rows[1];
+        M.SetActivePaletteForCombo(comboMode, r.name, r.storageSubjob);
+        return r.name, true;
+    end
+
     local newIndex = currentIndex + direction;
-    if newIndex < 1 then newIndex = #palettes; end
-    if newIndex > #palettes then newIndex = 1; end
+    if newIndex < 1 then newIndex = #rows; end
+    if newIndex > #rows then newIndex = 1; end
 
-    local newPalette = palettes[newIndex];
-    M.SetActivePaletteForCombo(comboMode, newPalette);
+    local pick = rows[newIndex];
+    M.SetActivePaletteForCombo(comboMode, pick.name, pick.storageSubjob);
 
-    return newPalette, true;  -- Second return = palettes exist
+    return pick.name, true;
 end
 
 -- Get the palette key suffix for crossbar (GLOBAL - same for all combo modes)
@@ -1304,8 +2287,9 @@ end
 
 -- Create a new palette for crossbar (stores in crossbar slotActions)
 -- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
+-- skipSave: when true, caller batches SaveSettingsToDisk (e.g. multi-job seed)
 -- Returns true on success, false with error message on failure
-function M.CreateCrossbarPalette(paletteName, jobId, subjobId)
+function M.CreateCrossbarPalette(paletteName, jobId, subjobId, skipSave)
     if not IsValidPaletteName(paletteName) then
         return false, 'Invalid palette name';
     end
@@ -1347,42 +2331,38 @@ function M.CreateCrossbarPalette(paletteName, jobId, subjobId)
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
 
-    SaveSettingsToDisk();
+    if not skipSave then
+        SaveSettingsToDisk();
+    end
     return true;
 end
 
 -- Ensure at least one crossbar palette exists for a job
--- Creates a "Default" palette if none exist
--- Returns the name of the first available palette
+-- Creates a "Default" palette at Job [J] tier if none exist
+-- Does not change the live active crossbar palette (config must not flip in-game scope)
+-- Returns the name of the first palette in merged order for this context
 function M.EnsureCrossbarDefaultPaletteExists(jobId, subjobId)
     local normalizedJobId = jobId or 1;
+    local sj = subjobId or 0;
 
-    -- Check if any palettes exist for this job
-    local availablePalettes = M.GetCrossbarAvailablePalettes(normalizedJobId, subjobId);
+    local rows = M.GetCrossbarManagePaletteRows(normalizedJobId, sj);
 
-    if #availablePalettes == 0 then
-        -- No palettes exist, create the default one at subjob 0 (shared)
-        -- This ensures imported data at subjob 0 isn't shadowed by empty subjob-specific palettes
+    if #rows == 0 then
         local success, err = M.CreateCrossbarPalette(M.DEFAULT_PALETTE_NAME, normalizedJobId, 0);
         if success then
-            -- Auto-activate the new palette
-            M.SetActivePaletteForCombo('L2', M.DEFAULT_PALETTE_NAME);
             return M.DEFAULT_PALETTE_NAME;
-        else
-            -- If "Default" already exists somehow, try numbered names
-            for i = 1, 99 do
-                local name = 'Palette ' .. i;
-                success, err = M.CreateCrossbarPalette(name, normalizedJobId, 0);
-                if success then
-                    M.SetActivePaletteForCombo('L2', name);
-                    return name;
-                end
+        end
+        for i = 1, 99 do
+            local name = 'Palette ' .. i;
+            success, err = M.CreateCrossbarPalette(name, normalizedJobId, 0);
+            if success then
+                return name;
             end
         end
-        return nil;  -- Failed to create
+        return nil;
     end
 
-    return availablePalettes[1];  -- Return first existing palette
+    return rows[1].name;
 end
 
 -- Helper: Find the actual crossbar storage key for a palette
@@ -1415,6 +2395,51 @@ local function FindCrossbarPaletteStorageKey(paletteName, jobId, subjobId)
     return nil;
 end
 
+-- If a Job [J] shared storage tier (tier 0) has zero palettes, create one blank Default (or Palette N).
+-- Subjob [SJ] tiers may be empty; gameplay falls back to shared job palettes.
+local function EnsureCrossbarStorageTierHasDefaultPalette(jobId, storageTier, skipSave)
+    local jid = jobId or 1;
+    local tier = storageTier or 0;
+    if #M.GetCrossbarPaletteNamesForOrderTier(jid, tier) > 0 then
+        return;
+    end
+    local ok, err = M.CreateCrossbarPalette(M.DEFAULT_PALETTE_NAME, jid, tier, skipSave);
+    if ok then
+        return;
+    end
+    for i = 1, 99 do
+        ok, err = M.CreateCrossbarPalette('Palette ' .. i, jid, tier, skipSave);
+        if ok then
+            return;
+        end
+    end
+end
+
+local CROSSBAR_JOB_SEED_MAX = 22;
+
+local function MaybeSeedBlankCrossbarDefaultPalettesForAllJobs()
+    if crossbarBlankDefaultsSeeded then
+        return;
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return;
+    end
+    crossbarBlankDefaultsSeeded = true;
+
+    local any = false;
+    for jid = 1, CROSSBAR_JOB_SEED_MAX do
+        if #M.GetCrossbarManagePaletteRows(jid, 0) == 0 then
+            EnsureCrossbarStorageTierHasDefaultPalette(jid, 0, true);
+            any = true;
+        end
+    end
+    if any then
+        InvalidatePaletteListCache();
+        SaveSettingsToDisk();
+    end
+end
+
 -- Delete a crossbar palette
 -- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
 -- Returns true on success, false with error message on failure
@@ -1437,8 +2462,18 @@ function M.DeleteCrossbarPalette(paletteName, jobId, subjobId)
         return false, 'Palette not found';
     end
 
+    local keyJobId, keySubjobId = storageKey:match('^(%d+):(%d+):');
+    local jidOrder = (keyJobId and tonumber(keyJobId)) or normalizedJobId;
+    local tierForOrder = (keySubjobId and tonumber(keySubjobId)) or normalizedSubjobId;
+    local orderedBefore = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, tierForOrder);
+    local neighborName = PickNeighborPaletteName(orderedBefore, paletteName);
+
     -- Delete the palette
     crossbarSettings.slotActions[storageKey] = nil;
+
+    if crossbarSettings.namedPaletteComboModeSettings then
+        crossbarSettings.namedPaletteComboModeSettings[storageKey] = nil;
+    end
 
     -- Determine which order key to use based on the storage key found
     local orderKey;
@@ -1459,13 +2494,52 @@ function M.DeleteCrossbarPalette(paletteName, jobId, subjobId)
         end
     end
 
-    -- If the GLOBAL crossbar palette was this palette, clear it
-    if state.crossbarActivePalette == paletteName then
-        state.crossbarActivePalette = nil;
+    if crossbarSettings.crossbarPaletteExcludeFromCycle and crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey] then
+        crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey][paletteName] = nil;
+        PrunePaletteExcludeSubtable(crossbarSettings.crossbarPaletteExcludeFromCycle, orderKey);
+    end
+
+    -- Only auto-fill Job [J] shared tier; SJ tiers can remain empty.
+    if tierForOrder == 0 then
+        EnsureCrossbarStorageTierHasDefaultPalette(jidOrder, tierForOrder);
+    end
+
+    if state.crossbarActivePalette == paletteName
+        and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == tierForOrder) then
+        local rest = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, tierForOrder);
+        local pickName = nil;
+        local pickTier = tierForOrder;
+        if neighborName then
+            for _, n in ipairs(rest) do
+                if n == neighborName then
+                    pickName = n;
+                    break;
+                end
+            end
+        end
+        if not pickName and #rest > 0 then
+            pickName = rest[1];
+        end
+        -- Last SJ palette removed: move active selection to Job [J] shared tier.
+        if not pickName and tierForOrder ~= 0 then
+            EnsureCrossbarStorageTierHasDefaultPalette(jidOrder, 0, true);
+            local jrest = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, 0);
+            if #jrest > 0 then
+                pickName = jrest[1];
+                pickTier = 0;
+            end
+        end
+        if pickName then
+            local changed = M.SetActivePaletteForCombo('L2', pickName, pickTier);
+            if not changed then
+                FireCrossbarComboRefreshNoop(pickName);
+            end
+        end
     end
 
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
 
     SaveSettingsToDisk();
     return true;
@@ -1518,6 +2592,14 @@ function M.RenameCrossbarPalette(oldName, newName, jobId, subjobId)
     crossbarSettings.slotActions[newStorageKey] = crossbarSettings.slotActions[oldStorageKey];
     crossbarSettings.slotActions[oldStorageKey] = nil;
 
+    if crossbarSettings.namedPaletteComboModeSettings then
+        local np = crossbarSettings.namedPaletteComboModeSettings;
+        if np[oldStorageKey] then
+            np[newStorageKey] = np[oldStorageKey];
+            np[oldStorageKey] = nil;
+        end
+    end
+
     -- Update crossbarPaletteOrder
     local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
     if crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[orderKey] then
@@ -1529,8 +2611,16 @@ function M.RenameCrossbarPalette(oldName, newName, jobId, subjobId)
         end
     end
 
-    -- Update GLOBAL crossbar active palette if this was the active one
-    if state.crossbarActivePalette == oldName then
+    if crossbarSettings.crossbarPaletteExcludeFromCycle and crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey] then
+        local ex = crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey];
+        if ex[oldName] then
+            ex[oldName] = nil;
+            ex[newName] = true;
+        end
+    end
+
+    if state.crossbarActivePalette == oldName
+        and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == effectiveSubjobId) then
         state.crossbarActivePalette = newName;
     end
 
@@ -1562,24 +2652,18 @@ function M.MoveCrossbarPalette(paletteName, direction, jobId, subjobId)
     local normalizedJobId = jobId or 1;
     local normalizedSubjobId = subjobId or 0;
 
-    -- If using fallback palettes, modify the shared order (subjob 0) instead
-    local effectiveSubjobId = normalizedSubjobId;
-    if normalizedSubjobId ~= 0 and M.IsUsingCrossbarFallbackPalettes(normalizedJobId, normalizedSubjobId) then
-        effectiveSubjobId = 0;
-    end
-    local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
+    -- subjobId is the storage tier for this palette (0 = Job [J], N = Subjob [SJ])
+    local orderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
 
-    -- Ensure crossbarPaletteOrder exists and is populated
     if not crossbarSettings.crossbarPaletteOrder then
         crossbarSettings.crossbarPaletteOrder = {};
     end
-    if not crossbarSettings.crossbarPaletteOrder[orderKey] then
-        -- Initialize crossbarPaletteOrder from current available palettes
-        crossbarSettings.crossbarPaletteOrder[orderKey] = {};
-        local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-        for _, name in ipairs(available) do
-            table.insert(crossbarSettings.crossbarPaletteOrder[orderKey], name);
-        end
+
+    -- Same merged order the UI lists (raw crossbarPaletteOrder can be stale or missing names)
+    local canonical = M.GetCrossbarPaletteNamesForOrderTier(normalizedJobId, normalizedSubjobId);
+    crossbarSettings.crossbarPaletteOrder[orderKey] = {};
+    for _, name in ipairs(canonical) do
+        table.insert(crossbarSettings.crossbarPaletteOrder[orderKey], name);
     end
 
     local order = crossbarSettings.crossbarPaletteOrder[orderKey];
@@ -1614,41 +2698,67 @@ function M.MoveCrossbarPalette(paletteName, direction, jobId, subjobId)
     return true;
 end
 
--- Check if a specific crossbar palette exists
-function M.CrossbarPaletteExists(paletteName, jobId, subjobId)
+-- Check if a specific crossbar palette exists (optional storage tier: 0 = Job [J], else Subjob [SJ])
+function M.CrossbarPaletteExists(paletteName, jobId, subjobId, storageTier)
     if not paletteName then
         return false;
     end
 
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    for _, name in ipairs(available) do
-        if name == paletteName then
+    local rows = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    for _, r in ipairs(rows) do
+        if r.name == paletteName and (storageTier == nil or r.storageSubjob == storageTier) then
             return true;
         end
     end
     return false;
 end
 
--- Get the index of a crossbar palette in the order list
--- Returns nil if palette not found
-function M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId)
+-- Crossbar rows that participate in RB+D-pad cycling (excludes Inactive in Palette Manager).
+function M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId)
+    local out = {};
+    for _, r in ipairs(M.GetCrossbarManagePaletteRows(jobId, subjobId)) do
+        if M.IsCrossbarPaletteInRbCycle(jobId, r.storageSubjob, r.name) then
+            table.insert(out, r);
+        end
+    end
+    return out;
+end
+
+-- Index in RB-cycle order only (1-based). Nil if palette is inactive or not found.
+function M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId, storageTier)
     if not paletteName then
         return nil;
     end
 
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    for i, name in ipairs(available) do
-        if name == paletteName then
+    local rows = M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+    for i, r in ipairs(rows) do
+        if r.name == paletteName and (storageTier == nil or r.storageSubjob == storageTier) then
             return i;
         end
     end
     return nil;
 end
 
--- Get the total number of crossbar palettes
 function M.GetCrossbarPaletteCount(jobId, subjobId)
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    return #available;
+    return #M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+end
+
+--- Index and total for the on-screen palette label (RB cycle): universal [G] uses universal cycle; job [J] uses job rows.
+function M.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId)
+    if not paletteName then
+        return nil, nil;
+    end
+    if M.GetCrossbarPaletteScope() == 'universal' then
+        local cycle = M.GetUniversalCrossbarPalettesForCycle();
+        local total = #cycle;
+        for i, n in ipairs(cycle) do
+            if n == paletteName then
+                return i, total;
+            end
+        end
+        return nil, (total > 0) and total or nil;
+    end
+    return M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId), M.GetCrossbarPaletteCount(jobId, subjobId);
 end
 
 -- ============================================
@@ -1657,8 +2767,9 @@ end
 
 -- Validate active palettes against current job's available palettes
 -- Ensures at least one palette exists, and auto-selects the first palette if none is active
--- Should be called on job change
-function M.ValidatePalettesForJob(jobId, subjobId)
+-- opts.applyDefaultCrossbarScope: only pass true when loading/reloading a profile (see XIUI xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad).
+-- Zone/job packets and leveling must not flip scope — user toggles L1+R1 for that session.
+function M.ValidatePalettesForJob(jobId, subjobId, opts)
     -- Ensure gConfig.hotbar structure exists before any palette operations
     if not EnsureHotbarConfigExists() then
         print('[XIUI palette] Warning: gConfig not available, skipping palette validation');
@@ -1669,6 +2780,9 @@ function M.ValidatePalettesForJob(jobId, subjobId)
     if NeedsPaletteMigration() then
         RunPaletteMigration();
     end
+
+    -- Blank Default crossbar palette per job (no live palette activation; avoids config/job clicks)
+    MaybeSeedBlankCrossbarDefaultPalettesForAllJobs();
 
     -- Ensure at least one palette exists for this job
     local firstPalette = M.EnsureDefaultPaletteExists(jobId, subjobId);
@@ -1683,56 +2797,59 @@ function M.ValidatePalettesForJob(jobId, subjobId)
     -- Try to restore saved palette state for this job:subjob
     local savedPalette = LoadPaletteState(jobId, subjobId);
 
-    -- Check if current hotbar palette is valid
+    -- First palette that participates in RB / keyboard cycling (Palette Manager "Active")
+    local function firstHotbarPaletteInCycle()
+        for _, name in ipairs(availablePalettes) do
+            if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+                return name;
+            end
+        end
+        if #availablePalettes > 0 then
+            return availablePalettes[1];
+        end
+        return firstPalette;
+    end
+
+    local function savedHotbarPaletteIfInCycle(name)
+        if not name then
+            return nil;
+        end
+        for _, n in ipairs(availablePalettes) do
+            if n == name and M.IsHotbarPaletteInRbCycle(jobId, subjobId, n) then
+                return name;
+            end
+        end
+        return nil;
+    end
+
+    -- Hotbar: do not keep a palette marked Inactive as the active palette after load / job change
+    local oldHotbarPalette = state.activePalette;
+    local desiredHotbar = nil;
     if state.activePalette then
-        local found = false;
+        local exists = false;
         for _, name in ipairs(availablePalettes) do
             if name == state.activePalette then
-                found = true;
+                exists = true;
                 break;
             end
         end
-        if not found then
-            -- Palette doesn't exist for this job, try saved state or use first available
-            local oldPalette = state.activePalette;
-            local newPalette = nil;
-
-            -- Check if saved palette exists for this job
-            if savedPalette then
-                for _, name in ipairs(availablePalettes) do
-                    if name == savedPalette then
-                        newPalette = savedPalette;
-                        break;
-                    end
-                end
-            end
-
-            state.activePalette = newPalette or firstPalette;
-            -- Fire callbacks for all bars
-            for i = 1, 6 do
-                M.FirePaletteChangedCallbacks(i, oldPalette, state.activePalette);
-            end
+        if exists and M.IsHotbarPaletteInRbCycle(jobId, subjobId, state.activePalette) then
+            desiredHotbar = state.activePalette;
+        else
+            desiredHotbar = savedHotbarPaletteIfInCycle(savedPalette) or firstHotbarPaletteInCycle();
         end
     else
-        -- No palette active, try saved state or select the first one
-        local newPalette = nil;
+        desiredHotbar = savedHotbarPaletteIfInCycle(savedPalette) or firstHotbarPaletteInCycle();
+    end
 
-        -- Check if saved palette exists for this job
-        if savedPalette then
-            for _, name in ipairs(availablePalettes) do
-                if name == savedPalette then
-                    newPalette = savedPalette;
-                    break;
-                end
-            end
-        end
-
-        state.activePalette = newPalette or firstPalette;
-        -- Fire callbacks for all bars
+    if oldHotbarPalette ~= desiredHotbar then
+        state.activePalette = desiredHotbar;
         for i = 1, 6 do
-            M.FirePaletteChangedCallbacks(i, nil, state.activePalette);
+            M.FirePaletteChangedCallbacks(i, oldHotbarPalette, desiredHotbar);
         end
     end
+
+    SavePaletteState(jobId, subjobId);
 
     -- Ensure at least one crossbar palette exists for this job
     local firstCrossbarPalette = M.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
@@ -1740,32 +2857,103 @@ function M.ValidatePalettesForJob(jobId, subjobId)
         print('[XIUI palette] Warning: Failed to create default crossbar palette for job ' .. tostring(jobId));
     end
 
-    -- Get available crossbar palettes
-    local availableCrossbarPalettes = M.GetCrossbarAvailablePalettes(jobId, subjobId);
+    -- Merge factory crossbar defaults into gConfig so keys like defaultCrossbarPaletteScope and
+    -- enableUniversalCrossbarPalettes always resolve (older/partial profiles omit nested fields).
+    if not gConfig.hotbarCrossbar then
+        gConfig.hotbarCrossbar = {};
+    end
+    local factories = require('core.settings.factories');
+    DeepMergeWithDefaults(gConfig.hotbarCrossbar, factories.createCrossbarDefaults());
 
-    -- Check if current crossbar palette is valid
-    if state.crossbarActivePalette then
-        local found = false;
-        for _, name in ipairs(availableCrossbarPalettes) do
-            if name == state.crossbarActivePalette then
-                found = true;
-                break;
+    local function ProfileDefaultWantsUniversalCrossbar(cs)
+        local v = cs and cs.defaultCrossbarPaletteScope;
+        if type(v) ~= 'string' then
+            return false;
+        end
+        local l = (v:lower():match('^%s*(.-)%s*$')) or '';
+        return l == 'universal' or l == 'global';
+    end
+
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    local firstUniversal = nil;
+    -- Apply Job vs Global [G] scope from profile before reconciling [J] tier palettes so callbacks see correct scope.
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes then
+        firstUniversal = M.EnsureUniversalCrossbarDefaultExists();
+        if opts and opts.applyDefaultCrossbarScope == true then
+            pendingApplyDefaultCrossbarScopeFromProfile = false;
+            if ProfileDefaultWantsUniversalCrossbar(crossbarSettings) then
+                state.crossbarPaletteScope = 'universal';
+            else
+                state.crossbarPaletteScope = 'job';
             end
         end
-        if not found then
-            -- Palette doesn't exist for this job, use first available
+        if state.crossbarActiveUniversalPalette then
+            local ulist = M.GetUniversalCrossbarPaletteNamesOrdered();
+            local ufound = false;
+            for _, n in ipairs(ulist) do
+                if n == state.crossbarActiveUniversalPalette then
+                    ufound = true;
+                    break;
+                end
+            end
+            if not ufound then
+                local cyc = M.GetUniversalCrossbarPalettesForCycle();
+                state.crossbarActiveUniversalPalette = (cyc[1] or firstUniversal);
+            end
+        elseif firstUniversal and state.crossbarPaletteScope == 'universal' then
+            state.crossbarActiveUniversalPalette = firstUniversal;
+        end
+    elseif crossbarSettings then
+        -- Feature explicitly disabled in profile — scope must be job tier only.
+        state.crossbarPaletteScope = 'job';
+    end
+
+    local crossbarRowsAll = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local crossbarRowsCycle = M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+
+    local function pickFirstCrossbarRowInCycle()
+        if #crossbarRowsCycle > 0 then
+            return crossbarRowsCycle[1];
+        end
+        if #crossbarRowsAll > 0 then
+            return crossbarRowsAll[1];
+        end
+        return nil;
+    end
+
+    if state.crossbarActivePalette then
+        local matchRow = nil;
+        for _, r in ipairs(crossbarRowsAll) do
+            if r.name == state.crossbarActivePalette then
+                if state.crossbarActiveStorageSubjob == nil then
+                    state.crossbarActiveStorageSubjob = r.storageSubjob;
+                end
+                if r.storageSubjob == state.crossbarActiveStorageSubjob then
+                    matchRow = r;
+                    break;
+                end
+            end
+        end
+        local ok = matchRow and M.IsCrossbarPaletteInRbCycle(jobId, matchRow.storageSubjob, matchRow.name);
+        if not ok then
             local oldPalette = state.crossbarActivePalette;
-            state.crossbarActivePalette = firstCrossbarPalette;
-            -- Fire callbacks for all combo modes
+            local pick = pickFirstCrossbarRowInCycle();
+            if pick then
+                state.crossbarActivePalette = pick.name;
+                state.crossbarActiveStorageSubjob = pick.storageSubjob;
+            elseif firstCrossbarPalette then
+                state.crossbarActivePalette = firstCrossbarPalette;
+                state.crossbarActiveStorageSubjob = 0;
+            end
             for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
                 M.FirePaletteChangedCallbacks('crossbar:' .. mode, oldPalette, state.crossbarActivePalette);
             end
         end
     else
-        -- No crossbar palette active, select the first one
-        if firstCrossbarPalette then
-            state.crossbarActivePalette = firstCrossbarPalette;
-            -- Fire callbacks for all combo modes
+        local pick = pickFirstCrossbarRowInCycle();
+        if pick then
+            state.crossbarActivePalette = pick.name;
+            state.crossbarActiveStorageSubjob = pick.storageSubjob;
             for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
                 M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, state.crossbarActivePalette);
             end
@@ -1777,6 +2965,9 @@ end
 function M.Reset()
     state.activePalette = nil;
     state.crossbarActivePalette = nil;
+    state.crossbarActiveStorageSubjob = nil;
+    state.crossbarPaletteScope = 'job';
+    state.crossbarActiveUniversalPalette = nil;
 end
 
 -- Get state for persistence (if needed)
@@ -1784,6 +2975,9 @@ function M.GetState()
     return {
         activePalette = state.activePalette,
         crossbarActivePalette = state.crossbarActivePalette,
+        crossbarActiveStorageSubjob = state.crossbarActiveStorageSubjob,
+        crossbarPaletteScope = state.crossbarPaletteScope,
+        crossbarActiveUniversalPalette = state.crossbarActiveUniversalPalette,
     };
 end
 
@@ -1792,6 +2986,11 @@ function M.RestoreState(savedState)
     if savedState then
         state.activePalette = savedState.activePalette;
         state.crossbarActivePalette = savedState.crossbarActivePalette;
+        state.crossbarActiveStorageSubjob = savedState.crossbarActiveStorageSubjob;
+        if savedState.crossbarPaletteScope == 'job' or savedState.crossbarPaletteScope == 'universal' then
+            state.crossbarPaletteScope = savedState.crossbarPaletteScope;
+        end
+        state.crossbarActiveUniversalPalette = savedState.crossbarActiveUniversalPalette;
     end
 end
 
@@ -1800,8 +2999,9 @@ end
 -- ============================================
 
 -- Copy a hotbar palette to a different job:subjob combination
--- Returns true on success, false with error message on failure
-function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName)
+-- newName: destination palette name (nil = same as source name)
+-- overwriteExisting: if true, replace data on an existing destination palette (slot actions / macros on all 6 bars)
+function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName, overwriteExisting)
     if not paletteName then
         return false, 'No palette specified';
     end
@@ -1820,13 +3020,23 @@ function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId
     -- Build destination storage key
     local destKey = M.BuildPaletteStorageKey(toJobId, toSubjobId, destName);
 
-    -- Check if destination already exists
+    local destExists = false;
     for barIdx = 1, 6 do
         local configKey = 'hotbarBar' .. barIdx;
         local barSettings = gConfig and gConfig[configKey];
         if barSettings and barSettings.slotActions and barSettings.slotActions[destKey] then
+            destExists = true;
+            break;
+        end
+    end
+
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
             return false, 'Palette already exists at destination';
         end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
     end
 
     -- Copy palette data to all bars
@@ -1858,26 +3068,29 @@ function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId
         end
     end
 
-    -- Add to destination's palette order
-    local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
-    if not gConfig.hotbar then
-        gConfig.hotbar = {};
+    -- Add to destination's palette order (new palette only)
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
+        if not gConfig.hotbar then
+            gConfig.hotbar = {};
+        end
+        if not gConfig.hotbar.paletteOrder then
+            gConfig.hotbar.paletteOrder = {};
+        end
+        if not gConfig.hotbar.paletteOrder[destOrderKey] then
+            gConfig.hotbar.paletteOrder[destOrderKey] = {};
+        end
+        table.insert(gConfig.hotbar.paletteOrder[destOrderKey], destName);
     end
-    if not gConfig.hotbar.paletteOrder then
-        gConfig.hotbar.paletteOrder = {};
-    end
-    if not gConfig.hotbar.paletteOrder[destOrderKey] then
-        gConfig.hotbar.paletteOrder[destOrderKey] = {};
-    end
-    table.insert(gConfig.hotbar.paletteOrder[destOrderKey], destName);
 
+    InvalidatePaletteListCache();
     SaveSettingsToDisk();
     return true;
 end
 
 -- Copy a crossbar palette to a different job:subjob combination
--- Returns true on success, false with error message on failure
-function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName)
+-- overwriteExisting: replace slot data on an existing destination palette
+function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName, overwriteExisting)
     if not paletteName then
         return false, 'No palette specified';
     end
@@ -1901,9 +3114,14 @@ function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, to
     -- Build destination storage key
     local destKey = M.BuildPaletteStorageKey(toJobId, toSubjobId, destName);
 
-    -- Check if destination already exists
-    if crossbarSettings.slotActions and crossbarSettings.slotActions[destKey] then
-        return false, 'Palette already exists at destination';
+    local destExists = crossbarSettings.slotActions and crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
     end
 
     -- Ensure slotActions structure
@@ -1937,16 +3155,166 @@ function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, to
         crossbarSettings.slotActions[destKey] = {};
     end
 
-    -- Add to destination's palette order
-    local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
-    if not crossbarSettings.crossbarPaletteOrder then
-        crossbarSettings.crossbarPaletteOrder = {};
+    -- Add to destination's palette order (new palette only)
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
+        if not crossbarSettings.crossbarPaletteOrder then
+            crossbarSettings.crossbarPaletteOrder = {};
+        end
+        if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
+            crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
+        end
+        table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], destName);
     end
-    if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
-        crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
-    end
-    table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], destName);
 
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Copy a Job [J]/Subjob-tier crossbar palette into the Global [G] (all-jobs universal) namespace.
+function M.CopyCrossbarPaletteToUniversal(paletteName, fromJobId, fromSubjobId, destName, overwriteExisting)
+    if not paletteName then
+        return false, 'No palette specified';
+    end
+    local outName = destName or paletteName;
+    if not IsValidPaletteName(outName) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    local sourceKey = FindCrossbarPaletteStorageKey(paletteName, fromJobId, fromSubjobId);
+    if not sourceKey then
+        return false, 'Source palette not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local destKey = M.BuildUniversalCrossbarStorageKey(outName);
+    if not destKey then
+        return false, 'Invalid destination key';
+    end
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    if sourceData then
+        local copiedData = {};
+        for comboMode, modeData in pairs(sourceData) do
+            if type(modeData) == 'table' then
+                copiedData[comboMode] = {};
+                for slotIdx, slotData in pairs(modeData) do
+                    if type(slotData) == 'table' then
+                        copiedData[comboMode][slotIdx] = {};
+                        for k, v in pairs(slotData) do
+                            copiedData[comboMode][slotIdx][k] = v;
+                        end
+                    else
+                        copiedData[comboMode][slotIdx] = slotData;
+                    end
+                end
+            else
+                copiedData[comboMode] = modeData;
+            end
+        end
+        crossbarSettings.slotActions[destKey] = copiedData;
+    else
+        crossbarSettings.slotActions[destKey] = {};
+    end
+    if not destExists then
+        if not crossbarSettings.universalCrossbarPaletteOrder then
+            crossbarSettings.universalCrossbarPaletteOrder = {};
+        end
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, outName);
+        if not crossbarSettings.crossbarUniversalPaletteMeta then
+            crossbarSettings.crossbarUniversalPaletteMeta = {};
+        end
+        if not crossbarSettings.crossbarUniversalPaletteMeta[outName] then
+            crossbarSettings.crossbarUniversalPaletteMeta[outName] = { includeInCycle = true };
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Copy a Global [G] universal crossbar palette into a Job [J]/Subjob-tier palette.
+function M.CopyUniversalCrossbarPaletteToJob(sourceName, destName, toJobId, toSubjobId, overwriteExisting)
+    if not sourceName or sourceName == '' then
+        return false, 'No palette specified';
+    end
+    local outName = destName or sourceName;
+    if not IsValidPaletteName(outName) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local sourceKey = M.BuildUniversalCrossbarStorageKey(sourceName);
+    if not crossbarSettings.slotActions[sourceKey] then
+        return false, 'Source palette not found';
+    end
+    local normalizedJobId = toJobId or 1;
+    local normalizedSubjobId = toSubjobId or 0;
+    local destKey = M.BuildPaletteStorageKey(normalizedJobId, normalizedSubjobId, outName);
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    if sourceData then
+        local copiedData = {};
+        for comboMode, modeData in pairs(sourceData) do
+            if type(modeData) == 'table' then
+                copiedData[comboMode] = {};
+                for slotIdx, slotData in pairs(modeData) do
+                    if type(slotData) == 'table' then
+                        copiedData[comboMode][slotIdx] = {};
+                        for k, v in pairs(slotData) do
+                            copiedData[comboMode][slotIdx][k] = v;
+                        end
+                    else
+                        copiedData[comboMode][slotIdx] = slotData;
+                    end
+                end
+            else
+                copiedData[comboMode] = modeData;
+            end
+        end
+        crossbarSettings.slotActions[destKey] = copiedData;
+    else
+        crossbarSettings.slotActions[destKey] = {};
+    end
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
+        if not crossbarSettings.crossbarPaletteOrder then
+            crossbarSettings.crossbarPaletteOrder = {};
+        end
+        if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
+            crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
+        end
+        table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], outName);
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
     SaveSettingsToDisk();
     return true;
 end


### PR DESCRIPTION
… inactive dim, palette scope icon

What changed
- crossbar.lua: CROSSBAR_WINDOW_TOP_DECOR_PAD = 80px - crossbar ImGui window opens higher and taller than slot grid so L2/R2 trigger icons, R1 pulse, palette name, action labels, and combo text are not clipped. ApplyCrossbarWindowPositionOnce/SaveCrossbarWindowSlotTopPosition persist slot-grid top Y (not window top); profile-compat on first load. imgui.PushStyleVar WindowPadding {0,0} before Begin/End recovers leftmost/rightmost diamond slot clipping and hitbox inset. useSharedExpandedBar: when L2+R2 chord held, both diamonds collapse to single centered 8-slot strip; GetDisplayModes returns 'Shared'; window force-centers; lastWideCrossbarWindowX stashed for exit-chord restore. DrawTriggerIconsSharedExpandedCenter for combined glyph. inactiveSideWhileTriggerDim = 0.15 (vs inactiveSlotDim 0.5) when activeCombo != NONE; threaded through 11 call sites for clearer visual focus on active half during trigger hold. GetInfinityPaletteIconTexture (lazy session-cached), GetPaletteJobIconThemeFromSettings, ShouldShowPaletteScopeIcon, DrawPaletteScopeIconAboveDivider - visual cue for Global vs Job palette scope above crossbar divider. GetCrossbarPaletteLabelIndexAndTotal: only renders (idx/total) suffix when total > 1 (suppresses '(1/1)' noise with one enabled palette). IsMovementLockedForDropZone routes crossbar_* -> crossbarLockMovement. MakePreviewSettings cache on geometry signature; double-tap preview early-exit. playerdata.RefreshCachedLists at DrawWindow top for crossbar-only setups. SMN crossbar: actionType=='pet' and /pet-primary macros routed through skillchain.GetSkillchainForBloodPact matching keyboard hotbar. ClassicFFXIV removed from paletteIconThemes dropdown; GetPaletteJobIconThemeFromSettings and GetCrossbarPaletteJobIconThemeFromSettings allowlists narrowed; one-shot migration falls back to Classic on first open.
- palette.lua: Cpal anchor API: SetCpalJobAnchorIfUnset/SetCpalUniversalAnchorIfUnset, GetCpalAnchor, ClearCpalAnchor, RestoreCpalAnchor. CLI preview state, clear on active palette / cycle. GetCrossbarSjOnlyPaletteNamesOrdered. Universal palette rename/delete syncs segmentOverrides refs. CopyCrossbarPaletteToUniversal / CopyUniversalCrossbarPaletteToJob with overwrite option. Cycle ordering. ValidatePalettesForJob with scope application.
- core/settings/factories.lua, migration.lua, user.lua: crossbarLockMovement, crossbarDisableInMenu, useSharedExpandedBar, inactiveSideWhileTriggerDim, paletteJobIconTheme defaults and migrations.

Why
- Foundational crossbar fixes: clipping (top/bottom decor + WindowPadding zero) must land before all crossbar UX slices. Shared expanded bar and inactive-side dim are layout/visual choices that all subsequent crossbar PRs depend on. Must merge before pr/15, pr/16, pr/17, pr/18.