### PR TITLE
Crossbar: floating double-tap preview windows for L2x2 and R2x2 bars

### DIFF
--- a/XIUI/config/crossbar_settings.lua
+++ b/XIUI/config/crossbar_settings.lua
@@ -1,0 +1,1479 @@
+--[[
+* XIUI Config - Crossbar settings (sidebar Crossbar category only)
+* Sibling to keyboard hotbar settings in config/hotbar.lua - not mixed at edit time.
+]]--
+
+require('common');
+require('handlers.helpers');
+local ffi = require('ffi');
+local TextureManager = require('libs.texturemanager');
+local components = require('config.components');
+local imgui = require('imgui');
+local data = require('modules.hotbar.data');
+local jobs = require('libs.jobs');
+local macropalette = require('modules.hotbar.macropalette');
+local palette = require('modules.hotbar.palette');
+local paletteManager = require('config.palettemanager');
+local controller = require('modules.hotbar.controller');
+
+local hotbarConfig = require('config.hotbar');
+
+local M = {};
+
+local lastConfigCategorySeenForCrossbar = nil;
+
+-- Crossbar config UI: default to Controller Settings (tab 1) each addon load until user picks another sub-tab this session
+local crossbarConfigSubTabUserChosen = false;
+
+-- Global Visual Settings (tab 3): collapse sections when switching to this tab unless the user expanded them this session
+local CROSSBAR_GLOBAL_VIS_KEYS = { 'palCtrl', 'slot', 'bg', 'text', 'vfb' };
+local crossbarGlobalVis_prevUit = nil;
+local crossbarGlobalVis_openedSections = {};
+local crossbarGlobalVis_sectionNonce = {};
+
+local function CrossbarGlobalVisualCollapsingSection(sectionKey, label, defaultOpen)
+    local nonce = crossbarGlobalVis_sectionNonce[sectionKey] or 0;
+    local fullLabel = string.format('%s##xbGlobalVis_%s_%d', label, sectionKey, nonce);
+    if defaultOpen == nil then defaultOpen = false; end
+    imgui.Spacing();
+    local flags = defaultOpen and ImGuiTreeNodeFlags_DefaultOpen or 0;
+    local isOpen = imgui.CollapsingHeader(fullLabel, flags);
+    if imgui.IsItemClicked() then
+        crossbarGlobalVis_openedSections[sectionKey] = true;
+    end
+    if isOpen then
+        imgui.Spacing();
+    end
+    return isOpen;
+end
+
+local function ResolveCrossbarPaletteJobIconTheme(cs)
+    local t = cs and cs.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+local buttonDetectionState = {
+    active = false,
+    progress = 0,
+};
+-- ============================================
+-- Crossbar Global Palettes UI Section
+-- ============================================
+
+-- Global crossbar palette error state
+local crossbarGlobalPaletteErrorMessage = nil;
+
+-- Enable Global crossbar sets + optional scope + default palette type (only when Global sets enabled)
+local function DrawCrossbarUniversalTierOptions(crossbarSettings, opts)
+    opts = opts or {};
+    if opts.showEnableCheckbox ~= false then
+        local uEn = { crossbarSettings.enableUniversalCrossbarPalettes == true };
+        if imgui.Checkbox('Enable "Global" Crossbar Sets##xcuEn', uEn) then
+            crossbarSettings.enableUniversalCrossbarPalettes = uEn[1];
+            if uEn[1] then
+                palette.EnsureUniversalCrossbarDefaultExists();
+            end
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Crossbar palettes shared by every job, labeled [G] in lists. Hold L1 and tap R1 in-game to switch between Global [G] storage and Job/Subjob [J] storage for the crossbar.\nWhen Global sets are off, only [J] job/subjob palettes are used.');
+    end
+
+    if not crossbarSettings.enableUniversalCrossbarPalettes then
+        return;
+    end
+
+    if opts.includeScopeLine ~= false then
+        local scope = palette.GetCrossbarPaletteScope();
+        imgui.TextColored({0.7, 0.75, 1.0, 1.0}, 'Scope: ' .. (scope == 'universal' and 'Global [G]' or 'Job / Subjob [J]'));
+        imgui.Spacing();
+    end
+
+    if not crossbarSettings.defaultCrossbarPaletteScope then
+        crossbarSettings.defaultCrossbarPaletteScope = 'job';
+    end
+    imgui.AlignTextToFramePadding();
+    imgui.Text('Default Palette Type on Profile Load:');
+    imgui.SameLine();
+    imgui.SetNextItemWidth(160);
+    local defLabel = crossbarSettings.defaultCrossbarPaletteScope == 'universal' and 'Global [G]' or 'Job / Subjob [J]';
+    if imgui.BeginCombo('##xcuDefScope', defLabel) then
+        if imgui.Selectable('Job / Subjob [J]', crossbarSettings.defaultCrossbarPaletteScope ~= 'universal') then
+            crossbarSettings.defaultCrossbarPaletteScope = 'job';
+            SaveSettingsOnly();
+        end
+        if imgui.Selectable('Global [G]', crossbarSettings.defaultCrossbarPaletteScope == 'universal') then
+            crossbarSettings.defaultCrossbarPaletteScope = 'universal';
+            SaveSettingsOnly();
+        end
+        imgui.EndCombo();
+    end
+    imgui.ShowHelp('Which Job vs Global [G] palette tier is applied when a profile is loaded or reloaded from disk. While playing, use L1+R1 to switch tier without changing this setting.');
+end
+
+-- Draw the global crossbar palettes management section
+-- opts.showEnableCheckbox (default true): show Enable "Global" Crossbar Sets (also on Controller tab)
+-- opts.skipUniversalTierOptions: when true, toggles were drawn elsewhere (e.g. Manage strip)
+-- opts.jobId / opts.subjobId: which job/subjob to edit for [J] palettes (config preview)
+local function DrawCrossbarGlobalPalettesSection(opts)
+    opts = opts or {};
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return;
+    end
+
+    if opts.skipUniversalTierOptions ~= true then
+        DrawCrossbarUniversalTierOptions(crossbarSettings, {
+            showEnableCheckbox = opts.showEnableCheckbox,
+            includeScopeLine = opts.includeScopeLine ~= false,
+        });
+    end
+
+    if crossbarSettings.enableUniversalCrossbarPalettes then
+        if opts.includeUniversalLists ~= false then
+        imgui.Spacing();
+        if opts.embedCrossbarUniversalPaletteManager then
+            palette.EnsureUniversalCrossbarDefaultExists();
+            paletteManager.DrawEmbeddedCrossbarManageUniversal();
+            imgui.Dummy({ 0, 4 });
+            imgui.AlignTextToFramePadding();
+            imgui.TextColored(components.TAB_STYLE.gold, 'Active palette');
+            imgui.SameLine();
+            imgui.ShowHelp('Active Global [G] palette when in-game scope is Global (toggle with L1+R1).');
+            local uList = palette.GetUniversalCrossbarPaletteNamesOrdered();
+            local uActive = palette.GetActiveUniversalCrossbarPalette();
+            local availU = imgui.GetContentRegionAvail();
+            local comboWU = math.max(220, ((type(availU) == 'table' and availU[1]) or availU or 400) * 0.5);
+            imgui.SetNextItemWidth(comboWU);
+            local comboLabelU = uActive or (#uList > 0 and uList[1]) or '(none)';
+            if imgui.BeginCombo('##xbManageActivePalUniversal', comboLabelU) then
+                for _, un in ipairs(uList) do
+                    local labelU = un .. ' (G)';
+                    local isSelU = (uActive == un);
+                    if imgui.Selectable(labelU .. '##xbActUni', isSelU) then
+                        palette.SetActiveUniversalCrossbarPalette(un);
+                    end
+                    if isSelU then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+        else
+            imgui.TextColored(components.TAB_STYLE.gold, 'Global [G] palette list');
+            local uList = palette.GetUniversalCrossbarPaletteNamesOrdered();
+            local lineH = imgui.GetTextLineHeightWithSpacing();
+            local globalScrollH = opts.compactGlobalPaletteScroll and (lineH * 4) or nil;
+            if globalScrollH then
+                imgui.BeginChild('##xcuGlobalPalScroll', { 0, globalScrollH }, true);
+            end
+            for _, un in ipairs(uList) do
+                imgui.PushID('xcuRow' .. un);
+                local inc = palette.GetUniversalPaletteIncludeInCycle(un);
+                local incBuf = { inc };
+                if imgui.Checkbox('Cycle##xcuCyc', incBuf) then
+                    palette.SetUniversalPaletteIncludeInCycle(un, incBuf[1]);
+                end
+                imgui.SameLine();
+                imgui.TextColored({0.85, 0.85, 0.5, 1.0}, '[G]');
+                imgui.SameLine();
+                imgui.Text(un);
+                imgui.PopID();
+            end
+            if globalScrollH then
+                imgui.EndChild();
+            end
+
+            imgui.Spacing();
+            imgui.PushStyleColor(ImGuiCol_Button, {0.15, 0.35, 0.2, 1.0});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.25, 0.45, 0.3, 1.0});
+            if imgui.Button('New Global palette##xcuNew', {140, 0}) then
+                hotbarConfig.OpenPaletteCreateModal('crossbar_universal');
+            end
+            imgui.PopStyleColor(2);
+
+            local uActive = palette.GetActiveUniversalCrossbarPalette();
+            if #uList > 0 then
+                imgui.SameLine();
+                imgui.SetNextItemWidth(180);
+                local comboLabel = uActive or uList[1];
+                if imgui.BeginCombo('##xcuActive', comboLabel) then
+                    for _, un in ipairs(uList) do
+                        if imgui.Selectable(un .. '##xcuSel' .. un, un == uActive) then
+                            palette.SetActiveUniversalCrossbarPalette(un);
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                imgui.ShowHelp('Active Global [G] palette when in-game scope is Global (toggle with L1+R1).');
+            end
+        end
+
+        imgui.Separator();
+        imgui.Spacing();
+        end
+    end
+
+    if opts.includeJobPalettes == false then
+        if crossbarGlobalPaletteErrorMessage then
+            imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
+        end
+        imgui.Spacing();
+        return;
+    end
+
+    local jobId = opts.jobId or data.jobId or 1;
+    local subjobId = opts.subjobId ~= nil and opts.subjobId or (data.subjobId or 0);
+
+    -- Embedded full Palette Manager (Manage tab): Job (J) + Subjob (SJ) tiers
+    if opts.embedCrossbarJobPaletteManager then
+        palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
+        paletteManager.DrawEmbeddedCrossbarManage(jobId, subjobId);
+        imgui.Dummy({ 0, 4 });
+        imgui.AlignTextToFramePadding();
+        imgui.TextColored(components.TAB_STYLE.gold, 'Active palette');
+        imgui.SameLine();
+        imgui.ShowHelp('Matches in-game crossbar scope: Global [G] shows universal palettes; Job [J]/[SJ] shows palettes for this job/subjob. (J) = job-wide; (SJ) = this job+subjob tier.');
+        local mergedRows = palette.GetCrossbarManagePaletteRows(jobId, subjobId);
+        local activeName = palette.GetActivePaletteForCombo('L2');
+        local activeSt = palette.GetCrossbarActiveStorageSubjob();
+        local scopeUniversal = palette.GetCrossbarPaletteScope() == 'universal';
+        local comboLabel = '(none)';
+        if scopeUniversal then
+            local uName = palette.GetActiveUniversalCrossbarPalette() or activeName;
+            if uName and uName ~= '' then
+                comboLabel = uName .. ' (G)';
+            end
+        else
+            for _, r in ipairs(mergedRows) do
+                if r.name == activeName and (activeSt == nil or activeSt == r.storageSubjob) then
+                    comboLabel = r.name .. palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+                    break;
+                end
+            end
+            if activeName and comboLabel == '(none)' then
+                comboLabel = activeName;
+            end
+        end
+        local avail = imgui.GetContentRegionAvail();
+        local comboW = math.max(220, ((type(avail) == 'table' and avail[1]) or avail or 400) * 0.5);
+        imgui.SetNextItemWidth(comboW);
+        if imgui.BeginCombo('##xbManageActivePal', comboLabel) then
+            if scopeUniversal then
+                local uList = palette.GetUniversalCrossbarPaletteNamesOrdered();
+                local uActive = palette.GetActiveUniversalCrossbarPalette();
+                for _, un in ipairs(uList) do
+                    local label = un .. ' (G)';
+                    local isSel = (uActive == un);
+                    if imgui.Selectable(label .. '##xbActU', isSel) then
+                        palette.SetActiveUniversalCrossbarPalette(un);
+                    end
+                    if isSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+            else
+                for _, r in ipairs(mergedRows) do
+                    local label = r.name .. palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+                    local isSel = (r.name == activeName and (activeSt == nil or activeSt == r.storageSubjob));
+                    if imgui.Selectable(label .. '##xbActPal', isSel) then
+                        palette.SetActivePaletteForCombo('L2', r.name, r.storageSubjob);
+                    end
+                    if isSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        if crossbarGlobalPaletteErrorMessage then
+            imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
+        end
+        imgui.Spacing();
+        return;
+    end
+
+    -- Ensure at least one palette exists for this job
+    palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
+    local mergedRows = palette.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local cycleRows = palette.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+    local currentPalette = palette.GetActivePaletteForCombo('L2');
+    local currentStorage = palette.GetCrossbarActiveStorageSubjob();
+
+    local paletteCount = #cycleRows;
+    local currentPaletteIndex = nil;
+    for i, r in ipairs(cycleRows) do
+        if r.name == currentPalette and (currentStorage == nil or currentStorage == r.storageSubjob) then
+            currentPaletteIndex = i;
+            break;
+        end
+    end
+    local totalMergedCount = #mergedRows;
+
+    if #mergedRows > 0 and not currentPalette then
+        local pick = cycleRows[1] or mergedRows[1];
+        palette.SetActivePaletteForCombo('L2', pick.name, pick.storageSubjob);
+        currentPalette = pick.name;
+        currentStorage = pick.storageSubjob;
+        currentPaletteIndex = 1;
+    end
+
+    imgui.TextColored(components.TAB_STYLE.gold, 'Job / subjob crossbar palettes  [J]');
+    components.PushPaletteManagerButtonStyle();
+    if imgui.SmallButton('Manage Palettes##crossbar') then
+        local xiuiConfig = require('config');
+        xiuiConfig.OpenCrossbarManagePalettes();
+    end
+    components.PopPaletteManagerButtonStyle();
+    imgui.Spacing();
+
+    -- Header with count
+    imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Palettes:');
+    imgui.SameLine();
+    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' in cycle');
+    imgui.ShowHelp('Create named palettes to quickly switch between crossbar configurations.\nPalettes are GLOBAL - switching changes all combo modes (L2, R2, L2+R2, etc.) at once.\n"Inactive" in Palette Manager is excluded from RB+D-pad cycling and from this count.');
+
+    local currentDisplayName = currentPalette or 'Select palette';
+    if currentPalette and currentPaletteIndex then
+        local r = nil;
+        for _, row in ipairs(cycleRows) do
+            if row.name == currentPalette and (currentStorage == nil or currentStorage == row.storageSubjob) then
+                r = row;
+                break;
+            end
+        end
+        local suf = r and palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId) or '';
+        currentDisplayName = currentPaletteIndex .. '. ' .. currentPalette .. suf;
+    elseif currentPalette then
+        local suf = '';
+        for _, r in ipairs(mergedRows) do
+            if r.name == currentPalette and (currentStorage == nil or currentStorage == r.storageSubjob) then
+                suf = palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+                break;
+            end
+        end
+        currentDisplayName = currentPalette .. suf .. ' (inactive)';
+    end
+
+    imgui.SetNextItemWidth(150);
+    if imgui.BeginCombo('##crossbarGlobalPalette', currentDisplayName) then
+        local cycleIdxByKey = {};
+        for i, r in ipairs(cycleRows) do
+            cycleIdxByKey[r.name .. '\0' .. tostring(r.storageSubjob)] = i;
+        end
+        for i, r in ipairs(mergedRows) do
+            local suf = palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+            local isSelected = (r.name == currentPalette and (currentStorage == nil or currentStorage == r.storageSubjob));
+            local cycIdx = cycleIdxByKey[r.name .. '\0' .. tostring(r.storageSubjob)];
+            local displayName = (cycIdx and (cycIdx .. '. ') or '– ') .. r.name .. suf;
+            if imgui.Selectable(displayName .. '##cbGlobalPal' .. i, isSelected) then
+                palette.SetActivePaletteForCombo('L2', r.name, r.storageSubjob);
+            end
+            if isSelected then
+                imgui.SetItemDefaultFocus();
+            end
+        end
+        imgui.EndCombo();
+    end
+
+    -- Rename button (for any palette)
+    if currentPalette then
+        imgui.SameLine();
+        if imgui.Button('Rename##cbGlobalPalette', {55, 0}) then
+            hotbarConfig.OpenPaletteRenameModal('crossbar', currentPalette);
+        end
+    end
+
+    -- New button (always visible, green)
+    imgui.SameLine();
+    imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.5, 0.2, 1.0});
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.3, 0.6, 0.3, 1.0});
+    if imgui.Button('New##cbGlobalPalette', {40, 0}) then
+        hotbarConfig.OpenPaletteCreateModal('crossbar');
+    end
+    imgui.PopStyleColor(2);
+
+    -- Delete button (only if more than 1 palette exists - can't delete the last one)
+    if currentPalette and totalMergedCount > 1 then
+        imgui.SameLine();
+        imgui.PushStyleColor(ImGuiCol_Button, {0.6, 0.2, 0.2, 1.0});
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.8, 0.3, 0.3, 1.0});
+        if imgui.Button('Delete##cbGlobalPalette', {50, 0}) then
+            local delTier = currentStorage or 0;
+            local success, err = palette.DeleteCrossbarPalette(currentPalette, jobId, delTier);
+            if not success then
+                crossbarGlobalPaletteErrorMessage = err or 'Failed to delete palette';
+            else
+                crossbarGlobalPaletteErrorMessage = nil;
+            end
+        end
+        imgui.PopStyleColor(2);
+    end
+
+    -- Reorder within the same storage tier (Job [J] vs Subjob [SJ])
+    if currentPalette and totalMergedCount > 1 then
+        imgui.SameLine();
+        imgui.TextColored({0.5, 0.5, 0.5, 1.0}, '|');
+        imgui.SameLine();
+
+        local moveTier = currentStorage or 0;
+        local tierNames = {};
+        for _, r in ipairs(mergedRows) do
+            if r.storageSubjob == moveTier then
+                table.insert(tierNames, r.name);
+            end
+        end
+        local idxInTier = nil;
+        for ti, n in ipairs(tierNames) do
+            if n == currentPalette then
+                idxInTier = ti;
+                break;
+            end
+        end
+        local canMoveUp = idxInTier and idxInTier > 1;
+        local canMoveDown = idxInTier and idxInTier < #tierNames;
+
+        if not canMoveUp then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
+        end
+        if imgui.Button('^##cbGlobalPaletteUp', {20, 0}) and canMoveUp then
+            palette.MoveCrossbarPalette(currentPalette, -1, jobId, moveTier);
+        end
+        if not canMoveUp then
+            imgui.PopStyleColor(3);
+        end
+
+        imgui.SameLine();
+
+        if not canMoveDown then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
+        end
+        if imgui.Button('v##cbGlobalPaletteDown', {20, 0}) and canMoveDown then
+            palette.MoveCrossbarPalette(currentPalette, 1, jobId, moveTier);
+        end
+        if not canMoveDown then
+            imgui.PopStyleColor(3);
+        end
+    end
+
+    -- Show error message (for delete failures)
+    if crossbarGlobalPaletteErrorMessage then
+        imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
+    end
+
+    imgui.Spacing();
+end
+
+local function SyncCrossbarPaletteEditContextFromLiveJob(crossbarSettings)
+    if not crossbarSettings or crossbarSettings.configFocus ~= 'job' then
+        return;
+    end
+    data.SetPlayerJob();
+    local j = data.jobId;
+    if not j or j < 1 then
+        return;
+    end
+    crossbarSettings.configEditJobId = j;
+    crossbarSettings.configEditSubjobId = data.subjobId or 0;
+    SaveSettingsOnly();
+end
+
+-- When entering the Crossbar sidebar category, align palette edit job/subjob with the live character
+local function MaybeSyncCrossbarEditContextOnCategoryEnter(crossbarSettings, menuState)
+    local crossIdx = menuState and menuState.crossbarCategoryIndex;
+    if not crossIdx then
+        return;
+    end
+    local cat = menuState.selectedCategory;
+    if cat == crossIdx then
+        if lastConfigCategorySeenForCrossbar ~= crossIdx then
+            SyncCrossbarPaletteEditContextFromLiveJob(crossbarSettings);
+        end
+        lastConfigCategorySeenForCrossbar = crossIdx;
+    else
+        lastConfigCategorySeenForCrossbar = cat;
+    end
+end
+
+local function GetSubjobMenuLabel(subjobId)
+    if subjobId == nil or subjobId == 0 then
+        return 'Shared';
+    end
+    return jobs[subjobId] or ('Job ' .. tostring(subjobId));
+end
+
+local function DrawCrossbarJobIconStrip(crossbarSettings, stripOpts)
+    stripOpts = stripOpts or {};
+    if not crossbarSettings.configFocus then
+        crossbarSettings.configFocus = 'job';
+    end
+    data.SetPlayerJob();
+    if crossbarSettings.configFocus == 'job' then
+        if crossbarSettings.configEditJobId == nil then
+            local j = data.jobId;
+            if j and j > 0 then
+                crossbarSettings.configEditJobId = j;
+            else
+                crossbarSettings.configEditJobId = 1;
+            end
+        end
+        if crossbarSettings.configEditSubjobId == nil then
+            crossbarSettings.configEditSubjobId = data.subjobId or 0;
+        end
+    end
+
+    -- Global [G] requires "Enable Global Crossbar Sets"; otherwise fall back to job context
+    if crossbarSettings.enableUniversalCrossbarPalettes ~= true and crossbarSettings.configFocus == 'universal' then
+        crossbarSettings.configFocus = 'job';
+        if crossbarSettings.configEditJobId == nil then
+            local j = data.jobId;
+            if j and j > 0 then
+                crossbarSettings.configEditJobId = j;
+            else
+                crossbarSettings.configEditJobId = 1;
+            end
+        end
+        if crossbarSettings.configEditSubjobId == nil then
+            crossbarSettings.configEditSubjobId = data.subjobId or 0;
+        end
+        SaveSettingsOnly();
+    end
+
+    imgui.TextColored(components.TAB_STYLE.gold, 'Palette edit context');
+    imgui.ShowHelp('Global [G] edits crossbar palettes shared by every job. A job icon selects that job’s [J] palettes here (separate from your live character; bindings follow your current job in-game).');
+    imgui.Spacing();
+
+    local iconSize = 34;
+    local pad = 3;
+
+    local function drawIconButton(id, tex, tip, selected, disabled, disabledTip)
+        disabled = disabled == true;
+        local showSel = selected and not disabled;
+        local pos = { imgui.GetCursorScreenPos() };
+        local clicked = false;
+        imgui.PushStyleVar(ImGuiStyleVar_FramePadding, { 0, 0 });
+        if showSel then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.12, 0.11, 0.1, 1.0});
+            imgui.PushStyleColor(ImGuiCol_Border, {1.0, 1.0, 1.0, 1.0});
+            imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
+        elseif disabled then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.10, 0.09, 0.08, 0.72});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.11, 0.10, 0.09, 0.82});
+            imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.11, 0.10, 0.09, 0.82});
+        else
+            imgui.PushStyleColor(ImGuiCol_Button, {0.18, 0.16, 0.14, 1.0});
+        end
+        if imgui.Button(id, { iconSize, iconSize }) then
+            if not disabled then
+                clicked = true;
+            end
+        end
+        if showSel then
+            imgui.PopStyleVar(1);
+            imgui.PopStyleColor(2);
+        elseif disabled then
+            imgui.PopStyleColor(3);
+        else
+            imgui.PopStyleColor(1);
+        end
+        imgui.PopStyleVar(1);
+        local dl = imgui.GetWindowDrawList();
+        if tex and tex.image and dl then
+            local p = tonumber(ffi.cast('uint32_t', tex.image));
+            if p then
+                local imgTint = disabled
+                    and imgui.GetColorU32({ 0.38, 0.10, 0.10, 0.88 })
+                    or imgui.GetColorU32({ 1, 1, 1, 1 });
+                dl:AddImage(
+                    p,
+                    { pos[1] + pad, pos[2] + pad },
+                    { pos[1] + iconSize - pad, pos[2] + iconSize - pad },
+                    { 0, 0 },
+                    { 1, 1 },
+                    imgTint
+                );
+            end
+        end
+        if showSel and dl then
+            local rMin = { imgui.GetItemRectMin() };
+            local rMax = { imgui.GetItemRectMax() };
+            dl:AddRect(rMin, rMax, 0xFFFFFFFF, 0, 0, 2.0);
+        end
+        local hoverTip = disabled and disabledTip or tip;
+        if hoverTip and imgui.IsItemHovered() then
+            imgui.BeginTooltip();
+            imgui.Text(hoverTip);
+            imgui.EndTooltip();
+        end
+        return clicked;
+    end
+
+    local infTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not infTex or not infTex.image then
+        infTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    local globalSetsEnabled = crossbarSettings.enableUniversalCrossbarPalettes == true;
+    local selG = crossbarSettings.configFocus == 'universal';
+    imgui.BeginGroup();
+    if drawIconButton(
+        '##xbJobInf',
+        infTex,
+        'Global [G] crossbar sets',
+        selG,
+        not globalSetsEnabled,
+        'Global Crossbar Sets must be enabled under Controller Settings.'
+    ) then
+        crossbarSettings.configFocus = 'universal';
+        crossbarSettings.configEditJobId = nil;
+        SaveSettingsOnly();
+    end
+    imgui.SameLine();
+    local col = 0;
+    local palJobIconTheme = ResolveCrossbarPaletteJobIconTheme(crossbarSettings);
+    for ji = 1, 22 do
+        local abbr = jobs[ji];
+        if abbr then
+            local jtex = TextureManager.getJobIcon(ji, palJobIconTheme);
+            local sel = crossbarSettings.configFocus == 'job' and (crossbarSettings.configEditJobId == ji);
+            if drawIconButton('##xbJobIcon' .. ji, jtex, abbr, sel) then
+                crossbarSettings.configFocus = 'job';
+                crossbarSettings.configEditJobId = ji;
+                -- Subjob (SJ) tier cannot match main job; fall back to Shared
+                if crossbarSettings.configEditSubjobId == ji then
+                    crossbarSettings.configEditSubjobId = 0;
+                end
+                SaveSettingsOnly();
+            end
+            col = col + 1;
+            if col < 11 then
+                imgui.SameLine();
+            else
+                col = 0;
+            end
+        end
+    end
+    imgui.EndGroup();
+    imgui.Spacing();
+
+    if stripOpts.showGlobalOptionsRow then
+        if crossbarSettings.configFocus == 'job' then
+            imgui.AlignTextToFramePadding();
+            imgui.Text('Subjob');
+            imgui.SameLine();
+            imgui.SetNextItemWidth(120);
+            local sjCur = crossbarSettings.configEditSubjobId;
+            if sjCur == nil then
+                sjCur = data.subjobId or 0;
+            end
+            local mainJobForTier = crossbarSettings.configEditJobId or data.jobId or 1;
+            if sjCur ~= 0 and sjCur == mainJobForTier then
+                crossbarSettings.configEditSubjobId = 0;
+                sjCur = 0;
+                SaveSettingsOnly();
+            end
+            local sjLabel = GetSubjobMenuLabel(sjCur);
+            if imgui.BeginCombo('##xbCfgSubjob', sjLabel) then
+                if imgui.Selectable('Shared##xbsj0', sjCur == 0) then
+                    crossbarSettings.configEditSubjobId = 0;
+                    SaveSettingsOnly();
+                end
+                for sj = 1, 22 do
+                    if sj ~= mainJobForTier then
+                        local nm = jobs[sj];
+                        if nm and imgui.Selectable(nm .. '##xbsj' .. sj, sjCur == sj) then
+                            crossbarSettings.configEditSubjobId = sj;
+                            SaveSettingsOnly();
+                        end
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.SameLine();
+            components.PushMacroManagerButtonStyle();
+            if imgui.Button('Macro Manager##xbMacro', {120, 0}) then
+                macropalette.TogglePalette();
+            end
+            components.PopMacroManagerButtonStyle();
+            imgui.ShowHelp('Palette storage tier for this job (Shared = job-wide library). Use Macro Manager for macro bar palettes.');
+        else
+            imgui.AlignTextToFramePadding();
+            imgui.TextColored({0.65, 0.65, 0.7, 1.0}, 'Editing Global [G] crossbar sets');
+            imgui.SameLine();
+            components.PushMacroManagerButtonStyle();
+            if imgui.Button('Macro Manager##xbMacroG', { 120, 0 }) then
+                macropalette.TogglePalette();
+            end
+            components.PopMacroManagerButtonStyle();
+            imgui.ShowHelp('Global [G] palettes are shared across all jobs. Use Macro Manager for macro bar palettes.');
+        end
+        imgui.Spacing();
+    end
+end
+
+local function DrawCrossbarSettings(selectedCrossbarTab, menuState)
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+        return selectedCrossbarTab;
+    end
+
+    data.SetPlayerJob();
+    MaybeSyncCrossbarEditContextOnCategoryEnter(crossbarSettings, menuState);
+
+    selectedCrossbarTab = selectedCrossbarTab or 1;
+
+    if not crossbarConfigSubTabUserChosen then
+        crossbarSettings.configUiTab = 1;
+    elseif not crossbarSettings.configUiTab or crossbarSettings.configUiTab < 1 or crossbarSettings.configUiTab > 3 then
+        crossbarSettings.configUiTab = 1;
+    end
+    local uit = crossbarSettings.configUiTab;
+    local function saveCrossbarConfigTab(i)
+        crossbarSettings.configUiTab = i;
+        if i ~= 1 then
+            crossbarConfigSubTabUserChosen = true;
+        end
+        SaveSettingsOnly();
+    end
+
+    do
+        local clicked1 = components.DrawStyledTab('Controller Settings', 'xbCfgTab1', uit == 1, nil, components.TAB_STYLE.height, components.TAB_STYLE.padding);
+        if clicked1 then
+            saveCrossbarConfigTab(1);
+        end
+        imgui.SameLine();
+        local clicked2 = components.DrawStyledTab('Manage Palettes & Crossbar', 'xbCfgTab2', uit == 2, nil, components.TAB_STYLE.height, components.TAB_STYLE.padding, 'green');
+        if clicked2 then
+            saveCrossbarConfigTab(2);
+        end
+        imgui.SameLine();
+        local clicked3 = components.DrawStyledTab('Global Visual Settings', 'xbCfgTab3', uit == 3, nil, components.TAB_STYLE.height, components.TAB_STYLE.padding);
+        if clicked3 then
+            saveCrossbarConfigTab(3);
+        end
+    end
+    imgui.Spacing();
+    imgui.Separator();
+    imgui.Spacing();
+
+    if uit == 1 then
+    -- Controller Settings section
+    imgui.TextColored(components.TAB_STYLE.gold, 'Controller Settings');
+    imgui.Spacing();
+
+    -- Controller Profile selection
+    local devices = require('modules.hotbar.devices');
+    local currentScheme = controller.GetControllerScheme();
+    local deviceSchemes = devices.GetSchemeNames();
+    local deviceDisplayNames = devices.GetSchemeDisplayNames();
+
+    -- Find current selection index
+    local currentIndex = 1;
+    for i, scheme in ipairs(deviceSchemes) do
+        if scheme == currentScheme then
+            currentIndex = i;
+            break;
+        end
+    end
+
+    -- Map profile to matching theme
+    local profileToTheme = {
+        xbox = 'Xbox',
+        dualsense = 'PlayStation',
+        switchpro = 'Nintendo',
+        dinput = 'Xbox',
+    };
+
+    imgui.AlignTextToFramePadding();
+    imgui.Text('Controller Profile:');
+    imgui.SameLine();
+    imgui.SetNextItemWidth(150);
+    if imgui.BeginCombo('##controllerSelect', deviceDisplayNames[currentScheme] or currentScheme, ImGuiComboFlags_None) then
+        for i, scheme in ipairs(deviceSchemes) do
+            local isSelected = (scheme == currentScheme);
+            if imgui.Selectable(deviceDisplayNames[scheme], isSelected) then
+                crossbarSettings.controllerScheme = scheme;
+                -- If switching to dinput, apply custom mapping if it exists
+                local customMapping = nil;
+                if scheme == 'dinput' and crossbarSettings.customControllerMappings and crossbarSettings.customControllerMappings.dinput then
+                    customMapping = crossbarSettings.customControllerMappings.dinput;
+                end
+                controller.SetControllerScheme(scheme, customMapping);
+                -- Auto-adjust theme to match profile
+                local matchingTheme = profileToTheme[scheme];
+                if matchingTheme then
+                    crossbarSettings.controllerTheme = matchingTheme;
+                end
+                SaveSettingsOnly();
+            end
+            if isSelected then
+                imgui.SetItemDefaultFocus();
+            end
+        end
+        imgui.EndCombo();
+    end
+    imgui.ShowHelp('Select which button mapping profile to use.\n\n- Xbox: For XInput controllers (Xbox, 8BitDo in X-mode)\n- PlayStation: For DualSense/DualShock via DirectInput\n- Switch Pro: For Nintendo Switch Pro controller\n- Generic DirectInput: For other DirectInput controllers\n\nChanging this will also update the button icon theme.');
+
+    local hasAnalogTriggers = (currentScheme == 'xbox' or currentScheme == 'dualsense');
+
+    -- Display Mode (directly under Controller Profile)
+    do
+        local displayModes = { 'normal', 'activeOnly' };
+        local displayModeLabels = { 'Normal', 'Active Only' };
+        local currentDisplayMode = crossbarSettings.displayMode or 'normal';
+        local currentDisplayIndex = 1;
+        for i, mode in ipairs(displayModes) do
+            if mode == currentDisplayMode then
+                currentDisplayIndex = i;
+                break;
+            end
+        end
+
+        imgui.Spacing();
+        imgui.AlignTextToFramePadding();
+        imgui.Text('Display Mode:');
+        imgui.SameLine();
+        imgui.SetNextItemWidth(150);
+        if imgui.BeginCombo('##displayModeCrossbar', displayModeLabels[currentDisplayIndex]) then
+            for i, label in ipairs(displayModeLabels) do
+                local isSelected = (i == currentDisplayIndex);
+                if imgui.Selectable(label, isSelected) then
+                    crossbarSettings.displayMode = displayModes[i];
+                    SaveSettingsOnly();
+                end
+                if isSelected then
+                    imgui.SetItemDefaultFocus();
+                end
+            end
+            imgui.EndCombo();
+        end
+        imgui.ShowHelp('Normal: Always show both sides (inactive side dimmed).\nActive Only: Show only when trigger is held, displaying only the active side.');
+    end
+
+    -- Analog Trigger Threshold Settings (Xbox and PlayStation only)
+    if hasAnalogTriggers then
+        imgui.Spacing();
+        imgui.Text('Analog Trigger Settings');
+        imgui.Separator();
+
+        components.DrawPartySliderInt(crossbarSettings, 'Press Threshold##crossbar', 'triggerPressThreshold', 5, 250, '%d', function()
+            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
+        end, 30);
+        imgui.ShowHelp('Analog trigger value (0-255) required to register as pressed. Higher values require a deeper press. Default: 30');
+
+        components.DrawPartySliderInt(crossbarSettings, 'Release Threshold##crossbar', 'triggerReleaseThreshold', 5, 250, '%d', function()
+            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
+        end, 15);
+        imgui.ShowHelp('Analog trigger value (0-255) below which the trigger is considered released. Provides hysteresis to prevent jitter. Default: 15');
+    end
+
+    imgui.Spacing();
+
+    -- Custom DirectInput button mapping section (only for dinput scheme)
+    if currentScheme == 'dinput' then
+        imgui.Indent(20);
+
+        local hasCustomMapping = crossbarSettings.customControllerMappings and 
+                                  crossbarSettings.customControllerMappings.dinput;
+
+        -- Configure button
+        if imgui.Button('Configure Button Mapping##dinput', {0, 0}) then
+            local buttondetect = require('modules.hotbar.buttondetect');
+            buttonDetectionState.active = true;
+            buttonDetectionState.progress = 0;
+            buttondetect.StartDetection(function(results)
+                if not crossbarSettings.customControllerMappings then
+                    crossbarSettings.customControllerMappings = {};
+                end
+                crossbarSettings.customControllerMappings.dinput = results;
+                buttonDetectionState.active = false;
+                SaveSettingsOnly();
+                -- Re-initialize controller with new mapping
+                controller.SetControllerScheme('dinput', results);
+            end);
+        end
+        imgui.SameLine();
+        imgui.ShowHelp('Launch wizard to configure button layout for your controller. Custom mappings allow you to define your own button layout for DirectInput controllers.');
+
+        -- Status indicator
+        imgui.SameLine();
+        if hasCustomMapping then
+            imgui.TextColored({0, 1, 0, 1}, '(Using custom mapping)');
+        else
+            imgui.TextColored({0.7, 0.7, 0.7, 1}, '(Using default mapping)');
+        end
+
+        -- Clear custom mapping button (only show if custom mapping exists)
+        if hasCustomMapping then
+            imgui.SameLine();
+            if imgui.Button('Clear Custom Mapping##dinput', {150, 0}) then
+                crossbarSettings.customControllerMappings.dinput = nil;
+                SaveSettingsOnly();
+                -- Re-initialize controller without custom mapping
+                controller.SetControllerScheme('dinput');
+            end
+            imgui.SameLine();
+            imgui.ShowHelp('Remove custom mapping and revert to defaults.');
+        end
+
+        -- Show progress bar during detection
+        if buttonDetectionState.active then
+            local buttondetect = require('modules.hotbar.buttondetect');
+            local progress, maxProgress = buttondetect.GetProgress();
+            imgui.ProgressBar(progress / maxProgress, {-1, 20}, string.format('Button %d of %d', progress, maxProgress));
+            imgui.TextWrapped('Detecting buttons... ' .. (buttondetect.GetCurrentPrompt() or ''));
+            if imgui.Button('Cancel##buttondetect', {0, 0}) then
+                buttondetect.Cancel();
+                buttonDetectionState.active = false;
+            end
+        end
+
+        imgui.Unindent(20);
+    end
+
+    imgui.Spacing();
+
+    -- Enable "Global" Crossbar Sets (+ default palette tier when enabled); omit live Scope preview line here
+    DrawCrossbarUniversalTierOptions(crossbarSettings, { includeScopeLine = false });
+
+    imgui.Spacing();
+
+    -- Double-Tap (window + minimum trigger hold under it when enabled)
+    components.DrawPartyCheckbox(crossbarSettings, 'Enable Double-Tap##crossbar', 'enableDoubleTap', DeferredUpdateVisuals);
+    imgui.ShowHelp('Enable L2x2 and R2x2 double-tap modes. Tap a trigger twice quickly (hold on second tap) to access double-tap bars.\nPer-trigger [G] attach and pet overrides are set in Edit Full Palette (Manage Palettes & Crossbar tab).');
+
+    if crossbarSettings.enableDoubleTap then
+        components.DrawPartySlider(crossbarSettings, 'Double-Tap Window##crossbar', 'doubleTapWindow', 0.1, 0.6, '%.2f sec', function()
+            controller.SetDoubleTapWindow(crossbarSettings.doubleTapWindow);
+        end, 0.3);
+        imgui.ShowHelp('Time window to register a double-tap (in seconds).');
+
+        if hasAnalogTriggers then
+            components.DrawPartySlider(crossbarSettings, 'Minimum Trigger Hold##crossbar', 'minTriggerHold', 0.01, 0.15, '%.3f sec', function()
+                controller.SetMinTriggerHold(crossbarSettings.minTriggerHold);
+            end, 0.05);
+            imgui.ShowHelp('Minimum time the trigger must be held before releasing for the release to count toward double-tap detection. Prevents false double-taps from analog jitter or accidental taps. Default: 0.050 sec (50ms)');
+        end
+
+        imgui.Spacing();
+        components.DrawPartyCheckbox(crossbarSettings, 'Show Double-Tap Crossbars Preview##crossbar', 'showDoubleTapPreview', DeferredUpdateVisuals);
+        imgui.ShowHelp('Show two small floating crossbar windows that always display your L2x2 and R2x2 double-tap bars,\nincluding cooldowns. While a double-tap is active, the preview swaps to show your base bar so you\ncan reference both at once. Drag anchors (visible when config is open) to reposition each preview.');
+
+        if crossbarSettings.showDoubleTapPreview then
+            imgui.Indent(20);
+            components.DrawPartySlider(crossbarSettings, 'Preview Scale##crossbar', 'doubleTapPreviewScale', 0.30, 1.0, '%.2f', DeferredUpdateVisuals, 0.60);
+            imgui.ShowHelp('Size of the preview windows relative to the main crossbar. 0.60 = 60% of full size.');
+            components.DrawPartySlider(crossbarSettings, 'Preview Opacity##crossbar', 'doubleTapPreviewOpacity', 0.20, 1.0, '%.2f', DeferredUpdateVisuals, 1.0);
+            imgui.ShowHelp('Base opacity of the preview windows. Follows trigger-dim behaviour: the inactive preview dims when\nthe opposite trigger is held, matching how the main crossbar dims its inactive side.');
+            components.DrawPartyCheckbox(crossbarSettings, 'Lock Preview Positions##crossbar', 'doubleTapPreviewLocked', DeferredUpdateVisuals);
+            imgui.ShowHelp('Lock the L2x2 and R2x2 preview windows in place so they cannot be dragged.\nIndependent of the main crossbar position lock.');
+            imgui.Unindent(20);
+        end
+    end
+
+    imgui.Spacing();
+
+    -- Chords: L2+R2 / R2+L2 expanded bars (+ shared expanded bar when enabled)
+    components.DrawPartyCheckbox(crossbarSettings, 'Enable Chords (L2+R2 / R2+L2)', 'enableExpandedCrossbar');
+    imgui.ShowHelp('Enable L2+R2 and R2+L2 combo modes. Hold one trigger, then press the other to access expanded bars.\nOptional Global [G] palette attach per trigger group is set in Edit Full Palette when editing a Job palette; [G] sets are labeled in palette lists.');
+
+    if crossbarSettings.enableExpandedCrossbar then
+        imgui.Indent(20);
+        components.DrawPartyCheckbox(crossbarSettings, 'Use Shared Expanded Bar##crossbar', 'useSharedExpandedBar', DeferredUpdateVisuals);
+        imgui.ShowHelp('When enabled, L2+R2 and R2+L2 will access the same shared expanded bar instead of separate bars.\nThis shared bar is completely independent from the separate L2+R2 and R2+L2 bars.');
+        imgui.Unindent(20);
+    end
+
+    imgui.Spacing();
+
+    DrawCrossbarGlobalPalettesSection({
+        skipUniversalTierOptions = true,
+        includeUniversalLists = false,
+        includeJobPalettes = false,
+    });
+
+    elseif uit == 2 then
+        DrawCrossbarJobIconStrip(crossbarSettings, { showGlobalOptionsRow = true });
+        if crossbarSettings.configFocus == 'universal' then
+            DrawCrossbarGlobalPalettesSection({
+                showEnableCheckbox = false,
+                skipUniversalTierOptions = true,
+                includeUniversalLists = true,
+                includeJobPalettes = false,
+                compactGlobalPaletteScroll = true,
+                embedCrossbarUniversalPaletteManager = true,
+            });
+        else
+            local effJob = crossbarSettings.configEditJobId or data.jobId or 1;
+            local effSub = crossbarSettings.configEditSubjobId;
+            if effSub == nil then
+                effSub = data.subjobId or 0;
+            end
+            DrawCrossbarGlobalPalettesSection({
+                showEnableCheckbox = false,
+                skipUniversalTierOptions = true,
+                includeUniversalLists = false,
+                includeJobPalettes = true,
+                jobId = effJob,
+                subjobId = effSub,
+                embedCrossbarJobPaletteManager = true,
+            });
+        end
+
+        if crossbarSettings.configFocus == 'job' then
+            imgui.Spacing();
+            imgui.TextWrapped(
+                'Per-trigger layout, Pet palette, and Global [G] overrides are edited in Edit Full Palette (button in the palette list above). ' ..
+                'Visual slot styling remains under Global Visual Settings.'
+            );
+        end
+
+    elseif uit == 3 then
+        imgui.TextColored(components.TAB_STYLE.gold, 'Global Visual Settings');
+        imgui.Spacing();
+
+        if crossbarGlobalVis_prevUit ~= 3 then
+            for _, sk in ipairs(CROSSBAR_GLOBAL_VIS_KEYS) do
+                if not crossbarGlobalVis_openedSections[sk] then
+                    crossbarGlobalVis_sectionNonce[sk] = (crossbarGlobalVis_sectionNonce[sk] or 0) + 1;
+                end
+            end
+        end
+
+        if crossbarSettings.paletteJobIconTheme == nil
+            or crossbarSettings.paletteJobIconTheme == 'ClassicFFXIV' then
+            crossbarSettings.paletteJobIconTheme = 'Classic';
+        end
+
+        if CrossbarGlobalVisualCollapsingSection('palCtrl', 'Palette & Controller Icons##crossbar', false) then
+            imgui.TextColored({ 0.85, 0.82, 0.7, 1.0 }, 'Palette Icons');
+            imgui.Spacing();
+            local paletteIconThemes = { 'Classic', 'FFXI', 'FFXIV-1' };
+            components.DrawPartyComboBox(crossbarSettings, 'Icon set##paletteJobIconTheme', 'paletteJobIconTheme', paletteIconThemes, DeferredUpdateVisuals);
+            imgui.ShowHelp('Job icons for Manage Palettes (crossbar) and the in-game palette scope icon when using Job [J] storage. Folders: addons/XIUI/assets/jobs/Classic, FFXI, FFXIV-1.');
+
+            components.DrawPartySlider(crossbarSettings, 'Icon Height##crossbarScopeLift', 'paletteScopeIconOffsetY', 0, 48, '%.0f', DeferredUpdateVisuals, 12);
+            imgui.ShowHelp('Vertical lift for the job / Global palette icon above the center line (pixels). Increase if it overlaps the L2/R2 combo text.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Icon Size (px)##crossbarScopeIconSize', 'paletteScopeIconSize', 8, 64, '%d', DeferredUpdateVisuals, 22);
+            imgui.ShowHelp('Width and height of the job or Global palette scope icon drawn above the center divider (when the scope icon is enabled).');
+
+            do
+                local effScope = crossbarSettings.showPaletteScopeIcon;
+                if effScope == nil then
+                    effScope = crossbarSettings.showPaletteName;
+                end
+                if imgui.Checkbox('Show Palette Scope Icon##crossbarPaletteScopeIcon', { effScope }) then
+                    crossbarSettings.showPaletteScopeIcon = not effScope;
+                    SaveSettingsOnly();
+                    UpdateUserSettings();
+                    DeferredUpdateVisuals();
+                end
+            end
+            imgui.ShowHelp('Infinity for Global [G] storage or main job icon for Job [J] storage, above the center line. Uncheck to hide only the icon; palette name is separate below.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Palette Name##crossbarPaletteName', 'showPaletteName');
+            if crossbarSettings.showPaletteName then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarpalette', 'paletteNameOffsetX', 'paletteNameOffsetY', 35);
+            end
+            imgui.ShowHelp('Current palette name and index below the crossbar (e.g. "Stuns (2/5)"). X/Y adjust position.');
+
+            imgui.Spacing();
+            imgui.Separator();
+            imgui.Spacing();
+
+            local controllerThemes = { 'PlayStation', 'Xbox', 'Nintendo' };
+            components.DrawPartyComboBox(crossbarSettings, 'Controller Theme##crossbar', 'controllerTheme', controllerThemes);
+            imgui.ShowHelp('Select controller button icon style. Nintendo layout: X top, A right, B bottom, Y left.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Button Icons##crossbar', 'showButtonIcons');
+            imgui.ShowHelp('Show d-pad and face button icons on slots.');
+
+            if crossbarSettings.showButtonIcons then
+                components.DrawPartySliderInt(crossbarSettings, 'Button Icon Size##crossbar', 'buttonIconSize', 8, 32, '%d', nil, 16);
+                imgui.ShowHelp('Size of controller button icons.');
+
+                components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (H)##crossbar', 'buttonIconGapH', 0, 24, '%d', nil, 2);
+                imgui.ShowHelp('Horizontal spacing between center controller icons.');
+
+                components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (V)##crossbar', 'buttonIconGapV', 0, 24, '%d', nil, 2);
+                imgui.ShowHelp('Vertical spacing between center controller icons.');
+            end
+
+            imgui.Separator();
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Trigger Icons##crossbar', 'showTriggerLabels');
+            imgui.ShowHelp('Show L2/R2 trigger icons above the crossbar groups.');
+
+            if crossbarSettings.showTriggerLabels then
+                components.DrawPartySlider(crossbarSettings, 'Trigger Icon Scale##crossbar', 'triggerIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
+                imgui.ShowHelp('Scale for L2/R2 trigger icons above groups (base size 49x28).');
+            end
+        end
+
+        if CrossbarGlobalVisualCollapsingSection('slot', 'Slot Settings##crossbar', false) then
+            components.DrawPartySliderInt(crossbarSettings, 'Slot Size (px)##crossbar', 'slotSize', 32, 64, '%d', nil, 48);
+            imgui.ShowHelp('Size of each slot in pixels.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Vertical)##crossbar', 'slotGapV', 0, 128, '%d', nil, 4);
+            imgui.ShowHelp('Vertical gap between top and bottom slots in each diamond.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Horizontal)##crossbar', 'slotGapH', 0, 128, '%d', nil, 4);
+            imgui.ShowHelp('Horizontal gap between left and right slots in each diamond.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Diamond Spacing##crossbar', 'diamondSpacing', 0, 128, '%d', nil, 20);
+            imgui.ShowHelp('Horizontal space between D-pad and face button diamonds.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Group Spacing##crossbar', 'groupSpacing', 0, 128, '%d', nil, 40);
+            imgui.ShowHelp('Space between L2 and R2 groups.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Divider##crossbar', 'showDivider');
+            imgui.ShowHelp('Show a divider line between L2 and R2 groups.');
+
+            -- Show MP Cost with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show MP Cost##crossbar', 'showMpCost');
+            if crossbarSettings.showMpCost then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarmp', 'mpCostOffsetX', 'mpCostOffsetY', 35);
+            end
+            imgui.ShowHelp('Display MP cost on spell slots. X/Y offsets adjust position.');
+
+            -- Show Item Quantity with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Item Quantity##crossbar', 'showQuantity');
+            if crossbarSettings.showQuantity then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarqty', 'quantityOffsetX', 'quantityOffsetY', 35);
+            end
+            imgui.ShowHelp('Display item quantity on item slots. X/Y offsets adjust position.');
+
+            -- 1.8.0 addition: full-stack count above the item quantity (only counts complete stacks)
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Stack Quantity##crossbar', 'showStackQuantity');
+            imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
+
+            -- Show Combo Text with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Combo Text##crossbar', 'showComboText');
+            if crossbarSettings.showComboText then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarcombo', 'comboTextOffsetX', 'comboTextOffsetY', 35);
+            end
+            imgui.ShowHelp('Show current combo mode text in center (L2+R2, R2+L2, L2x2, R2x2). X/Y offsets adjust position.');
+
+            -- Show Action Labels with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Action Labels##crossbar', 'showActionLabels');
+            if crossbarSettings.showActionLabels then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarlbl', 'actionLabelOffsetX', 'actionLabelOffsetY', 35);
+            end
+            imgui.ShowHelp('Show spell/ability names below slots. X/Y offsets adjust position.');
+        end
+
+        if CrossbarGlobalVisualCollapsingSection('bg', 'Background##crossbar', false) then
+            local bgThemes = {'-None-', 'Plain', 'Window1', 'Window2', 'Window3', 'Window4', 'Window5', 'Window6', 'Window7', 'Window8'};
+            components.DrawPartyComboBox(crossbarSettings, 'Theme##bgcrossbar', 'backgroundTheme', bgThemes, DeferredUpdateVisuals);
+            imgui.ShowHelp('Select the background window theme.');
+
+            components.DrawPartySlider(crossbarSettings, 'Background Scale##crossbar', 'bgScale', 0.1, 3.0, '%.2f', nil, 1.0);
+            imgui.ShowHelp('Scale of the background texture.');
+
+            components.DrawPartySlider(crossbarSettings, 'Border Scale##crossbar', 'borderScale', 0.1, 3.0, '%.2f', nil, 1.0);
+            imgui.ShowHelp('Scale of the window borders.');
+
+            components.DrawPartySlider(crossbarSettings, 'Background Opacity##crossbar', 'backgroundOpacity', 0.0, 1.0, '%.2f');
+            imgui.ShowHelp('Opacity of the background.');
+
+            components.DrawPartySlider(crossbarSettings, 'Border Opacity##crossbar', 'borderOpacity', 0.0, 1.0, '%.2f');
+            imgui.ShowHelp('Opacity of the window borders.');
+        end
+
+        -- Text section
+        if CrossbarGlobalVisualCollapsingSection('text', 'Text Settings##crossbar', false) then
+            components.DrawPartySliderInt(crossbarSettings, 'Keybind Text Size##crossbar', 'keybindFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for keybind labels.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Label Text Size##crossbar', 'labelFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for action labels.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Cooldown Text Size##crossbar', 'recastTimerFontSize', 6, 24, '%d', DeferredUpdateVisuals, 11);
+            imgui.ShowHelp('Text size for cooldown timer display.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Flash Under 5 Seconds##crossbar', 'flashCooldownUnder5');
+            imgui.ShowHelp('Flash the cooldown timer text when remaining time is under 5 seconds.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Use Hh:MM Cooldown Format##crossbar', 'useHHMMCooldownFormat');
+            imgui.ShowHelp('Display cooldown timers as Hh:MM (e.g., "1h:49") instead of "1h 49m" for shorter text.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Trigger Label Text Size##crossbar', 'triggerLabelFontSize', 6, 24, '%d', nil, 14);
+            imgui.ShowHelp('Text size for combo mode labels (L2, R2, etc.).');
+
+            components.DrawPartySliderInt(crossbarSettings, 'MP Cost Text Size##crossbar', 'mpCostFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for MP cost display.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Quantity Text Size##crossbar', 'quantityFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for item quantity display.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Combo Text Size##crossbar', 'comboTextFontSize', 8, 24, '%d', nil, 12);
+            imgui.ShowHelp('Font size for combo mode text (L2+R2, R2+L2, etc.).');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Palette Name Text Size##crossbar', 'paletteNameFontSize', 8, 24, '%d', nil, 10);
+            imgui.ShowHelp('Font size for palette name display.');
+        end
+
+        -- Visual Feedback section
+        if CrossbarGlobalVisualCollapsingSection('vfb', 'Visual Feedback##crossbar', false) then
+            components.DrawPartySlider(crossbarSettings, 'Inactive Dim##crossbar', 'inactiveSlotDim', 0.0, 1.0, '%.2f', nil, 0.5);
+            imgui.ShowHelp('Dim factor for inactive trigger side (0 = black, 1 = full brightness).');
+
+            components.DrawPartySlider(crossbarSettings, 'Inactive Dim (trigger held)##crossbar', 'inactiveSideWhileTriggerDim', 0.0, 1.0, '%.2f', nil, 0.15);
+            imgui.ShowHelp('Brightness for the half of the bar you are not using while L2 or R2 is held. Lower hides those slots so the active set stands out.');
+
+            -- Default to true if not set
+            if crossbarSettings.enableTransitionAnimations == nil then
+                crossbarSettings.enableTransitionAnimations = true;
+            end
+            local transAnimEnabled = { crossbarSettings.enableTransitionAnimations };
+            if imgui.Checkbox('Enable Transition Animations##crossbar', transAnimEnabled) then
+                crossbarSettings.enableTransitionAnimations = transAnimEnabled[1];
+                SaveSettingsOnly();
+            end
+            imgui.ShowHelp('Enable smooth animations when switching between crossbar modes (L2, R2, combos). Disable for instant transitions.');
+
+            -- Default to true if not set
+            if crossbarSettings.enablePressScale == nil then
+                crossbarSettings.enablePressScale = true;
+            end
+            local pressScaleEnabled = { crossbarSettings.enablePressScale };
+            if imgui.Checkbox('Enable Press Scale##crossbar', pressScaleEnabled) then
+                crossbarSettings.enablePressScale = pressScaleEnabled[1];
+                SaveSettingsOnly();
+            end
+            imgui.ShowHelp('Enable icon scaling animation when pressing an action slot. Disable for no visual feedback on press.');
+        end
+    end
+
+    crossbarGlobalVis_prevUit = uit;
+
+    -- Draw confirmation popup for job-specific toggle
+    hotbarConfig.DrawJobSpecificConfirmPopup();
+
+    -- Draw palette modal (unified for both hotbar and crossbar; implementation in config/hotbar.lua)
+    hotbarConfig.DrawPaletteModal();
+
+    return selectedCrossbarTab;
+end
+
+local function DrawCrossbarColorSettings()
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+        return;
+    end
+
+    local colorFlags = bit.bor(ImGuiColorEditFlags_NoInputs, ImGuiColorEditFlags_AlphaPreviewHalf, ImGuiColorEditFlags_AlphaBar);
+
+    imgui.TextColored(components.TAB_STYLE.gold, 'Crossbar Color Settings');
+    imgui.Spacing();
+
+    if components.CollapsingSection('Window Colors##crossbarcolor', true) then
+        local bgColor = crossbarSettings.bgColor or 0xFFFFFFFF;
+        local bgColorTable = ARGBToImGui(bgColor);
+        if imgui.ColorEdit4('Background Color##crossbar', bgColorTable, colorFlags) then
+            crossbarSettings.bgColor = ImGuiToARGB(bgColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color tint for the window background.');
+
+        local borderColor = crossbarSettings.borderColor or 0xFFFFFFFF;
+        local borderColorTable = ARGBToImGui(borderColor);
+        if imgui.ColorEdit4('Border Color##crossbar', borderColorTable, colorFlags) then
+            crossbarSettings.borderColor = ImGuiToARGB(borderColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color tint for the window borders.');
+    end
+
+    if components.CollapsingSection('Slot Colors##crossbarcolor', true) then
+        local slotBgColor = crossbarSettings.slotBackgroundColor or 0x55000000;
+        local slotBgColorTable = ARGBToImGui(slotBgColor);
+        if imgui.ColorEdit4('Slot Background##crossbar', slotBgColorTable, colorFlags) then
+            crossbarSettings.slotBackgroundColor = ImGuiToARGB(slotBgColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color and transparency of slot backgrounds.');
+
+        components.DrawPartySlider(crossbarSettings, 'Slot Opacity##crossbar', 'slotOpacity', 0.0, 1.0, '%.2f', nil, 1.0);
+        imgui.ShowHelp('Opacity of the slot background texture.');
+
+        local highlightColor = crossbarSettings.activeSlotHighlight or 0x44FFFFFF;
+        local highlightColorTable = ARGBToImGui(highlightColor);
+        if imgui.ColorEdit4('Active Highlight##crossbar', highlightColorTable, colorFlags) then
+            crossbarSettings.activeSlotHighlight = ImGuiToARGB(highlightColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Highlight color for slots when trigger is held.');
+    end
+
+    if components.CollapsingSection('Text Colors##crossbarcolor', true) then
+        local keybindColor = crossbarSettings.keybindFontColor or 0xFFFFFFFF;
+        local keybindColorTable = ARGBToImGui(keybindColor);
+        if imgui.ColorEdit4('Keybind Color##crossbar', keybindColorTable, colorFlags) then
+            crossbarSettings.keybindFontColor = ImGuiToARGB(keybindColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for keybind labels.');
+
+        local triggerLabelColor = crossbarSettings.triggerLabelColor or 0xFFFFCC00;
+        local triggerLabelColorTable = ARGBToImGui(triggerLabelColor);
+        if imgui.ColorEdit4('Trigger Label Color##crossbar', triggerLabelColorTable, colorFlags) then
+            crossbarSettings.triggerLabelColor = ImGuiToARGB(triggerLabelColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for combo mode labels (L2, R2, etc.).');
+
+        local mpCostColor = crossbarSettings.mpCostFontColor or 0xFFD4FF97;
+        local mpCostColorTable = ARGBToImGui(mpCostColor);
+        if imgui.ColorEdit4('MP Cost Color##crossbar', mpCostColorTable, colorFlags) then
+            crossbarSettings.mpCostFontColor = ImGuiToARGB(mpCostColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for MP cost display on spell slots.');
+
+        local quantityColor = crossbarSettings.quantityFontColor or 0xFFFFFFFF;
+        local quantityColorTable = ARGBToImGui(quantityColor);
+        if imgui.ColorEdit4('Quantity Color##crossbar', quantityColorTable, colorFlags) then
+            crossbarSettings.quantityFontColor = ImGuiToARGB(quantityColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for item quantity display. Note: Shows red when quantity is 0.');
+
+        local labelColor = crossbarSettings.labelFontColor or 0xFFFFFFFF;
+        local labelColorTable = ARGBToImGui(labelColor);
+        if imgui.ColorEdit4('Label Color##crossbar', labelColorTable, colorFlags) then
+            crossbarSettings.labelFontColor = ImGuiToARGB(labelColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for action labels below slots.');
+
+        local timerColor = crossbarSettings.recastTimerFontColor or 0xFFFFFFFF;
+        local timerColorTable = ARGBToImGui(timerColor);
+        if imgui.ColorEdit4('Cooldown Timer Color##crossbar', timerColorTable, colorFlags) then
+            crossbarSettings.recastTimerFontColor = ImGuiToARGB(timerColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for cooldown timer text displayed on slots.');
+    end
+end
+
+-- Controller palette cycle (hotbarGlobal); top strip in config/crossbar.lua when crossbar is enabled
+function M.DrawControllerPaletteCycleGlobalOptions()
+    local ctrlOptions = { 'Disabled', 'Enabled' };
+    local currentCtrlIndex = (gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false) and 2 or 1;
+
+    imgui.AlignTextToFramePadding();
+    imgui.Text('Palette Cycle:');
+    imgui.SameLine();
+    imgui.SetNextItemWidth(90);
+    if imgui.BeginCombo('##ctrlPaletteCycle', ctrlOptions[currentCtrlIndex]) then
+        for i, label in ipairs(ctrlOptions) do
+            local isSelected = currentCtrlIndex == i;
+            if imgui.Selectable(label, isSelected) then
+                gConfig.hotbarGlobal.paletteCycleControllerEnabled = (i == 2);
+                SaveSettingsOnly();
+            end
+            if isSelected then imgui.SetItemDefaultFocus(); end
+        end
+        imgui.EndCombo();
+    end
+
+    if gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false then
+        imgui.SameLine();
+        imgui.Text('Button:');
+        imgui.SameLine();
+
+        local buttonOptions = { 'R1', 'L1' };
+        local currentButton = gConfig.hotbarGlobal.hotbarPaletteCycleButton or 'R1';
+        local currentButtonIndex = 1;
+        for i, btn in ipairs(buttonOptions) do
+            if btn == currentButton then
+                currentButtonIndex = i;
+                break;
+            end
+        end
+
+        imgui.SetNextItemWidth(60);
+        if imgui.BeginCombo('##hotbarCycleBtn', currentButton) then
+            for i, btn in ipairs(buttonOptions) do
+                local isSelected = (i == currentButtonIndex);
+                if imgui.Selectable(btn .. '##hbCycleBtn' .. i, isSelected) then
+                    gConfig.hotbarGlobal.hotbarPaletteCycleButton = btn;
+                    SaveSettingsOnly();
+                end
+                if isSelected then imgui.SetItemDefaultFocus(); end
+            end
+            imgui.EndCombo();
+        end
+    end
+    imgui.ShowHelp('Controller shortcut to cycle palettes.\nHold the selected shoulder button + D-pad Up/Down to cycle keyboard hotbar palettes and the active crossbar palette.');
+end
+
+function M.DrawLogPaletteNameCheckboxCrossbar(idSuffix)
+    idSuffix = idSuffix or '##logPalNameXb';
+    local hg = gConfig.hotbarGlobal;
+    if not hg then
+        return;
+    end
+    local logPaletteName = hg.logPaletteNameCrossbar;
+    if logPaletteName == nil then logPaletteName = true; end
+    local logVal = { logPaletteName };
+    if imgui.Checkbox('Log Palette Name (crossbar)' .. idSuffix, logVal) then
+        hg.logPaletteNameCrossbar = logVal[1];
+        SaveSettingsOnly();
+    end
+    imgui.ShowHelp('Log crossbar palette lines in chat for /xiui cpal and controller palette cycling.');
+    if logVal[1] then
+        imgui.Indent(18);
+        local hintOn = hg.logPaletteNameCrossbarCycleHint;
+        if hintOn == nil then hintOn = true; end
+        local hintVal = { hintOn };
+        if imgui.Checkbox('Include RB(R1)+Up/Down return hint (CLI preview)' .. idSuffix .. '_rbHint', hintVal) then
+            hg.logPaletteNameCrossbarCycleHint = hintVal[1];
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Extra line after /xiui cpal when previewing another job palette.');
+        imgui.Unindent(18);
+    end
+end
+
+-- Invoked from config/crossbar.lua only (Hotbar category uses config/hotbar.lua M.DrawSettings).
+function M.DrawStandaloneCrossbarSettings(state)
+    local selectedCrossbarTab = state and state.selectedCrossbarTab or 1;
+    selectedCrossbarTab = DrawCrossbarSettings(selectedCrossbarTab, state);
+    return { selectedCrossbarTab = selectedCrossbarTab };
+end
+
+function M.DrawStandaloneCrossbarColorSettings(_state)
+    DrawCrossbarColorSettings();
+end
+
+-- Via config/crossbar.lua when the XIUI config window opens (resync Crossbar palette edit job from player)
+function M.OnConfigWindowOpened()
+    lastConfigCategorySeenForCrossbar = nil;
+end
+
+-- Select Crossbar → Manage Palettes & Crossbar (middle tab); used by /xiui cpalette
+function M.OpenCrossbarManagePalettesTab()
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false;
+    end
+    crossbarSettings.configUiTab = 2;
+    crossbarConfigSubTabUserChosen = true;
+    return true;
+end
+
+return M;

--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -274,7 +274,7 @@ end
 function M.createHotbarGlobalDefaults()
     return T{
         -- Game UI patches
-        disableMacroBars = false,  -- Disable native XI macros (macro bar display + controller macro blocking)
+        disableMacroBars = false,  -- Keyboard: hide native macro bar UI + block Ctrl/Alt+number macro keys (controller blocking is Crossbar → Disable XI Macros)
         controllerHoldToShow = true,  -- Controller triggers use hold-to-show (like macrofix addon) instead of tap-to-toggle
 
         -- Blocked game keys - array of key definitions that should be blocked from reaching the game
@@ -292,6 +292,10 @@ function M.createHotbarGlobalDefaults()
         -- Palette cycling controller (RB + Dpad)
         paletteCycleControllerEnabled = true,  -- Enable controller palette cycling
         hotbarPaletteCycleButton = 'R1',       -- 'R1' or 'L1' for hotbar cycling
+
+        logPaletteName = true,                 -- Log palette name when cycling keyboard hotbars
+        logPaletteNameCrossbar = true,         -- Log palette name when cycling via controller (crossbar)
+        logPaletteNameCrossbarCycleHint = true, -- Second CLI line: RB+D-pad return hint after job preview
 
         -- Visual settings
         slotSize = 48,          -- Slot size in pixels
@@ -333,7 +337,7 @@ function M.createHotbarGlobalDefaults()
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -350,7 +354,16 @@ function M.createHotbarGlobalDefaults()
         skillchainIconScale = 1.0,              -- Scale multiplier for icon (0.5-2.0)
         skillchainIconOffsetX = 0,              -- X offset in pixels
         skillchainIconOffsetY = 0,              -- Y offset in pixels
-    
+
+        -- Magic Burst highlight settings. Window opens IMMEDIATELY when a SC closes and runs
+        -- for 7.0s (matches retail's MB cutoff at the back end while front-loading the visual
+        -- cue). Highlights spell / magical pact rage / /ma-or-/pet macro slots whose element
+        -- matches one of the SC's burstable elements. Uses the same corner icon as the
+        -- skillchain highlight (the SC's name asset) but in the bottom-left corner with a
+        -- cyan-blue border to keep the two highlights visually distinct.
+        magicBurstHighlightEnabled = true,      -- Show MB highlight on element-matching spell slots
+        magicBurstHighlightColor = 0xFF44D4FF,  -- Cyan-blue (ARGB) — distinct from gold SC border
+
         -- Cooldown timer settings
         recastTimerFontSize = 11,               -- Font size for cooldown timer display
         recastTimerFontColor = 0xFFFFFFFF,      -- Color for cooldown timer text
@@ -372,6 +385,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Pet-aware toggle (when true, hotbar can have different palettes per pet for SMN/BST/DRG/PUP)
         petAware = false,
         showPetIndicator = true,  -- Show indicator dot when petAware is enabled
+        -- When set: array of type tokens 'avatars'|'elementals'|'beasts'|'wyvern'|'puppet' (legacy 'summons' = avatars+elementals). nil = all.
+        petPalettePetKeys = nil,
 
         -- Layout settings (always per-bar)
         enabled = true,
@@ -420,7 +435,7 @@ function M.createHotbarBarDefaults(overrides)
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -443,6 +458,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Structure: paletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Palettes are displayed in this order; missing palettes are appended alphabetically
         paletteOrder = {},
+        -- paletteExcludeFromCycle[orderKey][paletteName] = true skips palette for RB / keyboard cycling only
+        paletteExcludeFromCycle = {},
     };
     if overrides then
         for k, v in pairs(overrides) do
@@ -460,22 +477,51 @@ end
 -- The crossbar provides 4 combo modes: L2, R2, L2+R2, R2+L2 (32 total slots)
 function M.createCrossbarDefaults()
     return T{
-        -- Layout mode: 'hotbar', 'crossbar', or 'both'
-        mode = 'hotbar',
+        -- Show controller crossbar UI (mirrors gConfig.crossbarEnabled; kept for migration)
+        showCrossbar = true,
+
+        -- Hide crossbar when game menu open (independent from Hotbar → Hide When Menu Open)
+        crossbarHideOnMenuFocus = false,
+
+        -- Disable crossbar input while a game menu is open (keeps it visible but blocks trigger macros)
+        crossbarDisableInMenu = true,
+
+        -- Config UI: which main section is active (1=Controller, 2=Manage palettes, 3=Global visuals)
+        configUiTab = 1,
+        -- 'universal' = editing [G] all-jobs sets; 'job' = editing palettes for configEditJobId
+        configFocus = 'job',
+        configEditJobId = nil,   -- nil = use live main job from data when in job focus
+        configEditSubjobId = nil,
 
         -- Job-specific toggle (when true, actions are stored per-job; when false, actions are shared across all jobs)
         jobSpecific = true,
 
-        -- Per-combo-mode settings (pet-aware is per-combo, palettes are GLOBAL)
-        -- NOTE: activePalette was removed - crossbar palettes are now global (see palette.lua state.crossbarActivePalette)
+        -- All-jobs universal crossbar palettes (storage: global:palette:{name} in slotActions)
+        enableUniversalCrossbarPalettes = false,
+        -- 'job' = job/subjob named palettes; 'universal' = all-jobs sets (toggle L1+R1 when enabled)
+        defaultCrossbarPaletteScope = 'job',
+        -- Per-palette: includeInCycle = false hides palette from RB+D-pad when scope is universal
+        crossbarUniversalPaletteMeta = {},
+        universalCrossbarPaletteOrder = {},
+
+        -- Per-segment: petAware, optional per-segment petPalettePetKeys, universalOverridePalette = all-jobs palette name. Default pet types: petPalettePetKeys on parent.
         comboModeSettings = {
-            L2 = { petAware = false },
-            R2 = { petAware = false },
-            L2R2 = { petAware = false },
-            R2L2 = { petAware = false },
-            L2x2 = { petAware = false },
-            R2x2 = { petAware = false },
+            L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
         },
+        -- Optional per named [J] palette: comboMode -> { petAware?, universalOverridePalette? } (nil field = inherit Crossbar defaults)
+        namedPaletteComboModeSettings = {},
+
+        -- Crossbar [J] only: which pet families (avatars/elementals/beasts/wyvern/puppet) use pet hotbar storage; nil = all. Not per named palette.
+        petPalettePetKeys = nil,
+
+        -- Per main job id (string key): effective combo mode -> { scope = 'jobShared' | 'global', globalPalette = name? }
+        -- Primary L2/R2 are not used. Resolves slot data to jobsegment:{jobId}:{mode} or global:palette:{name}.
+        segmentOverrides = {},
 
         -- Layout
         slotSize = 40,              -- Slot size in pixels
@@ -495,7 +541,8 @@ function M.createCrossbarDefaults()
         slotBackgroundColor = 0x55000000,
         slotOpacity = 1.0,                  -- Opacity multiplier for slot.png (0.0-1.0)
         activeSlotHighlight = 0x44FFFFFF,   -- Highlight color when trigger held
-        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side
+        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side (expanded / non-trigger dim)
+        inactiveSideWhileTriggerDim = 0.15, -- Dim for the non-active half while L2 or R2 is held
 
         -- Display mode
         displayMode = 'normal',             -- 'normal' or 'activeOnly'
@@ -511,6 +558,8 @@ function M.createCrossbarDefaults()
         buttonIconGapH = 8,                 -- Horizontal spacing between center icons
         buttonIconGapV = 2,                 -- Vertical spacing between center icons
         buttonIconPosition = 'corner',      -- 'corner' or 'replace_keybind'
+        -- Job icon set for palette UI (Manage Palettes strip + in-game palette scope icon when Job [J])
+        paletteJobIconTheme = 'Classic',     -- 'Classic', 'FFXI', 'FFXIV-1' (under assets/jobs/)
         controllerTheme = 'Xbox',           -- 'PlayStation', 'Xbox', or 'Nintendo' button icons
         controllerScheme = 'xbox',          -- Controller profile: 'xbox', 'dualsense', 'switchpro', 'dinput'
         triggerIconScale = 0.8,             -- Scale for L2/R2 trigger icons (base 49x28)
@@ -545,10 +594,14 @@ function M.createCrossbarDefaults()
         comboTextOffsetY = 0,               -- Y offset for combo text position
 
         -- Palette name display (shows current palette and index, e.g., "Stuns (2/5)")
-        showPaletteName = false,            -- Toggle to show palette name
+        showPaletteName = false,            -- Toggle to show palette name text below crossbar
+        showPaletteScopeIcon = true,        -- Job / Global scope icon above divider; nil in saved config = legacy (follow showPaletteName)
         paletteNameFontSize = 10,           -- Font size for palette name
         paletteNameOffsetX = 0,             -- X offset for position
         paletteNameOffsetY = 0,             -- Y offset for position
+        -- Job / Global palette scope icon above center divider
+        paletteScopeIconOffsetY = 12,       -- Vertical lift (px); higher = icon moves up
+        paletteScopeIconSize = 22,          -- Icon width/height (px); legacy profiles fall back to font-based size if unset
 
         -- Expanded crossbar (L2+R2 combos)
         enableExpandedCrossbar = true,      -- Enable L2+R2 and R2+L2 combos
@@ -557,6 +610,12 @@ function M.createCrossbarDefaults()
         -- Double-tap crossbar (tap trigger twice quickly)
         enableDoubleTap = false,            -- Enable L2x2 and R2x2 double-tap modes
         doubleTapWindow = 0.3,              -- Time window for double-tap detection (seconds)
+
+        -- Double-tap preview windows (always-visible overlays showing L2x2 / R2x2 bars)
+        showDoubleTapPreview    = false,     -- Show floating preview windows for double-tap bars
+        doubleTapPreviewScale   = 0.60,     -- Preview scale relative to main crossbar (0.3–1.0)
+        doubleTapPreviewOpacity = 1.0,      -- Preview opacity multiplier (0.2–1.0; dims with trigger)
+        doubleTapPreviewLocked  = false,    -- Lock preview positions independently of the main crossbar
 
         -- Analog trigger thresholds (0-255 normalized range)
         -- Used by Xbox (XInput) and PlayStation (DirectInput with signed->unsigned conversion)
@@ -587,6 +646,8 @@ function M.createCrossbarDefaults()
         -- Structure: crossbarPaletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Note: Crossbar palettes are independent from hotbar palettes
         crossbarPaletteOrder = {},
+        -- Same shape as paletteExcludeFromCycle on hotbar; per job:storage-tier key
+        crossbarPaletteExcludeFromCycle = {},
     };
 end
 

--- a/XIUI/libs/drawing.lua
+++ b/XIUI/libs/drawing.lua
@@ -158,7 +158,9 @@ local ANCHOR_DEFAULTS = {
 ---@param id string Unique identifier for this anchor
 ---@param windowX number Current window X position
 ---@param windowY number Current window Y position
----@param options table|nil Optional configuration (size, padding, colors, etc.)
+---@param options table|nil Optional configuration (size, padding, anchorSide, windowWidth, colors, etc.)
+---  options.anchorSide   : 'left' (default) or 'top' — where the handle sits relative to the window
+---  options.windowWidth  : required when anchorSide = 'top' to centre the handle horizontally
 ---@return number|nil newX New X position if dragged, nil otherwise
 ---@return number|nil newY New Y position if dragged, nil otherwise
 function M.DrawMoveAnchor(id, windowX, windowY, options)
@@ -175,9 +177,17 @@ function M.DrawMoveAnchor(id, windowX, windowY, options)
     local padding = options.padding or ANCHOR_DEFAULTS.padding;
     local rounding = options.rounding or ANCHOR_DEFAULTS.rounding;
 
-    -- Calculate anchor position (left of target window)
-    local anchorX = windowX - size - padding;
-    local anchorY = windowY;
+    -- Calculate anchor position: 'left' (default) or 'top'
+    local anchorX, anchorY;
+    if options.anchorSide == 'top' then
+        local ww = options.windowWidth or 0;
+        anchorX = windowX + math.floor(ww / 2) - math.floor(size / 2);
+        anchorY = windowY - size - padding;
+    else
+        -- Default: left of the target window
+        anchorX = windowX - size - padding;
+        anchorY = windowY;
+    end
 
     -- Window flags for the anchor (invisible, draggable)
     local windowFlags = bit.bor(

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -17,13 +17,35 @@ local dragdrop = require('libs.dragdrop');
 local data = require('modules.hotbar.data');
 local actions = require('modules.hotbar.actions');
 local textures = require('modules.hotbar.textures');
+-- TextureManager is used for the palette scope icon overlay (job icon / infinity for universal palettes).
+local TextureManager = require('libs.texturemanager');
 local controller = require('modules.hotbar.controller');
 local recast = require('modules.hotbar.recast');
 local slotrenderer = require('modules.hotbar.slotrenderer');
+-- playerdata caches the player's known abilities + weaponskills; `IsActionAvailable` falls
+-- back to "unavailable" when the caches are empty. Keyboard hotbars warm these from their
+-- own DrawWindow, but crossbar-only setups (`hotbarEnabled=false, crossbarEnabled=true`)
+-- never touched playerdata before — every JA/WS slot then read as unavailable (grayed +
+-- "X") even on jobs that knew the abilities. We now refresh once per frame from crossbar
+-- DrawWindow as well; the refresh is signature-gated internally (job/level/equip diff) so
+-- the steady-state cost is a few cache reads, not a full re-scan.
+local playerdata = require('modules.hotbar.playerdata');
 local animation = require('libs.animation');
 local skillchain = require('modules.hotbar.skillchain');
+-- macroparse extracts the primary line + JA badge type from a /ws or /pet macro body, so we can
+-- predict skillchain icons on macro slots whose first line is a weapon skill or blood pact.
+-- Display.lua does the same thing for keyboard hotbars; without it, crossbar macro slots whose
+-- primary line is /ws or /pet would never light up even though firing the macro IS the WS/pact.
+local macroparse = require('modules.hotbar.macroparse');
 local targetLib = require('libs.target');
 local palette = require('modules.hotbar.palette');
+-- Used to dim the crossbar when a blocking game menu is open AND `crossbarDisableInMenu`
+-- is enabled, so the player can see at a glance that controller input is paused.
+local gamestate = require('core.gamestate');
+-- macropalette is required only for the palette-editor drop handlers (effective palette key
+-- + macro source store). Required at module scope here (mirrors Ferris); if a future
+-- circular dependency creeps in this can be flipped to a lazy `require` inside the closures.
+local macropalette = require('modules.hotbar.macropalette');
 
 local M = {};
 
@@ -75,6 +97,13 @@ end
 
 local SLOTS_PER_SIDE = 8;
 local COMBO_MODES = controller.COMBO_MODES;
+-- Full enumeration of combo-mode storage keys (used by the Edit Full Palette editor and the
+-- pet-tab filter). 'Shared' is the chord-fallback for sharedExpanded layouts where both
+-- L2+R2 and R2+L2 collapse to one set.
+local ALL_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', 'Shared' };
+-- Naming prefix on resource maps + IDs used by the Edit Full Palette draft layer so its
+-- ImGui drop zones / animation keys never collide with the live HUD's 'crossbar_*' set.
+local PAL_ED_PREFIX = 'PalEd_';
 
 -- ============================================
 -- Layout Calculation Functions
@@ -277,7 +306,14 @@ local function GetCachedCrossbarIcon(comboMode, slotIndex, slotData)
 end
 
 -- Clear crossbar icon cache
+-- iconCache rows hold the only Lua ref to D3D textures returned by actions.GetBindIcon
+-- (LoadTextureFromPath wires a gc_safe_release finalizer). Wiping mid-frame — e.g. palette
+-- deletion fires InvalidateAllVisualCachesAfterPaletteListMutation while the crossbar
+-- DrawWindow is still building this frame's ImGui draw list — lets Lua GC finalize the COM
+-- texture while AddImage still references it (CTD on Ashita 4.16). DeferRelease holds the
+-- old table alive until FlushPendingReleases runs at the top of the next d3d_present.
 local function ClearCrossbarIconCache()
+    TextureManager.DeferRelease(iconCache);
     iconCache = {};
 end
 
@@ -286,6 +322,10 @@ local function ClearCrossbarIconCacheForSlot(comboMode, slotIndex)
     -- Use effective combo mode for cache key (Shared when shared expanded bar is enabled)
     comboMode = data.GetEffectiveComboModeForStorage and data.GetEffectiveComboModeForStorage(comboMode) or comboMode;
     if iconCache[comboMode] then
+        local oldRow = iconCache[comboMode][slotIndex];
+        if oldRow ~= nil then
+            TextureManager.DeferRelease(oldRow);
+        end
         iconCache[comboMode][slotIndex] = nil;
     end
 end
@@ -328,6 +368,16 @@ local state = {
         progress = 1.0,
         wasHidden = false,
     },
+
+    -- useSharedExpandedBar bookkeeping. The shared-center layout collapses the bar to one
+    -- diamond width and forces the X anchor to screen-center every frame; without these the
+    -- normal X anchor would either get persisted as the centered narrow value (chord persists
+    -- across a save) or snap back to the leftmost saved position on chord exit. The two-step
+    -- handoff is: while in chord we stash the last "wide" window X here, then on the first
+    -- frame that exits chord we re-anchor to that stashed X so the bar returns where the
+    -- user actually placed it (rather than wherever the centered narrow bar happened to land).
+    lastWideCrossbarWindowX = nil,
+    wasSharedCenterChordLayout = false,
 };
 
 -- ============================================
@@ -376,12 +426,24 @@ end
 -- ============================================
 
 -- Determine which combo modes to display on left/right based on active combo
--- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'both', or nil)
-local function GetDisplayModes(activeCombo)
+-- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'center', 'both', or nil)
+-- When useSharedExpandedBar is enabled and the user holds a chord (L2+R2 / R2+L2), expandedSide
+-- becomes 'center': only the left column is drawn (using the 'Shared' storage key), the window
+-- shrinks to one diamond width, and DrawWindow re-centers it to screen X (a single 8-slot strip
+-- centered like the FFXIV controller bar) rather than the two-diamond wide layout.
+local function GetDisplayModes(activeCombo, settings)
+    settings = settings or (gConfig and gConfig.hotbarCrossbar);
+    local useSharedExp = settings and settings.useSharedExpandedBar == true;
     if activeCombo == COMBO_MODES.L2_THEN_R2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: L2 first, then R2 -> show L2R2 on left side only, right side dimmed (shows R2)
         return 'L2R2', 'R2', true, 'left';
     elseif activeCombo == COMBO_MODES.R2_THEN_L2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: R2 first, then L2 -> show R2L2 on right side only, left side dimmed (shows L2)
         return 'L2', 'R2L2', true, 'right';
     elseif activeCombo == 'Shared' then
@@ -585,6 +647,69 @@ local function GetSlotPositionInWindow(side, slotIndex, windowX, windowY, settin
 end
 
 -- ============================================
+-- Window-decor padding (slot-top vs window-top accounting)
+-- ============================================
+-- ImGui clips anything we draw OUTSIDE the window's content rect. The crossbar paints a
+-- lot of decoration above the slot grid (L2/R2 trigger icons, combo text, R1 cpal-anchor
+-- pulse, palette-modifier refresh glyph) and below it (palette name, action labels). To
+-- keep all of that inside the window's draw region we open the ImGui window taller than
+-- the slot grid by CROSSBAR_WINDOW_TOP_DECOR_PAD on top and `GetCrossbarWindowBottomPad`
+-- on the bottom, then offset the window-top so the SLOT GRID still lands at the user's
+-- saved (or default) Y. `state.windowY` continues to mean "slot grid top" everywhere
+-- else in this module, which lets the rest of the layout code stay unchanged.
+local CROSSBAR_WINDOW_TOP_DECOR_PAD = 80;
+
+local function GetCrossbarWindowBottomPad(settings)
+    settings = settings or {};
+    local pad = 10;
+    if settings.showActionLabels then
+        pad = pad + (settings.labelFontSize or 10) + 6 + math.max(0, tonumber(settings.actionLabelOffsetY) or 0);
+    end
+    pad = pad + math.floor(((settings.mpCostFontSize or 10) + (settings.quantityFontSize or 10)) * 0.15 + 0.5);
+    return math.min(72, math.max(10, pad));
+end
+
+-- Profile stores SLOT TOP Y (`gConfig.windowPositions.Crossbar.y`), not window-top. When
+-- we apply a saved position we subtract the decor pad so the slot grid lands where the
+-- user originally placed it. The `appliedPositions` flag keeps ImGui's drag from being
+-- overridden every frame (ImGuiCond_Always otherwise).
+local function ApplyCrossbarWindowPositionOnce()
+    if not gConfig or not gConfig.windowPositions or not gConfig.windowPositions['Crossbar'] then
+        return false;
+    end
+    if not gConfig.appliedPositions then
+        gConfig.appliedPositions = {};
+    end
+    if gConfig.appliedPositions['Crossbar'] then
+        return false;
+    end
+    local pos = gConfig.windowPositions['Crossbar'];
+    imgui.SetNextWindowPos({ pos.x, pos.y - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    gConfig.appliedPositions['Crossbar'] = true;
+    return true;
+end
+
+-- Save SLOT TOP Y, not window-top, so the saved coordinate stays meaningful even if the
+-- decor pad changes between releases (or a future patch adds more decoration above the
+-- slot grid). Skips writes when nothing changed to avoid table churn / unnecessary disk
+-- saves on every frame.
+local function SaveCrossbarWindowSlotTopPosition()
+    if not gConfig then return; end
+    local wx, wy = imgui.GetWindowPos();
+    if not gConfig.windowPositions then
+        gConfig.windowPositions = {};
+    end
+    local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+    local saved = gConfig.windowPositions['Crossbar'];
+    if not saved then
+        gConfig.windowPositions['Crossbar'] = { x = wx, y = slotTopY };
+    elseif saved.x ~= wx or saved.y ~= slotTopY then
+        saved.x = wx;
+        saved.y = slotTopY;
+    end
+end
+
+-- ============================================
 -- Initialization
 -- ============================================
 
@@ -671,12 +796,147 @@ end
 -- animOpacity: 0-1 for animation fade (default 1.0)
 -- yOffset: Y offset in pixels for animation (default 0)
 -- skillchainName: (optional) Skillchain name for WS slots
-local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName)
+-- Reusable cbInteraction sub-tables built lazily for palette-editor slots so the editor and
+-- the live crossbar each get their own slotInteraction set (different idPrefix/buttonId/
+-- dropZoneId — palette editor uses 'paled_*'; live crossbar uses 'crossbar_*'). Keeping
+-- them separate also lets the slotrenderer drop-zone-lock semantics treat them differently
+-- (paled_* are never locked; crossbar_* respect crossbarLockMovement).
+local cbInteractionPalEd = {};
+
+local function GetCbInteractionPaletteEditor(comboMode, slotIndex)
+    if not cbInteractionPalEd[comboMode] then cbInteractionPalEd[comboMode] = {}; end
+    local cached = cbInteractionPalEd[comboMode][slotIndex];
+    if cached then return cached; end
+
+    local entry = {
+        buttonId = string.format('##paled_%s_%d', comboMode, slotIndex),
+        dropZoneId = string.format('paled_%s_%d', comboMode, slotIndex),
+        pressKey = 'paled_' .. comboMode .. '_' .. slotIndex,
+        onDrop = function(payload)
+            -- Palette-editor drops go through the draft layer; Apply Draft promotes them to live.
+            -- All branches normalize through the overlay (draft falls back to live) and finalize
+            -- before writing so dual-arm macros swap correctly and empty results clear properly.
+            if payload.type == 'macro' then
+                if payload.data and payload.data.macroPaletteKey == nil then
+                    if macropalette.GetEffectivePaletteType then
+                        payload.data.macroPaletteKey = macropalette.GetEffectivePaletteType();
+                    else
+                        payload.data.macroPaletteKey = data.jobId or 1;
+                    end
+                end
+                if payload.data and macropalette.GetMacroSourceTagForDrops
+                    and payload.data.macroSourceStore == nil then
+                    payload.data.macroSourceStore = macropalette.GetMacroSourceTagForDrops();
+                end
+                local arm = {};
+                for k, v in pairs(payload.data) do arm[k] = v; end
+                if arm.macroRef == nil and payload.data.id then
+                    arm.macroRef = payload.data.id;
+                end
+                local existingRaw = data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex);
+                local existing = data.NormalizeCrossbarSlotRawForSwap(existingRaw);
+                local store = arm.macroSourceStore
+                    or (macropalette.GetMacroSourceTagForDrops and macropalette.GetMacroSourceTagForDrops())
+                    or 'profile';
+                local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                data.SetDraftSlotData(comboMode, slotIndex, built);
+            elseif payload.type == 'crossbar_slot' then
+                -- Always read source/target from overlay at drop time; payload.data was captured
+                -- at drag start and can alias stale tables after earlier moves in the same session.
+                local srcCombo = payload.comboMode;
+                local srcSlot = payload.slotIndex;
+                if srcCombo == comboMode and srcSlot == slotIndex then return; end
+                if data.BeginDraftUndoGroup then data.BeginDraftUndoGroup(); end
+                local srcRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(srcCombo, srcSlot));
+                local tgtRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+                local newTgt, newSrc = data.SwapActiveMacroArmsInPlace(srcRaw, tgtRaw);
+                local fT = data.FinalizeCrossbarRawSlotForStorage(newTgt);
+                local fS = data.FinalizeCrossbarRawSlotForStorage(newSrc);
+                if fT == nil then
+                    data.ClearDraftSlotData(comboMode, slotIndex);
+                else
+                    data.SetDraftSlotData(comboMode, slotIndex, fT);
+                end
+                if fS == nil then
+                    data.ClearDraftSlotData(srcCombo, srcSlot);
+                else
+                    data.SetDraftSlotData(srcCombo, srcSlot, fS);
+                end
+                if data.EndDraftUndoGroup then data.EndDraftUndoGroup(); end
+                -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+                -- the icon cache clear above is the only refresh needed for the source slot.
+                ClearCrossbarIconCacheForSlot(srcCombo, srcSlot);
+            elseif payload.type == 'slot' then
+                if payload.data then
+                    local c = data.FinalizeCrossbarRawSlotForStorage(data.CopyTable(payload.data));
+                    if c == nil then
+                        data.ClearDraftSlotData(comboMode, slotIndex);
+                    else
+                        data.SetDraftSlotData(comboMode, slotIndex, c);
+                    end
+                end
+            end
+            -- Visual refresh for the target slot (matches live-HUD drop behaviour).
+            -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+            -- the icon cache clear is the only refresh needed (the bind hash on next frame
+            -- naturally re-derives slot draw state — see ClearSlotIconCache notes in macropalette).
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        getDragData = function()
+            -- Use overlay (draft falling back to live) so dragging a slot that hasn't been
+            -- touched in this edit session still carries its persisted data. Reading draft-only
+            -- here would drag nil and the drop handler would clear the target slot.
+            local raw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+            return {
+                type = 'crossbar_slot',
+                comboMode = comboMode,
+                slotIndex = slotIndex,
+                data = raw,
+            };
+        end,
+        onRightClick = function()
+            data.ClearDraftSlotData(comboMode, slotIndex);
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        -- Double-click in Edit Full Palette opens the macro editor for the slot's draft
+        -- content. For empty slots that resolves to nil and macropalette.OpenEditorForSlotData
+        -- starts a fresh "creating new" session seeded with the active palette type's defaults.
+        -- The (comboMode, slotIndex) carried in the pending edit lets palettemanager auto-bind
+        -- the new macro to this slot after Save (see config/palettemanager.lua consume site).
+        -- We funnel through data.SetPendingPaletteSlotEdit so the editor opens on the NEXT
+        -- frame (consumed by config/palettemanager.lua after slots draw); opening it directly
+        -- inside this click handler would put a modal inside the hotbar's draw pass and skip
+        -- the macropalette draw-order assumptions.
+        onDoubleClick = function()
+            local slotData = data.GetDraftSlotData
+                and data.GetDraftSlotData(comboMode, slotIndex)
+                or nil;
+            data.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex);
+        end,
+    };
+    cbInteractionPalEd[comboMode][slotIndex] = entry;
+    return entry;
+end
+
+-- Palette-editor empty-slot panel tint (matches the Edit Full Palette row fill in palettemanager.lua).
+-- Lighter than the live crossbar's 0x55000000 so slot outlines read clearly against the editor row.
+local PAL_ED_EMPTY_SLOT_BG = 0xFF8E96AC;
+
+local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName, activeCombo, editorClipRect, magicBurstName)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
-    -- Get pre-created interaction closures and IDs
-    local interaction = GetCbInteraction(comboMode, slotIndex);
+    -- Edit Full Palette state: when active, this slot belongs to the editor's draft layer
+    -- rather than the live crossbar. palSk is the storage-key the editor is targeting; the
+    -- draft layer is separate per-key (so editing one palette doesn't touch the live binding).
+    local palSk = data.GetCrossbarPaletteEditSessionKey and data.GetCrossbarPaletteEditSessionKey();
+    local isEditor = palSk ~= nil;
+
+    -- Get pre-created interaction closures and IDs. Editor and live get different prefixes so
+    -- the slotrenderer drop-zone-lock policy can distinguish them (paled_* are never locked).
+    local interaction = isEditor
+        and GetCbInteractionPaletteEditor(comboMode, slotIndex)
+        or GetCbInteraction(comboMode, slotIndex);
 
     -- Apply Y offset for animation
     local drawY = y + yOffset;
@@ -687,8 +947,14 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
         iconPressScale = animation.getPressScale(interaction.pressKey, isPressed and isActive);
     end
 
-    -- Get slot data
-    local slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    -- Slot data source: editor reads from the draft layer (synced from live at session start
+    -- via data.SyncDraftSlotFromLive); live crossbar always reads the persisted binding.
+    local slotData;
+    if isEditor then
+        slotData = data.GetDraftSlotData and data.GetDraftSlotData(comboMode, slotIndex) or nil;
+    else
+        slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    end
 
     -- Get icon + cached abbreviation for this action (cached - only rebuilds when bind changes)
     local icon, cachedAbbr, cachedAbbrW = GetCachedCrossbarIcon(comboMode, slotIndex, slotData);
@@ -696,6 +962,33 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     -- Global UI scale (slotSize/x/y come in already scaled; we apply gs here to
     -- font sizes and pixel offsets that come straight from settings).
     local gs = (gConfig and gConfig.globalScale) or 1.0;
+
+    -- Diamond position: 1=Top, 2=Right, 3=Bottom, 4=Left (slots 5-8 map via -4 for face buttons).
+    -- Top-slot labels placed below would overlap the bottom slot's MP/quantity text, so the
+    -- editor (and any caller that asks for labels) flips them above for the top position.
+    local posIndex = (slotIndex <= 4) and slotIndex or (slotIndex - 4);
+    local labelAboveSlot = (posIndex == 1);
+
+    -- Dim policy. Live crossbar: inactive sides get a softer dim; when a trigger is held the
+    -- non-active half dims much harder so the active set pops. Editor: nothing is "inactive".
+    local dimFactor = 1.0;
+    if not isEditor and not isActive then
+        if activeCombo and activeCombo ~= COMBO_MODES.NONE then
+            dimFactor = settings.inactiveSideWhileTriggerDim;
+            if dimFactor == nil then dimFactor = 0.15; end
+        else
+            dimFactor = settings.inactiveSlotDim or 0.5;
+        end
+    end
+
+    -- Editor background: lighter tint behind empty editor slots so slot borders pop on the
+    -- panel row; filled editor slots use the user's normal background.
+    local slotBgColor = settings.slotBackgroundColor or 0x55000000;
+    local slotOpacity = settings.slotOpacity or 1.0;
+    if isEditor and not slotData then
+        slotBgColor = PAL_ED_EMPTY_SLOT_BG;
+        slotOpacity = 1.0;
+    end
 
     -- Update reusable params table in-place
     local p = cbParams;
@@ -707,28 +1000,30 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.cachedAbbrW = cachedAbbrW;
     p.bind = slotData;
     p.icon = icon;
-    p.slotBgColor = settings.slotBackgroundColor or 0x55000000;
-    p.slotOpacity = settings.slotOpacity or 1.0;
-    p.dimFactor = isActive and 1.0 or (settings.inactiveSlotDim or 0.5);
+    p.slotBgColor = slotBgColor;
+    p.slotOpacity = slotOpacity;
+    p.dimFactor = dimFactor;
     p.animOpacity = animOpacity;
     p.isPressed = isPressed and isActive;
     p.iconPressScale = iconPressScale;
-    p.showMpCost = settings.showMpCost ~= false;
+    p.showMpCost = isEditor and false or (settings.showMpCost ~= false);
     p.mpCostFontSize = (settings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = settings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = settings.mpCostNoMpColor or 0xFFFF4444;
     p.mpCostOffsetX = (settings.mpCostOffsetX or 0) * gs;
     p.mpCostOffsetY = (settings.mpCostOffsetY or 0) * gs;
-    p.showQuantity = settings.showQuantity ~= false;
+    p.showQuantity = isEditor and false or (settings.showQuantity ~= false);
     p.showStackQuantity = settings.showStackQuantity == true;
     p.quantityFontSize = (settings.quantityFontSize or 10) * gs;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
     p.quantityOffsetX = (settings.quantityOffsetX or 0) * gs;
     p.quantityOffsetY = (settings.quantityOffsetY or 0) * gs;
-    p.showLabel = settings.showActionLabels or false;
+    -- Editor: always show labels (on-slot abbrev with hover popup); live crossbar respects the user setting.
+    p.showLabel = isEditor and true or (settings.showActionLabels or false);
     p.labelText = slotData and (slotData.displayName or slotData.action or '') or '';
-    p.labelOffsetX = (settings.actionLabelOffsetX or 0) * gs;
-    p.labelOffsetY = ((settings.actionLabelOffsetY or 0) + 2) * gs;
+    p.labelOffsetX = isEditor and 0 or ((settings.actionLabelOffsetX or 0) * gs);
+    p.labelOffsetY = isEditor and 0 or (((settings.actionLabelOffsetY or 0) + 2) * gs);
+    p.labelAboveSlot = labelAboveSlot;
     p.labelFontSize = (settings.labelFontSize or 10) * gs;
     p.recastTimerFontSize = (settings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = settings.recastTimerFontColor or 0xFFFFFFFF;
@@ -744,10 +1039,29 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.dragType = 'crossbar_slot';
     p.getDragData = interaction.getDragData;
     p.onRightClick = interaction.onRightClick;
+    -- Editor slots: double-click opens the macro editor (empty slot = new macro seeded
+    -- with palette defaults, filled slot = edit existing). Live crossbar slots leave
+    -- onDoubleClick nil so single-click executes the action immediately.
+    p.onDoubleClick = isEditor and interaction.onDoubleClick or nil;
+    -- Editor slots don't have a "live" action to execute; suppressing the single-click
+    -- action is what enables the click-tracking pipeline in slotrenderer to detect a
+    -- second click and dispatch onDoubleClick. Live HUD keeps the default behavior.
+    p.suppressActionOnClick = isEditor and true or false;
     p.showTooltip = true;
-    -- Skillchain highlight
-    p.skillchainName = skillchainName;
+    -- Editor-only params consumed by slotrenderer Pass 2 (clip culling + on-slot multi-line label).
+    p.editorClipRect = editorClipRect;
+    p.editorMinimalView = isEditor;
+    p.labelForeground = isEditor;
+    -- Editor drops should win against the live crossbar zone underneath when the editor preview
+    -- overlaps the HUD (FlushDeferredDrops resolves overlaps by highest priority).
+    p.dropPriority = isEditor and 10 or nil;
+    -- Skillchain highlight (only on live crossbar; editor preview suppresses it).
+    p.skillchainName = (not isEditor) and skillchainName or nil;
     p.skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44;
+    -- Magic Burst highlight — same suppression rules as skillchain (editor preview has no
+    -- live target so the prediction would be meaningless / misleading there).
+    p.magicBurstName = (not isEditor) and magicBurstName or nil;
+    p.magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF;
 
     -- Render slot using shared renderer (handles ALL rendering and interactions)
     slotrenderer.DrawSlot(p);
@@ -879,8 +1193,125 @@ local function DrawTriggerIcons(activeCombo, l2GroupX, r2GroupX, groupY, groupWi
                 {0, 0}, {1, 1},
                 tintColor
             );
+
+            -- R1 return indicator: rendered above R2 when the user has set a "cpal" anchor
+            -- (via `/xiui cpal <Job>`). Pulses to draw the eye toward the return-to-anchor
+            -- shortcut. Per-scope so anchors don't leak across universal vs job-scoped views.
+            local scope = palette.GetCrossbarPaletteScope();
+            local anchor = palette.GetCpalAnchor and palette.GetCpalAnchor(scope);
+            if anchor then
+                local r1Texture = textures:GetControllerIcon('R1');
+                if r1Texture and r1Texture.image then
+                    local r1Ptr = tonumber(ffi.cast('uint32_t', r1Texture.image));
+                    if r1Ptr then
+                        local r1Width = baseIconWidth;
+                        local r1Height = baseIconHeight;
+                        local r1IconX = r2GroupX + (groupWidth / 2) - (r1Width / 2);
+                        local r1IconY = r2IconY - r1Height - 4;
+
+                        -- ~2.5 Hz size pulse (peak +30%) keeps the indicator visible without
+                        -- being distracting. Sin → abs so the icon "breathes" symmetrically.
+                        local pulse = math.abs(math.sin(os.clock() * 2.5));
+                        local sizeScale = 1.0 + 0.30 * pulse;
+                        local sw = r1Width * sizeScale;
+                        local sh = r1Height * sizeScale;
+                        local sx = r1IconX + r1Width * 0.5 - sw * 0.5;
+                        local sy = r1IconY + r1Height * 0.5 - sh * 0.5;
+
+                        -- Pill-shaped dark backdrop spans the icon + "x2" text so they read
+                        -- as a single legend regardless of the underlying scene.
+                        local textGap, textEstW, pad = 3, 14, 4;
+                        drawList:AddRectFilled(
+                            { r1IconX - pad, r1IconY - pad },
+                            { r1IconX + r1Width + textGap + textEstW + pad, r1IconY + r1Height + pad },
+                            0x99000000, 5
+                        );
+
+                        drawList:AddImage(r1Ptr, { sx, sy }, { sx + sw, sy + sh }, { 0, 0 }, { 1, 1 }, 0xFFFFFFFF);
+                        -- Gold ARGB: A=FF R=FF G=C8 B=32 → ImGui's GetColorU32 byte order is 0xAABBGGRR
+                        drawList:AddText(
+                            { r1IconX + r1Width + textGap, r1IconY + r1Height * 0.5 - 6 },
+                            0xFF32C8FF,
+                            'x2'
+                        );
+                    end
+                end
+            end
         end
     end
+end
+
+-- Shared expanded bar (useSharedExpandedBar): the L2+R2 / R2+L2 chord collapses both diamonds
+-- into a single centered 8-slot strip, so DrawTriggerIcons can't position L2 over the left group
+-- and R2 over the (now-absent) right group. This variant renders an "L2 + R2" chord glyph centred
+-- on the single visible diamond: both icons inline with a small "+" between them, tinted brighter
+-- when their trigger is part of the active combo. Same draw list as DrawTriggerIcons so the chord
+-- glyph layers with the same z-order as the regular trigger labels.
+local function DrawTriggerIconsSharedExpandedCenter(activeCombo, groupLeftX, groupY, groupWidth, settings, drawList)
+    if not settings.showTriggerLabels then return; end
+    if not drawList then return; end
+
+    local baseScale = settings.triggerIconScale or 1.0;
+    local iw = 49 * baseScale;
+    local ih = 28 * baseScale;
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    -- chordTight: pull the +/glyphs closer together as the icons shrink so the legend stays compact
+    -- (matches the spacing the editor's shared-chord glyph uses in DrawPaletteEditorL2R2TriggerGlyphs).
+    local chordTight = math.max(0.5, 0.65 * baseScale);
+    local cx = groupLeftX + groupWidth * 0.5;
+    local cy = groupY - ih * 0.5;
+
+    -- Both triggers participate in any chord / double-tap involving them, so animate accordingly.
+    local l2Active = activeCombo == COMBO_MODES.L2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.L2_DOUBLE;
+    local r2Active = activeCombo == COMBO_MODES.R2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.R2_DOUBLE;
+    if activeCombo == COMBO_MODES.NONE then
+        l2Active = false;
+        r2Active = false;
+    end
+
+    local l2PressScale = 1.0;
+    local r2PressScale = 1.0;
+    if settings.enablePressScale ~= false then
+        l2PressScale = animation.getPressScale('trigger_L2', l2Active);
+        r2PressScale = animation.getPressScale('trigger_R2', r2Active);
+    end
+
+    -- Measure the "+" once so the chord can be centered as a single unit (icon + plus + icon).
+    -- Fallback dims 10x14 keep layout sensible on builds where imgui.CalcTextSize isn't bound.
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImageScaled(texName, ix, iy, w, h, tintColor)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        drawList:AddImage(p, { ix, iy }, { ix + w, iy + h }, { 0, 0 }, { 1, 1 }, tintColor);
+    end
+
+    local ptw, pth = plusSize();
+    local lw = iw * l2PressScale;
+    local lh = ih * l2PressScale;
+    local rw = iw * r2PressScale;
+    local rh = ih * r2PressScale;
+    local total = lw + chordTight + ptw + chordTight + rw;
+    local leftX = cx - total * 0.5;
+    local l2Tint = l2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    local r2Tint = r2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    drawImageScaled('L2', leftX, cy - lh * 0.5, lw, lh, l2Tint);
+    drawList:AddText({ leftX + lw + chordTight, cy - pth * 0.5 }, textCol, '+');
+    drawImageScaled('R2', leftX + lw + chordTight + ptw + chordTight, cy - rh * 0.5, rw, rh, r2Tint);
 end
 
 -- Draw combo text in center for complex combos (L2R2, R2L2, L2x2, R2x2) or edit mode
@@ -934,7 +1365,13 @@ local function DrawComboText(activeCombo, centerX, topY, settings)
     end
 end
 
--- Draw palette name below crossbar (e.g., "Stuns (2/5)")
+-- Draw palette name below crossbar (e.g., "Stuns (2/5)"). The index/total count is
+-- restricted to ENABLED palettes (RB-cycle filtered) and is hidden entirely when there
+-- is only one cycleable palette (a 1/1 badge is just noise). For universal [G] scope,
+-- routes through GetCrossbarPaletteLabelIndexAndTotal which uses the universal cycle list
+-- instead of the per-job rows. (Lookup is microseconds at typical 1-10 palette counts; a
+-- per-frame label cache was tried and reverted because it could go stale on PaletteManager
+-- CRUD without a roster-version invalidation hook.)
 local function DrawPaletteName(centerX, bottomY, settings)
     if not settings.showPaletteName then return; end
 
@@ -943,10 +1380,14 @@ local function DrawPaletteName(centerX, bottomY, settings)
 
     local jobId = data.jobId or 1;
     local subjobId = data.subjobId or 0;
-    local index = palette.GetCrossbarPaletteIndex(paletteName, jobId, subjobId) or 1;
-    local total = palette.GetCrossbarPaletteCount(jobId, subjobId) or 1;
+    local index, total = palette.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId);
 
-    local displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    local displayText;
+    if index and total and total > 1 then
+        displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    else
+        displayText = paletteName;
+    end
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local fontSize = (settings.paletteNameFontSize or 10) * gs;
     local offsetX = (settings.paletteNameOffsetX or 0) * gs;
@@ -961,8 +1402,97 @@ local function DrawPaletteName(centerX, bottomY, settings)
     end
 end
 
--- Helper to draw just the left side
-local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- ============================================
+-- Palette scope icon (above the center divider)
+-- Shows the infinity glyph for Global/universal palettes, or the job icon for job-scoped.
+-- Lazily caches the infinity texture; the job-icon TextureManager has its own cache.
+-- ============================================
+local cachedInfinityPaletteTex = nil;
+
+local function GetInfinityPaletteIconTexture()
+    if cachedInfinityPaletteTex and cachedInfinityPaletteTex.image then
+        return cachedInfinityPaletteTex;
+    end
+    cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not cachedInfinityPaletteTex or not cachedInfinityPaletteTex.image then
+        cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    return cachedInfinityPaletteTex;
+end
+
+local function GetPaletteJobIconThemeFromSettings(settings)
+    local t = settings and settings.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+
+-- When showPaletteScopeIcon is nil (legacy profiles), the scope icon follows showPaletteName;
+-- explicit true/false overrides. Keeps the icon visible by default for existing users without
+-- forcing them through the settings menu after the upgrade.
+local function ShouldShowPaletteScopeIcon(settings)
+    if not settings then return false; end
+    if settings.showPaletteScopeIcon == false then return false; end
+    if settings.showPaletteScopeIcon == true then return true; end
+    return settings.showPaletteName == true;
+end
+
+-- Draws the scope marker (infinity for Global / universal, job icon otherwise) centred just
+-- above the divider. Only fires when a palette is actually active for the L2 group.
+local function DrawPaletteScopeIconAboveDivider(dividerX, dividerTopY, settings, drawList)
+    if not ShouldShowPaletteScopeIcon(settings) or not drawList then return; end
+
+    local paletteName = palette.GetActivePaletteForCombo('L2');
+    if not paletteName then return; end
+
+    local jobId = data.jobId or 1;
+    local iconTex;
+    if palette.GetCrossbarPaletteScope() == 'universal' then
+        iconTex = GetInfinityPaletteIconTexture();
+    else
+        iconTex = TextureManager.getJobIcon(jobId, GetPaletteJobIconThemeFromSettings(settings));
+    end
+
+    if not iconTex or not iconTex.image then return; end
+
+    local iconPtr = tonumber(ffi.cast('uint32_t', iconTex.image));
+    if not iconPtr then return; end
+
+    -- Size: explicit slider override (8..64 px) or auto-derive from palette-name font size.
+    local iconSize;
+    local explicitSize = tonumber(settings.paletteScopeIconSize);
+    if explicitSize and explicitSize > 0 then
+        iconSize = math.floor(math.max(8, math.min(64, explicitSize)) + 0.5);
+    else
+        local fontSize = settings.paletteNameFontSize or 10;
+        iconSize = math.max(12, math.min(22, math.floor(fontSize * 1.45)));
+        iconSize = math.floor(iconSize * 1.50 + 0.5);
+    end
+    local gapAboveLine = 3;
+    local scopeLiftY = tonumber(settings.paletteScopeIconOffsetY) or 6;
+    -- Clearance above the L2 / R2 combo-text strip at the top of the window.
+    local clearanceAboveComboText = 6;
+    -- Horizontally align with palette-name X offset so the icon stacks with the name.
+    local iconCenterX = dividerX + (settings.paletteNameOffsetX or 0);
+    local iconTopY = dividerTopY - gapAboveLine - iconSize - scopeLiftY - clearanceAboveComboText;
+    local leftX = iconCenterX - iconSize / 2;
+
+    drawList:AddImage(
+        iconPtr,
+        { leftX, iconTopY },
+        { leftX + iconSize, iconTopY + iconSize },
+        { 0, 0 },
+        { 1, 1 },
+        imgui.GetColorU32({ 1, 1, 1, 1 })
+    );
+end
+
+-- Helper to draw just the left side. `activeCombo` is threaded through so DrawSlot's dim
+-- policy can apply Ferris's "stronger dim on the inactive half while a trigger is held"
+-- behavior (settings.inactiveSideWhileTriggerDim, default 0.15) — without it the inactive
+-- half just gets settings.inactiveSlotDim (default 0.5) like 1.7.5/early-1.8.0.
+local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -970,15 +1500,40 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('L2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- Resolve slotData ONCE per slot so both prediction paths (skillchain + magic burst)
+        -- share the same fetch; previously the SC path re-fetched per branch. Cheap either
+        -- way, but cleaner now that two features need the same row.
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
+        -- Skillchain prediction: matches display.lua's coverage so the crossbar lights up the
+        -- same WS / Blood Pact / macro slots the keyboard hotbar does. Bloodpact slots use the
+        -- separate name->attributes map in skillchain.lua (bloodPactResonationMap); macro slots
+        -- run through macroparse to extract the primary /ws or /pet line and then route to the
+        -- matching predictor. Without the pet/macro branches, SMN ability slots and any /pet or
+        -- /ws macro would never get a skillchain icon overlay on the crossbar.
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        -- Magic Burst prediction: spells / magical pact rages / /ma|/pet-primary macros. The
+        -- single GetMagicBurstForSlot call internally routes by actionType + (for macros) the
+        -- macroparse primary line — mirrors the dispatch pattern used by display.lua.
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -989,8 +1544,9 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     end
 end
 
--- Helper to draw just the right side
-local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- Helper to draw just the right side. See DrawLeftSide above for the rationale on the
+-- trailing activeCombo / magicBurstEnabled parameters.
+local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -998,15 +1554,29 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('R2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- See DrawLeftSide for slotData / SC / MB routing rationale (identical logic).
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -1017,17 +1587,260 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     end
 end
 
--- Helper to draw a complete bar set (both sides) - used for non-animated drawing
+-- Helper to draw a complete bar set (both sides) - used for non-animated drawing.
+-- activeCombo flows from M.DrawWindow down to DrawSlot for the trigger-held dim policy.
 local function DrawBarSet(leftMode, rightMode, leftGroupX, leftGroupY, rightGroupX, rightGroupY,
                           slotSize, settings, leftActive, rightActive, pressedSlot,
-                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
-    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
-    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
+                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
+    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+end
+
+-- ============================================
+-- Double-Tap Preview Windows
+-- ============================================
+-- Reference floating windows that mirror the L2x2 / R2x2 bars at user-configurable scale
+-- and opacity. Rendered as independent ImGui windows AFTER the main crossbar so they have
+-- their own position/draw list (no shared primitives, no z-fighting). Drawn non-interactive
+-- (suppressActionOnClick) — the previews are visual reference only; actual slot activation
+-- still routes through the main bar's controller path.
+
+-- Return a shallow copy of settings with all layout-affecting fields scaled. Preserves the
+-- caller's settings unchanged so the main bar keeps its own layout numbers.
+--
+-- Result is cached on a (settings ref, scale, layout-key signature) tuple — the full
+-- shallow-copy is the dominant cost when the preview is on (8 slots × 2 windows × scaled
+-- settings every frame). Invalidates only when the caller passes a new settings table OR
+-- changes one of the geometry/scale inputs. This avoids the per-frame table-copy churn
+-- without going stale on slider drags (signature changes immediately).
+local previewSettingsCache = {
+    settingsRef = nil,
+    scale       = nil,
+    signature   = nil,
+    result      = nil,
+};
+
+local function MakePreviewSettings(settings, scale)
+    -- Cheap signature: only the fields MakePreviewSettings actually reads. Keep this in
+    -- sync with the scaled fields below — additions need a sig entry or the cache goes stale.
+    local sig = string.format('%s|%s|%s|%s|%s|%s|%s|%s|%s',
+        tostring(settings.slotSize), tostring(settings.slotGapV), tostring(settings.slotGapH),
+        tostring(settings.diamondSpacing), tostring(settings.groupSpacing),
+        tostring(settings.buttonIconSize), tostring(settings.buttonIconGapH), tostring(settings.buttonIconGapV),
+        tostring(settings.triggerIconScale));
+
+    if previewSettingsCache.settingsRef == settings
+        and previewSettingsCache.scale == scale
+        and previewSettingsCache.signature == sig then
+        return previewSettingsCache.result;
+    end
+
+    local s = {};
+    for k, v in pairs(settings) do s[k] = v; end
+    s.slotSize       = math.max(8, math.floor((settings.slotSize       or 40) * scale));
+    s.slotGapV       = math.max(1, math.floor((settings.slotGapV       or 2)  * scale));
+    s.slotGapH       = math.max(1, math.floor((settings.slotGapH       or 2)  * scale));
+    s.diamondSpacing = math.max(2, math.floor((settings.diamondSpacing or 16) * scale));
+    s.groupSpacing   = math.max(4, math.floor((settings.groupSpacing   or 24) * scale));
+    s.buttonIconSize = math.max(4, math.floor((settings.buttonIconSize or 24) * scale));
+    s.buttonIconGapH = math.max(1, math.floor((settings.buttonIconGapH or 2)  * scale));
+    s.buttonIconGapV = math.max(1, math.floor((settings.buttonIconGapV or 2)  * scale));
+    s.triggerIconScale = (settings.triggerIconScale or 1.0) * scale;
+
+    previewSettingsCache.settingsRef = settings;
+    previewSettingsCache.scale       = scale;
+    previewSettingsCache.signature   = sig;
+    previewSettingsCache.result      = s;
+    return s;
+end
+
+-- Draw one side of a double-tap preview using ImGui-only rendering (non-interactive).
+-- winX/winY    : top-left of the preview ImGui window (slot grid origin).
+-- side         : always 'L2' for single-group preview windows (slots start at window left).
+-- mode         : crossbar storage mode string ('L2x2', 'R2x2', 'L2', 'R2', etc.) whose slots to render.
+-- baseOp       : base opacity for the slot backgrounds (NOT dimmed) so frames stay visible.
+-- dimFactor    : 0-1 multiplier applied to icon/text rendering (mirrors main bar dim policy).
+-- targetServerId / skillchainEnabled / magicBurstEnabled: same per-slot SC/MB resolution
+--                inputs used by the main DrawLeftSide/DrawRightSide path. Letting the preview
+--                share them keeps the highlight calculus identical between live and preview
+--                (a slot that lights up on the live bar lights up on its preview).
+local function DrawPreviewSide(winX, winY, windowKey, side, mode, ps, baseOp, dimFactor, drawList, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize  = ps.slotSize or 40;
+    local contentOp = baseOp * dimFactor;
+
+    -- Slot background (flat rounded rect). slotrenderer's built-in bg path requires a D3D
+    -- slot primitive (we have none in preview), so paint it manually with baseOp so the
+    -- frame stays visible while icons dim with contentOp.
+    local bgArgb = ps.slotBackgroundColor or 0x55000000;
+    local bgA_raw = bit.rshift(bit.band(bgArgb, 0xFF000000), 24) / 255;
+    local bgA = math.max(bgA_raw, 0.55) * baseOp;
+    local bgR = bit.rshift(bit.band(bgArgb, 0x00FF0000), 16) / 255;
+    local bgG = bit.rshift(bit.band(bgArgb, 0x0000FF00), 8) / 255;
+    local bgB = bit.band(bgArgb, 0x000000FF) / 255;
+    local cornerR = math.max(4, math.min(10, math.floor(slotSize * 0.125 + 0.5)));
+    local bgU32 = imgui.GetColorU32({ bgR, bgG, bgB, bgA });
+
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        local slotX, slotY = GetSlotPositionInWindow(side, slotIndex, winX, winY, ps);
+
+        if drawList then
+            drawList:AddRectFilled({ slotX, slotY }, { slotX + slotSize, slotY + slotSize }, bgU32, cornerR);
+        end
+
+        local slotData = data.GetCrossbarSlotData(mode, slotIndex);
+        local icon = GetCachedCrossbarIcon(mode, slotIndex, slotData);
+
+        -- Per-slot skillchain + magic burst resolution — identical dispatch to DrawLeftSide
+        -- so a slot that highlights on the live crossbar highlights on its preview window
+        -- too. Without this the preview would silently omit both borders, hiding useful
+        -- "you could chain/MB from the other bar" cues exactly when the player is deciding
+        -- whether to commit to a double-tap.
+        local slotSkillchainName = nil;
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
+                slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
+            end
+        end
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+
+        slotrenderer.DrawSlot({
+            x    = slotX,
+            y    = slotY,
+            size = slotSize,
+            windowName = windowKey,
+            bind = slotData,
+            icon = icon,
+            slotBgColor = 0x00000000,
+            slotOpacity = 1.0,
+            dimFactor   = 1.0,
+            animOpacity = contentOp,
+            isPressed   = false,
+            iconPressScale = 1.0,
+            -- MP cost + quantity are intentionally OFF on the double-tap preview regardless of
+            -- the user's main-bar settings: the preview is a transient "what's on the other
+            -- bar" overlay, not an action-resolution surface, so a player glancing at it just
+            -- wants the icon + cooldown to decide if the next press is worth it. Showing MP /
+            -- charges duplicates the info on the live bar and crowds an already-small preview.
+            -- Cooldowns are kept (recastTimer* + flashCooldownUnder5) — they ARE useful here
+            -- because the preview's whole purpose is "should I commit to this bar".
+            showMpCost = false,
+            showQuantity = false,
+            showLabel = false,
+            recastTimerFontSize   = ps.recastTimerFontSize or 11,
+            recastTimerFontColor  = ps.recastTimerFontColor or 0xFFFFFFFF,
+            flashCooldownUnder5   = ps.flashCooldownUnder5 or false,
+            useHHMMCooldownFormat = ps.useHHMMCooldownFormat or false,
+            -- Skillchain + Magic Burst highlights. Colors fall back to the live-bar defaults
+            -- so the preview matches the main bar without requiring its own settings keys.
+            skillchainName  = slotSkillchainName,
+            skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44,
+            magicBurstName  = slotMagicBurstName,
+            magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF,
+            buttonId              = string.format('##dtprev_%s_%s_%d', windowKey, mode, slotIndex),
+            suppressActionOnClick = true,
+            forceImGuiIcon        = true,
+            drawCornerTextForeground = true,
+        });
+    end
+
+    if drawList and ps.showButtonIcons and contentOp > 0.05 then
+        DrawDiamondCenterIconsImGui('dpad', winX, winY, ps, true, drawList, contentOp);
+        DrawDiamondCenterIconsImGui('face', winX, winY, ps, true, drawList, contentOp);
+    end
+end
+
+-- Draw one double-tap preview window (L2x2 or R2x2 reference).
+-- windowKey : unique ImGui window name and persisted-position key.
+-- mode      : crossbar storage mode for the 8 slots displayed (e.g. 'L2x2', 'R2x2', 'L2', 'R2').
+-- ps        : scaled settings table (from MakePreviewSettings).
+-- baseOp    : base opacity (user slider * visibilityOpacity).
+-- dimFactor : 0-1 content dim (1.0 = at rest, inactiveSideWhileTriggerDim while any trigger held).
+-- settings  : raw crossbar settings (used for doubleTapPreviewLocked move-anchor gating).
+local function DrawDoubleTapPreviewWindow(windowKey, mode, ps, baseOp, dimFactor, activeCombo, settings, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize = ps.slotSize or 40;
+    local gw, gh = CalculateGroupDimensions(slotSize, ps.slotGapV or 2, ps.slotGapH or 2, ps.diamondSpacing or 16);
+    local totalW = gw;
+    local totalH = gh;
+
+    local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+    if savedPos then
+        imgui.SetNextWindowPos({savedPos.x, savedPos.y}, ImGuiCond_Always);
+    else
+        imgui.SetNextWindowPos({200, 200}, ImGuiCond_FirstUseEver);
+    end
+    imgui.SetNextWindowSize({totalW, totalH}, ImGuiCond_Always);
+
+    -- Preview windows intentionally omit NoBringToFrontOnFocus so they stay layered above the
+    -- main crossbar (which has that flag set). NoMove + the move anchor below gives us
+    -- explicit positioning control without ImGui drifting the window on focus.
+    local flags = bit.bor(
+        ImGuiWindowFlags_NoDecoration,
+        ImGuiWindowFlags_NoResize,
+        ImGuiWindowFlags_NoFocusOnAppearing,
+        ImGuiWindowFlags_NoNav,
+        ImGuiWindowFlags_NoBackground,
+        ImGuiWindowFlags_NoDocking,
+        ImGuiWindowFlags_NoMove
+    );
+
+    -- Zero window padding so the draw list clip rect matches the window bounds exactly.
+    -- Without this the default 8 px padding clips slots at the left/right edges (same fix
+    -- that landed for the main crossbar window in the previous smoke-test pass).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+    local didBegin = imgui.Begin(windowKey, true, flags);
+    imgui.PopStyleVar();
+
+    if didBegin then
+        local wX, wY = imgui.GetWindowPos();
+        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+        if savedPos == nil then
+            gConfig.windowPositions[windowKey] = {x = wX, y = wY};
+        end
+
+        local dl = imgui.GetWindowDrawList();
+        DrawPreviewSide(wX, wY, windowKey, 'L2', mode, ps, baseOp, dimFactor, dl, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled);
+    end
+    imgui.End();
+
+    -- Move anchor: independent lock so previews can be repositioned without unlocking the
+    -- main crossbar (and vice versa).
+    local previewLocked = settings and settings.doubleTapPreviewLocked;
+    if not previewLocked then
+        local pos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+        local anchorX = pos and pos.x or 200;
+        local anchorY = pos and pos.y or 200;
+        local newX, newY = drawing.DrawMoveAnchor(windowKey, anchorX, anchorY, {
+            anchorSide  = 'top',
+            windowWidth = totalW,
+        });
+        if newX ~= nil then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[windowKey] = {x = newX, y = newY};
+        end
+    end
 end
 
 -- Main draw function
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
+
+    -- Warm playerdata caches even when keyboard hotbars are disabled. Cheap on cache hit
+    -- (signature compare against job/level/equip ids), only does the heavy ability/WS scan
+    -- when the signature changes. See the require-site comment for the user-visible bug
+    -- this prevents (all JA/WS slots reading as unavailable on crossbar-only setups).
+    playerdata.RefreshCachedLists(data);
 
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local slotSize = (settings.slotSize or 48) * gs;
@@ -1037,34 +1850,12 @@ function M.DrawWindow(settings, moduleSettings)
     local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate dimensions using layout functions
-    local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local fullWidth, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local width = fullWidth;
 
-    -- Window flags (dummy window for positioning, like hotbar display.lua)
-    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
-
-    local windowName = 'Crossbar';
-    local defaultX, defaultY = GetDefaultPosition(settings);
-
-    -- Check if anchor is currently being dragged - if so, force position
-    local anchorDragging = drawing.IsAnchorDragging(windowName);
-    
-    if anchorDragging then
-        -- Use state position directly during drag for immediate response
-        imgui.SetNextWindowPos({state.windowX, state.windowY}, ImGuiCond_Always);
-    else
-        -- Apply saved position (once) or default
-        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-
-        if hasSaved then
-            ApplyWindowPosition(windowName);
-        else
-            imgui.SetNextWindowPos({defaultX, defaultY}, ImGuiCond_FirstUseEver);
-        end
-    end
-    
-    imgui.SetNextWindowSize({width, height}, ImGuiCond_Always);
-
-    -- Get current combo mode and pressed slot from controller
+    -- Get current combo mode and pressed slot from controller. Resolved BEFORE the window
+    -- size/position calls so the useSharedExpandedBar branch can shrink the window to a single
+    -- diamond and re-center it (a chord with useSharedExp on collapses to one 8-slot strip).
     local activeCombo = controller.GetActiveCombo();
     local pressedSlot = controller.GetPressedSlot();
 
@@ -1075,6 +1866,75 @@ function M.DrawWindow(settings, moduleSettings)
         activeCombo = editBar;
         pressedSlot = nil;  -- Don't show pressed state in edit mode
     end
+
+    -- Determine which bar set to display based on active combo. expandedSide == 'center' is
+    -- the useSharedExpandedBar branch (chord collapses both diamonds into one centered strip).
+    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo, settings);
+
+    -- useSharedExpandedBar special layout: shrink window to one diamond, re-center on screen X,
+    -- skip the right group draw + center divider/scope icon (they have no meaning when there's
+    -- only one diamond visible). Outside of chord, behaves identically to the standard 2-diamond
+    -- layout. exitingChordCenter catches the FIRST frame after the user releases the chord: we
+    -- restore the stashed wide-bar X so SaveCrossbarWindowSlotTopPosition doesn't persist the
+    -- narrow centered value.
+    local hideRightForSharedCenter = (isExpanded and expandedSide == 'center');
+    if hideRightForSharedCenter then
+        width = groupWidth;
+    end
+    local exitingChordCenter = state.wasSharedCenterChordLayout and (not hideRightForSharedCenter);
+
+    -- Window flags (dummy window for positioning, like hotbar display.lua)
+    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
+
+    local windowName = 'Crossbar';
+    local defaultX, defaultY = GetDefaultPosition(settings);
+
+    local function storedCrossbarPosY()
+        local posY = defaultY;
+        local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowName];
+        if savedPos and savedPos.y ~= nil then
+            posY = savedPos.y;
+        elseif state.windowY ~= nil then
+            posY = state.windowY;
+        end
+        return posY;
+    end
+
+    -- Check if anchor is currently being dragged - if so, force position
+    local anchorDragging = drawing.IsAnchorDragging(windowName);
+
+    -- state.windowX / state.windowY track the SLOT GRID origin. ImGui's window must open
+    -- CROSSBAR_WINDOW_TOP_DECOR_PAD pixels higher so the decoration above the slots
+    -- (L2/R2 triggers, combo text, R1 cpal-anchor pulse) stays inside the window's
+    -- content rect and doesn't get clipped.
+    if anchorDragging then
+        -- Use state position directly during drag for immediate response
+        imgui.SetNextWindowPos({ state.windowX, state.windowY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif hideRightForSharedCenter then
+        -- Shared-center chord: force X to screen-center each frame so the narrow window reads as
+        -- the FFXIV-style single 8-slot strip (Y persists from the last wide-bar position).
+        local io = imgui.GetIO();
+        local screenW = (io and io.DisplaySize and io.DisplaySize.x) or 1920;
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ (screenW - width) * 0.5, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif exitingChordCenter and state.lastWideCrossbarWindowX ~= nil then
+        -- First frame after chord release: re-anchor to the wide-bar X we stashed before the
+        -- chord, otherwise the user-visible position would briefly snap to the centered narrow X.
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ state.lastWideCrossbarWindowX, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    else
+        -- Apply saved position (once, slot-top -> window-top offset handled inside) or default
+        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+
+        if hasSaved then
+            ApplyCrossbarWindowPositionOnce();
+        else
+            imgui.SetNextWindowPos({ defaultX, defaultY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_FirstUseEver);
+        end
+    end
+
+    local bottomPad = GetCrossbarWindowBottomPad(settings);
+    imgui.SetNextWindowSize({ width, height + CROSSBAR_WINDOW_TOP_DECOR_PAD + bottomPad }, ImGuiCond_Always);
 
     -- Determine visibility for activeOnly display mode
     local leftVisible, rightVisible, crossbarVisible = GetVisibilityState(activeCombo, settings, isEditMode);
@@ -1100,8 +1960,14 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
-    -- Determine which bar set to display based on active combo
-    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo);
+    -- Menu-open dim: when a blocking game menu is open and the user has "Disable Crossbar
+    -- While In Menu" enabled, controller.lua already stops routing input — we additionally
+    -- dim everything the crossbar draws so it visually reads as "paused" rather than just
+    -- silently unresponsive. visibilityOpacity propagates into every slot via the per-slot
+    -- animOpacity param plus the background / border / trigger / divider alpha scales below.
+    if gamestate.IsMenuOpen() and settings.crossbarDisableInMenu ~= false then
+        visibilityOpacity = visibilityOpacity * 0.35;
+    end
 
     -- Check if animations are disabled - if so, force complete any in-progress animation
     if settings.enableTransitionAnimations == false and state.animation.active then
@@ -1143,7 +2009,11 @@ function M.DrawWindow(settings, moduleSettings)
     local leftActive, rightActive;
     if isExpanded then
         -- In expanded mode, only the expanded side is active, other side is dimmed
-        if expandedSide == 'left' then
+        if expandedSide == 'center' then
+            -- useSharedExpandedBar: only the left column is drawn (no right group exists this frame)
+            leftActive = true;
+            rightActive = false;
+        elseif expandedSide == 'left' then
             leftActive = true;
             rightActive = false;
         elseif expandedSide == 'right' then
@@ -1171,10 +2041,13 @@ function M.DrawWindow(settings, moduleSettings)
     -- Get draw list for ImGui-based rendering (behind config when open)
     local drawList = GetUIDrawList();
 
-    -- Get target server ID for skillchain prediction (cached for all slots)
+    -- Get target server ID for skillchain / magic burst prediction (cached for all slots).
+    -- Both features key off the same target so a single resolve+cache covers everything; the
+    -- per-slot SC and MB calls are no-ops when their respective enable flags are off.
     local targetServerId = nil;
     local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
-    if skillchainEnabled then
+    local magicBurstEnabled = gConfig.hotbarGlobal.magicBurstHighlightEnabled ~= false;
+    if skillchainEnabled or magicBurstEnabled then
         local mainTargetIdx = targetLib.GetTargets();
         if mainTargetIdx and mainTargetIdx ~= 0 then
             local targetEntity = GetEntity(mainTargetIdx);
@@ -1184,15 +2057,48 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
+    -- Zero out WindowPadding so the leftmost and rightmost diamond slots (which sit flush
+    -- against the window's content rect) aren't clipped by ImGui's default 8px padding.
+    -- Without this the left/right slots of each diamond render partially off-window and
+    -- their button hitboxes get pushed inward (slot interactions become unreliable).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
     -- Begin ImGui window - ALL slot rendering happens inside to enable interactions
     if imgui.Begin('Crossbar', true, windowFlags) then
-        -- Save position if moved (profile support)
-        SaveWindowPosition('Crossbar');
+        -- Save SLOT-TOP position if moved (decor-pad-aware; profile coordinate stays the
+        -- slot grid top so the saved value is meaningful even if decor pad changes later).
+        -- During the shared-center chord the X is force-centered each frame, so we MUST NOT
+        -- let SaveCrossbarWindowSlotTopPosition persist that narrow centered X — only sync Y.
+        if hideRightForSharedCenter then
+            if gConfig.windowPositions and gConfig.windowPositions[windowName] then
+                local wx, wy = imgui.GetWindowPos();
+                local s = gConfig.windowPositions[windowName];
+                local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+                if s.y ~= slotTopY then
+                    s.y = slotTopY;
+                end
+                -- Track the centered window X for free (used by lastWideCrossbarWindowX restore)
+                if s.x ~= wx then
+                    s.x = wx;
+                end
+            end
+        else
+            SaveCrossbarWindowSlotTopPosition();
+        end
         windowPosX, windowPosY = imgui.GetWindowPos();
 
-        -- Update stored position
+        -- Update stored position. state.windowY = slot grid top (window top + decor pad);
+        -- the rest of the layout code references state.windowY as the slot origin.
         state.windowX = windowPosX;
-        state.windowY = windowPosY;
+        state.windowY = windowPosY + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+
+        -- Stash the wide-bar X so that when the user releases the chord we can restore it
+        -- (otherwise the narrow centered X from this frame would be the "last" saved X).
+        if not hideRightForSharedCenter then
+            state.lastWideCrossbarWindowX = windowPosX;
+        end
+        -- Remember the layout for the NEXT frame so exitingChordCenter (above) can detect
+        -- the chord-release transition and re-anchor X.
+        state.wasSharedCenterChordLayout = hideRightForSharedCenter;
 
         -- Recalculate group positions with updated window position
         leftGroupX = state.windowX;
@@ -1244,35 +2150,36 @@ function M.DrawWindow(settings, moduleSettings)
                     -- Left side changed - animate it
                     if outOpacity > 0.01 then
                         DrawLeftSide(state.animation.fromLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Left side didn't change - draw at full opacity (with visibility fade)
                     DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
 
-            -- Draw RIGHT side (skip in activeOnly mode if not visible)
-            if not isActiveOnlyMode or rightVisible then
+            -- Draw RIGHT side (skip in activeOnly mode if not visible, or whenever the chord
+            -- collapsed both groups into a single centered strip — there is no right group).
+            if (not hideRightForSharedCenter) and (not isActiveOnlyMode or rightVisible) then
                 if state.animation.rightChanged then
                     -- Right side changed - animate it
                     if outOpacity > 0.01 then
                         DrawRightSide(state.animation.fromRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Right side didn't change - draw at full opacity (with visibility fade)
                     DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
         else
@@ -1281,12 +2188,16 @@ function M.DrawWindow(settings, moduleSettings)
                 -- ActiveOnly mode: draw only visible sides with visibility fade
                 if leftVisible then
                     DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
-                if rightVisible then
+                if (not hideRightForSharedCenter) and rightVisible then
                     DrawRightSide(state.currentRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
+            elseif hideRightForSharedCenter then
+                -- Shared-center chord: render only the (now-Shared) left column as one centered strip.
+                DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
+                    leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
             else
                 -- Normal mode: draw both sides at full opacity
                 DrawBarSet(
@@ -1295,17 +2206,21 @@ function M.DrawWindow(settings, moduleSettings)
                     slotSize, settings,
                     leftActive, rightActive,
                     pressedSlot, leftShowPressed, rightShowPressed,
-                    1.0, drawList, 0, targetServerId, skillchainEnabled
+                    1.0, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled
                 );
             end
         end
 
         imgui.End();
     end
+    -- Pop the WindowPadding style we pushed before Begin. Has to be unconditional (must match
+    -- the push even when Begin returns false / window is collapsed).
+    imgui.PopStyleVar();
 
-    -- Draw move anchor (only visible when config is open)
-    -- Only show when crossbar movement is NOT locked (uses global lock setting)
-    local crossbarLocked = gConfig and gConfig.hotbarLockMovement;
+    -- Draw move anchor (only visible when config is open).
+    -- Uses the crossbar-specific lock so Hotbar's lock toggle doesn't accidentally freeze
+    -- the crossbar (fixes the issue where Lock Crossbar was tied to Hotbar's setting).
+    local crossbarLocked = gConfig and gConfig.crossbarLockMovement;
     if not crossbarLocked then
         -- Use same window name as ImGui window so positions are shared
         local anchorNewX, anchorNewY = drawing.DrawMoveAnchor('Crossbar', state.windowX, state.windowY);
@@ -1323,22 +2238,36 @@ function M.DrawWindow(settings, moduleSettings)
     local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
     local showCenterElements = not isActiveOnlyMode;
 
-    -- Draw center divider (optional, hidden in activeOnly mode)
-    if settings.showDivider and drawList and showCenterElements then
-        local dividerX = state.windowX + groupWidth + (groupSpacing / 2);
-        local dividerY1 = state.windowY + 10;
-        local dividerY2 = state.windowY + height - 10;
+    -- Center decor (divider line, scope icon, combo text, palette name): all hidden in
+    -- activeOnly mode since that layout collapses to a single side and the divider has no meaning.
+    -- Shared-center chord layout: centerX is the middle of the (now single-diamond) window so the
+    -- scope icon / combo text / palette name still sit over the visible bar. The DIVIDER itself
+    -- is suppressed in chord since there's no longer a left/right split to divide.
+    local centerX;
+    if hideRightForSharedCenter then
+        centerX = state.windowX + width * 0.5;
+    else
+        centerX = state.windowX + groupWidth + (groupSpacing / 2);
+    end
+    local dividerTopY = state.windowY + 10;
 
+    if settings.showDivider and drawList and showCenterElements and (not hideRightForSharedCenter) then
+        local dividerY2 = state.windowY + height - 10;
         drawList:AddLine(
-            { dividerX, dividerY1 },
-            { dividerX, dividerY2 },
+            { centerX, dividerTopY },
+            { centerX, dividerY2 },
             imgui.GetColorU32({ 1, 1, 1, 0.3 }),
             2
         );
     end
 
+    -- Palette scope icon (infinity for Global / job icon for job-scoped) — drawn above the
+    -- divider's top endpoint. Same drawList as the divider so z-order is consistent.
+    if showCenterElements and drawList then
+        DrawPaletteScopeIconAboveDivider(centerX, dividerTopY, settings, drawList);
+    end
+
     -- Draw combo text in center for complex combos (hidden in activeOnly mode)
-    local centerX = state.windowX + groupWidth + (groupSpacing / 2);
     local topY = state.windowY - 4;  -- Above the window
     if showCenterElements then
         DrawComboText(activeCombo, centerX, topY, settings);
@@ -1350,9 +2279,15 @@ function M.DrawWindow(settings, moduleSettings)
         DrawPaletteName(centerX, bottomY, settings);
     end
 
-    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode)
+    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode). The shared-center
+    -- chord uses a different glyph (L2 + R2 chord centred on the single visible diamond) since
+    -- there's no left-vs-right group to position labels against.
     if drawList and showCenterElements then
-        DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        if hideRightForSharedCenter then
+            DrawTriggerIconsSharedExpandedCenter(activeCombo, leftGroupX, leftGroupY, groupWidth, settings, drawList);
+        else
+            DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        end
     end
 
     -- Draw palette modifier indicator (refresh icon when modifier key is held)
@@ -1380,6 +2315,41 @@ function M.DrawWindow(settings, moduleSettings)
                 );
             end
         end
+    end
+
+    -- Double-tap preview windows. Drawn AFTER the main crossbar so they end up in
+    -- separate ImGui windows with their own draw list / position, layered above the main
+    -- bar. Gated on both `enableDoubleTap` (the L2x2/R2x2 modes have to be enabled at all)
+    -- and `showDoubleTapPreview` (the per-feature visibility toggle). When the active combo
+    -- IS the matching double-tap, the preview swaps to the BASE L2/R2 slots as a reference
+    -- — the main bar is already showing the double-tap content.
+    if settings.enableDoubleTap and settings.showDoubleTapPreview then
+        local scale  = settings.doubleTapPreviewScale  or 0.60;
+        local baseOp = (settings.doubleTapPreviewOpacity or 1.0) * visibilityOpacity;
+        -- Skip the preview render path entirely when nothing would be visible (menu dim or
+        -- activeOnly hide). Saves the 16-slot DrawSlot + ImGui begin/end overhead per frame.
+        if baseOp <= 0.02 then return; end
+        local dimFact = settings.inactiveSideWhileTriggerDim;
+        if dimFact == nil then dimFact = 0.15; end
+        local ps = MakePreviewSettings(settings, scale);
+
+        local isL2xActive = (activeCombo == COMBO_MODES.L2_DOUBLE);
+        local isR2xActive = (activeCombo == COMBO_MODES.R2_DOUBLE);
+        local anyTriggerHeld = (activeCombo ~= COMBO_MODES.NONE);
+        local previewDim = anyTriggerHeld and dimFact or 1.0;
+
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewL2x2',
+            isL2xActive and 'L2' or 'L2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewR2x2',
+            isR2xActive and 'R2' or 'R2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
     end
 end
 
@@ -1467,6 +2437,11 @@ end
 -- Clear icon cache (call when job changes)
 function M.ClearIconCache()
     ClearCrossbarIconCache();
+    -- Mirror the wipe to actions.lua's negative-result cache so "no icon" decisions
+    -- pinned from a previous state don't survive into the new job/palette context.
+    if actions and actions.ClearNoIconCache then
+        actions.ClearNoIconCache();
+    end
 end
 
 -- Clear icon cache for a specific slot (call on targeted slot updates)
@@ -1487,6 +2462,187 @@ function M.ResetPositions()
     if gConfig.appliedPositions then
         gConfig.appliedPositions['Crossbar'] = nil;
     end
+end
+
+-- ============================================
+-- Edit Full Palette (called from config/palettemanager.lua's ImGui window)
+-- ============================================
+-- The editor draws a static representation of a crossbar row using the SAME DrawSlot path
+-- as the live HUD, so layout (diamond geometry, slot size, label position, MP/quantity)
+-- always matches what the user actually plays with. The editor differs from the HUD in:
+--   * Slot data is read from the draft layer (data.GetDraftSlotData) not the live binding.
+--   * MP / quantity / cooldown text are suppressed (showMpCost=false, showQuantity=false).
+--   * The action name renders ON the slot (labelForeground + editorMinimalView).
+--   * Drop zones use 'paled_*' IDs with dropPriority=10 so they win against the HUD zones
+--     underneath when the editor window overlaps the live crossbar.
+--   * Optional editorClipRect culls slots scrolled off the editor panel.
+-- These are all set by the local DrawSlot wrapper above; the public functions here just
+-- iterate the 8 slots of each diamond and call DrawSlot once per slot.
+
+-- Shared palette-editor slot row. Either or both of modeLeft (L2 group) and modeRight
+-- (R2 group) may be set; pass nil on a side to omit it (Pets tab filter renders single-sided rows).
+local function DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    if not state.initialized then return; end
+    if not modeLeft and not modeRight then return; end
+    local editorClipRect;
+    if clipMinX and clipMinY and clipMaxX and clipMaxY then
+        editorClipRect = { clipMinX, clipMinY, clipMaxX, clipMaxY };
+    end
+    local slotSize = settings.slotSize or 48;
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        if modeLeft then
+            local sx, sy = GetSlotPositionInWindow('L2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeLeft, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+        if modeRight then
+            local sx, sy = GetSlotPositionInWindow('R2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeRight, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+    end
+end
+
+function M.DrawPaletteEditorL2R2Row(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+function M.DrawPaletteEditorSingleRow(screenOriginX, screenOriginY, settings, modeOnly, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeOnly, nil, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+-- Trigger glyphs raised above the editor's slot cluster. glyphMode:
+--   'primary'     — L2 | R2 (one glyph per side, gap between d-pad and face).
+--   'doubleTap'   — L2 + "x2", R2 + "x2".
+--   'chordCombo'  — Left: L2+R2, Right: R2+L2 (with text "+" between).
+--   'sharedChord' — Single L2+R2 glyph centred over the shared diamond.
+-- Optional sides = { l=bool, r=bool } (default both true) — used by Pets-tab single-sided rows.
+function M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, glyphMode, sides)
+    local dl = imgui.GetWindowDrawList();
+    if not dl then return; end
+    glyphMode = glyphMode or 'primary';
+    local sl = (not sides or sides.l ~= false);
+    local sr = (not sides or sides.r ~= false);
+    local totalW, _, groupW, ghgt = GetCrossbarDimensions(settings);
+    local gs = totalW - 2 * groupW;
+    local slotSize = settings.slotSize or 48;
+    local scale = (settings.triggerIconScale or 1.0) * math.max(0.42, math.min(1.1, slotSize / 48));
+    local iw = 49 * scale;
+    local ih = 28 * scale;
+    local yLift = 35;
+    local cy = screenOriginY + ghgt * 0.5 - yLift;
+    local tint = imgui.GetColorU32({ 1, 1, 1, 0.88 });
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    local chordTight = math.max(0.5, 0.65 * scale);
+    local doubleTapImgGap = math.max(1, 2 * scale);
+
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImage(texName, ix, iy)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+    end
+
+    local function drawComboAtCenter(cx, firstTex, secondTex)
+        local ptw, pth = plusSize();
+        local gL, gR = chordTight, chordTight;
+        local total = iw + gL + ptw + gR + iw;
+        local leftX = cx - total * 0.5;
+        drawImage(firstTex, leftX, cy - ih * 0.5);
+        dl:AddText({ leftX + iw + gL, cy - pth * 0.5 }, textCol, '+');
+        drawImage(secondTex, leftX + iw + gL + ptw + gR, cy - ih * 0.5);
+    end
+
+    if glyphMode == 'sharedChord' then
+        drawComboAtCenter(screenOriginX + groupW * 0.5, 'L2', 'R2');
+        return;
+    end
+
+    if glyphMode == 'chordCombo' then
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then drawComboAtCenter(l2cx, 'L2', 'R2'); end
+        if sr then drawComboAtCenter(r2cx, 'R2', 'L2'); end
+        return;
+    end
+
+    if glyphMode == 'doubleTap' then
+        local x2Str = 'x2';
+        local tw, th = 18, 16;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize(x2Str);
+            if type(ts) == 'table' then
+                tw = ts[1] or ts.x or tw;
+                th = ts[2] or ts.y or th;
+            end
+        end
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then
+            local l2Tex = textures:GetControllerIcon('L2');
+            if l2Tex and l2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', l2Tex.image));
+                if p and p ~= 0 then
+                    local ix = l2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        if sr then
+            local r2Tex = textures:GetControllerIcon('R2');
+            if r2Tex and r2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', r2Tex.image));
+                if p and p ~= 0 then
+                    local ix = r2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        return;
+    end
+
+    -- primary
+    local l2cx = screenOriginX + groupW * 0.5;
+    local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+    if sl then drawImage('L2', l2cx - iw * 0.5, cy - ih * 0.5); end
+    if sr then drawImage('R2', r2cx - iw * 0.5, cy - ih * 0.5); end
+end
+
+-- Convenience wrapper used by the Shared (chord-fallback) row.
+function M.DrawPaletteEditorSharedChordTriggerGlyphs(screenOriginX, screenOriginY, settings)
+    M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, 'sharedChord');
+end
+
+-- Exposed so palettemanager.lua can size the editor row to match the live HUD dimensions
+-- without duplicating the math (slot size, gaps, diamond spacing, etc. all flow through here).
+function M.GetEditorCrossbarRowDimensions(settings)
+    return GetCrossbarDimensions(settings);
+end
+
+-- Legacy GDI hook (kept as a no-op for API compatibility with `palettemanager.lua`).
+-- Pre-1.8.0 this hid the persistent D3D/GDI primitives backing the editor's slot row when
+-- the editor window was not currently drawing. Under 1.8.0's imtext architecture there are
+-- no persistent objects to hide — un-emitted draw calls simply don't render. The function
+-- is retained so callers don't break and so the contract is documented; consider removing
+-- once palettemanager.lua's six call sites are updated.
+function M.HidePaletteEditorPrimitives()
 end
 
 return M;


### PR DESCRIPTION
What changed
- modules/hotbar/crossbar.lua: Two independent floating ImGui windows (CrossbarPreviewL2x2, CrossbarPreviewR2x2) always display the 8-slot diamond for the corresponding double-tap bar including live cooldowns. Slot backgrounds render at base opacity; icon/text dims with inactiveSideWhileTriggerDim when any trigger is held (both previews dim equally). When a double-tap is live the preview swaps to show the base L2 or R2 bar as reference. Windows omit NoBringToFrontOnFocus so they stay in front of the main crossbar; WindowPadding zeroed to prevent clip-rect edge clipping. Drag anchors sit above the window via anchorSide=top. MakePreviewSettings cached on geometry signature; early-exit when baseOp <= 0.02. Skillchain and Magic Burst borders enabled in preview slot rendering; MP cost and quantity displays suppressed.
- config/crossbar_settings.lua: Show Double-Tap Crossbars Preview checkbox, Preview Scale slider (0.30-1.0), Preview Opacity slider (0.20-1.0), Lock Preview Positions toggle - all nested under Enable Double-Tap.
- core/settings/factories.lua: showDoubleTapPreview=false, doubleTapPreviewScale=0.60, doubleTapPreviewOpacity=1.0, doubleTapPreviewLocked=false defaults.
- libs/drawing.lua: DrawMoveAnchor gains anchorSide='top' option (with windowWidth for centering) so the drag handle can be placed above the target window rather than to its left.

Why
- Players can see their double-tap bar contents and cooldowns at a glance without activating the double-tap. Preview swaps to base bar while double-tap is live so both bars are always visible. SC/MB borders show eligibility in preview; quantity and MP cost omitted to reduce preview noise.