### PR TITLE
Crossbar Edit Full Palette: draft layer, drag-drop, undo, Move Macro,…

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -55,6 +55,31 @@ local settingsUpdater = require('core.settings.updater');
 local gameState = require('core.gamestate');
 local uiModules = require('core.moduleregistry');
 local profileManager = require('core.profile_manager');
+local sharedMacroStore = require('core.shared_macro_store');
+
+-- When gConfig is replaced, hotbar data caches must be invalidated (macroIdLookup points into macroDB)
+local function xiuiInvalidateHotbarDataCaches()
+    local ok, d = pcall(require, 'modules.hotbar.data');
+    if (ok and d and d.InvalidateConfigDerivedCaches) then
+        d.InvalidateConfigDerivedCaches();
+    end
+end
+
+-- Apply Crossbar "Default Palette Type" from the loaded profile only (not on zone/level/job packets).
+local function xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad()
+    local okD, dataMod = pcall(require, 'modules.hotbar.data');
+    local okP, paletteMod = pcall(require, 'modules.hotbar.palette');
+    if not (okD and okP and dataMod and paletteMod) then
+        return;
+    end
+    if dataMod.SetPlayerJob and dataMod.SetPlayerJob() and dataMod.jobId then
+        pcall(function()
+            paletteMod.ValidatePalettesForJob(dataMod.jobId, dataMod.subjobId or 0, { applyDefaultCrossbarScope = true });
+        end);
+    else
+        paletteMod.NotifyProfileSettingsLoaded();
+    end
+end
 
 -- UI modules
 local uiMods = require('modules.init');
@@ -82,6 +107,7 @@ local palette = require('modules.hotbar.palette');
 local skillchainModule = require('modules.hotbar.skillchain');
 local slotrenderer = require('modules.hotbar.slotrenderer');
 local configMenu = require('config');
+local paletteManager = require('config.palettemanager');
 local debuffHandler = require('handlers.debuffhandler');
 local petBuffHandler = require('handlers.petbuffhandler');
 local actionTracker = require('handlers.actiontracker');
@@ -283,7 +309,6 @@ uiModules.Register('hotbar', {
     settingsKey = 'hotbarSettings',
     configKey = 'showhotbar',
     hideOnEventKey = 'hotbarHideDuringEvents',
-    hideOnMenuFocusKey = 'hotbarHideOnMenuFocus',
     hasSetHidden = true,
 });
 uiModules.Register('readyCheck', {
@@ -307,7 +332,7 @@ local migrationResult = settingsMigration.MigrateFromHXUI();
 -- Load raw settings to detect legacy data (without default filtering)
 -- Use pcall to handle first-load case where no settings exist
 local rawSettingsSuccess, rawSettings = pcall(function()
-    return settings.load({});
+    return settings.load(T{});
 end);
 if not rawSettingsSuccess then
     rawSettings = {}; -- No existing settings, nothing to migrate
@@ -460,8 +485,19 @@ end
 -- ==========================================================
 
 -- Load character settings (tracks which profile is active)
-local charSettings = settings.load({ currentProfile = 'Default' });
+local charSettings = settings.load(T{ currentProfile = 'Default' });
 config = charSettings; -- Keep reference to character config
+
+-- Initialize per-character known weaponskills cache
+do
+    if not charSettings.knownWeaponskills then
+        charSettings.knownWeaponskills = {};
+    end
+    local okPd, pd = pcall(require, 'modules.hotbar.playerdata');
+    if okPd and pd and pd.SetKnownWeaponskills then
+        pd.SetKnownWeaponskills(charSettings.knownWeaponskills);
+    end
+end
 
 -- Global profiles list
 local globalProfiles = profileManager.GetGlobalProfiles();
@@ -539,6 +575,9 @@ end
 
 gConfigVersion = 0;
 settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+xiuiInvalidateHotbarDataCaches();
+xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
 
 -- Show migration message
 
@@ -595,7 +634,12 @@ function CreateProfile(name)
     return true;
 end
 
-function DuplicateProfile(name)
+-- options.includeMacroLibrary: default true (full file clone). When false, macroDB is reset and
+-- palette-macro bar slots are cleared; use for a new character that should keep layout but not
+-- the source macro library. Use Profile -> Export/Import JSON to move a chosen macro set.
+function DuplicateProfile(name, options)
+    options = options or {};
+    local includeMacroLibrary = (options.includeMacroLibrary ~= false);
     local baseName = name;
     -- If duplicating Default, we might want to name it "Profile (1)" or just "Default (1)"
 
@@ -611,6 +655,17 @@ function DuplicateProfile(name)
     if (currentSettings == nil) then return false; end
 
     local newSettings = deep_copy_table(currentSettings);
+    if (not includeMacroLibrary) then
+        newSettings.macroDB = {};
+        newSettings.macroCustomCategories = deep_copy_table(defaultUserSettings.macroCustomCategories or T{});
+        newSettings.macroCustomNextSeq = defaultUserSettings.macroCustomNextSeq or 1;
+        newSettings.macroXiuiDefaultsSeeded = false;
+        newSettings.macroGlobalUniversalTwoHourSeeded = false;
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if (ok and hotbarData and hotbarData.StripPaletteMacroBindsFromSettings) then
+            hotbarData.StripPaletteMacroBindsFromSettings(newSettings);
+        end
+    end
     profileManager.SaveProfileSettings(newName, newSettings);
 
     local globalProfiles = profileManager.GetGlobalProfiles();
@@ -622,13 +677,27 @@ function DuplicateProfile(name)
     return true;
 end
 
+-- Writes profiles/<name>.lua. When macroStorageScope is shared, the profile file keeps the frozen
+-- macroDB snapshot; the live global library is saved to SharedMacros.lua.
+function SaveCurrentProfileFileToDisk()
+    if sharedMacroStore.IsSharedScope(gConfig) then
+        local oldM = gConfig.macroDB;
+        gConfig.macroDB = sharedMacroStore.GetProfileMacroDbForSave(gConfig);
+        profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+        gConfig.macroDB = oldM;
+        sharedMacroStore.PersistSharedLibraryIfNeeded(gConfig);
+    else
+        profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    end
+end
+
 
 
 function ChangeProfile(name)
     if (not profileManager.ProfileExists(name)) then return false; end
 
     -- Always save current profile before switching (positions, etc.)
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
 
     config.currentProfile = name;
     bInternalSave = true;
@@ -650,6 +719,9 @@ function ChangeProfile(name)
     end
 
     settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+    sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+    xiuiInvalidateHotbarDataCaches();
+    xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
     UpdateSettings();
     return true;
 end
@@ -678,7 +750,11 @@ function ResetSettings()
     gConfig = deep_copy_table(defaultUserSettings);
     gConfig.windowPositions = GetDefaultWindowPositions();
     gConfig.appliedPositions = {};
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+    sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+    xiuiInvalidateHotbarDataCaches();
+    xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
+    SaveCurrentProfileFileToDisk();
 
     -- Reset all module positions to defaults BEFORE deferring visuals so the
     -- next-frame UpdateVisualsAll picks up the corrected positions.
@@ -722,7 +798,7 @@ function RecoverAllPositions()
     gConfig.partyListState = {};
 
     -- Save
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
     bInternalSave = true;
     settings.save();
     if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
@@ -747,7 +823,7 @@ function SaveSettingsToDisk()
         gConfig.colorCustomization = deep_copy_table(defaultUserSettings.colorCustomization);
     end
     gConfigVersion = gConfigVersion + 1; -- Notify caches of settings change
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
     bInternalSave = true;
     settings.save();
     if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
@@ -758,7 +834,7 @@ function SaveSettingsOnly()
         gConfig.colorCustomization = deep_copy_table(defaultUserSettings.colorCustomization);
     end
     gConfigVersion = gConfigVersion + 1; -- Notify caches of settings change
-    profileManager.SaveProfileSettings(config.currentProfile, gConfig);
+    SaveCurrentProfileFileToDisk();
     bInternalSave = true;
     settings.save();
     if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
@@ -942,6 +1018,9 @@ settings.register('settings', 'settings_update', function (s)
 
         -- Run migrations
         settingsMigration.RunStructureMigrations(gConfig, defaultUserSettings);
+        sharedMacroStore.ApplyAfterProfileLoad(gConfig);
+        xiuiInvalidateHotbarDataCaches();
+        xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad();
 
         -- Update visuals
         UpdateSettings();
@@ -962,6 +1041,14 @@ ashita.events.register('d3d_present', 'present_cb', function ()
     if not bInitialized then return; end
 
     local ok, err = pcall(function()
+        -- Reset ImGui cursor to Arrow at the start of every frame.
+        -- FFXI uses a DirectX hardware cursor that can get lost on alt+tab;
+        -- resetting here ensures we never leave a stale Hand/None cursor
+        -- state that survives into the first frame after the game regains focus.
+        if imgui and imgui.SetMouseCursor then
+            imgui.SetMouseCursor(0); -- 0 = ImGuiMouseCursor_Arrow
+        end
+
         -- Drop references to textures evicted/cleared during the PREVIOUS
         -- frame so Lua GC is free to run d3d8.gc_safe_release on them.
         -- Must run before anything else this frame queues new draws or
@@ -1018,6 +1105,13 @@ ashita.events.register('d3d_present', 'present_cb', function ()
             end
 
             configMenu.DrawWindow();
+            -- Floating Palette Manager + shared modals (must run outside config hotbar/crossbar tabs or /xiui pal never draws)
+            paletteManager.Draw();
+
+            -- Finalize drag-drop after all drop zones (including palette editor) have been processed
+            if hotbar.FinalizeFrame then
+                hotbar.FinalizeFrame();
+            end
 
             -- Render deferred hotbar tooltip after all modules (correct z-order)
             slotrenderer.FlushTooltip();
@@ -1118,6 +1212,26 @@ ashita.events.register('command', 'command_cb', function (e)
             return;
         end
 
+        -- Debug: print the current FFXI menu name to chat: /xiui menuname
+        if (#command_args == 2 and command_args[2]:any('menuname', 'menu')) then
+            local gamestate = require('core.gamestate');
+            local raw  = gamestate.GetMenuName();
+            local isContainer = gamestate.IsContainerNavigationMenu();
+            AshitaCore:GetChatManager():QueueCommand(1, string.format(
+                '/echo [XIUI] Menu: "%s" | container-nav: %s', raw, tostring(isContainer)));
+            return;
+        end
+
+        -- /xiui pal - toggle floating Palette Manager (hotbar); /xiui pal <...> still cycles/selects palettes below
+        if #command_args == 2 and command_args[2] == 'pal' then
+            if paletteManager.ToggleHotbarPaletteManager() then
+                print('[XIUI] Palette Manager opened (Hotbar).');
+            else
+                print('[XIUI] Palette Manager closed.');
+            end
+            return;
+        end
+
         -- Open keybind editor: /xiui keybinds or /xiui binds [bar]
         if (#command_args >= 2 and command_args[2]:any('keybinds', 'keybind', 'binds', 'bind')) then
             local hotbarConfig = require('config.hotbar');
@@ -1197,7 +1311,7 @@ ashita.events.register('command', 'command_cb', function (e)
         -- Switch between named palettes. Hotbar palettes (bars 1-6) and the crossbar
         -- have separate palette pools; "all" applies across both, "crossbar"/"cb"/"xb"
         -- targets the crossbar only, a bar number targets a single hotbar.
-        if (command_args[2] == 'palette' or command_args[2] == 'pal') then
+        if (command_args[2] == 'palette' or (command_args[2] == 'pal' and #command_args >= 3)) then
             local paletteModule = require('modules.hotbar.palette');
             local hotbarData = require('modules.hotbar.data');
             local jobId = hotbarData.jobId or 1;
@@ -1380,6 +1494,353 @@ ashita.events.register('command', 'command_cb', function (e)
                     end
                 end
             end
+            return;
+        end
+
+        -- Toggle Edit Full Palette for the currently active crossbar palette (silent): /xiui cpaledit
+        if (command_args[2] == 'cpaledit') then
+            paletteManager.ToggleEditFullPaletteForCurrent();
+            return;
+        end
+
+        -- Crossbar palettes: /xiui cpalette toggles config; Global [G] vs Job storage are separate CLI paths (no Global-Sets gate). Aliases: cpal, xcpalette, xcpal.
+        if (command_args[2] == 'cpalette' or command_args[2] == 'cpal' or command_args[2] == 'xcpalette' or command_args[2] == 'xcpal') then
+            if #command_args == 2 then
+                configMenu.ToggleCrossbarManagePalettes();
+                return;
+            end
+
+            local sub = command_args[3];
+            local originalArgs = e.command:args();
+
+            if sub == 'help' or sub == '?' then
+                print('[XIUI] Crossbar palette:');
+                print('  /xiui cpalette          Toggle Crossbar -> Manage Palettes in config');
+                print('  /xiui cpaledit          Toggle Edit Full Palette for current active palette');
+                print('  /xiui cpalette list     List Global [G] crossbar palettes');
+                print('  /xiui cpalette scope job|universal');
+                print('  /xiui cpalette toggle   (same as controller: hold L1, tap R1)');
+                print('  /xiui cpalette g <name>   Global [G] only (also: global, gname)');
+                print('  /xiui cpalette <JOB> <name|#>   Job [J]-tier (# = order in list)');
+                print('  /xiui cpalette WHMSMN <name|#>   SJ-tier: # = (SJ) rows in Manage, e.g. WHMBLM 1');
+                print('  /xiui cpalette job <JOB> <...>   optional keyword (J-tier)');
+                print('  Other job than yours = temporary preview; RB+D-pad still cycles live job');
+                print('  /xiui cpalette cycle on|off <name>   Global [G] RB+D-pad cycle include');
+                print('  Optional legacy prefix: active ...');
+                return;
+            end
+
+            local cross = gConfig and gConfig.hotbarCrossbar;
+
+            local function cpalXbLogVerbose()
+                local hg = gConfig and gConfig.hotbarGlobal;
+                local v = hg and hg.logPaletteNameCrossbar;
+                if v == nil then return true; end
+                return v == true;
+            end
+            local function cpalXbLogRbHint()
+                if not cpalXbLogVerbose() then return false; end
+                local hg = gConfig and gConfig.hotbarGlobal;
+                local v = hg and hg.logPaletteNameCrossbarCycleHint;
+                if v == nil then return true; end
+                return v == true;
+            end
+            local function cpalNotice(msg)
+                print('[XIUI Notice] ' .. msg);
+            end
+            local function cpalLogJobSuccess(mainAbbr, storageSubjob, sjAbbr, paletteName)
+                if not cpalXbLogVerbose() then return; end
+                local loc;
+                if storageSubjob == 0 then
+                    loc = mainAbbr .. '[J]';
+                else
+                    loc = mainAbbr .. '[SJ:' .. (sjAbbr or '?') .. ']';
+                end
+                print('[XIUI] Crossbar Palette: ' .. loc .. ' "' .. paletteName .. '".');
+            end
+            local function cpalLogGlobalSuccess(paletteName)
+                if not cpalXbLogVerbose() then return; end
+                print('[XIUI] Crossbar Palette: Global[G] "' .. paletteName .. '".');
+            end
+            local function cpalLogPreviewHint()
+                if not cpalXbLogRbHint() then return; end
+                print('[XIUI] RB(R1)+Up/Down to return to Job Palettes.');
+            end
+
+            if sub == 'list' then
+                local names = palette.GetUniversalCrossbarPaletteNamesOrdered();
+                local active = palette.GetActiveUniversalCrossbarPalette();
+                local scope = palette.GetCrossbarPaletteScope();
+                print('[XIUI] Global [G] crossbar palettes (scope: ' .. scope .. '):');
+                for _, name in ipairs(names) do
+                    local inc = palette.GetUniversalPaletteIncludeInCycle(name);
+                    local m = (name == active) and ' *' or '';
+                    local c = inc and '' or ' [cycle off]';
+                    print('  - ' .. name .. m .. c);
+                end
+                return;
+            end
+
+            if sub == 'toggle' then
+                if palette.ToggleCrossbarPaletteScope() then
+                    if cpalXbLogVerbose() then
+                        print('[XIUI] Crossbar palette scope: ' .. palette.GetCrossbarPaletteScope());
+                    end
+                else
+                    if cpalXbLogVerbose() then
+                        print('[XIUI] Scope unchanged (debounced or already toggling).');
+                    end
+                end
+                return;
+            end
+
+            if sub == 'scope' then
+                if not command_args[4] then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+                local s = command_args[4]:lower();
+                if s == 'job' or s == 'universal' then
+                    if palette.SetCrossbarPaletteScope(s) then
+                        if cpalXbLogVerbose() then
+                            print('[XIUI] Crossbar palette scope: ' .. s);
+                        end
+                    else
+                        if cpalXbLogVerbose() then
+                            print('[XIUI] Scope unchanged (already ' .. s .. ').');
+                        end
+                    end
+                else
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                end
+                return;
+            end
+
+            if sub == 'cycle' then
+                if not command_args[4] or #originalArgs < 5 then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+                local onoff = command_args[4]:lower();
+                if onoff ~= 'on' and onoff ~= 'off' then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+                local nameParts = {};
+                for i = 5, #originalArgs do
+                    table.insert(nameParts, originalArgs[i]);
+                end
+                local paletteName = table.concat(nameParts, ' ');
+                local key = palette.BuildUniversalCrossbarStorageKey(paletteName);
+                if not cross or not cross.slotActions or not cross.slotActions[key] then
+                    cpalNotice('Cannot find the requested Palette.');
+                    return;
+                end
+                palette.SetUniversalPaletteIncludeInCycle(paletteName, onoff == 'on');
+                if cpalXbLogVerbose() then
+                    print('[XIUI] ' .. paletteName .. ' include in RB+D-pad cycle: ' .. onoff);
+                end
+                return;
+            end
+
+            -- Select crossbar palette: first token at [ps], or after optional "active" at [3].
+            local ps = 3;
+            if sub == 'active' then
+                ps = 4;
+                if #command_args < ps then
+                    cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                    return;
+                end
+            end
+
+            if #command_args >= ps then
+                local tbarMigration = require('handlers.tbar_migration');
+                local hotbarData = require('modules.hotbar.data');
+
+                local function joinOriginalName(fromIdx)
+                    local nameParts = {};
+                    for i = fromIdx, #originalArgs do
+                        table.insert(nameParts, originalArgs[i]);
+                    end
+                    return table.concat(nameParts, ' ');
+                end
+
+                -- Compact MAIN(3)+SUB(3) only (e.g. WHMSMN).
+                local function splitCompactMainSub(compactTok)
+                    local s = compactTok:upper();
+                    if #s ~= 6 then
+                        return nil, nil;
+                    end
+                    local a = s:sub(1, 3);
+                    local b = s:sub(4, 6);
+                    local j1 = tbarMigration.GetJobId(a);
+                    local j2 = tbarMigration.GetJobId(b);
+                    if not j1 or not j2 then
+                        return nil, nil;
+                    end
+                    return j1, j2;
+                end
+
+                local function paletteNameFromTierIndex(mainJobId, storageTier, idx)
+                    local names = palette.GetCrossbarPaletteNamesForOrderTier(mainJobId, storageTier);
+                    if #names == 0 or idx < 1 or idx > #names or idx ~= math.floor(idx) then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return nil;
+                    end
+                    return names[idx];
+                end
+
+                -- WHMSMN # numbering matches (SJ) rows only in Manage (not full SJ bucket list).
+                local function paletteNameFromSjExtrasIndex(mainJobId, sjId, idx)
+                    local names = palette.GetCrossbarSjOnlyPaletteNamesOrdered(mainJobId, sjId);
+                    if #names == 0 or idx < 1 or idx > #names or idx ~= math.floor(idx) then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return nil;
+                    end
+                    return names[idx];
+                end
+
+                local function applyJobPaletteCli(mainJobId, storageSubjob, paletteName)
+                    if not cross then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    if not cross.slotActions then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    local key = palette.BuildPaletteStorageKey(mainJobId, storageSubjob, paletteName);
+                    if not cross.slotActions[key] then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    local crossCfg = cross;
+                    if crossCfg.enableUniversalCrossbarPalettes and palette.GetCrossbarPaletteScope() == 'universal' then
+                        cpalNotice('Cannot apply Job Palettes to Global.');
+                        return;
+                    end
+                    local liveJob = hotbarData.jobId;
+                    local liveSub = hotbarData.subjobId or 0;
+                    local commit = liveJob
+                        and mainJobId == liveJob
+                        and (storageSubjob == 0 or storageSubjob == liveSub);
+                    local jobs = require('libs.jobs');
+                    local jn = jobs[mainJobId] or ('JOB' .. tostring(mainJobId));
+                    local sjAbbr = (storageSubjob ~= 0) and (jobs[storageSubjob] or nil) or nil;
+                    if commit then
+                        palette.SetCpalJobAnchorIfUnset(
+                            palette.GetActivePaletteForCombo(nil),
+                            palette.GetCrossbarActiveStorageSubjob(),
+                            hotbarData.jobId
+                        );
+                        palette.SetActivePaletteForCombo(nil, paletteName, storageSubjob);
+                        cpalLogJobSuccess(jn, storageSubjob, sjAbbr, paletteName);
+                    else
+                        palette.SetCrossbarCliPreview(mainJobId, storageSubjob, paletteName);
+                        cpalLogJobSuccess(jn, storageSubjob, sjAbbr, paletteName);
+                        cpalLogPreviewHint();
+                    end
+                end
+
+                local function parseJobAndApply(firstIdx)
+                    if #command_args < firstIdx + 1 then
+                        cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                        return true;
+                    end
+                    local mainId = tbarMigration.GetJobId(command_args[firstIdx]:upper());
+                    if not mainId then
+                        return false;
+                    end
+                    local tok = command_args[firstIdx + 1];
+                    local idx = tonumber(tok);
+                    if idx and idx >= 1 and idx == math.floor(idx) then
+                        if #command_args > firstIdx + 1 then
+                            cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                            return true;
+                        end
+                        local jobs = require('libs.jobs');
+                        local jn = jobs[mainId] or ('JOB' .. tostring(mainId));
+                        local name = paletteNameFromTierIndex(mainId, 0, idx);
+                        if not name then
+                            return true;
+                        end
+                        applyJobPaletteCli(mainId, 0, name);
+                        return true;
+                    end
+                    local paletteName = joinOriginalName(firstIdx + 1);
+                    if paletteName == '' then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return true;
+                    end
+                    applyJobPaletteCli(mainId, 0, paletteName);
+                    return true;
+                end
+
+                local caFirst = command_args[ps];
+
+                if caFirst == 'global' or caFirst == 'g' or caFirst == 'gname' then
+                    local paletteName = joinOriginalName(ps + 1);
+                    if paletteName == '' then
+                        cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                        return;
+                    end
+                    local key = palette.BuildUniversalCrossbarStorageKey(paletteName);
+                    if cross and cross.slotActions and cross.slotActions[key] then
+                        palette.SetCpalUniversalAnchorIfUnset(palette.GetActiveUniversalCrossbarPalette());
+                        palette.SetActiveUniversalCrossbarPalette(paletteName);
+                        cpalLogGlobalSuccess(paletteName);
+                    else
+                        cpalNotice('Cannot find the requested Palette.');
+                    end
+                    return;
+                end
+
+                local cMain, cSub = splitCompactMainSub(caFirst);
+                if cMain and cSub and #command_args >= ps + 1 then
+                    local tok = command_args[ps + 1];
+                    local idx = tonumber(tok);
+                    if idx and idx >= 1 and idx == math.floor(idx) then
+                        if #command_args > ps + 1 then
+                            cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                            return;
+                        end
+                        local name = paletteNameFromSjExtrasIndex(cMain, cSub, idx);
+                        if not name then
+                            return;
+                        end
+                        applyJobPaletteCli(cMain, cSub, name);
+                        return;
+                    end
+                    local paletteName = joinOriginalName(ps + 1);
+                    if paletteName == '' then
+                        cpalNotice('Cannot find the requested Palette.');
+                        return;
+                    end
+                    applyJobPaletteCli(cMain, cSub, paletteName);
+                    return;
+                end
+
+                if caFirst == 'job' then
+                    if #command_args < ps + 2 then
+                        cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                        return;
+                    end
+                    if parseJobAndApply(ps + 1) then
+                        return;
+                    end
+                    cpalNotice('Cannot find the requested Palette.');
+                    return;
+                end
+
+                if parseJobAndApply(ps) then
+                    return;
+                end
+
+                cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
+                return;
+            end
+
+            cpalNotice('Invalid /xiui cpal command. Try /xiui cpal help');
             return;
         end
 
@@ -1616,8 +2077,8 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         petBar.HandlePacket(e);
     end
 
-    -- Hotbar pet palette sync (0x0068 Pet Sync)
-    if e.id == 0x0068 and gConfig.hotbarEnabled then
+    -- Hotbar pet palette sync (0x0068 Pet Sync) - also updates crossbar pet palettes
+    if e.id == 0x0068 and (gConfig.hotbarEnabled or gConfig.crossbarEnabled) then
         hotbar.HandlePetSyncPacket();
     end
 
@@ -1635,7 +2096,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
             actionTracker.HandleActionPacket(actionPacket);
             if gConfig.showNotifications then notifications.HandleActionPacket(actionPacket); end
             -- Skillchain tracking for hotbar/crossbar WS highlighting
-            if gConfig.hotbarEnabled then
+            if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
                 skillchainModule.HandleActionPacket(actionPacket);
             end
         end
@@ -1660,8 +2121,8 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         ClearEntityCache();
         ResetD3D8Device();
         bLoggedIn = true;
-        -- Initialize hotbar job on zone-in (handles initial login and job change during zone)
-        if gConfig.hotbarEnabled then
+        -- Initialize hotbar/crossbar job on zone-in (handles initial login and job change during zone)
+        if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
             hotbar.HandleJobChangePacket(e);
         end
     elseif (e.id == 0x0029) then
@@ -1708,14 +2169,14 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         TextureManager.clearOnZone();
         ResetD3D8Device();
         bLoggedIn = false;
-        -- Also notify hotbar of zone (clears state)
-        if gConfig.hotbarEnabled then
+        -- Also notify hotbar/crossbar of zone (clears state)
+        if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
             hotbar.HandleZonePacket();
             skillchainModule.ClearState();  -- Clear skillchain tracking on zone
         end
     elseif (e.id == 0x001B) then
-        -- Job change packet - update hotbar to show new job's actions
-        if gConfig.hotbarEnabled then
+        -- Job change packet - update hotbar/crossbar to show new job's actions
+        if gConfig.hotbarEnabled or gConfig.crossbarEnabled then
             hotbar.HandleJobChangePacket(e);
         end
     elseif (e.id == 0x076) then

--- a/XIUI/config/palettemanager.lua
+++ b/XIUI/config/palettemanager.lua
@@ -1,16 +1,25 @@
---[[
+﻿--[[
 * XIUI Config - Palette Manager
-* A separate modal window for managing palettes across job/subjob combinations
-* Supports creating, renaming, deleting, reordering, and copying palettes
+* Floating "Palette Manager" window (hotbar + crossbar list) and shared create/rename/copy modals.
+* Crossbar-only embed (Manage Palettes strip under XIUI Config) also lives here so modals stay one place;
+* the Crossbar *settings* shell is config/crossbar_settings.lua â€” that file calls into this module.
+* Keyboard hotbar palettes: Hotbar category. Controller crossbar palettes: Crossbar category â€” separate edit paths.
 ]]--
 
 require('common');
 require('handlers.helpers');
+local ffi = require('ffi');
 local imgui = require('imgui');
 local jobs = require('libs.jobs');
+local TextureManager = require('libs.texturemanager');
 local palette = require('modules.hotbar.palette');
 local data = require('modules.hotbar.data');
+local crossbar = require('modules.hotbar.crossbar');
+local macropalette = require('modules.hotbar.macropalette');
+local dragdrop = require('libs.dragdrop');
 local components = require('config.components');
+local petAllowlist = require('modules.hotbar.pet_palette_allowlist');
+local efpPets = require('config.efp_pets_tab');
 
 local M = {};
 
@@ -21,6 +30,8 @@ local windowState = {
     selectedSubjobId = nil,  -- 0 = shared
     selectedPaletteType = 'hotbar',  -- 'hotbar' or 'crossbar'
     selectedPaletteName = nil,
+    -- Crossbar floating list: which storage tier (0 = Job [J], N = Subjob [SJ]) is selected
+    selectedCrossbarStorageSubjob = nil,
     statusMessage = nil,  -- Brief status feedback for operations
     statusMessageTime = 0,  -- Time when status was set
 };
@@ -36,12 +47,1789 @@ local modalState = {
     copyTargetSubjobId = nil,
     -- For delete confirmation
     deletePaletteName = nil,
+    -- Crossbar embedded Manage: storage tier for rename/delete/move (merged Shared + subjob view)
+    crossbarOperationSubjob = nil,
+    crossbarCopyFromSubjob = nil,
+    -- Copy: overwrite existing destination palette (same name resolution as palette.lua)
+    copyOverwriteExisting = false,
+    copyDestExistingIndex = 1,
+    -- Crossbar Copy To: destination is Job [J]/Subjob storage vs Global [G] (universal)
+    copyDestScope = 'job', -- 'job' | 'universal'
+    -- Crossbar Job [J]/Subjob [SJ] create: job + storage tier (non-modal; see Copy Toâ€¦ popup)
+    crossbarCreateJobId = nil,
+    crossbarCreateStorageSubjob = nil,
 };
+
+-- Status icons for palette active/inactive display.
+local STATUS_ICON_SIZE = 18;
+local STATUS_COL_W     = 32;
+local COPY_COL_W       = 52;
+-- Status icons (Active/Inactive palette indicators) live at the addon's `assets/` root:
+-- `<addon>/assets/checkmark.png` and `<addon>/assets/x.png`. Loaded via getFileTexture so
+-- `loadTextureFromFile` resolves them under `assets/` and auto-appends the .png extension.
+-- Lazy-cached on first draw and held in module locals so the lookup happens once per session.
+local statusIconCheck  = nil;
+local statusIconX      = nil;
+
+local function DrawStatusIcon(isActive)
+    if isActive then
+        statusIconCheck = statusIconCheck or TextureManager.getFileTexture('checkmark');
+    else
+        statusIconX = statusIconX or TextureManager.getFileTexture('x');
+    end
+    local tex = isActive and statusIconCheck or statusIconX;
+    -- Center within column 0: use offset of separator 0→1 for the true pixel span.
+    local colStart = imgui.GetColumnOffset(0);
+    local colEnd   = imgui.GetColumnOffset(1);
+    local iconX    = colStart + math.floor((colEnd - colStart - STATUS_ICON_SIZE) / 2);
+    imgui.SetCursorPosX(math.max(colStart, iconX));
+    if tex and tex.image then
+        local ptr = tonumber(ffi.cast('uint32_t', tex.image));
+        if ptr then
+            imgui.Image(ptr, { STATUS_ICON_SIZE, STATUS_ICON_SIZE }, { 0, 0 }, { 1, 1 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 });
+            return;
+        end
+    end
+    -- Fallback if texture not available
+    if isActive then
+        imgui.TextColored({ 0.3, 0.9, 0.3, 1.0 }, 'v');
+    else
+        imgui.TextColored({ 0.9, 0.3, 0.3, 1.0 }, 'x');
+    end
+end
+
+local function DrawCreateMacroButton(cmd, displayName, uniqueId)
+    imgui.PushStyleColor(ImGuiCol_Button,        { 0.15, 0.30, 0.50, 0.80 });
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.25, 0.45, 0.70, 0.95 });
+    imgui.PushStyleColor(ImGuiCol_ButtonActive,  { 0.10, 0.35, 0.60, 1.00 });
+    if imgui.SmallButton('+M##' .. uniqueId) then
+        macropalette.OpenNewMacroWithText(cmd, displayName);
+    end
+    imgui.PopStyleColor(3);
+    if imgui.IsItemHovered() then
+        imgui.BeginTooltip();
+        imgui.Text('Create macro with command:');
+        imgui.TextColored({ 0.85, 0.85, 0.35, 1.0 }, cmd);
+        imgui.EndTooltip();
+    end
+end
+
+-- One-shot open flags: imgui.OpenPopup must be called exactly once (not every frame).
+-- If called every frame it overrides ImGui's close-on-click-outside, causing popups to
+-- reposition to the cursor instead of closing.
+local xbJobCreatePopupPending  = false;
+local createRenamePopupPendingId = nil;
+local copyPopupPending         = false;
+local deletePopupPending       = false;
+local useSharedPopupPending    = false;
+
+-- Persists the last-selected job/storageSubjob in the crossbar New popup across opens.
+-- Resets to live character job/sj only when the actual job or subjob changes.
+local xbCreatePersisted = {
+    jobId = nil,
+    storageSubjob = nil,
+    lastSeenJobId = nil,
+    lastSeenSubjobId = nil,
+};
+
+local function GetOrResetXbCreateDefaults()
+    local liveJob = data.jobId or 1;
+    local liveSj  = data.subjobId or 0;
+    if xbCreatePersisted.lastSeenJobId ~= liveJob or xbCreatePersisted.lastSeenSubjobId ~= liveSj then
+        xbCreatePersisted.jobId          = liveJob;
+        xbCreatePersisted.storageSubjob  = liveSj;
+        xbCreatePersisted.lastSeenJobId  = liveJob;
+        xbCreatePersisted.lastSeenSubjobId = liveSj;
+    end
+    return xbCreatePersisted.jobId, xbCreatePersisted.storageSubjob;
+end
+
+-- Embedded Crossbar Palette Manager (Manage Palettes & Crossbar tab â€” no floating window)
+local embedCrossbarJobContext = {
+    selectedPaletteName = nil,
+    selectedStorageSubjob = nil,
+};
+
+local embedCrossbarUniversalContext = {
+    selectedPaletteName = nil,
+};
+
+-- "Edit Full Palette": large floating window (same idea as Palette Manager, not a dimming modal)
+-- ctx: { kind = 'job'|'universal', name, jobId?, subjobId?, st? } (legacy: missing kind => job)
+local embedCrossbarComboCtx = nil;
+local embedCrossbarComboWinOpen = { false };
+-- After "Edit Full Palette" click: avoid clearing ctx on the first frame before Begin() succeeds (some ImGui builds).
+local embedCrossbarComboWinGraceFrames = 0;
+local embedCrossbarComboHasDrawn = false;
+-- Stable height for ##xbFullPalScroll: recomputing GetContentRegionAvail() every frame can jitter 1px and reset scroll.
+local editFullPaletteScrollHCached = nil;
+local EDIT_FULL_PALETTE_WINDOW_KEY = 'EditFullPalette';
+-- Default / clamp width for the embedded Edit Full Palette window (was 680; wider helps L2/R2 footer columns)
+local EDIT_FULL_PALETTE_WIN_W = 700;
+-- When true, horizontal size is fixed to EDIT_FULL_PALETTE_WIN_W (constraints min/max width equal); height still obeys limits below.
+local EDIT_FULL_PALETTE_WIN_LOCK_WIDTH = false;
+local EDIT_FULL_PALETTE_WIN_W_MIN = 700;
+local EDIT_FULL_PALETTE_WIN_W_MAX = 1400;
+-- Default height: inner area scrolls; do not drive window height from content (that caused scroll â€œjumpingâ€).
+local EDIT_FULL_PALETTE_WIN_H_DEFAULT = 760;
+-- Resizable height range (constraints). When LOCK_HEIGHT is true, min/max height both use H_DEFAULT (fixed height).
+local EDIT_FULL_PALETTE_WIN_H_MIN = 400;
+local EDIT_FULL_PALETTE_WIN_H_MAX = 1150;
+local EDIT_FULL_PALETTE_WIN_LOCK_HEIGHT = false;
+-- Vertical slice reserved for the gap after the scroll child + Undo/Apply/Close row (must stay fixed frame-to-frame).
+local EDIT_FULL_PALETTE_FOOTER_BLOCK_H = 44;
+-- Per-segment work copies for inline pet type editor (Edit Full Palette); reset when embedded window reopens
+local petEfpModeWork = nil;
+
+-- User closed XIUI Config while Edit Full Palette was open: show confirm on next palette draw.
+local openCloseConfigConfirmPopup = false;
+local openUnsavedChangesPopup = false;
+-- Pending palette switch: when the user picks a different palette from the dropdown but has unsaved changes.
+local pendingPaletteSwitchName = nil;
+-- Edit Full Palette: Slots (0) vs Pets (1) for job palettes; set when a tab change needs Apply/Discard.
+local embedEfpSubTab = 0;
+local pendingEfpSubTab = nil;
+
+-- Embedded Palette Manager (Crossbar tab): fixed list viewport = column headers + N rows, then scroll.
+local EMBED_CROSSBAR_PAL_LIST_VISIBLE_ROWS = 3;
+
+local function GetItemSpacingY()
+    local st = imgui.GetStyle and imgui.GetStyle();
+    if not st or not st.ItemSpacing then
+        return 8;
+    end
+    local is = st.ItemSpacing;
+    if type(is) == 'table' then
+        return math.floor((is[2] or is.y or 8) + 0.5);
+    end
+    return math.floor((tonumber(is) or 8) + 0.5);
+end
+
+local function GetContentRegionAvailHeight()
+    if not imgui.GetContentRegionAvail then
+        return 200;
+    end
+    local a, b = imgui.GetContentRegionAvail();
+    local h = 200;
+    if type(a) == 'table' then
+        h = a[2] or a.y or 200;
+    elseif type(b) == 'number' then
+        h = b;
+    end
+    -- Whole pixels: sub-pixel avail jitter changes BeginChild height and fights scroll at the bottom.
+    return math.floor(h + 0.5);
+end
+
+-- Two button rows + spacing (New/Rename/Copy/Delete/Up/Down, Enable/Disable + Edit Full Palette).
+local function GetEmbedCrossbarPalMgrActionBlockH()
+    local lineH = imgui.GetTextLineHeightWithSpacing();
+    local frameH = (imgui.GetFrameHeight and imgui.GetFrameHeight()) or (lineH * 1.45);
+    local gap = GetItemSpacingY();
+    return math.ceil(frameH * 2 + gap);
+end
+
+local function ForceCloseEditFullPaletteWindow()
+    embedCrossbarComboWinOpen[1] = false;
+    embedCrossbarComboCtx = nil;
+    embedCrossbarComboWinGraceFrames = 0;
+    embedCrossbarComboHasDrawn = false;
+    editFullPaletteScrollHCached = nil;
+    data.FullyClosePaletteEditSession();
+    crossbar.HidePaletteEditorPrimitives();
+end
+
+-- Called from config.lua when the user dismisses the main XIUI Config window.
+function M.DeferConfigCloseIfEditFullPaletteOpen()
+    -- Only block when the Edit Full Palette *window* is still open (not just grace-held ctx after close).
+    if not embedCrossbarComboWinOpen[1] then
+        return false;
+    end
+    -- No unsaved crossbar draft: close the editor and allow config to close without a modal.
+    if not data.IsDraftDirty() then
+        ForceCloseEditFullPaletteWindow();
+        return false;
+    end
+    openCloseConfigConfirmPopup = true;
+    return true;
+end
+
+local function BuildEditFullPaletteViewSettings(cross)
+    local v = {};
+    -- Copy all non-visual properties (palette data, mode toggles, overrides, etc.)
+    for k, val in pairs(cross or {}) do
+        v[k] = val;
+    end
+    -- Fixed visual constants â€” not derived from the user's crossbar display config.
+    -- Every user sees an identical editor layout regardless of their gameplay crossbar settings.
+    v.slotSize            = 38;
+    v.buttonIconSize      = 20;
+    v.labelFontSize       = 13;
+    v.recastTimerFontSize = 9;
+    v.mpCostFontSize      = 9;
+    v.quantityFontSize    = 9;
+    v.slotGapV            = 6;
+    v.slotGapH            = 6;
+    v.diamondSpacing      = 20;
+    v.groupSpacing        = 40;
+    return v;
+end
+
+-- Storage tier for named job palettes (0 = Job [J] shared tier, N = that subjob's tier).
+-- Must match data.GetCrossbarStorageKeyForCombo / palette.GetCrossbarActivePaletteStorageSubjobForResolution,
+-- not raw live subjob id â€” otherwise "shared" palettes used while /SJ is equipped resolve to an empty bucket.
+local function GetEmbedJobPaletteStorageTier(jobId, liveSubjobId)
+    local lj = liveSubjobId or 0;
+    if lj == 0 then
+        return 0;
+    end
+    if palette.GetCrossbarActivePaletteStorageSubjobForResolution then
+        return palette.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, lj) or 0;
+    end
+    return 0;
+end
+
+function M.ToggleEditFullPaletteForCurrent()
+    if embedCrossbarComboWinOpen[1] and embedCrossbarComboCtx then
+        ForceCloseEditFullPaletteWindow();
+        return false;
+    end
+    local activeName = palette.GetActivePaletteForCombo and palette.GetActivePaletteForCombo('L2') or nil;
+    if not activeName or activeName == '' then
+        return nil;
+    end
+    local scope = palette.GetCrossbarPaletteScope and palette.GetCrossbarPaletteScope() or 'job';
+    if scope == 'universal' then
+        embedCrossbarComboCtx = { kind = 'universal', name = activeName };
+    else
+        local jid = data.jobId or 1;
+        local sj = data.subjobId or 0;
+        embedCrossbarComboCtx = {
+            kind = 'job',
+            jobId = jid,
+            subjobId = sj,
+            name = activeName,
+            st = GetEmbedJobPaletteStorageTier(jid, sj),
+        };
+    end
+    embedCrossbarComboWinOpen[1] = true;
+    embedCrossbarComboWinGraceFrames = 0;
+    embedCrossbarComboHasDrawn = false;
+    return true;
+end
+
+local function GetEmbedFullPaletteStorageKey(ctx)
+    local kind = ctx.kind or 'job';
+    if kind == 'universal' then
+        return palette.BuildUniversalCrossbarStorageKey(ctx.name);
+    end
+    local jobId = ctx.jobId or 1;
+    local tier = tonumber(ctx.st) or 0;
+    return palette.BuildPaletteStorageKey(jobId, tier, ctx.name);
+end
+
+local function JobNameShort(jobId)
+    if jobId == nil or jobId == 0 then
+        return 'Shared';
+    end
+    return jobs[jobId] or ('Job ' .. tostring(jobId));
+end
+
+local function BuildEmbedFullPaletteScopeLine(ctx, kind)
+    if kind == 'universal' then
+        return 'Global [G] - "' .. (ctx.name or '?') .. '"';
+    end
+    local jid = ctx.jobId or 1;
+    local st = tonumber(ctx.st) or 0;
+    local tier = (st == 0) and 'Shared (J)' or string.format('%s (SJ)', JobNameShort(st));
+    if st == 0 then
+        return string.format('%s - %s - "%s"', JobNameShort(jid), tier, ctx.name or '?');
+    else
+        local tabSj = ctx.subjobId or 0;
+        return string.format(
+            '%s/%s - %s - "%s"',
+            JobNameShort(jid),
+            (tabSj == 0) and 'Shared' or JobNameShort(tabSj),
+            tier,
+            ctx.name or '?'
+        );
+    end
+end
+
+-- Screen-space AABB of the current window's content region (for clipping embedded D3D / GDI crossbar draws).
+local function GetCurrentWindowContentScreenRect()
+    if not imgui.GetWindowPos or not imgui.GetWindowContentRegionMin or not imgui.GetWindowContentRegionMax then
+        return nil;
+    end
+    local wx, wy = imgui.GetWindowPos();
+    local cminX, cminY = imgui.GetWindowContentRegionMin();
+    local cmaxX, cmaxY = imgui.GetWindowContentRegionMax();
+    if wx == nil or cminX == nil or cmaxX == nil then
+        return nil;
+    end
+    return wx + cminX, wy + cminY, wx + cmaxX, wy + cmaxY;
+end
+
+local function GetCurrentWindowScreenRect()
+    if not imgui.GetWindowPos or not imgui.GetWindowSize then
+        return nil;
+    end
+    local wx, wy = imgui.GetWindowPos();
+    local ww, wh = imgui.GetWindowSize();
+    if wx == nil or ww == nil then
+        return nil;
+    end
+    return wx, wy, wx + ww, wy + wh;
+end
+
+local function IntersectRect(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2)
+    if not ax1 or not bx1 then
+        return nil;
+    end
+    local x1 = math.max(ax1, bx1);
+    local y1 = math.max(ay1, by1);
+    local x2 = math.min(ax2, bx2);
+    local y2 = math.min(ay2, by2);
+    if x1 >= x2 or y1 >= y2 then
+        return nil;
+    end
+    return x1, y1, x2, y2;
+end
+
+local function copyAllowlistTbl(v)
+    if v == nil then return nil; end
+    local c = {};
+    for i = 1, #v do
+        c[i] = v[i];
+    end
+    return c;
+end
+
+-- Resolve pet type list for a segment: per-mode, else default on crossbar, else all (nil).
+local function getEffectiveSegPetKeys(cross, mode)
+    if not cross or not mode then
+        return nil;
+    end
+    local cm = cross.comboModeSettings and cross.comboModeSettings[mode];
+    if cm and cm.petPalettePetKeys ~= nil then
+        return cm.petPalettePetKeys;
+    end
+    if cross.petPalettePetKeys ~= nil then
+        return cross.petPalettePetKeys;
+    end
+    return nil;
+end
+
+-- Edit Full Palette Pets tab: which segments map to the chosen pet and Pet Palette / allowlist (Slots tab).
+local function petEfpSegmentRowVisible(cross, mode, petKey)
+    if not cross or not mode or not petKey or petKey == '' then
+        return false;
+    end
+    local m = cross.comboModeSettings and cross.comboModeSettings[mode];
+    if not m or m.petAware ~= true then
+        return false;
+    end
+    return petAllowlist.Allows({ petPalettePetKeys = getEffectiveSegPetKeys(cross, mode) }, petKey);
+end
+
+local function stripNamedPalettePetFields(cross)
+    if not cross or not cross.namedPaletteComboModeSettings then
+        return;
+    end
+    for sk, row in pairs(cross.namedPaletteComboModeSettings) do
+        if type(row) == 'table' then
+            for _, m in ipairs({ 'L2', 'R2', 'L2x2', 'R2x2', 'L2R2', 'R2L2' }) do
+                local c = row[m];
+                if c and type(c) == 'table' then
+                    c.petPalettePetKeys = nil;
+                    c.petAware = nil;
+                    if next(c) == nil then
+                        row[m] = nil;
+                    end
+                end
+            end
+            if next(row) == nil then
+                cross.namedPaletteComboModeSettings[sk] = nil;
+            end
+        end
+    end
+end
+
+local function applySegmentPetTypeKeys(cross, mode, newList)
+    if not cross or not mode then
+        return;
+    end
+    if not cross.comboModeSettings then
+        cross.comboModeSettings = {};
+    end
+    if not cross.comboModeSettings[mode] then
+        cross.comboModeSettings[mode] = {};
+    end
+    if petAllowlist.IsEffectivelyAllTypes(newList) then
+        cross.comboModeSettings[mode].petPalettePetKeys = nil;
+    else
+        cross.comboModeSettings[mode].petPalettePetKeys = copyAllowlistTbl(newList) or {};
+    end
+    stripNamedPalettePetFields(cross);
+    if petEfpModeWork then
+        petEfpModeWork[mode] = nil;
+    end
+end
+
+local function drawJobSegmentInlinePetTypes(cross, mode, _maxWidth, idSuffix, jobId)
+    if not cross or not mode or not jobId then
+        return;
+    end
+    local baseM = cross.comboModeSettings and cross.comboModeSettings[mode];
+    if not baseM or not baseM.petAware then
+        return;
+    end
+    if not petEfpModeWork then
+        petEfpModeWork = {};
+    end
+    if not petEfpModeWork[mode] then
+        petEfpModeWork[mode] = { petPalettePetKeys = petAllowlist.CopyAllowlistForEditor(getEffectiveSegPetKeys(cross, mode)) };
+    end
+    local wk = petEfpModeWork[mode];
+    local function onInv()
+        if data.InvalidateStorageKeyCache then
+            data.InvalidateStorageKeyCache();
+        end
+        if data.InvalidateCrossbarDraftLayout then
+            data.InvalidateCrossbarDraftLayout();
+        end
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+    local function onSave()
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+    end
+    local function onApply(w)
+        applySegmentPetTypeKeys(cross, mode, w.petPalettePetKeys);
+    end
+    -- ASCII-only labels: game fonts often render em dash / ellipsis as "?"
+    local popupId = 'pet_type_cfg_' .. (tostring(idSuffix or 'x') .. '_' .. tostring(mode)):gsub('%W', '_');
+    imgui.Dummy({ 0, 6 });
+    imgui.PushID('petinline_' .. popupId);
+    imgui.TextColored(components.TAB_STYLE.gold, 'Pet types: ' .. tostring(mode));
+    imgui.SameLine(0, 10);
+    if imgui.SmallButton('Configure##' .. popupId) then
+        if imgui.SetNextWindowSize and ImGuiCond_Appearing ~= nil then
+            imgui.SetNextWindowSize({ 400, 0 }, ImGuiCond_Appearing);
+        end
+        imgui.OpenPopup(popupId);
+    end
+    if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
+        imgui.TextWrapped(
+            'Applies to this trigger segment for every [J] named palette. If you leave a segment empty here, the crossbar-wide default list is used (if you set one). L2, R2, L2x2, and chord rows can each be different.'
+        );
+        imgui.Spacing();
+        petAllowlist.DrawEditorPanel(wk, jobId, onSave, onInv, onApply);
+        imgui.EndPopup();
+    end
+    imgui.PopID();
+end
+
+-- Pet Palette toggle per combo-mode segment: stored on comboModeSettings[mode] only (job-wide, not per named palette).
+local function DrawJobSegmentPetGlobalControls(_storageKey, mode, label, cross, _named, opts)
+    opts = opts or {};
+    local showGoldLabel = opts.showGoldLabel ~= false;
+    if not cross or not cross.comboModeSettings then
+        return;
+    end
+    if not cross.comboModeSettings[mode] then
+        cross.comboModeSettings[mode] = {};
+    end
+    local baseM = cross.comboModeSettings[mode];
+    if baseM.petAware == nil then
+        baseM.petAware = false;
+    end
+    local effPet = baseM.petAware == true;
+
+    if showGoldLabel and label and label ~= '' then
+        imgui.TextColored(components.TAB_STYLE.gold, label);
+    end
+    local petBuf = { effPet };
+    if imgui.Checkbox('Pet Palette##petxb_' .. mode, petBuf) then
+        baseM.petAware = not effPet;
+        if not baseM.petAware and petEfpModeWork then
+            petEfpModeWork[mode] = nil;
+        end
+        if SaveSettingsOnly then SaveSettingsOnly(); end
+        if data.InvalidateStorageKeyCache then data.InvalidateStorageKeyCache(); end
+        if data.InvalidateCrossbarDraftLayout then data.InvalidateCrossbarDraftLayout(); end
+        if DeferredUpdateVisuals then DeferredUpdateVisuals(); end
+    end
+    imgui.ShowHelp(
+        'When enabled, this 8-slot group can use pet/avatar hotbar storage while a matching pet is out. '
+            .. 'Set which pet types count per segment in the â€œPet typesâ€ block below. Same for every [J] named palette, not per palette name.'
+    );
+end
+
+-- Job [J] Edit Full Palette: segment override (Job-shared storage or Global [G] source). Primary L2/R2 omit via caller.
+local SEGMENT_OVERRIDE_COMBO_W = 220;
+-- Segment overrides are keyed per job in settings, but gameplay resolves using the *current* job id.
+-- Global [G] redirects must therefore exist for every job id, or only the row you edited would work in-game.
+local SEGMENT_OVERRIDE_JOB_MAX = 22;
+
+local function ClearSegmentOverrideModeForAllJobs(cross, eff)
+    if not cross or not cross.segmentOverrides or not eff then
+        return;
+    end
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local jks = tostring(jid);
+        local modes = cross.segmentOverrides[jks];
+        if modes and modes[eff] then
+            modes[eff] = nil;
+            if next(modes) == nil then
+                cross.segmentOverrides[jks] = nil;
+            end
+        end
+    end
+    if cross.segmentOverrides and next(cross.segmentOverrides) == nil then
+        cross.segmentOverrides = nil;
+    end
+end
+
+-- One shared table for all jobs so palette name edits stay in sync in the UI.
+local function ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, globalPaletteName)
+    if not cross then
+        return;
+    end
+    if not cross.segmentOverrides then
+        cross.segmentOverrides = {};
+    end
+    local gp = (type(globalPaletteName) == 'string' and globalPaletteName ~= '') and globalPaletteName or nil;
+    local ent = { scope = 'global', globalPalette = gp };
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local jks = tostring(jid);
+        if not cross.segmentOverrides[jks] then
+            cross.segmentOverrides[jks] = {};
+        end
+        cross.segmentOverrides[jks][eff] = ent;
+    end
+end
+
+-- Switching one job from Global to Job-shared must not mutate the shared global table (same ref on all jobs).
+local function SplitGlobalSegmentToJobSharedForOneJob(cross, eff, editedJkStr, globalPaletteName)
+    if not cross then
+        return;
+    end
+    if not cross.segmentOverrides then
+        cross.segmentOverrides = {};
+    end
+    local gp = (type(globalPaletteName) == 'string' and globalPaletteName ~= '') and globalPaletteName or nil;
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local jks = tostring(jid);
+        if not cross.segmentOverrides[jks] then
+            cross.segmentOverrides[jks] = {};
+        end
+        if jks == editedJkStr then
+            cross.segmentOverrides[jks][eff] = { scope = 'jobShared' };
+        else
+            cross.segmentOverrides[jks][eff] = { scope = 'global', globalPalette = gp };
+        end
+    end
+end
+
+-- Persist full job rows for legacy configs that only stored Global on one job id.
+-- Do not run when any job uses Job-shared for this segment (valid per-job mix with others on Global).
+local function ReconcileGlobalSegmentOverrideRows(cross, eff)
+    if not cross or not eff then
+        return;
+    end
+    if not cross.segmentOverrides then
+        return;
+    end
+    local gp;
+    local anyJobShared = false;
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local s = cross.segmentOverrides[tostring(jid)] and cross.segmentOverrides[tostring(jid)][eff];
+        if s and s.scope == 'jobShared' then
+            anyJobShared = true;
+        elseif s and s.scope == 'global' and type(s.globalPalette) == 'string' and s.globalPalette ~= '' then
+            gp = s.globalPalette;
+        end
+    end
+    if anyJobShared or not gp then
+        return;
+    end
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local s = cross.segmentOverrides[tostring(jid)] and cross.segmentOverrides[tostring(jid)][eff];
+        if not s or s.scope ~= 'global' or s.globalPalette ~= gp then
+            ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, gp);
+            if SaveSettingsOnly then
+                SaveSettingsOnly();
+            end
+            return;
+        end
+    end
+end
+
+local function DrawJobSegmentOverrideCheckboxRow(jobId, comboMode, cross, idSuffix, _columnMaxW)
+    if not jobId or not cross then
+        return;
+    end
+    local eff = data.GetEffectiveComboModeForStorage(comboMode);
+    if eff == 'L2' or eff == 'R2' then
+        return;
+    end
+    if not cross.segmentOverrides then
+        cross.segmentOverrides = {};
+    end
+    local jk = tostring(jobId);
+    if not cross.segmentOverrides[jk] then
+        cross.segmentOverrides[jk] = {};
+    end
+    local ent = cross.segmentOverrides[jk][eff];
+    local enabled = ent ~= nil and ent.scope ~= nil;
+
+    imgui.PushID('segov_' .. (idSuffix or 'm') .. '_' .. eff);
+    local ovBuf = { enabled };
+    if imgui.Checkbox('Override##ovren', ovBuf) then
+        if ovBuf[1] then
+            cross.segmentOverrides[jk][eff] = { scope = 'jobShared' };
+        else
+            if ent and ent.scope == 'global' then
+                ClearSegmentOverrideModeForAllJobs(cross, eff);
+            else
+                cross.segmentOverrides[jk][eff] = nil;
+                if next(cross.segmentOverrides[jk]) == nil then
+                    cross.segmentOverrides[jk] = nil;
+                end
+                if next(cross.segmentOverrides) == nil then
+                    cross.segmentOverrides = nil;
+                end
+            end
+        end
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+        data.InvalidateCrossbarDraftLayout();
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+    imgui.SameLine();
+    imgui.ShowHelp(
+        'Override: use one shared bar for this trigger segment across palettes (job-wide), or bind to a Global [G] palette so the same slots appear on every job. Global [G] applies to all jobs in-game (same redirect for every job id). Does not duplicate palette data; it redirects where slots load and save.'
+    );
+    imgui.PopID();
+end
+
+local function DrawJobSegmentOverrideDetailBlock(jobId, comboMode, cross, idSuffix, columnMaxW)
+    if not jobId or not cross then
+        return;
+    end
+    local comboW = SEGMENT_OVERRIDE_COMBO_W;
+    if columnMaxW and columnMaxW > 40 then
+        comboW = math.min(SEGMENT_OVERRIDE_COMBO_W, columnMaxW - 8);
+    end
+    local eff = data.GetEffectiveComboModeForStorage(comboMode);
+    if eff == 'L2' or eff == 'R2' then
+        return;
+    end
+    local jk = tostring(jobId);
+    local ent = cross.segmentOverrides and cross.segmentOverrides[jk] and cross.segmentOverrides[jk][eff];
+    if not ent or not ent.scope then
+        return;
+    end
+
+    imgui.PushID('segdet_' .. (idSuffix or 'm') .. '_' .. eff);
+    imgui.Dummy({ 0, 2 });
+    if imgui.RadioButton('Job-shared##rj_' .. eff, ent.scope == 'jobShared') then
+        if ent.scope == 'global' then
+            local gp = (type(ent.globalPalette) == 'string' and ent.globalPalette ~= '') and ent.globalPalette or nil;
+            local names = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+            if (not gp or gp == '') and names[1] then
+                gp = names[1];
+            end
+            SplitGlobalSegmentToJobSharedForOneJob(cross, eff, jk, gp);
+        else
+            ent.scope = 'jobShared';
+            ent.globalPalette = nil;
+        end
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+        data.InvalidateCrossbarDraftLayout();
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+    imgui.SameLine(0, 12);
+    if imgui.RadioButton('Global [G]##rg_' .. eff, ent.scope == 'global') then
+        local names = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+        local gp = (type(ent.globalPalette) == 'string' and ent.globalPalette ~= '') and ent.globalPalette or nil;
+        if (not gp or gp == '') and names[1] then
+            gp = names[1];
+        end
+        ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, gp);
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+        data.InvalidateCrossbarDraftLayout();
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+
+    if ent.scope == 'global' then
+        imgui.Dummy({ 0, 4 });
+        imgui.PushItemWidth(comboW);
+        local names = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+        local preview = (type(ent.globalPalette) == 'string' and ent.globalPalette ~= '') and ent.globalPalette or '(select)';
+        if imgui.BeginCombo('Palette##gp_' .. eff, preview, 0) then
+            for _, nm in ipairs(names) do
+                if imgui.Selectable(nm, nm == ent.globalPalette) then
+                    ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, nm);
+                    if SaveSettingsOnly then
+                        SaveSettingsOnly();
+                    end
+                    data.InvalidateCrossbarDraftLayout();
+                    if DeferredUpdateVisuals then
+                        DeferredUpdateVisuals();
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        imgui.PopItemWidth();
+        imgui.SameLine(0, 8);
+        imgui.TextColored({ 0.7, 0.68, 0.6, 1.0 }, 'Palette');
+    end
+
+    imgui.Dummy({ 0, 4 });
+    -- Job-shared: short manual lines only. Even with \n, a long first line still *soft-wraps* in narrow
+    -- double-tap columns; when L2x2 and R2x2 both show this, line count could flicker and bounce scroll.
+    if ent.scope == 'jobShared' then
+        imgui.TextColored(
+            { 0.92, 0.32, 0.32, 1.0 },
+            'Job-shared crossbar:\nEdits apply to all\nnamed palettes\nfor this job on\nthis segment.'
+        );
+    elseif ent.scope == 'global' and type(ent.globalPalette) == 'string' and ent.globalPalette ~= '' then
+        local wrapPushed = false;
+        if columnMaxW and columnMaxW > 40 and imgui.PushTextWrapPos and imgui.GetCursorPosX then
+            local cx = math.floor(imgui.GetCursorPosX() + 0.5);
+            local w = math.floor(columnMaxW + 0.5) - 6;
+            if w > 40 then
+                imgui.PushTextWrapPos(cx + w);
+                wrapPushed = true;
+            end
+        end
+        imgui.PushStyleColor(ImGuiCol_Text, { 0.92, 0.32, 0.32, 1.0 });
+        if imgui.TextWrapped then
+            imgui.TextWrapped(
+                'Global palette "'
+                    .. ent.globalPalette
+                    .. '": edits change that [G] set for everyone using it (including Universal crossbar when active).'
+            );
+        else
+            imgui.TextColored(
+                { 0.92, 0.32, 0.32, 1.0 },
+                'Global palette "'
+                    .. ent.globalPalette
+                    .. '": edits change that [G] palette for everyone using it (including Universal crossbar when this set is active).'
+            );
+        end
+        imgui.PopStyleColor(1);
+        if wrapPushed and imgui.PopTextWrapPos then
+            imgui.PopTextWrapPos();
+        end
+    end
+    imgui.PopID();
+end
+
+-- Override + Pet on one row; when Override is on, Job/Global on the next row; Global adds palette row + warnings below.
+-- maxWidth = that columnâ€™s usable width (keeps text/combo from spilling into the other half).
+local function DrawJobSegmentFooterOverrideAndPet(storageKey, mode, cross, named, jobId, showOverride, idTag, maxWidth)
+    maxWidth = maxWidth or 400;
+    if not showOverride or not jobId then
+        DrawJobSegmentPetGlobalControls(storageKey, mode, '', cross, named, { showGoldLabel = false, jobId = jobId or data.jobId or 1 });
+        if jobId and cross and cross.comboModeSettings and cross.comboModeSettings[mode] and cross.comboModeSettings[mode].petAware == true then
+            drawJobSegmentInlinePetTypes(cross, mode, maxWidth, idTag or 'pet1', jobId);
+        end
+        return;
+    end
+
+    imgui.PushID('ovpetblk_' .. idTag);
+    if showOverride and jobId then
+        local eff = data.GetEffectiveComboModeForStorage(mode);
+        if eff ~= 'L2' and eff ~= 'R2' then
+            ReconcileGlobalSegmentOverrideRows(cross, eff);
+        end
+    end
+    -- Override | Pet on one row. Do not use imgui.Columns here (breaks the outer L2/R2 pair Columns).
+    -- Height must NOT be 0: in ImGui, BeginChild(..., { w, 0 }) uses remaining vertical space and stretches
+    -- the row to the bottom of the parent, leaving a huge empty band before Job/Global below.
+    local gap = 6;
+    local half = math.max(96, math.floor(((maxWidth - gap) * 0.5) + 0.5));
+    local wRight = math.max(80, maxWidth - half - gap);
+    local fh = (imgui.GetFrameHeightWithSpacing and imgui.GetFrameHeightWithSpacing())
+        or ((imgui.GetFrameHeight and imgui.GetFrameHeight()) + GetItemSpacingY())
+        or 26;
+    -- Right column: Pet Palette only (Petsâ€¦ moved to Edit Full Palette Pets tab).
+    local row1H = math.ceil(math.max(24, fh + 4));
+
+    imgui.BeginChild('##ovpetL_' .. idTag, { half, row1H }, false);
+    DrawJobSegmentOverrideCheckboxRow(jobId, mode, cross, idTag, half);
+    imgui.EndChild();
+    imgui.SameLine(0, gap);
+    imgui.BeginChild('##ovpetR_' .. idTag, { wRight, row1H }, false);
+    DrawJobSegmentPetGlobalControls(storageKey, mode, '', cross, named, { showGoldLabel = false, jobId = jobId });
+    imgui.EndChild();
+
+    if jobId and cross and cross.comboModeSettings and cross.comboModeSettings[mode] and cross.comboModeSettings[mode].petAware == true then
+        drawJobSegmentInlinePetTypes(cross, mode, maxWidth, idTag, jobId);
+    end
+
+    DrawJobSegmentOverrideDetailBlock(jobId, mode, cross, idTag, maxWidth);
+
+    imgui.PopID();
+end
+
+-- Full crossbar row using the same DrawSlot / slotrenderer path as the in-game crossbar (requires data.BeginCrossbarPaletteEditSession).
+-- Clip rect is taken *inside* each row BeginChild only. Do not intersect with a scroll snapshot from before layout:
+-- ContentRegionMax at the top of an empty scroll pane is wrong and would drop every row after the first.
+local function DrawFullPaletteCrossbarPair(storageKey, modeLeft, modeRight, idFix, cs, parentClipX1, parentClipY1, parentClipX2, parentClipY2, drawPetFooters, cross, named, segmentOverrideJobId)
+    local w, h, gw, ghgt = crossbar.GetEditorCrossbarRowDimensions(cs);
+    local gs = w - 2 * gw;
+    -- Action names render on top of slot icons (not above/below the grid); keep row padding compact.
+    local rowPadTop = 14;
+    local rowPadBottom = 14;
+    local rowPadH = (cs.labelFontSize or 10) + 22;
+    local rowPadLeft = rowPadH;
+    local rowPadRight = rowPadH + 16;
+    local rowHeight = ghgt + rowPadTop + rowPadBottom;
+    local rowWidth = w + rowPadLeft + rowPadRight;
+    local flags = 0;
+    if ImGuiWindowFlags_NoScrollbar ~= nil then
+        flags = ImGuiWindowFlags_NoScrollbar;
+    end
+    imgui.PushStyleColor(ImGuiCol_ChildBg, { 0.176, 0.161, 0.137, 0.95 });
+    imgui.BeginChild('##xbpair_' .. idFix, { rowWidth, rowHeight }, true, flags);
+    do
+        local dlBg = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+        local wx, wy = imgui.GetWindowPos();
+        local ww, wh = imgui.GetWindowSize();
+        if dlBg and wx and ww then
+            dlBg:AddRectFilled({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32({ 0.176, 0.161, 0.137, 0.95 }), 4);
+            dlBg:AddRect({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32(components.TAB_STYLE.gold), 4, 0, 1.5);
+        end
+    end
+    local rowX1, rowY1, rowX2, rowY2 = GetCurrentWindowContentScreenRect();
+    local dl = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+    local pushedClip = false;
+    local cx1, cy1, cx2, cy2 = rowX1, rowY1, rowX2, rowY2;
+    if parentClipX1 then
+        cx1, cy1, cx2, cy2 = IntersectRect(rowX1, rowY1, rowX2, rowY2, parentClipX1, parentClipY1, parentClipX2, parentClipY2);
+    end
+    if cx1 and dl and dl.PushClipRect then
+        dl:PushClipRect({ cx1, cy1 }, { cx2, cy2 }, true);
+        pushedClip = true;
+    end
+    local slotGridLeftScreenX = nil;
+    local slotGridRightScreenX = nil;
+    if cx1 then
+        local px, py = imgui.GetCursorScreenPos();
+        local drawOriginX = px + rowPadLeft;
+        slotGridLeftScreenX = drawOriginX;
+        slotGridRightScreenX = drawOriginX + gw + gs;
+        local drawOriginY = py + rowPadTop;
+        if modeLeft and modeRight then
+            local dividerX = drawOriginX + (w / 2);
+            if dl and dl.AddLine then
+                dl:AddLine(
+                    { dividerX, drawOriginY + 10 },
+                    { dividerX, drawOriginY + ghgt - 10 },
+                    imgui.GetColorU32({ 1, 1, 1, 0.3 }),
+                    2
+                );
+            end
+        end
+        local glyphMode = (idFix == 'dbl') and 'doubleTap' or (idFix == 'chord') and 'chordCombo' or 'primary';
+        local gSides = { l = (modeLeft ~= nil), r = (modeRight ~= nil) };
+        crossbar.DrawPaletteEditorL2R2TriggerGlyphs(drawOriginX, drawOriginY, cs, glyphMode, gSides);
+        crossbar.DrawPaletteEditorL2R2Row(drawOriginX, drawOriginY, cs, modeLeft, modeRight, cx1, cy1, cx2, cy2);
+    end
+    if pushedClip and dl and dl.PopClipRect then
+        dl:PopClipRect();
+    end
+    imgui.EndChild();
+    imgui.PopStyleColor(1);
+    if drawPetFooters and cross and named and slotGridLeftScreenX then
+        imgui.Dummy({ 0, 6 });
+        imgui.PushID('petfoot_' .. idFix);
+        local haveBoth = (modeLeft ~= nil and modeRight ~= nil);
+        if haveBoth then
+            -- Match slot row width so L2/R2 footers align with the diamonds; ImGui columns draw the vertical separator between them
+            local leftColW = rowPadLeft + (w / 2);
+            local rightColW = rowWidth - leftColW;
+            local cellPad = 10;
+            local leftInner = math.max(120, leftColW - cellPad);
+            local rightInner = math.max(120, rightColW - cellPad);
+
+            -- Avoid nested BeginChild(..., height 0) inside the main scroll: auto-height stacking bugs / huge gaps on some ImGui builds.
+            imgui.Columns(2, '##pairFootCols_' .. idFix, true);
+            imgui.SetColumnWidth(0, leftColW);
+            imgui.SetColumnWidth(1, rightColW);
+
+            DrawJobSegmentFooterOverrideAndPet(
+                storageKey,
+                modeLeft,
+                cross,
+                named,
+                segmentOverrideJobId,
+                drawPetFooters and segmentOverrideJobId and idFix ~= 'pri',
+                'L_' .. idFix,
+                leftInner
+            );
+            imgui.NextColumn();
+            DrawJobSegmentFooterOverrideAndPet(
+                storageKey,
+                modeRight,
+                cross,
+                named,
+                segmentOverrideJobId,
+                drawPetFooters and segmentOverrideJobId and idFix ~= 'pri',
+                'R_' .. idFix,
+                rightInner
+            );
+            imgui.Columns(1);
+        else
+            local m = modeLeft or modeRight;
+            local tag = (modeLeft and 'L_') or 'R_';
+            if m then
+                DrawJobSegmentFooterOverrideAndPet(
+                    storageKey,
+                    m,
+                    cross,
+                    named,
+                    segmentOverrideJobId,
+                    drawPetFooters and segmentOverrideJobId and idFix ~= 'pri',
+                    tag .. idFix,
+                    math.max(160, rowWidth - 16)
+                );
+            end
+        end
+
+        imgui.Dummy({ 0, 10 });
+        imgui.PopID();
+    end
+end
+
+-- Single 8-slot group (shared chord bar): one double-diamond wide
+local function DrawFullPaletteSingleCrossbarGroup(storageKey, comboMode, idFix, cs, parentClipX1, parentClipY1, parentClipX2, parentClipY2, drawPetFooters, cross, named, segmentOverrideJobId)
+    local w, h, gw, ghgt = crossbar.GetEditorCrossbarRowDimensions(cs);
+    local rowPadTop = 14;
+    local rowPadBottom = 14;
+    local rowPadH = (cs.labelFontSize or 10) + 22;
+    local rowPadLeft = rowPadH;
+    local rowPadRight = rowPadH + 16;
+    local rowHeight = ghgt + rowPadTop + rowPadBottom;
+    local rowWidth = gw + rowPadLeft + rowPadRight;
+    local flags = 0;
+    if ImGuiWindowFlags_NoScrollbar ~= nil then
+        flags = ImGuiWindowFlags_NoScrollbar;
+    end
+    imgui.PushStyleColor(ImGuiCol_ChildBg, { 0.176, 0.161, 0.137, 0.95 });
+    imgui.BeginChild('##xbone_' .. idFix, { rowWidth, rowHeight }, true, flags);
+    do
+        local dlBg = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+        local wx, wy = imgui.GetWindowPos();
+        local ww, wh = imgui.GetWindowSize();
+        if dlBg and wx and ww then
+            dlBg:AddRectFilled({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32({ 0.176, 0.161, 0.137, 0.95 }), 4);
+            dlBg:AddRect({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32(components.TAB_STYLE.gold), 4, 0, 1.5);
+        end
+    end
+    local rowX1, rowY1, rowX2, rowY2 = GetCurrentWindowContentScreenRect();
+    local dl = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+    local pushedClip = false;
+    local cx1, cy1, cx2, cy2 = rowX1, rowY1, rowX2, rowY2;
+    if parentClipX1 then
+        cx1, cy1, cx2, cy2 = IntersectRect(rowX1, rowY1, rowX2, rowY2, parentClipX1, parentClipY1, parentClipX2, parentClipY2);
+    end
+    if cx1 and dl and dl.PushClipRect then
+        dl:PushClipRect({ cx1, cy1 }, { cx2, cy2 }, true);
+        pushedClip = true;
+    end
+    local slotGridLeftScreenX = nil;
+    if cx1 then
+        local px, py = imgui.GetCursorScreenPos();
+        local drawOriginX = px + rowPadLeft;
+        slotGridLeftScreenX = drawOriginX;
+        local drawOriginY = py + rowPadTop;
+        crossbar.DrawPaletteEditorSharedChordTriggerGlyphs(drawOriginX, drawOriginY, cs);
+        crossbar.DrawPaletteEditorSingleRow(drawOriginX, drawOriginY, cs, comboMode, cx1, cy1, cx2, cy2);
+    end
+    if pushedClip and dl and dl.PopClipRect then
+        dl:PopClipRect();
+    end
+    imgui.EndChild();
+    imgui.PopStyleColor(1);
+    if drawPetFooters and cross and named and slotGridLeftScreenX then
+        imgui.Dummy({ 0, 6 });
+        imgui.PushID('petfoot_' .. idFix);
+        DrawJobSegmentFooterOverrideAndPet(
+            storageKey,
+            comboMode,
+            cross,
+            named,
+            segmentOverrideJobId,
+            drawPetFooters and segmentOverrideJobId,
+            'S_' .. idFix,
+            math.max(160, rowWidth - 16)
+        );
+        imgui.Dummy({ 0, 10 });
+        imgui.PopID();
+    end
+end
+
+-- "Not in use" warning in Edit Full Palette: larger, bright red, draw-list shadow/glow (when available).
+local function drawPaletteNotInUseWarning()
+    local text = 'This palette is not currently in use.';
+    local dl = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+    local canDl = (dl and dl.AddText and imgui.GetCursorScreenPos and imgui.GetColorU32);
+    if not canDl then
+        if imgui.SetWindowFontScale then
+            imgui.SetWindowFontScale(1.18);
+        end
+        imgui.TextColored({ 1, 0.2, 0.14, 1.0 }, text);
+        if imgui.SetWindowFontScale then
+            imgui.SetWindowFontScale(1.0);
+        end
+        return;
+    end
+    local scale = 1.2;
+    if imgui.SetWindowFontScale then
+        imgui.SetWindowFontScale(scale);
+    end
+    local tw, th;
+    if imgui.CalcTextSize then
+        local ts, t2 = imgui.CalcTextSize(text);
+        if type(ts) == 'table' then
+            tw, th = (ts[1] or ts.x or 0), (ts[2] or ts.y or 0);
+        elseif type(t2) == 'number' then
+            tw, th = ts, t2;
+        else
+            tw, th = ts, (imgui.GetTextLineHeight and imgui.GetTextLineHeight()) or 20;
+        end
+    else
+        tw, th = 300, 24;
+    end
+    if not tw or tw < 1 then
+        tw = 280;
+    end
+    if not th or th < 1 then
+        th = 22;
+    end
+    local x, y = imgui.GetCursorScreenPos();
+    local function c32(r, g, b, a)
+        return imgui.GetColorU32({ r, g, b, a or 1.0 });
+    end
+    -- Outer soft halo
+    for _, o in ipairs({ {2,0},{-2,0},{0,2},{0,-2}, {1,0},{-1,0},{0,1},{0,-1} }) do
+        dl:AddText({ x + o[1] * 2, y + o[2] * 2 }, c32(0.7, 0, 0, 0.35), text);
+    end
+    for _, o in ipairs({ {2,0},{-2,0},{0,2},{0,-2}, {2,2},{-2,2},{2,-2},{-2,-2} }) do
+        dl:AddText({ x + o[1], y + o[2] }, c32(0.85, 0.1, 0.08, 0.4), text);
+    end
+    for _, o in ipairs({ {1,0},{-1,0},{0,1},{0,-1}, {1,1},{-1,1},{1,-1},{-1,-1} }) do
+        dl:AddText({ x + o[1], y + o[2] }, c32(0.08, 0, 0, 0.92), text);
+    end
+    dl:AddText({ x, y }, c32(1, 0.2, 0.12, 1.0), text);
+    if imgui.SetWindowFontScale then
+        imgui.SetWindowFontScale(1.0);
+    end
+    imgui.Dummy({ tw, th });
+end
+
+local function DrawEmbeddedCrossbarComboModesPopup()
+    if not embedCrossbarComboCtx then
+        embedCrossbarComboWinOpen[1] = false;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+        editFullPaletteScrollHCached = nil;
+        return;
+    end
+
+    local ctx = embedCrossbarComboCtx;
+    local cross = gConfig and gConfig.hotbarCrossbar;
+    if not cross then
+        embedCrossbarComboCtx = nil;
+        embedCrossbarComboWinOpen[1] = false;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+        editFullPaletteScrollHCached = nil;
+        return;
+    end
+
+    embedCrossbarComboWinGraceFrames = embedCrossbarComboWinGraceFrames + 1;
+
+    -- Min/max every frame. Position + size only on the *first draw* of an open window (grace == 1).
+    -- Re-applying SetNextWindowSize/Pos every frame with Appearing fights layout and resets the inner scroll.
+    local wMin = EDIT_FULL_PALETTE_WIN_W_MIN;
+    local wMax = EDIT_FULL_PALETTE_WIN_W_MAX;
+    if EDIT_FULL_PALETTE_WIN_LOCK_WIDTH then
+        wMin = EDIT_FULL_PALETTE_WIN_W;
+        wMax = EDIT_FULL_PALETTE_WIN_W;
+    end
+    local hMin = EDIT_FULL_PALETTE_WIN_H_MIN;
+    local hMax = EDIT_FULL_PALETTE_WIN_H_MAX;
+    if EDIT_FULL_PALETTE_WIN_LOCK_HEIGHT then
+        hMin = EDIT_FULL_PALETTE_WIN_H_DEFAULT;
+        hMax = EDIT_FULL_PALETTE_WIN_H_DEFAULT;
+    end
+    imgui.SetNextWindowSizeConstraints({ wMin, hMin }, { wMax, hMax });
+
+    do
+        local applySavedGeom = (embedCrossbarComboWinGraceFrames == 1);
+        if applySavedGeom then
+            local saved = gConfig and gConfig.windowPositions and gConfig.windowPositions[EDIT_FULL_PALETTE_WINDOW_KEY];
+            local geomOnce = ImGuiCond_Always;
+            if saved and saved.x and saved.y then
+                imgui.SetNextWindowPos({ saved.x, saved.y }, geomOnce);
+            else
+                local g = rawget(_G, '_XIUI_CONFIG_LAST_GEOM');
+                if type(g) == 'table' and g[1] and g[2] then
+                    imgui.SetNextWindowPos({ g[1] + 36, g[2] + 36 }, geomOnce);
+                end
+            end
+
+            local sw = EDIT_FULL_PALETTE_WIN_W;
+            local sh = EDIT_FULL_PALETTE_WIN_H_DEFAULT;
+            if saved and type(saved.w) == 'number' and saved.w > 0 then
+                sw = math.max(wMin, math.min(wMax, saved.w));
+            end
+            if saved and type(saved.h) == 'number' and saved.h > 0 then
+                sh = math.max(hMin, math.min(hMax, saved.h));
+            end
+            imgui.SetNextWindowSize({ sw, sh }, geomOnce);
+        end
+    end
+    local winFlags = ImGuiWindowFlags_None;
+    if ImGuiWindowFlags_NoSavedSettings ~= nil and bit and bit.bor then
+        winFlags = bit.bor(winFlags, ImGuiWindowFlags_NoSavedSettings);
+    end
+    if ImGuiWindowFlags_NoDocking ~= nil and bit and bit.bor then
+        winFlags = bit.bor(winFlags, ImGuiWindowFlags_NoDocking);
+    end
+    -- Only the inner ##xbFullPalScroll should scroll; outer window scrollbar fights it and feels like â€œjumpingâ€.
+    if ImGuiWindowFlags_NoScrollbar ~= nil and bit and bit.bor then
+        winFlags = bit.bor(winFlags, ImGuiWindowFlags_NoScrollbar);
+    end
+
+    local kind = ctx.kind or 'job';
+    local scopeLine = BuildEmbedFullPaletteScopeLine(ctx, kind);
+    local winTitle = 'Edit Full Palette - ' .. scopeLine .. '###xbEmbCombWin';
+
+    if imgui.Begin(winTitle, embedCrossbarComboWinOpen, winFlags) then
+    embedCrossbarComboHasDrawn = true;
+    if embedCrossbarComboWinGraceFrames == 1 and (ctx.kind or 'job') == 'job' then
+        petEfpModeWork = nil;
+    end
+    if embedCrossbarComboWinGraceFrames == 1 then
+        embedEfpSubTab = 0;
+    end
+    do
+        local wx, wy = imgui.GetWindowPos();
+        local ww, wh = imgui.GetWindowSize();
+        if wx and wy and ww and wh then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[EDIT_FULL_PALETTE_WINDOW_KEY] = { x = wx, y = wy, w = ww, h = wh };
+        end
+    end
+    if not cross.namedPaletteComboModeSettings then
+        cross.namedPaletteComboModeSettings = {};
+    end
+    local named = cross.namedPaletteComboModeSettings;
+    local editJobId = (kind == 'job') and (ctx.jobId or data.jobId) or nil;
+    local segmentOverrideJobId = (kind == 'job') and (ctx.jobId or 1) or nil;
+    local editCross = BuildEditFullPaletteViewSettings(cross);
+
+    -- Header row 1: Macro Manager button + description
+    components.PushMacroManagerButtonStyle();
+    if imgui.Button('Macro Manager##xbEmbCombMacro') then
+        macropalette.OpenPalette();
+    end
+    components.PopMacroManagerButtonStyle();
+    imgui.SameLine();
+    imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Right-click a slot to clear; drag macros or slots to rearrange. Double-click to edit.');
+
+    -- Header row 2: Job/scope label + "not in use" warning
+    do
+        local jobLabel;
+        if kind == 'universal' then
+            jobLabel = 'Global [G]';
+        else
+            local jid = ctx.jobId or 1;
+            jobLabel = jobs[jid] or ('Job ' .. tostring(jid));
+        end
+        imgui.TextColored(components.TAB_STYLE.gold, jobLabel);
+        imgui.SameLine(0, 12);
+        imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Palette:');
+        imgui.SameLine(0, 4);
+        imgui.TextColored({ 0.85, 0.82, 0.72, 1.0 }, '"' .. (ctx.name or '?') .. '"');
+
+        local activeScope = palette.GetCrossbarPaletteScope and palette.GetCrossbarPaletteScope() or 'job';
+        local activeName = palette.GetActivePaletteForCombo and palette.GetActivePaletteForCombo('L2') or nil;
+        local isActive = false;
+        if kind == 'universal' and activeScope == 'universal' then
+            isActive = (activeName == ctx.name);
+        elseif kind == 'job' and activeScope == 'job' then
+            isActive = (activeName == ctx.name);
+        end
+        if not isActive then
+            imgui.SameLine(0, 16);
+            drawPaletteNotInUseWarning();
+        end
+    end
+
+    -- Job [J]: Slots = named palette storage; Pets = petpalette:* for the selected pet (see config/efp_pets_tab.lua).
+    if kind == 'job' then
+        imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'View:');
+        imgui.SameLine(0, 8);
+        local jTab = tostring(ctx.jobId or 1);
+        local function tryEfpTab(which)
+            if embedEfpSubTab == which then
+                return;
+            end
+            if data.IsDraftDirty() then
+                pendingEfpSubTab = which;
+                openUnsavedChangesPopup = true;
+            else
+                embedEfpSubTab = which;
+                editFullPaletteScrollHCached = nil;
+            end
+        end
+        if components.DrawStyledTab('Slots', 'efpViewSlot' .. jTab, embedEfpSubTab == 0, nil, nil, nil, 'palette') then
+            tryEfpTab(0);
+        end
+        imgui.SameLine(0, 4);
+        if components.DrawStyledTab('Pets', 'efpViewPet' .. jTab, embedEfpSubTab == 1, nil, nil, nil, 'palette') then
+            tryEfpTab(1);
+        end
+        if embedEfpSubTab == 1 then
+            imgui.Spacing();
+            do
+                local _wrapPop = false;
+                if imgui.GetContentRegionAvail and imgui.GetCursorPosX and imgui.PushTextWrapPos then
+                    local aw, _h = imgui.GetContentRegionAvail();
+                    local wrapW = 420;
+                    if type(aw) == 'table' then
+                        wrapW = math.max(200, (aw[1] or aw.x or wrapW) - 4);
+                    elseif type(aw) == 'number' then
+                        wrapW = math.max(200, aw - 4);
+                    end
+                    local cx = imgui.GetCursorPosX and imgui.GetCursorPosX() or 0;
+                    imgui.PushTextWrapPos(cx + wrapW);
+                    _wrapPop = true;
+                end
+                efpPets.draw(cross, data.IsDraftDirty());
+                if _wrapPop and imgui.PopTextWrapPos then
+                    imgui.PopTextWrapPos();
+                end
+            end
+        end
+    end
+
+    -- Header row 3: Quick palette switcher (selection only)
+    do
+        if kind == 'job' and embedEfpSubTab ~= 0 then
+            -- Pets view edits a different storage root; avoid switching named palette here.
+        else
+        local paletteNames;
+        if kind == 'universal' then
+            paletteNames = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+        else
+            paletteNames = palette.GetCrossbarPaletteNamesForOrderTier and palette.GetCrossbarPaletteNamesForOrderTier(ctx.jobId or 1, tonumber(ctx.st) or 0) or {};
+        end
+        if #paletteNames > 1 then
+            imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Switch Palette:');
+            imgui.SameLine(0, 6);
+            imgui.PushStyleColor(ImGuiCol_FrameBg, { 0.10, 0.09, 0.07, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, { 0.14, 0.13, 0.11, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_FrameBgActive, { 0.14, 0.13, 0.11, 1.0 });
+            imgui.SetNextItemWidth(200);
+            if imgui.BeginCombo('##xbEditPalSwitch', ctx.name or '?') then
+                for _, pName in ipairs(paletteNames) do
+                    local isSel = (pName == ctx.name);
+                    if isSel then
+                        imgui.PushStyleColor(ImGuiCol_Text, components.TAB_STYLE.gold);
+                    end
+                    if imgui.Selectable(pName, isSel) then
+                        if pName ~= ctx.name then
+                            if data.IsDraftDirty() then
+                                pendingPaletteSwitchName = pName;
+                                openUnsavedChangesPopup = true;
+                            else
+                                data.FullyClosePaletteEditSession();
+                                crossbar.HidePaletteEditorPrimitives();
+                                ctx.name = pName;
+                                editFullPaletteScrollHCached = nil;
+                                embedCrossbarComboWinGraceFrames = 0;
+                            end
+                        end
+                    end
+                    if isSel then
+                        imgui.PopStyleColor();
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopStyleColor(3);
+        end
+        end
+    end
+    imgui.Spacing();
+
+    local storageKey;
+    if kind == 'job' and embedEfpSubTab == 1 then
+        storageKey = 'petpalette:' .. efpPets.getPetKeyString();
+    else
+        storageKey = GetEmbedFullPaletteStorageKey(ctx);
+    end
+    data.BeginCrossbarPaletteEditSession(storageKey, editJobId);
+    if not embedCrossbarComboWinOpen[1] and data.IsDraftDirty() then
+        embedCrossbarComboWinOpen[1] = true;
+        openUnsavedChangesPopup = true;
+    end
+
+    -- Scroll region height: cache + quantized avail (see GetContentRegionAvailHeight). Refresh when the user
+    -- resizes the outer window enough; avoids 1px jitter resetting scroll.
+    do
+        local regionBelowHeaderH = GetContentRegionAvailHeight();
+        local computed = math.max(120, math.floor(regionBelowHeaderH - EDIT_FULL_PALETTE_FOOTER_BLOCK_H + 0.5));
+        if embedCrossbarComboWinGraceFrames == 1 or editFullPaletteScrollHCached == nil then
+            editFullPaletteScrollHCached = computed;
+        elseif math.abs(computed - editFullPaletteScrollHCached) >= 8 then
+            editFullPaletteScrollHCached = computed;
+        end
+    end
+    -- Always reserve the scrollbar gutter: when optional override rows appear/disappear, content height crosses
+    -- the "needs scroll" threshold and the bar popping in/out reflows text width and bounces scroll to top.
+    local xbScrollFlags = 0;
+    if ImGuiWindowFlags_AlwaysVerticalScrollbar ~= nil then
+        xbScrollFlags = ImGuiWindowFlags_AlwaysVerticalScrollbar;
+    end
+    local isPetsEfp = (kind == 'job' and embedEfpSubTab == 1);
+    local petKeyEfp = isPetsEfp and efpPets.getPetKeyString() or nil;
+    local function efpPetsModeOrNil(mode)
+        if not isPetsEfp or not petKeyEfp then
+            return mode;
+        end
+        if not petEfpSegmentRowVisible(cross, mode, petKeyEfp) then
+            return nil;
+        end
+        return mode;
+    end
+    local drawEfpJobFoot = (kind == 'job' and not isPetsEfp);
+    local function drawEfpScrollBody()
+        local scrollX1, scrollY1, scrollX2, scrollY2 = GetCurrentWindowScreenRect();
+        -- TextColored does not wrap; these info lines are long in Pets view
+        local function efpPetsInfoWrapped(c, s)
+            if not s or s == '' then
+                return;
+            end
+            if not c then
+                c = { 0.75, 0.55, 0.4, 1.0 };
+            end
+            if imgui.PushStyleColor and ImGuiCol_Text then
+                imgui.PushStyleColor(ImGuiCol_Text, c);
+            end
+            local didWrap = false;
+            if imgui.GetCursorPosX and imgui.GetContentRegionAvail and imgui.PushTextWrapPos then
+                local aw, _h = imgui.GetContentRegionAvail();
+                local wavail = 400;
+                if type(aw) == 'table' then
+                    wavail = (aw[1] or aw.x or wavail) - 12;
+                elseif type(aw) == 'number' then
+                    wavail = aw - 12;
+                end
+                wavail = math.max(100, wavail);
+                local cx = imgui.GetCursorPosX();
+                imgui.PushTextWrapPos(cx + wavail);
+                didWrap = true;
+            end
+            if imgui.TextWrapped then
+                imgui.TextWrapped(s);
+            else
+                imgui.Text(s);
+            end
+            if didWrap and imgui.PopTextWrapPos then
+                imgui.PopTextWrapPos();
+            end
+            if imgui.PopStyleColor and ImGuiCol_Text then
+                imgui.PopStyleColor(1);
+            end
+        end
+        local function sectionHeader(text)
+            imgui.Spacing();
+            imgui.Spacing();
+            imgui.Separator();
+            imgui.Spacing();
+            imgui.TextColored(components.TAB_STYLE.gold, text);
+        end
+        sectionHeader('Primary (hold L2 / R2)');
+        do
+            local pL, pR = efpPetsModeOrNil('L2'), efpPetsModeOrNil('R2');
+            if isPetsEfp and (not pL) and (not pR) then
+                efpPetsInfoWrapped(
+                    { 0.75, 0.55, 0.4, 1.0 },
+                    'No L2/R2 pet bar for the selected pet. On the Slots view, turn on "Pet Palette" and include this pet for L2 and/or R2, or select another family/pet above.'
+                );
+            else
+                DrawFullPaletteCrossbarPair(storageKey, pL, pR, 'pri', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+            end
+        end
+        sectionHeader('Double-tap (L2x2 / R2x2)');
+        if not cross.enableDoubleTap then
+            imgui.BeginDisabled();
+            imgui.TextColored({ 0.55, 0.55, 0.55, 1.0 }, 'Enable Double-Tap in Controller Settings to use these bars.');
+            imgui.EndDisabled();
+        else
+            do
+                local pL, pR = efpPetsModeOrNil('L2x2'), efpPetsModeOrNil('R2x2');
+                if isPetsEfp and (not pL) and (not pR) then
+                    efpPetsInfoWrapped(
+                        { 0.75, 0.55, 0.4, 1.0 },
+                        'No double-tap pet bars for this pet. Use the Slots view to set Pet Palette for L2x2 and/or R2x2, or select another pet above.'
+                    );
+                else
+                    DrawFullPaletteCrossbarPair(storageKey, pL, pR, 'dbl', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+                end
+            end
+        end
+        sectionHeader('Chord (L2+R2 / R2+L2)');
+        if not cross.enableExpandedCrossbar then
+            imgui.BeginDisabled();
+            imgui.TextColored({ 0.55, 0.55, 0.55, 1.0 }, 'Enable L2+R2 / R2+L2 in Controller Settings to use these bars.');
+            imgui.EndDisabled();
+        elseif cross.useSharedExpandedBar then
+            efpPetsInfoWrapped(
+                { 0.7, 0.68, 0.6, 1.0 },
+                'Shared expanded bar: L2+R2 and R2+L2 use the same 8 slots.'
+            );
+            do
+                local pM = efpPetsModeOrNil('L2R2');
+                if isPetsEfp and (not pM) then
+                    efpPetsInfoWrapped(
+                        { 0.75, 0.55, 0.4, 1.0 },
+                        'No shared chord bar for this pet. On the Slots view, enable "Pet Palette" for L2+R2 / R2+L2 (shared) or change pet above.'
+                    );
+                else
+                    DrawFullPaletteSingleCrossbarGroup(storageKey, pM, 'chsh', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+                end
+            end
+        else
+            do
+                local pL, pR = efpPetsModeOrNil('L2R2'), efpPetsModeOrNil('R2L2');
+                if isPetsEfp and (not pL) and (not pR) then
+                    efpPetsInfoWrapped(
+                        { 0.75, 0.55, 0.4, 1.0 },
+                        'No chord pet bars for this pet. On the Slots view, enable Pet Palette for the chord row(s) or change pet above.'
+                    );
+                else
+                    DrawFullPaletteCrossbarPair(storageKey, pL, pR, 'chord', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+                end
+            end
+        end
+        imgui.Dummy({ 0, 10 });
+    end
+
+    imgui.BeginChild('##xbFullPalScroll', { 0, editFullPaletteScrollHCached or 200 }, true, xbScrollFlags);
+    drawEfpScrollBody();
+    imgui.EndChild();
+
+    -- After slots draw: open macro editor from double-click (same frame as SetPending).
+    -- When the source slot was empty (slotData nil → "creating new" mode), forward the
+    -- (comboMode, slotIndex) as a bindTargetSlot so SaveMacro will auto-bind the new macro
+    -- to the slot the user actually double-clicked. Double-clicking a filled slot just
+    -- edits the existing macro in place, no bind target needed.
+    local pendingEdit = data.ConsumePendingPaletteSlotEdit();
+    if pendingEdit then
+        local editorOpts;
+        if pendingEdit.slotData == nil and pendingEdit.comboMode and pendingEdit.slotIndex then
+            editorOpts = {
+                bindTargetSlot = {
+                    comboMode = pendingEdit.comboMode,
+                    slotIndex = pendingEdit.slotIndex,
+                },
+            };
+        end
+        macropalette.OpenEditorForSlotData(pendingEdit.slotData, editorOpts);
+        -- hotbar.DrawPalette runs before paletteManager; draw editor here so it appears same frame.
+        if macropalette.DrawMacroEditor then
+            macropalette.DrawMacroEditor();
+        end
+    end
+
+    -- Footer: Undo + Apply + Close
+    local isDirty = data.IsDraftDirty();
+    local canUndo = data.CanUndoDraft();
+    if not canUndo then
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.20, 0.20, 0.20, 1.0 });
+    else
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.35, 0.30, 0.18, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.45, 0.38, 0.22, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.28, 0.24, 0.14, 1.0 });
+    end
+    if imgui.Button('Undo##xbEmbUndo', { 70, 0 }) and canUndo then
+        data.UndoDraft();
+    end
+    imgui.PopStyleColor(3);
+    imgui.SameLine();
+    if isDirty then
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.22, 0.55, 0.22, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.28, 0.65, 0.28, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.16, 0.44, 0.16, 1.0 });
+    else
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.20, 0.20, 0.20, 1.0 });
+    end
+    if imgui.Button('Apply Changes##xbEmbApply', { 140, 0 }) then
+        if isDirty then
+            data.ApplyDraft();
+        end
+    end
+    imgui.PopStyleColor(3);
+    imgui.SameLine();
+    if imgui.Button('Close##xbEmbCombClose', { 80, 0 }) then
+        if isDirty then
+            openUnsavedChangesPopup = true;
+        else
+            embedCrossbarComboWinOpen[1] = false;
+        end
+    end
+    if isDirty then
+        imgui.SameLine();
+        imgui.TextColored({ 0.9, 0.75, 0.3, 1.0 }, 'Unsaved changes');
+    end
+
+    -- Unsaved changes modal
+    if openUnsavedChangesPopup then
+        imgui.OpenPopup('Unsaved Changes##xbUnsavedModal');
+        openUnsavedChangesPopup = false;
+    end
+    if imgui.BeginPopup('Unsaved Changes##xbUnsavedModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        local isSwitching = (pendingPaletteSwitchName ~= nil);
+        local isEfpTab = (pendingEfpSubTab ~= nil);
+        if isSwitching then
+            imgui.TextWrapped('You have unsaved changes. Apply before switching palettes?');
+        elseif isEfpTab then
+            imgui.TextWrapped('You have unsaved changes. Apply before switching between Slots and Pets?');
+        else
+            imgui.TextWrapped('You have unsaved changes. Apply changes before closing?');
+        end
+        imgui.Spacing();
+        local applyLabel = 'Apply & Close';
+        if isSwitching then
+            applyLabel = 'Apply & Switch';
+        elseif isEfpTab then
+            applyLabel = 'Apply & Continue';
+        end
+        if imgui.Button(applyLabel .. '##xbUnsavedApply', { 130, 0 }) then
+            data.ApplyDraft();
+            if isSwitching then
+                data.FullyClosePaletteEditSession();
+                crossbar.HidePaletteEditorPrimitives();
+                ctx.name = pendingPaletteSwitchName;
+                editFullPaletteScrollHCached = nil;
+                embedCrossbarComboWinGraceFrames = 0;
+                pendingPaletteSwitchName = nil;
+            elseif isEfpTab then
+                embedEfpSubTab = pendingEfpSubTab;
+                pendingEfpSubTab = nil;
+                editFullPaletteScrollHCached = nil;
+            else
+                embedCrossbarComboWinOpen[1] = false;
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Discard##xbUnsavedDiscard', { 100, 0 }) then
+            data.DiscardDraft();
+            if isSwitching then
+                data.FullyClosePaletteEditSession();
+                crossbar.HidePaletteEditorPrimitives();
+                ctx.name = pendingPaletteSwitchName;
+                editFullPaletteScrollHCached = nil;
+                embedCrossbarComboWinGraceFrames = 0;
+                pendingPaletteSwitchName = nil;
+            elseif isEfpTab then
+                embedEfpSubTab = pendingEfpSubTab;
+                pendingEfpSubTab = nil;
+                editFullPaletteScrollHCached = nil;
+            else
+                embedCrossbarComboWinOpen[1] = false;
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Cancel##xbUnsavedCancel', { 100, 0 }) then
+            pendingPaletteSwitchName = nil;
+            pendingEfpSubTab = nil;
+            imgui.CloseCurrentPopup();
+        end
+        imgui.EndPopup();
+    end
+
+    data.EndCrossbarPaletteEditSession();
+    imgui.End();
+    else
+        data.EndCrossbarPaletteEditSession();
+        crossbar.HidePaletteEditorPrimitives();
+    end
+
+    if not embedCrossbarComboWinOpen[1] then
+        if embedCrossbarComboHasDrawn or embedCrossbarComboWinGraceFrames > 8 then
+            embedCrossbarComboCtx = nil;
+            embedCrossbarComboWinGraceFrames = 0;
+            embedCrossbarComboHasDrawn = false;
+            editFullPaletteScrollHCached = nil;
+            data.FullyClosePaletteEditSession();
+            crossbar.HidePaletteEditorPrimitives();
+        end
+    end
+end
+
+local function GetCrossbarModalStorageSubjob()
+    if windowState.selectedPaletteType == 'crossbar' and modalState.crossbarOperationSubjob ~= nil then
+        return modalState.crossbarOperationSubjob;
+    end
+    return windowState.selectedSubjobId;
+end
+
+local function ClearCrossbarEmbedModalFields()
+    modalState.crossbarOperationSubjob = nil;
+    modalState.crossbarCopyFromSubjob = nil;
+    modalState.embedCrossbarUniversal = false;
+    modalState.embedCrossbarUniversalCopy = false;
+    modalState.copyDestScope = 'job';
+end
+
+-- ImGui Selectable uses Header colors; push muted gold for unselected rows so hover is visible (font lacks em dash glyph; use ASCII in UI strings).
+local function PushPaletteRowStyle(isSelected)
+    local gold = components.TAB_STYLE.gold;
+    if isSelected then
+        imgui.PushStyleColor(ImGuiCol_Header, { gold[1], gold[2], gold[3], 0.4 });
+        imgui.PushStyleColor(ImGuiCol_HeaderHovered, { gold[1], gold[2], gold[3], 0.5 });
+        imgui.PushStyleColor(ImGuiCol_HeaderActive, { gold[1], gold[2], gold[3], 0.6 });
+    else
+        imgui.PushStyleColor(ImGuiCol_Header, { gold[1], gold[2], gold[3], 0.08 });
+        imgui.PushStyleColor(ImGuiCol_HeaderHovered, { gold[1], gold[2], gold[3], 0.22 });
+        imgui.PushStyleColor(ImGuiCol_HeaderActive, { gold[1], gold[2], gold[3], 0.32 });
+    end
+end
+
+local function PopPaletteRowStyle()
+    imgui.PopStyleColor(3);
+end
+
+-- Same palette as config.lua DrawWindow so the floating manager matches XIUI when drawn from d3d_present
+local function PushXiuiFloatingWindowTheme()
+    local gold = components.TAB_STYLE.gold;
+    local goldDark = {0.765, 0.684, 0.474, 1.0};
+    local goldDarker = {0.573, 0.512, 0.355, 1.0};
+    local bgDark = {0.051, 0.051, 0.051, 0.95};
+    local bgMedium = components.TAB_STYLE.bgMedium;
+    local bgLight = components.TAB_STYLE.bgLight;
+    local bgLighter = components.TAB_STYLE.bgLighter;
+    local textLight = {0.878, 0.855, 0.812, 1.0};
+    local borderDark = {0.3, 0.275, 0.235, 1.0};
+    local bgColor = bgDark;
+    local buttonColor = bgMedium;
+    local buttonHoverColor = bgLight;
+    local buttonActiveColor = bgLighter;
+    local tabColor = bgMedium;
+    local tabHoverColor = bgLight;
+    local tabActiveColor = {gold[1], gold[2], gold[3], 0.3};
+    local borderColor = borderDark;
+    local textColor = textLight;
+
+    imgui.PushStyleColor(ImGuiCol_WindowBg, bgColor);
+    imgui.PushStyleColor(ImGuiCol_ChildBg, {0, 0, 0, 0});
+    imgui.PushStyleColor(ImGuiCol_TitleBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_TitleBgActive, bgLight);
+    imgui.PushStyleColor(ImGuiCol_TitleBgCollapsed, bgDark);
+    imgui.PushStyleColor(ImGuiCol_FrameBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_FrameBgHovered, bgLight);
+    imgui.PushStyleColor(ImGuiCol_FrameBgActive, bgLighter);
+    imgui.PushStyleColor(ImGuiCol_Header, bgLight);
+    imgui.PushStyleColor(ImGuiCol_HeaderHovered, bgLighter);
+    imgui.PushStyleColor(ImGuiCol_HeaderActive, {gold[1], gold[2], gold[3], 0.3});
+    imgui.PushStyleColor(ImGuiCol_Border, borderColor);
+    imgui.PushStyleColor(ImGuiCol_Text, textColor);
+    imgui.PushStyleColor(ImGuiCol_TextDisabled, goldDark);
+    imgui.PushStyleColor(ImGuiCol_Button, buttonColor);
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, buttonHoverColor);
+    imgui.PushStyleColor(ImGuiCol_ButtonActive, buttonActiveColor);
+    imgui.PushStyleColor(ImGuiCol_CheckMark, gold);
+    imgui.PushStyleColor(ImGuiCol_SliderGrab, goldDark);
+    imgui.PushStyleColor(ImGuiCol_SliderGrabActive, gold);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarGrab, bgLighter);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarGrabHovered, borderDark);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarGrabActive, goldDark);
+    imgui.PushStyleColor(ImGuiCol_Separator, borderDark);
+    imgui.PushStyleColor(ImGuiCol_PopupBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_Tab, tabColor);
+    imgui.PushStyleColor(ImGuiCol_TabHovered, tabHoverColor);
+    imgui.PushStyleColor(ImGuiCol_TabActive, tabActiveColor);
+    imgui.PushStyleColor(ImGuiCol_TabUnfocused, bgDark);
+    imgui.PushStyleColor(ImGuiCol_TabUnfocusedActive, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_ResizeGrip, goldDarker);
+    imgui.PushStyleColor(ImGuiCol_ResizeGripHovered, goldDark);
+    imgui.PushStyleColor(ImGuiCol_ResizeGripActive, gold);
+
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {12, 12});
+    imgui.PushStyleVar(ImGuiStyleVar_FramePadding, {6, 4});
+    imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {8, 6});
+    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0);
+    imgui.PushStyleVar(ImGuiStyleVar_ChildRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_PopupRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_ScrollbarRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_GrabRounding, 4.0);
+end
+
+local function PopXiuiFloatingWindowTheme()
+    imgui.PopStyleVar(9);
+    imgui.PopStyleColor(34);
+end
+
+local function GetCopyDestinationNamesForModal()
+    local j = modalState.copyTargetJobId or 1;
+    local s = modalState.copyTargetSubjobId or 0;
+    if windowState.selectedPaletteType == 'hotbar' then
+        return palette.GetAvailablePalettes(1, j, s);
+    end
+    if modalState.copyDestScope == 'universal' then
+        return palette.GetUniversalCrossbarPaletteNamesOrdered();
+    end
+    return palette.GetCrossbarPaletteNamesForOrderTier(j, s);
+end
 
 -- Get job name from ID (uses libs/jobs.lua)
 local function GetJobName(jobId)
     if jobId == 0 then return 'Shared'; end
     return jobs[jobId] or ('Job ' .. jobId);
+end
+
+local function GetCrossbarPaletteJobIconTheme()
+    local c = gConfig and gConfig.hotbarCrossbar;
+    local t = c and c.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
 end
 
 -- Check if using fallback (shared) palettes for the selected type
@@ -55,9 +1843,21 @@ local function SetStatusMessage(message)
     windowState.statusMessageTime = os.clock();
 end
 
--- Open the palette manager window
+local function DrawStatusMessage()
+    if not windowState.statusMessage then return; end
+    if os.clock() - windowState.statusMessageTime < 3 then
+        imgui.Spacing();
+        imgui.TextColored({ 1.0, 0.6, 0.3, 1.0 }, windowState.statusMessage);
+    else
+        windowState.statusMessage = nil;
+    end
+end
+
+-- Open the floating Palette Manager (keyboard hotbar palettes only; crossbar uses config /xiui cpalette)
 function M.Open()
     windowState.isOpen = true;
+    windowState.selectedPaletteType = 'hotbar';
+    windowState.selectedPaletteName = nil;
     -- Initialize with current job if not set
     if not windowState.selectedJobId then
         windowState.selectedJobId = data.jobId or 1;
@@ -77,19 +1877,14 @@ function M.IsOpen()
     return windowState.isOpen;
 end
 
--- Helper: Draw palette type selector (hotbar vs crossbar)
-local function DrawPaletteTypeSelector()
-    imgui.Text('Type:');
-    imgui.SameLine();
-    if imgui.RadioButton('Hotbar##paletteType', windowState.selectedPaletteType == 'hotbar') then
-        windowState.selectedPaletteType = 'hotbar';
-        windowState.selectedPaletteName = nil;
+-- Toggle floating Palette Manager (/xiui pal)
+function M.ToggleHotbarPaletteManager()
+    if windowState.isOpen then
+        M.Close();
+        return false;
     end
-    imgui.SameLine();
-    if imgui.RadioButton('Crossbar##paletteType', windowState.selectedPaletteType == 'crossbar') then
-        windowState.selectedPaletteType = 'crossbar';
-        windowState.selectedPaletteName = nil;
-    end
+    M.Open();
+    return true;
 end
 
 -- Helper: Draw job selector dropdown
@@ -165,24 +1960,11 @@ local function DrawSubjobSelector()
     return changed;
 end
 
--- Helper: Draw palette list
+-- Helper: Draw palette list (floating window: keyboard hotbar only)
 local function DrawPaletteList()
-    local palettes;
+    palette.EnsureDefaultPaletteExists(windowState.selectedJobId, 0);
+    local palettes = palette.GetAvailablePalettes(1, windowState.selectedJobId, windowState.selectedSubjobId);
 
-    -- Always ensure default shared palette exists for this job
-    -- This handles both direct shared view and fallback scenarios
-    if windowState.selectedPaletteType == 'hotbar' then
-        palette.EnsureDefaultPaletteExists(windowState.selectedJobId, 0);
-        palettes = palette.GetAvailablePalettes(1, windowState.selectedJobId, windowState.selectedSubjobId);
-    else
-        palette.EnsureCrossbarDefaultPaletteExists(windowState.selectedJobId, 0);
-        palettes = palette.GetCrossbarAvailablePalettes(windowState.selectedJobId, windowState.selectedSubjobId);
-    end
-
-    -- Check fallback status using centralized function
-    local usingFallback = IsUsingFallback(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteType);
-
-    -- Palette list header with clearer source indication
     local headerText;
     if windowState.selectedSubjobId == 0 then
         headerText = string.format('Shared Library (%s)', GetJobName(windowState.selectedJobId));
@@ -190,40 +1972,39 @@ local function DrawPaletteList()
         headerText = string.format('%s/%s', GetJobName(windowState.selectedJobId), GetJobName(windowState.selectedSubjobId));
     end
     imgui.Text(headerText);
-    if usingFallback then
-        imgui.SameLine();
-        imgui.TextColored({0.4, 0.8, 1.0, 1.0}, '(Shared Library)');
-    end
     imgui.Separator();
 
-    -- List of palettes
     local listHeight = 150;
     imgui.BeginChild('##paletteList', { 0, listHeight }, true);
 
     if #palettes == 0 then
         imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'No palettes defined');
     else
+        local hbW = imgui.GetWindowWidth();
+        imgui.Columns(3, '##hbPalCols', true);
+        imgui.SetColumnWidth(0, STATUS_COL_W);
+        imgui.SetColumnWidth(1, math.max(60, hbW - STATUS_COL_W - COPY_COL_W - 40));
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Text('Palette');
+        imgui.NextColumn();
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Separator();
         for i, paletteName in ipairs(palettes) do
             local isSelected = windowState.selectedPaletteName == paletteName;
+            local inRb = palette.IsHotbarPaletteInRbCycle(windowState.selectedJobId, windowState.selectedSubjobId, paletteName);
 
-            -- Custom selected state styling using XIUI colors
-            if isSelected then
-                local gold = components.TAB_STYLE.gold;
-                imgui.PushStyleColor(ImGuiCol_Header, {gold[1], gold[2], gold[3], 0.4});
-                imgui.PushStyleColor(ImGuiCol_HeaderHovered, {gold[1], gold[2], gold[3], 0.5});
-                imgui.PushStyleColor(ImGuiCol_HeaderActive, {gold[1], gold[2], gold[3], 0.6});
-            end
-
-            if imgui.Selectable(paletteName .. '##palette' .. i, isSelected) then
+            imgui.PushID('hbp' .. i);
+            DrawStatusIcon(inRb);
+            imgui.NextColumn();
+            PushPaletteRowStyle(isSelected);
+            if imgui.Selectable(paletteName .. '##palette', isSelected) then
                 windowState.selectedPaletteName = paletteName;
             end
+            PopPaletteRowStyle();
 
-            if isSelected then
-                imgui.PopStyleColor(3);
-            end
-
-            -- Context menu for right-click
-            if imgui.BeginPopupContextItem('##paletteContext' .. i) then
+            if imgui.BeginPopupContextItem('##paletteContext') then
                 if imgui.MenuItem('Rename') then
                     modalState.mode = 'rename';
                     modalState.inputBuffer[1] = paletteName;
@@ -235,8 +2016,12 @@ local function DrawPaletteList()
                     modalState.mode = 'copy';
                     modalState.inputBuffer[1] = paletteName;
                     modalState.errorMessage = nil;
+                    modalState.copyOverwriteExisting = false;
+                    modalState.copyDestExistingIndex = 1;
+                    modalState.crossbarCopyFromSubjob = nil;
                     modalState.copyTargetJobId = windowState.selectedJobId;
                     modalState.copyTargetSubjobId = windowState.selectedSubjobId;
+                    modalState.copyDestScope = 'job';
                     modalState.isOpen = true;
                     windowState.selectedPaletteName = paletteName;
                 end
@@ -252,7 +2037,13 @@ local function DrawPaletteList()
                 end
                 imgui.EndPopup();
             end
+
+            imgui.NextColumn();
+            DrawCreateMacroButton('/xiui palette ' .. paletteName, paletteName, 'hbp' .. i);
+            imgui.NextColumn();
+            imgui.PopID();
         end
+        imgui.Columns(1);
     end
 
     imgui.EndChild();
@@ -260,19 +2051,25 @@ local function DrawPaletteList()
     return palettes;
 end
 
--- Helper: Draw action buttons
+-- Helper: Draw action buttons (floating window: keyboard hotbar only)
 local function DrawActionButtons(palettes)
-    -- New palette button
     if imgui.Button('+ New') then
         modalState.mode = 'create';
         modalState.inputBuffer[1] = '';
         modalState.errorMessage = nil;
+        if windowState.selectedPaletteType == 'crossbar' then
+            local j, s = GetOrResetXbCreateDefaults();
+            modalState.crossbarCreateJobId = j;
+            modalState.crossbarCreateStorageSubjob = s;
+        else
+            modalState.crossbarCreateJobId = nil;
+            modalState.crossbarCreateStorageSubjob = nil;
+        end
         modalState.isOpen = true;
     end
 
     imgui.SameLine();
 
-    -- Rename button (enabled if palette selected)
     local hasSelection = windowState.selectedPaletteName ~= nil;
     if not hasSelection then imgui.BeginDisabled(); end
     if imgui.Button('Rename') then
@@ -285,7 +2082,6 @@ local function DrawActionButtons(palettes)
 
     imgui.SameLine();
 
-    -- Delete button (enabled if palette selected and more than 1 palette)
     local canDelete = hasSelection and #palettes > 1;
     if not canDelete then imgui.BeginDisabled(); end
     if imgui.Button('Delete') then
@@ -298,85 +2094,222 @@ local function DrawActionButtons(palettes)
 
     imgui.SameLine();
 
-    -- Copy To button
     if not hasSelection then imgui.BeginDisabled(); end
     if imgui.Button('Copy To...') then
         modalState.mode = 'copy';
         modalState.inputBuffer[1] = windowState.selectedPaletteName;
         modalState.errorMessage = nil;
+        modalState.copyOverwriteExisting = false;
+        modalState.copyDestExistingIndex = 1;
         modalState.copyTargetJobId = windowState.selectedJobId;
         modalState.copyTargetSubjobId = windowState.selectedSubjobId;
+        modalState.crossbarCopyFromSubjob = nil;
+        modalState.copyDestScope = 'job';
         modalState.isOpen = true;
     end
     if not hasSelection then imgui.EndDisabled(); end
 
-    -- Reorder buttons on next line
     imgui.Spacing();
 
-    if not hasSelection then imgui.BeginDisabled(); end
-    if imgui.Button('Move Up') then
-        local success, err;
-        if windowState.selectedPaletteType == 'hotbar' then
-            success, err = palette.MovePalette(1, windowState.selectedPaletteName, -1, windowState.selectedJobId, windowState.selectedSubjobId);
-        else
-            success, err = palette.MoveCrossbarPalette(windowState.selectedPaletteName, -1, windowState.selectedJobId, windowState.selectedSubjobId);
+    local canMoveUp = false;
+    local canMoveDown = false;
+    if hasSelection and palettes and #palettes > 0 then
+        local ix;
+        for i, n in ipairs(palettes) do
+            if n == windowState.selectedPaletteName then
+                ix = i;
+                break;
+            end
         end
+        canMoveUp = ix ~= nil and ix > 1;
+        canMoveDown = ix ~= nil and ix < #palettes;
+    end
+
+    if not canMoveUp then imgui.BeginDisabled(); end
+    if imgui.Button('Move Up') then
+        local success, err = palette.MovePalette(1, windowState.selectedPaletteName, -1, windowState.selectedJobId, windowState.selectedSubjobId);
         if not success and err then
             SetStatusMessage(err);
         end
     end
+    if not canMoveUp then imgui.EndDisabled(); end
     imgui.SameLine();
+    if not canMoveDown then imgui.BeginDisabled(); end
     if imgui.Button('Move Down') then
-        local success, err;
-        if windowState.selectedPaletteType == 'hotbar' then
-            success, err = palette.MovePalette(1, windowState.selectedPaletteName, 1, windowState.selectedJobId, windowState.selectedSubjobId);
-        else
-            success, err = palette.MoveCrossbarPalette(windowState.selectedPaletteName, 1, windowState.selectedJobId, windowState.selectedSubjobId);
-        end
+        local success, err = palette.MovePalette(1, windowState.selectedPaletteName, 1, windowState.selectedJobId, windowState.selectedSubjobId);
         if not success and err then
             SetStatusMessage(err);
         end
+    end
+    if not canMoveDown then imgui.EndDisabled(); end
+    imgui.SameLine();
+    if not hasSelection then imgui.BeginDisabled(); end
+    local inRbCycle = hasSelection and palette.IsHotbarPaletteInRbCycle(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteName);
+    if imgui.Button((inRbCycle and 'Disable' or 'Enable') .. '##palRbTgl') then
+        palette.SetHotbarPaletteInRbCycle(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteName, not inRbCycle);
     end
     if not hasSelection then imgui.EndDisabled(); end
 
-    -- Show status message (auto-clears after 3 seconds)
-    if windowState.statusMessage then
-        if os.clock() - windowState.statusMessageTime < 3 then
-            imgui.TextColored({1.0, 0.6, 0.3, 1.0}, windowState.statusMessage);
-        else
-            windowState.statusMessage = nil;
-        end
-    end
-
-    -- "Use Shared Library" button (only when viewing subjob-specific palettes)
-    local usingFallback = IsUsingFallback(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteType);
-    if windowState.selectedSubjobId ~= 0 and not usingFallback then
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-        imgui.TextColored({0.6, 0.6, 0.6, 1.0}, 'Subjob-specific palettes override Shared Library.');
-        if imgui.Button('Use Shared Library') then
-            modalState.mode = 'use_shared';
-            modalState.isOpen = true;
-        end
-        if imgui.IsItemHovered() then
-            imgui.SetTooltip('Delete all subjob-specific palettes and use the Shared Library instead.');
-        end
-    end
+    DrawStatusMessage();
 end
 
 -- Helper: Draw create/rename modal
 local function DrawCreateRenameModal()
     if not modalState.isOpen or (modalState.mode ~= 'create' and modalState.mode ~= 'rename') then
+        xbJobCreatePopupPending  = false;
+        createRenamePopupPendingId = nil;
+        return;
+    end
+
+    -- Job crossbar palette create: non-modal (BeginPopup) â€” name + job + Shared/SJ storage; defaults to live job/subjob.
+    if modalState.mode == 'create' and windowState.selectedPaletteType == 'crossbar' and not modalState.embedCrossbarUniversal then
+        if modalState.crossbarCreateJobId == nil or modalState.crossbarCreateStorageSubjob == nil then
+            local j, s = GetOrResetXbCreateDefaults();
+            modalState.crossbarCreateJobId = j;
+            modalState.crossbarCreateStorageSubjob = s;
+        end
+        local cj = modalState.crossbarCreateJobId;
+        if cj < 1 then cj = 1; end
+        if cj > 22 then cj = 22; end
+        modalState.crossbarCreateJobId = cj;
+        local storSj = modalState.crossbarCreateStorageSubjob or 0;
+
+        if not xbJobCreatePopupPending then
+            imgui.SetNextWindowSize({ 560, 0 }, ImGuiCond_Always);
+            imgui.OpenPopup('Create Crossbar Palette##palMgrXbJobNm');
+            xbJobCreatePopupPending = true;
+        end
+        if imgui.BeginPopup('Create Crossbar Palette##palMgrXbJobNm', ImGuiWindowFlags_AlwaysAutoResize) then
+            components.PushPaletteManagerButtonStyle();
+            imgui.TextWrapped('Create a new palette for Job [J] / Subjob [SJ] crossbar storage.');
+            imgui.Spacing();
+
+            if storSj ~= 0 then
+                local usingFallback = IsUsingFallback(cj, storSj, 'crossbar');
+                if usingFallback then
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'Warning: Creating this palette will stop');
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'using shared palettes for ' .. GetJobName(cj) .. '/' .. GetJobName(storSj) .. '.');
+                    imgui.Spacing();
+                end
+            end
+
+            imgui.Text('Job:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            if imgui.BeginCombo('##palMgrXbCreateJob', GetJobName(cj)) then
+                for jobId = 1, 22 do
+                    local isSelected = (jobId == cj);
+                    if imgui.Selectable(GetJobName(jobId) .. '##palMgrXbCj' .. jobId, isSelected) then
+                        modalState.crossbarCreateJobId = jobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.SameLine();
+            imgui.Text('Subjob storage:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            local subLabel = storSj == 0 and 'Shared' or GetJobName(storSj);
+            if imgui.BeginCombo('##palMgrXbCreateSub', subLabel) then
+                local sharedSel = (storSj == 0);
+                if imgui.Selectable('Shared##palMgrXbCs0', sharedSel) then
+                    modalState.crossbarCreateStorageSubjob = 0;
+                end
+                if sharedSel then
+                    imgui.SetItemDefaultFocus();
+                end
+                for subjobId = 1, 22 do
+                    local isSelected = (subjobId == storSj);
+                    if imgui.Selectable(GetJobName(subjobId) .. '##palMgrXbCs' .. subjobId, isSelected) then
+                        modalState.crossbarCreateStorageSubjob = subjobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.Spacing();
+            imgui.Text('Palette name:');
+            imgui.PushItemWidth(220);
+            local enterPressed = imgui.InputText('##palMgrXbCreateName', modalState.inputBuffer, 32, ImGuiInputTextFlags_EnterReturnsTrue);
+            imgui.PopItemWidth();
+
+            if modalState.errorMessage then
+                imgui.TextColored({ 1.0, 0.3, 0.3, 1.0 }, modalState.errorMessage);
+            end
+
+            imgui.Spacing();
+
+            local newName = modalState.inputBuffer[1];
+            local canSubmit = newName and newName ~= '';
+
+            if not canSubmit then
+                imgui.BeginDisabled();
+            end
+            if imgui.Button('Create##palMgrXbCreateOk', { 88, 0 }) or (enterPressed and canSubmit) then
+                if canSubmit then
+                    storSj = modalState.crossbarCreateStorageSubjob or 0;
+                    local createJob = modalState.crossbarCreateJobId;
+                    local success, err = palette.CreateCrossbarPalette(newName, createJob, storSj);
+                    if success then
+                        xbCreatePersisted.jobId         = createJob;
+                        xbCreatePersisted.storageSubjob = storSj;
+                        ClearCrossbarEmbedModalFields();
+                        modalState.isOpen = false;
+                        modalState.crossbarCreateJobId = nil;
+                        modalState.crossbarCreateStorageSubjob = nil;
+                        imgui.CloseCurrentPopup();
+                    else
+                        modalState.errorMessage = err or 'Operation failed';
+                    end
+                end
+            end
+            if not canSubmit then
+                imgui.EndDisabled();
+            end
+
+            imgui.SameLine();
+            if imgui.Button('Cancel##palMgrXbCreateCancel', { 88, 0 }) then
+                modalState.isOpen = false;
+                modalState.crossbarCreateJobId = nil;
+                modalState.crossbarCreateStorageSubjob = nil;
+                ClearCrossbarEmbedModalFields();
+                imgui.CloseCurrentPopup();
+            end
+
+            components.PopPaletteManagerButtonStyle();
+            imgui.EndPopup();
+        else
+            -- Dismissed by clicking outside
+            xbJobCreatePopupPending = false;
+            modalState.isOpen = false;
+            modalState.crossbarCreateJobId = nil;
+            modalState.crossbarCreateStorageSubjob = nil;
+            ClearCrossbarEmbedModalFields();
+        end
         return;
     end
 
     local title = modalState.mode == 'create' and 'Create New Palette' or 'Rename Palette';
-    imgui.OpenPopup(title .. '##paletteModal');
+    local popupId = title .. '##paletteModal';
+    if createRenamePopupPendingId ~= popupId then
+        imgui.SetNextWindowSize({ 320, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup(popupId);
+        createRenamePopupPendingId = popupId;
+    end
 
-    if imgui.BeginPopupModal(title .. '##paletteModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
-        -- Warning when creating will break away from shared palettes
-        if modalState.mode == 'create' and windowState.selectedSubjobId ~= 0 then
+    if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
+        local embedU = modalState.embedCrossbarUniversal == true;
+        if modalState.mode == 'create' and not embedU and windowState.selectedSubjobId ~= 0 and windowState.selectedPaletteType == 'hotbar' then
             local usingFallback = IsUsingFallback(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteType);
             if usingFallback then
                 imgui.TextColored({1.0, 0.7, 0.3, 1.0}, 'Warning: Creating this palette will stop');
@@ -385,6 +2318,24 @@ local function DrawCreateRenameModal()
             end
         end
 
+        -- Main job profile for this palette (Shared vs SJ tier does not change the icon)
+        if not embedU then
+            do
+                local jid = windowState.selectedJobId or 1;
+                local jtex = TextureManager.getJobIcon(jid, GetCrossbarPaletteJobIconTheme());
+                if jtex and jtex.image then
+                    local p = tonumber(ffi.cast('uint32_t', jtex.image));
+                    if p then
+                        imgui.AlignTextToFramePadding();
+                        imgui.Image(p, { 18, 18 });
+                        imgui.SameLine(0, 6);
+                    end
+                end
+            end
+        else
+            imgui.TextColored({ 0.85, 0.85, 0.5, 1.0 }, 'Global [G]');
+            imgui.SameLine(0, 8);
+        end
         imgui.Text('Palette Name:');
         imgui.PushItemWidth(200);
         local enterPressed = imgui.InputText('##paletteName', modalState.inputBuffer, 32, ImGuiInputTextFlags_EnterReturnsTrue);
@@ -404,40 +2355,32 @@ local function DrawCreateRenameModal()
         if imgui.Button('OK', { 80, 0 }) or enterPressed then
             if canSubmit then
                 local success, err;
-                if modalState.mode == 'create' then
-                    if windowState.selectedPaletteType == 'hotbar' then
-                        success, err = palette.CreatePalette(1, newName, windowState.selectedJobId, windowState.selectedSubjobId);
+                if embedU then
+                    if modalState.mode == 'create' then
+                        success, err = palette.CreateUniversalCrossbarPalette(newName);
                     else
-                        success, err = palette.CreateCrossbarPalette(newName, windowState.selectedJobId, windowState.selectedSubjobId);
+                        success, err = palette.RenameUniversalCrossbarPalette(windowState.selectedPaletteName, newName);
                     end
+                elseif modalState.mode == 'create' then
+                    -- Job crossbar create uses non-modal BeginPopup (see early exit above).
+                    success, err = palette.CreatePalette(1, newName, windowState.selectedJobId, windowState.selectedSubjobId);
                 else  -- rename
                     if windowState.selectedPaletteType == 'hotbar' then
                         success, err = palette.RenamePalette(1, windowState.selectedPaletteName, newName, windowState.selectedJobId, windowState.selectedSubjobId);
                     else
-                        success, err = palette.RenameCrossbarPalette(windowState.selectedPaletteName, newName, windowState.selectedJobId, windowState.selectedSubjobId);
+                        local opSub = GetCrossbarModalStorageSubjob();
+                        success, err = palette.RenameCrossbarPalette(windowState.selectedPaletteName, newName, windowState.selectedJobId, opSub);
                     end
                 end
 
                 if success then
                     windowState.selectedPaletteName = newName;
-
-                    -- Activate the newly created palette if viewing current job's palettes
-                    if modalState.mode == 'create' then
-                        local currentJobId = data.jobId;
-                        local currentSubjobId = data.subjobId or 0;
-                        local viewingShared = (windowState.selectedSubjobId == 0);
-                        local viewingCurrentJob = (windowState.selectedJobId == currentJobId);
-                        local viewingCurrentSubjob = (windowState.selectedSubjobId == currentSubjobId);
-
-                        -- Activate if: viewing this job's shared library OR viewing exact job/subjob match
-                        if viewingCurrentJob and (viewingShared or viewingCurrentSubjob) then
-                            if windowState.selectedPaletteType == 'hotbar' then
-                                palette.SetActivePalette(1, newName, currentJobId, currentSubjobId);
-                            else
-                                palette.SetActivePaletteForCombo('L2', newName);
-                            end
-                        end
+                    if embedU then
+                        embedCrossbarUniversalContext.selectedPaletteName = newName;
+                    elseif modalState.mode == 'rename' and windowState.selectedPaletteType == 'crossbar' then
+                        embedCrossbarJobContext.selectedPaletteName = newName;
                     end
+                    ClearCrossbarEmbedModalFields();
 
                     modalState.isOpen = false;
                     imgui.CloseCurrentPopup();
@@ -451,89 +2394,165 @@ local function DrawCreateRenameModal()
 
         if imgui.Button('Cancel', { 80, 0 }) then
             modalState.isOpen = false;
+            ClearCrossbarEmbedModalFields();
             imgui.CloseCurrentPopup();
         end
 
+        components.PopPaletteManagerButtonStyle();
         imgui.EndPopup();
+    else
+        -- Dismissed by clicking outside
+        createRenamePopupPendingId = nil;
+        modalState.isOpen = false;
+        ClearCrossbarEmbedModalFields();
     end
 end
 
 -- Helper: Draw copy modal
 local function DrawCopyModal()
     if not modalState.isOpen or modalState.mode ~= 'copy' then
+        copyPopupPending = false;
         return;
     end
 
-    imgui.OpenPopup('Copy Palette##copyModal');
+    if not copyPopupPending then
+        imgui.SetNextWindowSize({ 420, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup('Copy Palette##copyModal');
+        copyPopupPending = true;
+    end
+    if imgui.BeginPopup('Copy Palette##copyModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
+        local embedUcopy = modalState.embedCrossbarUniversalCopy == true;
+        local copySourceName = windowState.selectedPaletteName;
+        local isCrossbar = windowState.selectedPaletteType == 'crossbar';
 
-    if imgui.BeginPopupModal('Copy Palette##copyModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
-        imgui.Text('Copy "' .. windowState.selectedPaletteName .. '" to:');
+        if embedUcopy and modalState.copyDestScope == 'universal' then
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to another Global [G] palette:');
+        elseif embedUcopy and modalState.copyDestScope == 'job' then
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to a Job [J] palette:');
+        elseif not embedUcopy and isCrossbar and modalState.copyDestScope == 'universal' then
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to a Global [G] palette:');
+        else
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to:');
+        end
         imgui.Spacing();
 
-        -- Job selector
-        imgui.Text('Job:');
-        imgui.SameLine();
-        imgui.PushItemWidth(100);
-        if imgui.BeginCombo('##copyJobSelector', GetJobName(modalState.copyTargetJobId)) then
-            for jobId = 1, 22 do
-                local isSelected = (jobId == modalState.copyTargetJobId);
-                if imgui.Selectable(GetJobName(jobId), isSelected) then
-                    modalState.copyTargetJobId = jobId;
+        if isCrossbar then
+            imgui.Text('Destination storage:');
+            local scopeJob = modalState.copyDestScope == 'job';
+            if imgui.RadioButton('Job / Subjob [J]##palCopyDestJob', scopeJob) then
+                modalState.copyDestScope = 'job';
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('Global [G]##palCopyDestG', not scopeJob) then
+                modalState.copyDestScope = 'universal';
+            end
+            imgui.ShowHelp('Job [J] copies into per-job crossbar storage (shared tier or subjob tier). Global [G] copies into all-jobs universal crossbar palettes.');
+            imgui.Spacing();
+        end
+
+        local showJobDestControls = (windowState.selectedPaletteType == 'hotbar')
+            or (isCrossbar and modalState.copyDestScope == 'job');
+
+        if showJobDestControls then
+            -- Job selector
+            imgui.Text('Job:');
+            imgui.SameLine();
+            imgui.PushItemWidth(100);
+            if imgui.BeginCombo('##copyJobSelector', GetJobName(modalState.copyTargetJobId)) then
+                for jobId = 1, 22 do
+                    local isSelected = (jobId == modalState.copyTargetJobId);
+                    if imgui.Selectable(GetJobName(jobId), isSelected) then
+                        modalState.copyTargetJobId = jobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
                 end
-                if isSelected then
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            -- Subjob selector
+            imgui.SameLine();
+            imgui.Text('Subjob:');
+            imgui.SameLine();
+            imgui.PushItemWidth(100);
+            local currentSubjobLabel = modalState.copyTargetSubjobId == 0 and 'Shared' or GetJobName(modalState.copyTargetSubjobId);
+            if imgui.BeginCombo('##copySubjobSelector', currentSubjobLabel) then
+                local sharedSelected = (modalState.copyTargetSubjobId == 0);
+                if imgui.Selectable('Shared', sharedSelected) then
+                    modalState.copyTargetSubjobId = 0;
+                end
+                if sharedSelected then
                     imgui.SetItemDefaultFocus();
                 end
-            end
-            imgui.EndCombo();
-        end
-        imgui.PopItemWidth();
-
-        -- Subjob selector
-        imgui.SameLine();
-        imgui.Text('Subjob:');
-        imgui.SameLine();
-        imgui.PushItemWidth(100);
-        local currentSubjobLabel = modalState.copyTargetSubjobId == 0 and 'Shared' or GetJobName(modalState.copyTargetSubjobId);
-        if imgui.BeginCombo('##copySubjobSelector', currentSubjobLabel) then
-            -- Shared option
-            local sharedSelected = (modalState.copyTargetSubjobId == 0);
-            if imgui.Selectable('Shared', sharedSelected) then
-                modalState.copyTargetSubjobId = 0;
-            end
-            if sharedSelected then
-                imgui.SetItemDefaultFocus();
-            end
-            -- Job options
-            for subjobId = 1, 22 do
-                local isSelected = (subjobId == modalState.copyTargetSubjobId);
-                if imgui.Selectable(GetJobName(subjobId), isSelected) then
-                    modalState.copyTargetSubjobId = subjobId;
+                for subjobId = 1, 22 do
+                    local isSelected = (subjobId == modalState.copyTargetSubjobId);
+                    if imgui.Selectable(GetJobName(subjobId), isSelected) then
+                        modalState.copyTargetSubjobId = subjobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
                 end
-                if isSelected then
-                    imgui.SetItemDefaultFocus();
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.Spacing();
+
+            if modalState.copyTargetSubjobId ~= 0 then
+                local targetUsingFallback = IsUsingFallback(modalState.copyTargetJobId, modalState.copyTargetSubjobId, windowState.selectedPaletteType);
+                if targetUsingFallback then
+                    imgui.TextColored({1.0, 0.7, 0.3, 1.0}, 'Warning: This will stop using shared palettes for');
+                    imgui.TextColored({1.0, 0.7, 0.3, 1.0}, GetJobName(modalState.copyTargetJobId) .. '/' .. GetJobName(modalState.copyTargetSubjobId) .. '.');
+                    imgui.Spacing();
                 end
             end
-            imgui.EndCombo();
         end
-        imgui.PopItemWidth();
 
-        imgui.Spacing();
+        local destNames = GetCopyDestinationNamesForModal();
+        if #destNames == 0 then
+            modalState.copyDestExistingIndex = 1;
+        elseif modalState.copyDestExistingIndex > #destNames then
+            modalState.copyDestExistingIndex = #destNames;
+        elseif modalState.copyDestExistingIndex < 1 then
+            modalState.copyDestExistingIndex = 1;
+        end
 
-        -- Warning when copying to a subjob-specific location that currently uses shared palettes
-        if modalState.copyTargetSubjobId ~= 0 then
-            local targetUsingFallback = IsUsingFallback(modalState.copyTargetJobId, modalState.copyTargetSubjobId, windowState.selectedPaletteType);
-            if targetUsingFallback then
-                imgui.TextColored({1.0, 0.7, 0.3, 1.0}, 'Warning: This will stop using shared palettes for');
-                imgui.TextColored({1.0, 0.7, 0.3, 1.0}, GetJobName(modalState.copyTargetJobId) .. '/' .. GetJobName(modalState.copyTargetSubjobId) .. '.');
-                imgui.Spacing();
+        local copyOwBuf = { modalState.copyOverwriteExisting == true };
+        imgui.Checkbox('Overwrite an existing palette##copyPalOw', copyOwBuf);
+        modalState.copyOverwriteExisting = copyOwBuf[1];
+
+        if modalState.copyOverwriteExisting then
+            imgui.TextColored({1.0, 0.65, 0.35, 1.0}, 'Warning: All slot actions on the destination palette will be replaced.');
+            imgui.Spacing();
+            if #destNames == 0 then
+                imgui.TextColored({0.75, 0.75, 0.75, 1.0}, 'No palettes exist at this destination yet.');
+            else
+                imgui.Text('Destination palette:');
+                imgui.PushItemWidth(220);
+                local comboLabel = destNames[modalState.copyDestExistingIndex] or destNames[1];
+                if imgui.BeginCombo('##copyDestExisting', comboLabel) then
+                    for di, pname in ipairs(destNames) do
+                        if imgui.Selectable(pname .. '##copyDest' .. di, di == modalState.copyDestExistingIndex) then
+                            modalState.copyDestExistingIndex = di;
+                        end
+                        if di == modalState.copyDestExistingIndex then
+                            imgui.SetItemDefaultFocus();
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                imgui.PopItemWidth();
             end
+        else
+            imgui.Text('New name (leave blank to keep the same):');
+            imgui.PushItemWidth(200);
+            imgui.InputText('##copyNewName', modalState.inputBuffer, 32);
+            imgui.PopItemWidth();
         end
-
-        -- New name input
-        imgui.Text('New Name (leave blank to keep same):');
-        imgui.PushItemWidth(200);
-        imgui.InputText('##copyNewName', modalState.inputBuffer, 32);
-        imgui.PopItemWidth();
 
         -- Show error if any
         if modalState.errorMessage then
@@ -542,16 +2561,65 @@ local function DrawCopyModal()
 
         imgui.Spacing();
 
-        -- Check if copying to same location with same name
         local newName = modalState.inputBuffer[1];
         if newName == '' then newName = nil; end
-        local effectiveName = newName or windowState.selectedPaletteName;
-        local isSameLocation = modalState.copyTargetJobId == windowState.selectedJobId and
-                               modalState.copyTargetSubjobId == windowState.selectedSubjobId and
-                               effectiveName == windowState.selectedPaletteName;
+
+        local overwrite = modalState.copyOverwriteExisting == true;
+        local destArg;
+        if overwrite then
+            destArg = destNames[modalState.copyDestExistingIndex];
+        else
+            destArg = newName;
+        end
+
+        local effectiveName;
+        if overwrite then
+            effectiveName = destArg;
+        else
+            effectiveName = newName or windowState.selectedPaletteName;
+        end
+
+        local copyFromSubjob = windowState.selectedSubjobId;
+        if windowState.selectedPaletteType == 'crossbar' and modalState.crossbarCopyFromSubjob ~= nil then
+            copyFromSubjob = modalState.crossbarCopyFromSubjob;
+        end
+
+        local isCopyNoOp;
+        if embedUcopy then
+            if modalState.copyDestScope == 'universal' then
+                if overwrite then
+                    isCopyNoOp = not destArg or destArg == '' or destArg == copySourceName;
+                else
+                    isCopyNoOp = (not newName or newName == '') or (newName == copySourceName);
+                end
+            else
+                isCopyNoOp = false;
+            end
+        elseif isCrossbar and modalState.copyDestScope == 'universal' then
+            isCopyNoOp = false;
+        else
+            isCopyNoOp = modalState.copyTargetJobId == windowState.selectedJobId and
+                modalState.copyTargetSubjobId == copyFromSubjob and
+                effectiveName == windowState.selectedPaletteName;
+        end
+
+        local canCopy;
+        if embedUcopy then
+            if modalState.copyDestScope == 'universal' then
+                if overwrite then
+                    canCopy = not isCopyNoOp and destArg ~= nil and destArg ~= '' and #destNames > 0;
+                else
+                    canCopy = not isCopyNoOp and newName and newName ~= '';
+                end
+            else
+                canCopy = not isCopyNoOp and (not overwrite or (destArg ~= nil and destArg ~= '' and #destNames > 0));
+            end
+        else
+            canCopy = not isCopyNoOp and (not overwrite or (destArg ~= nil and destArg ~= '' and #destNames > 0));
+        end
 
         -- Buttons
-        if isSameLocation then imgui.BeginDisabled(); end
+        if not canCopy then imgui.BeginDisabled(); end
         if imgui.Button('Copy', { 80, 0 }) then
             local success, err;
             if windowState.selectedPaletteType == 'hotbar' then
@@ -561,48 +2629,85 @@ local function DrawCopyModal()
                     windowState.selectedSubjobId,
                     modalState.copyTargetJobId,
                     modalState.copyTargetSubjobId,
-                    newName
+                    destArg,
+                    overwrite
+                );
+            elseif embedUcopy then
+                if modalState.copyDestScope == 'universal' then
+                    local destFinal = overwrite and destArg or newName;
+                    success, err = palette.CopyUniversalCrossbarPalette(copySourceName, destFinal, overwrite);
+                else
+                    local destFinal = overwrite and destArg or (newName or copySourceName);
+                    success, err = palette.CopyUniversalCrossbarPaletteToJob(
+                        copySourceName,
+                        destFinal,
+                        modalState.copyTargetJobId,
+                        modalState.copyTargetSubjobId,
+                        overwrite
+                    );
+                end
+            elseif isCrossbar and modalState.copyDestScope == 'universal' then
+                local destFinal = overwrite and destArg or (newName or windowState.selectedPaletteName);
+                success, err = palette.CopyCrossbarPaletteToUniversal(
+                    windowState.selectedPaletteName,
+                    windowState.selectedJobId,
+                    copyFromSubjob,
+                    destFinal,
+                    overwrite
                 );
             else
                 success, err = palette.CopyCrossbarPalette(
                     windowState.selectedPaletteName,
                     windowState.selectedJobId,
-                    windowState.selectedSubjobId,
+                    copyFromSubjob,
                     modalState.copyTargetJobId,
                     modalState.copyTargetSubjobId,
-                    newName
+                    destArg,
+                    overwrite
                 );
             end
 
             if success then
                 modalState.isOpen = false;
+                ClearCrossbarEmbedModalFields();
                 imgui.CloseCurrentPopup();
             else
                 modalState.errorMessage = err or 'Copy failed';
             end
         end
-        if isSameLocation then imgui.EndDisabled(); end
+        if not canCopy then imgui.EndDisabled(); end
 
         imgui.SameLine();
 
         if imgui.Button('Cancel', { 80, 0 }) then
             modalState.isOpen = false;
+            ClearCrossbarEmbedModalFields();
             imgui.CloseCurrentPopup();
         end
 
+        components.PopPaletteManagerButtonStyle();
         imgui.EndPopup();
+    else
+        copyPopupPending = false;
+        modalState.isOpen = false;
+        ClearCrossbarEmbedModalFields();
     end
 end
 
 -- Helper: Draw delete confirmation modal
 local function DrawDeleteConfirmModal()
     if not modalState.isOpen or modalState.mode ~= 'delete' then
+        deletePopupPending = false;
         return;
     end
 
-    imgui.OpenPopup('Delete Palette##deleteModal');
-
-    if imgui.BeginPopupModal('Delete Palette##deleteModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if not deletePopupPending then
+        imgui.SetNextWindowSize({ 300, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup('Delete Palette##deleteModal');
+        deletePopupPending = true;
+    end
+    if imgui.BeginPopup('Delete Palette##deleteModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
         imgui.Text('Are you sure you want to delete');
         imgui.Text('"' .. (modalState.deletePaletteName or '') .. '"?');
         imgui.Spacing();
@@ -619,14 +2724,21 @@ local function DrawDeleteConfirmModal()
         -- Buttons
         if imgui.Button('Delete', { 80, 0 }) then
             local success, err;
-            if windowState.selectedPaletteType == 'hotbar' then
+            if modalState.embedCrossbarUniversal == true then
+                success, err = palette.DeleteUniversalCrossbarPalette(modalState.deletePaletteName);
+            elseif windowState.selectedPaletteType == 'hotbar' then
                 success, err = palette.DeletePalette(1, modalState.deletePaletteName, windowState.selectedJobId, windowState.selectedSubjobId);
             else
-                success, err = palette.DeleteCrossbarPalette(modalState.deletePaletteName, windowState.selectedJobId, windowState.selectedSubjobId);
+                local opSub = GetCrossbarModalStorageSubjob();
+                success, err = palette.DeleteCrossbarPalette(modalState.deletePaletteName, windowState.selectedJobId, opSub);
             end
             if success then
                 windowState.selectedPaletteName = nil;
+                embedCrossbarJobContext.selectedPaletteName = nil;
+                embedCrossbarJobContext.selectedStorageSubjob = nil;
+                embedCrossbarUniversalContext.selectedPaletteName = nil;
                 modalState.isOpen = false;
+                ClearCrossbarEmbedModalFields();
                 imgui.CloseCurrentPopup();
             else
                 modalState.errorMessage = err or 'Delete failed';
@@ -637,22 +2749,33 @@ local function DrawDeleteConfirmModal()
 
         if imgui.Button('Cancel', { 80, 0 }) then
             modalState.isOpen = false;
+            ClearCrossbarEmbedModalFields();
             imgui.CloseCurrentPopup();
         end
 
+        components.PopPaletteManagerButtonStyle();
         imgui.EndPopup();
+    else
+        deletePopupPending = false;
+        modalState.isOpen = false;
+        ClearCrossbarEmbedModalFields();
     end
 end
 
 -- Helper: Draw "Use Shared Library" confirmation modal
 local function DrawUseSharedModal()
     if not modalState.isOpen or modalState.mode ~= 'use_shared' then
+        useSharedPopupPending = false;
         return;
     end
 
-    imgui.OpenPopup('Use Shared Library##useSharedModal');
-
-    if imgui.BeginPopupModal('Use Shared Library##useSharedModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if not useSharedPopupPending then
+        imgui.SetNextWindowSize({ 380, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup('Use Shared Library##useSharedModal');
+        useSharedPopupPending = true;
+    end
+    if imgui.BeginPopup('Use Shared Library##useSharedModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
         local jobName = GetJobName(windowState.selectedJobId);
         local subjobName = GetJobName(windowState.selectedSubjobId);
 
@@ -690,48 +2813,685 @@ local function DrawUseSharedModal()
             modalState.isOpen = false;
             imgui.CloseCurrentPopup();
         end
+        components.PopPaletteManagerButtonStyle();
+        imgui.EndPopup();
+    else
+        useSharedPopupPending = false;
+        modalState.isOpen = false;
+    end
+end
+
+-- Embedded Global [G] crossbar palette manager (same interaction model as Job/J+SJ embed, no job binding)
+function M.DrawEmbeddedCrossbarManageUniversal()
+    windowState.selectedPaletteType = 'crossbar';
+
+    palette.EnsureUniversalCrossbarDefaultExists();
+    local names = palette.GetUniversalCrossbarPaletteNamesOrdered();
+
+    if #names > 0 then
+        local sn = embedCrossbarUniversalContext.selectedPaletteName;
+        local needPick = sn == nil;
+        if not needPick then
+            local found = false;
+            for _, n in ipairs(names) do
+                if n == sn then
+                    found = true;
+                    break;
+                end
+            end
+            if not found then
+                needPick = true;
+            end
+        end
+        if needPick then
+            embedCrossbarUniversalContext.selectedPaletteName = names[1];
+            windowState.selectedPaletteName = names[1];
+        end
+    end
+
+    local avail = imgui.GetContentRegionAvail();
+    local availW = type(avail) == 'table' and avail[1] or avail or 400;
+    -- Wider than 50%: config tab has room; avoids cramped Palette / Status columns
+    local shellW = math.max(300, math.min(availW * 0.62, 720));
+
+    -- List: column headers + separator + fixed visible rows; extra palettes scroll inside the child.
+    local lineH = imgui.GetTextLineHeightWithSpacing();
+    local nNames = #names;
+    local headerChromeH = math.floor(lineH * 2 + 6);
+    local listH;
+    if nNames == 0 then
+        listH = math.floor(lineH * 3 + 12);
+    else
+        listH = headerChromeH + EMBED_CROSSBAR_PAL_LIST_VISIBLE_ROWS * lineH + 2;
+    end
+    local headerBlockH = math.floor(lineH * 3 + 8);
+    local listToButtonsPad = 4;
+    local actionBlockH = GetEmbedCrossbarPalMgrActionBlockH();
+    local shellH = headerBlockH + listH + listToButtonsPad + actionBlockH;
+
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 12, 6 });
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgMedium);
+    imgui.PushStyleColor(ImGuiCol_Border, { 0.42, 0.36, 0.26, 0.85 });
+    imgui.BeginChild('##xbEmbedUniversalPalMgrShell', { shellW, shellH }, true, 0);
+
+    imgui.TextColored(components.MANAGER_BUTTON_STYLE.palette.headerText, 'Palette Manager');
+    imgui.Spacing();
+    imgui.TextColored({ 0.85, 0.82, 0.7, 1.0 }, 'Palettes - Global [G]');
+    imgui.Separator();
+
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgLighter);
+    -- Scrollbar only when content exceeds listH (not AlwaysVerticalScrollbar â€” avoids permanent gutter + squeeze)
+    imgui.BeginChild('##xbEmbedUniversalPalList', { 0, listH }, true, 0);
+
+    if #names == 0 then
+        imgui.TextColored({ 0.5, 0.5, 0.5, 1.0 }, 'No palettes');
+    else
+        local xbUW = imgui.GetWindowWidth();
+        imgui.Columns(3, '##xbEmbUCols', true);
+        imgui.SetColumnWidth(0, STATUS_COL_W);
+        imgui.SetColumnWidth(1, math.max(60, xbUW - STATUS_COL_W - COPY_COL_W - 40));
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Text('Palette');
+        imgui.NextColumn();
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Separator();
+        for i, name in ipairs(names) do
+            local isSel = embedCrossbarUniversalContext.selectedPaletteName == name;
+            local inCyc = palette.GetUniversalPaletteIncludeInCycle(name);
+            imgui.PushID('xbemu' .. i .. '_' .. name);
+            DrawStatusIcon(inCyc);
+            imgui.NextColumn();
+            local label = name .. ' (G)';
+            PushPaletteRowStyle(isSel);
+            if imgui.Selectable(label .. '##sel', isSel) then
+                embedCrossbarUniversalContext.selectedPaletteName = name;
+                windowState.selectedPaletteName = name;
+            end
+            PopPaletteRowStyle();
+            if imgui.BeginPopupContextItem('##ctxu') then
+                if imgui.MenuItem('Rename##xbemu') then
+                    modalState.mode = 'rename';
+                    modalState.inputBuffer[1] = name;
+                    modalState.errorMessage = nil;
+                    modalState.isOpen = true;
+                    modalState.embedCrossbarUniversal = true;
+                    embedCrossbarUniversalContext.selectedPaletteName = name;
+                    windowState.selectedPaletteName = name;
+                end
+                if imgui.MenuItem('Copy To...##xbemu') then
+                    modalState.mode = 'copy';
+                    modalState.inputBuffer[1] = name;
+                    modalState.errorMessage = nil;
+                    modalState.copyOverwriteExisting = false;
+                    modalState.copyDestExistingIndex = 1;
+                    modalState.embedCrossbarUniversalCopy = true;
+                    modalState.copyDestScope = 'universal';
+                    modalState.copyTargetJobId = data.jobId or 1;
+                    modalState.copyTargetSubjobId = data.subjobId or 0;
+                    embedCrossbarUniversalContext.selectedPaletteName = name;
+                    windowState.selectedPaletteName = name;
+                    modalState.isOpen = true;
+                end
+                if #names > 1 then
+                    imgui.Separator();
+                    if imgui.MenuItem('Delete##xbemu') then
+                        modalState.mode = 'delete';
+                        modalState.deletePaletteName = name;
+                        modalState.errorMessage = nil;
+                        modalState.embedCrossbarUniversal = true;
+                        modalState.isOpen = true;
+                        windowState.selectedPaletteName = name;
+                    end
+                end
+                imgui.EndPopup();
+            end
+            imgui.NextColumn();
+            DrawCreateMacroButton('/xiui cpal g ' .. name, name, 'xbemu' .. i);
+            imgui.NextColumn();
+            imgui.PopID();
+        end
+        imgui.Columns(1);
+    end
+
+    imgui.EndChild();
+    imgui.PopStyleColor();
+    imgui.Dummy({ 0, listToButtonsPad });
+
+    local selName = embedCrossbarUniversalContext.selectedPaletteName;
+    local hasSel = selName ~= nil;
+
+    components.PushPaletteManagerButtonStyle();
+    if imgui.Button('+ New##xbemuNew') then
+        modalState.mode = 'create';
+        modalState.inputBuffer[1] = '';
+        modalState.errorMessage = nil;
+        modalState.isOpen = true;
+        modalState.embedCrossbarUniversal = true;
+    end
+
+    imgui.SameLine();
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Rename##xbemuRen') then
+        modalState.mode = 'rename';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.embedCrossbarUniversal = true;
+        modalState.isOpen = true;
+        windowState.selectedPaletteName = selName;
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    local canDel = hasSel and #names > 1;
+    if not canDel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Delete##xbemuDel') then
+        modalState.mode = 'delete';
+        modalState.deletePaletteName = selName;
+        modalState.errorMessage = nil;
+        modalState.embedCrossbarUniversal = true;
+        modalState.isOpen = true;
+        windowState.selectedPaletteName = selName;
+    end
+    if not canDel then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Copy To...##xbemuCp') then
+        modalState.mode = 'copy';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.copyOverwriteExisting = false;
+        modalState.copyDestExistingIndex = 1;
+        modalState.embedCrossbarUniversalCopy = true;
+        modalState.copyDestScope = 'universal';
+        modalState.copyTargetJobId = data.jobId or 1;
+        modalState.copyTargetSubjobId = data.subjobId or 0;
+        modalState.embedCrossbarUniversal = true;
+        windowState.selectedPaletteName = selName;
+        modalState.isOpen = true;
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+
+    imgui.Spacing();
+
+    local idxInList = nil;
+    if hasSel then
+        for ti, n in ipairs(names) do
+            if n == selName then
+                idxInList = ti;
+                break;
+            end
+        end
+    end
+    local canUp = hasSel and idxInList ~= nil and idxInList > 1;
+    local canDown = hasSel and idxInList ~= nil and idxInList < #names;
+
+    if not canUp then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Move Up##xbemuUp') and canUp then
+        local success, err = palette.MoveUniversalCrossbarPalette(selName, -1);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canUp then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    if not canDown then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Move Down##xbemuDn') and canDown then
+        local success, err = palette.MoveUniversalCrossbarPalette(selName, 1);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canDown then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    local inRbSel = hasSel and palette.GetUniversalPaletteIncludeInCycle(selName);
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button((inRbSel and 'Disable' or 'Enable') .. '##xbemuRbTgl') then
+        palette.SetUniversalPaletteIncludeInCycle(selName, not inRbSel);
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Edit Full Palette##xbemuFullPal') and hasSel then
+        embedCrossbarComboCtx = {
+            kind = 'universal',
+            name = selName,
+        };
+        embedCrossbarComboWinOpen[1] = true;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+    imgui.SameLine();
+    imgui.ShowHelp(
+        'Tip: put /xiui cpaledit in a macro to toggle this editor for your currently active crossbar palette (same as this button).'
+    );
+
+    components.PopPaletteManagerButtonStyle();
+    DrawStatusMessage();
+
+    imgui.EndChild();
+    imgui.PopStyleColor(2);
+    imgui.PopStyleVar();
+end
+
+-- Embedded job/subjob crossbar palette manager (Manage Palettes & Crossbar â€” no separate window)
+function M.DrawEmbeddedCrossbarManage(jobId, subjobId)
+    windowState.selectedPaletteType = 'crossbar';
+    windowState.selectedJobId = jobId;
+    windowState.selectedSubjobId = subjobId;
+
+    palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
+
+    local rows = palette.GetCrossbarManagePaletteRows(jobId, subjobId);
+
+    local function tierKeyEq(a, b)
+        return (tonumber(a) or 0) == (tonumber(b) or 0);
+    end
+
+    -- Ensure a valid selection so Move Up/Down can resolve index (storage tier must match row data).
+    if #rows > 0 then
+        local sn = embedCrossbarJobContext.selectedPaletteName;
+        local ss = embedCrossbarJobContext.selectedStorageSubjob;
+        local needPick = sn == nil or ss == nil;
+        if not needPick then
+            local found = false;
+            for _, r in ipairs(rows) do
+                if r.name == sn and tierKeyEq(r.storageSubjob, ss) then
+                    found = true;
+                    break;
+                end
+            end
+            if not found then
+                needPick = true;
+            end
+        end
+        if needPick then
+            local r0 = rows[1];
+            embedCrossbarJobContext.selectedPaletteName = r0.name;
+            embedCrossbarJobContext.selectedStorageSubjob = r0.storageSubjob;
+            windowState.selectedPaletteName = r0.name;
+            windowState.selectedCrossbarStorageSubjob = r0.storageSubjob;
+        end
+    end
+
+    local avail = imgui.GetContentRegionAvail();
+    local availW = type(avail) == 'table' and avail[1] or avail or 400;
+    local shellW = math.max(300, math.min(availW * 0.62, 720));
+
+    local lineH = imgui.GetTextLineHeightWithSpacing();
+    local nRows = #rows;
+    local headerChromeH = math.floor(lineH * 2 + 6);
+    local listH;
+    if nRows == 0 then
+        listH = math.floor(lineH * 3 + 12);
+    else
+        listH = headerChromeH + EMBED_CROSSBAR_PAL_LIST_VISIBLE_ROWS * lineH + 2;
+    end
+    local headerBlockH = math.floor(lineH * 3 + 8);
+    local listToButtonsPad = 4;
+    local actionBlockH = GetEmbedCrossbarPalMgrActionBlockH();
+    local shellH = headerBlockH + listH + listToButtonsPad + actionBlockH;
+
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 12, 6 });
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgMedium);
+    imgui.PushStyleColor(ImGuiCol_Border, { 0.42, 0.36, 0.26, 0.85 });
+    imgui.BeginChild('##xbEmbedPalMgrShell', { shellW, shellH }, true, 0);
+
+    imgui.TextColored(components.MANAGER_BUTTON_STYLE.palette.headerText, 'Palette Manager');
+    imgui.Spacing();
+    if subjobId == 0 then
+        imgui.TextColored({0.85, 0.82, 0.7, 1.0}, string.format('Palettes - Job (J) %s + Shared', GetJobName(jobId)));
+    else
+        imgui.TextColored({0.85, 0.82, 0.7, 1.0}, string.format('Palettes - Job (J) %s + Subjob (SJ) %s', GetJobName(jobId), GetJobName(subjobId)));
+    end
+    imgui.Separator();
+
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgLighter);
+    imgui.BeginChild('##xbEmbedPalList', { 0, listH }, true, 0);
+
+    if #rows == 0 then
+        imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'No palettes');
+    else
+        local xbW = imgui.GetWindowWidth();
+        imgui.Columns(3, '##xbEmbCols', true);
+        imgui.SetColumnWidth(0, STATUS_COL_W);
+        imgui.SetColumnWidth(1, math.max(60, xbW - STATUS_COL_W - COPY_COL_W - 40));
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Text('Palette');
+        imgui.NextColumn();
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Separator();
+        for i, row in ipairs(rows) do
+            local label = row.name .. palette.FormatCrossbarTierSuffixLabel(row.storageSubjob, subjobId);
+            local isSel = embedCrossbarJobContext.selectedPaletteName == row.name
+                and tierKeyEq(embedCrossbarJobContext.selectedStorageSubjob, row.storageSubjob);
+            local inRbEmb = palette.IsCrossbarPaletteInRbCycle(jobId, row.storageSubjob, row.name);
+            -- Build the CLI command for this palette row.
+            -- J tier (storageSubjob == 0): /xiui cpal BLM Name
+            -- SJ tier: /xiui cpal BLMNIN Name
+            local jobPrefix = GetJobName(jobId);
+            if row.storageSubjob ~= 0 then
+                jobPrefix = jobPrefix .. GetJobName(row.storageSubjob);
+            end
+            local rowCmd = '/xiui cpal ' .. jobPrefix .. ' ' .. row.name;
+            imgui.PushID('xbem' .. i .. '_' .. row.storageSubjob .. '_' .. row.name);
+            DrawStatusIcon(inRbEmb);
+            imgui.NextColumn();
+            PushPaletteRowStyle(isSel);
+            if imgui.Selectable(label .. '##sel', isSel) then
+                embedCrossbarJobContext.selectedPaletteName = row.name;
+                embedCrossbarJobContext.selectedStorageSubjob = row.storageSubjob;
+                windowState.selectedPaletteName = row.name;
+                windowState.selectedCrossbarStorageSubjob = row.storageSubjob;
+            end
+            PopPaletteRowStyle();
+            if imgui.BeginPopupContextItem('##ctx') then
+                if imgui.MenuItem('Rename##xbem') then
+                    modalState.mode = 'rename';
+                    modalState.inputBuffer[1] = row.name;
+                    modalState.errorMessage = nil;
+                    modalState.isOpen = true;
+                    modalState.crossbarOperationSubjob = row.storageSubjob;
+                    embedCrossbarJobContext.selectedPaletteName = row.name;
+                    embedCrossbarJobContext.selectedStorageSubjob = row.storageSubjob;
+                    windowState.selectedPaletteName = row.name;
+                end
+                if imgui.MenuItem('Copy To...##xbem') then
+                    modalState.mode = 'copy';
+                    modalState.inputBuffer[1] = row.name;
+                    modalState.errorMessage = nil;
+                    modalState.copyOverwriteExisting = false;
+                    modalState.copyDestExistingIndex = 1;
+                    modalState.copyDestScope = 'job';
+                    modalState.copyTargetJobId = jobId;
+                    modalState.copyTargetSubjobId = subjobId;
+                    modalState.crossbarCopyFromSubjob = row.storageSubjob;
+                    embedCrossbarJobContext.selectedPaletteName = row.name;
+                    embedCrossbarJobContext.selectedStorageSubjob = row.storageSubjob;
+                    windowState.selectedPaletteName = row.name;
+                    windowState.selectedCrossbarStorageSubjob = row.storageSubjob;
+                    modalState.isOpen = true;
+                end
+                if #rows > 1 then
+                    imgui.Separator();
+                    if imgui.MenuItem('Delete##xbem') then
+                        modalState.mode = 'delete';
+                        modalState.deletePaletteName = row.name;
+                        modalState.errorMessage = nil;
+                        modalState.crossbarOperationSubjob = row.storageSubjob;
+                        modalState.isOpen = true;
+                        windowState.selectedPaletteName = row.name;
+                    end
+                end
+                imgui.EndPopup();
+            end
+            imgui.NextColumn();
+            DrawCreateMacroButton(rowCmd, row.name, 'xbem' .. i);
+            imgui.NextColumn();
+            imgui.PopID();
+        end
+        imgui.Columns(1);
+    end
+
+    imgui.EndChild();
+    imgui.PopStyleColor();
+    imgui.Dummy({ 0, listToButtonsPad });
+
+    local selName = embedCrossbarJobContext.selectedPaletteName;
+    local selSt = embedCrossbarJobContext.selectedStorageSubjob;
+    local hasSel = selName ~= nil and selSt ~= nil;
+
+    components.PushPaletteManagerButtonStyle();
+    if imgui.Button('+ New##xbemNew') then
+        local j, s = GetOrResetXbCreateDefaults();
+        modalState.mode = 'create';
+        modalState.inputBuffer[1] = '';
+        modalState.errorMessage = nil;
+        modalState.crossbarCreateJobId = j;
+        modalState.crossbarCreateStorageSubjob = s;
+        modalState.isOpen = true;
+        ClearCrossbarEmbedModalFields();
+    end
+
+    imgui.SameLine();
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button('Rename##xbemRen') then
+        modalState.mode = 'rename';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.isOpen = true;
+        modalState.crossbarOperationSubjob = selSt;
+        windowState.selectedPaletteName = selName;
+    end
+    if not hasSel then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    local canDel = hasSel and #rows > 1;
+    if not canDel then imgui.BeginDisabled(); end
+    if imgui.Button('Delete##xbemDel') then
+        modalState.mode = 'delete';
+        modalState.deletePaletteName = selName;
+        modalState.errorMessage = nil;
+        modalState.isOpen = true;
+        modalState.crossbarOperationSubjob = selSt;
+        windowState.selectedPaletteName = selName;
+    end
+    if not canDel then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button('Copy To...##xbemCp') then
+        modalState.mode = 'copy';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.copyOverwriteExisting = false;
+        modalState.copyDestExistingIndex = 1;
+        modalState.copyDestScope = 'job';
+        modalState.copyTargetJobId = jobId;
+        modalState.copyTargetSubjobId = subjobId;
+        modalState.crossbarCopyFromSubjob = selSt;
+        windowState.selectedPaletteName = selName;
+        windowState.selectedCrossbarStorageSubjob = selSt;
+        modalState.isOpen = true;
+    end
+    if not hasSel then imgui.EndDisabled(); end
+
+    imgui.Spacing();
+
+    -- Same ordered name list as MoveCrossbarPalette (per storage tier), so index matches swap logic
+    local tierNames = {};
+    local idxInTier = nil;
+    if hasSel then
+        tierNames = palette.GetCrossbarPaletteNamesForOrderTier(jobId, tonumber(selSt) or 0);
+        for ti, n in ipairs(tierNames) do
+            if n == selName then
+                idxInTier = ti;
+                break;
+            end
+        end
+    end
+    local canUp = hasSel and idxInTier ~= nil and idxInTier > 1;
+    local canDown = hasSel and idxInTier ~= nil and idxInTier < #tierNames;
+
+    if not canUp then imgui.BeginDisabled(); end
+    if imgui.Button('Move Up##xbemUp') and canUp then
+        local success, err = palette.MoveCrossbarPalette(selName, -1, jobId, selSt);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canUp then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    if not canDown then imgui.BeginDisabled(); end
+    if imgui.Button('Move Down##xbemDn') and canDown then
+        local success, err = palette.MoveCrossbarPalette(selName, 1, jobId, selSt);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canDown then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    local inRbEmbSel = false;
+    if hasSel then
+        inRbEmbSel = palette.IsCrossbarPaletteInRbCycle(jobId, selSt or 0, selName);
+    end
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button((inRbEmbSel and 'Disable' or 'Enable') .. '##xbemRbTgl') then
+        palette.SetCrossbarPaletteInRbCycle(jobId, selSt or 0, selName, not inRbEmbSel);
+    end
+    if not hasSel then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button('Edit Full Palette##xbemMpal') and hasSel then
+        embedCrossbarComboCtx = {
+            kind = 'job',
+            jobId = jobId,
+            subjobId = subjobId,
+            name = selName,
+            st = selSt,
+        };
+        embedCrossbarComboWinOpen[1] = true;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+    end
+    if not hasSel then imgui.EndDisabled(); end
+    imgui.SameLine();
+    imgui.ShowHelp(
+        'Tip: put /xiui cpaledit in a macro to toggle this editor for your currently active crossbar palette (same as this button).'
+    );
+
+    components.PopPaletteManagerButtonStyle();
+    DrawStatusMessage();
+
+    imgui.EndChild();
+    imgui.PopStyleColor(2);
+    imgui.PopStyleVar();
+end
+
+-- Confirm closing XIUI Config while Edit Full Palette has unsaved draft changes (see DeferConfigCloseIfEditFullPaletteOpen).
+local function DrawCloseConfigWhileEditPaletteModal()
+    if openCloseConfigConfirmPopup then
+        imgui.OpenPopup('Unsaved Edit Full Palette##xiuiCloseCfgEditPalModal');
+        openCloseConfigConfirmPopup = false;
+    end
+    if imgui.BeginPopup('Unsaved Edit Full Palette##xiuiCloseCfgEditPalModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        imgui.TextWrapped('You have unsaved changes in Edit Full Palette. What would you like to do?');
+        imgui.Spacing();
+        local cfg = require('config');
+        if imgui.Button('Save and Close##xiuiCfgClosePalSave', { 140, 0 }) then
+            data.ApplyDraft();
+            if SaveSettingsToDisk then
+                SaveSettingsToDisk();
+            end
+            ForceCloseEditFullPaletteWindow();
+            if cfg.SetWindowOpen then
+                cfg.SetWindowOpen(false);
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Revert and Close##xiuiCfgClosePalRevert', { 140, 0 }) then
+            data.DiscardDraft();
+            ForceCloseEditFullPaletteWindow();
+            if cfg.SetWindowOpen then
+                cfg.SetWindowOpen(false);
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Cancel##xiuiCfgClosePalCancel', { 100, 0 }) then
+            imgui.CloseCurrentPopup();
+        end
         imgui.EndPopup();
     end
 end
 
+-- Modals + embedded Crossbar "Edit Full Palette" window run even when the floating Palette Manager is closed.
+local function DrawPaletteManagerModals()
+    DrawCloseConfigWhileEditPaletteModal();
+    DrawCreateRenameModal();
+    DrawCopyModal();
+    DrawDeleteConfirmModal();
+    DrawUseSharedModal();
+    DrawEmbeddedCrossbarComboModesPopup();
+end
+
 -- Draw the main palette manager window
 function M.Draw()
-    if not windowState.isOpen then
-        return;
+    -- Theme applies to the floating window, modals, and the large Crossbar "Edit Full Palette" window
+    local applyTheme = windowState.isOpen or modalState.isOpen or (embedCrossbarComboCtx ~= nil);
+    if applyTheme then
+        PushXiuiFloatingWindowTheme();
     end
 
-    -- Window size
-    imgui.SetNextWindowSize({ 350, 400 }, ImGuiCond_FirstUseEver);
+    if windowState.isOpen then
+        imgui.SetNextWindowSize({ 350, 400 }, ImGuiCond_FirstUseEver);
 
-    local windowFlags = ImGuiWindowFlags_None;
-    local isOpen = { windowState.isOpen };
+        local windowFlags = ImGuiWindowFlags_None;
+        local isOpen = { windowState.isOpen };
 
-    if imgui.Begin('Palette Manager##paletteManager', isOpen, windowFlags) then
-        -- Type selector
-        DrawPaletteTypeSelector();
-        imgui.Spacing();
+        if imgui.Begin('Palette Manager##paletteManager', isOpen, windowFlags) then
+            components.PushPaletteManagerButtonStyle();
+            DrawJobSelector();
+            DrawSubjobSelector();
+            imgui.Spacing();
 
-        -- Job/Subjob selectors
-        DrawJobSelector();
-        DrawSubjobSelector();
-        imgui.Spacing();
+            local palettes = DrawPaletteList();
+            imgui.Spacing();
 
-        -- Palette list
-        local palettes = DrawPaletteList();
-        imgui.Spacing();
+            DrawActionButtons(palettes);
+            components.PopPaletteManagerButtonStyle();
+        end
+        imgui.End();
 
-        -- Action buttons
-        DrawActionButtons(palettes);
-
-        -- Draw modals
-        DrawCreateRenameModal();
-        DrawCopyModal();
-        DrawDeleteConfirmModal();
-        DrawUseSharedModal();
+        windowState.isOpen = isOpen[1];
     end
-    imgui.End();
 
-    windowState.isOpen = isOpen[1];
+    DrawPaletteManagerModals();
+
+    if applyTheme then
+        PopXiuiFloatingWindowTheme();
+    end
 end
 
 return M;
+

--- a/XIUI/libs/dragdrop.lua
+++ b/XIUI/libs/dragdrop.lua
@@ -18,7 +18,7 @@
 *       onDrop = function(payload, zoneId) ... end,
 *   });
 *
-*   -- Render drag preview (call at end of frame)
+*   -- After all DropZone calls for the frame (and FlushDeferredDrops if overlapping rects exist), render preview
 *   dragdrop.Render();
 ]]--
 
@@ -46,6 +46,10 @@ local state = {
     -- Track if drop was handled this frame (vs dropped outside)
     dropHandledThisFrame = false,
     lastPayload = nil,  -- Preserved after drag ends for outside drop handling
+
+    -- Overlapping rects (e.g. HUD crossbar + Edit Full Palette preview): queue candidates and run one winner in FlushDeferredDrops (priority + registration order).
+    deferredDropCandidates = nil,
+    deferredDropSeq = 0,
 
     -- Drop zone registry
     zones = {},
@@ -110,6 +114,7 @@ function dragdrop.CancelDrag()
     state.dragActivated = false;
     state.activeZoneId = nil;
     state.previousZoneId = nil;
+    state.deferredDropCandidates = nil;
     state.dragEndedThisFrame = true;
 end
 
@@ -267,17 +272,49 @@ function dragdrop.DropZone(id, x, y, width, height, options)
         state.activeZoneId = nil;
     end
 
-    -- Check for drop (mouse released while hovering valid zone)
+    -- Queue drop for end-of-frame resolution (overlapping zones: highest dropPriority wins; tie → later registration).
     local dropped = false;
     if isHovered and canAccept and imgui.IsMouseReleased(0) then
         dropped = true;
-        state.dropHandledThisFrame = true;  -- Mark that drop was handled
         if options.onDrop then
-            options.onDrop(state.payload, id);
+            if not state.deferredDropCandidates then
+                state.deferredDropCandidates = {};
+            end
+            state.deferredDropSeq = state.deferredDropSeq + 1;
+            table.insert(state.deferredDropCandidates, {
+                priority = options.dropPriority or 0,
+                seq = state.deferredDropSeq,
+                zoneId = id,
+                onDrop = options.onDrop,
+            });
         end
     end
 
     return dropped, isHovered and canAccept;
+end
+
+---Resolve overlapping drop zones for this frame. Call once after every DropZone has run (e.g. hotbar FinalizeFrame), before Render().
+function dragdrop.FlushDeferredDrops()
+    local candidates = state.deferredDropCandidates;
+    state.deferredDropCandidates = nil;
+    if not candidates or #candidates == 0 then
+        return;
+    end
+    local payload = state.payload;
+    if not payload then
+        return;
+    end
+    table.sort(candidates, function(a, b)
+        if a.priority ~= b.priority then
+            return a.priority > b.priority;
+        end
+        return a.seq > b.seq;
+    end);
+    local winner = candidates[1];
+    if winner and winner.onDrop then
+        state.dropHandledThisFrame = true;
+        winner.onDrop(payload, winner.zoneId);
+    end
 end
 
 -- ============================================
@@ -369,6 +406,8 @@ function dragdrop.Update()
     state.dragEndedThisFrame = false;
     state.dropHandledThisFrame = false;
     state.lastPayload = nil;
+    state.deferredDropCandidates = nil;
+    state.deferredDropSeq = 0;
 
     -- Clear zones from previous frame
     state.zones = {};
@@ -411,6 +450,7 @@ function dragdrop.Reset()
     state.zones = {};
     state.activeZoneId = nil;
     state.previousZoneId = nil;
+    state.deferredDropCandidates = nil;
 end
 
 return dragdrop;

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -17,13 +17,35 @@ local dragdrop = require('libs.dragdrop');
 local data = require('modules.hotbar.data');
 local actions = require('modules.hotbar.actions');
 local textures = require('modules.hotbar.textures');
+-- TextureManager is used for the palette scope icon overlay (job icon / infinity for universal palettes).
+local TextureManager = require('libs.texturemanager');
 local controller = require('modules.hotbar.controller');
 local recast = require('modules.hotbar.recast');
 local slotrenderer = require('modules.hotbar.slotrenderer');
+-- playerdata caches the player's known abilities + weaponskills; `IsActionAvailable` falls
+-- back to "unavailable" when the caches are empty. Keyboard hotbars warm these from their
+-- own DrawWindow, but crossbar-only setups (`hotbarEnabled=false, crossbarEnabled=true`)
+-- never touched playerdata before — every JA/WS slot then read as unavailable (grayed +
+-- "X") even on jobs that knew the abilities. We now refresh once per frame from crossbar
+-- DrawWindow as well; the refresh is signature-gated internally (job/level/equip diff) so
+-- the steady-state cost is a few cache reads, not a full re-scan.
+local playerdata = require('modules.hotbar.playerdata');
 local animation = require('libs.animation');
 local skillchain = require('modules.hotbar.skillchain');
+-- macroparse extracts the primary line + JA badge type from a /ws or /pet macro body, so we can
+-- predict skillchain icons on macro slots whose first line is a weapon skill or blood pact.
+-- Display.lua does the same thing for keyboard hotbars; without it, crossbar macro slots whose
+-- primary line is /ws or /pet would never light up even though firing the macro IS the WS/pact.
+local macroparse = require('modules.hotbar.macroparse');
 local targetLib = require('libs.target');
 local palette = require('modules.hotbar.palette');
+-- Used to dim the crossbar when a blocking game menu is open AND `crossbarDisableInMenu`
+-- is enabled, so the player can see at a glance that controller input is paused.
+local gamestate = require('core.gamestate');
+-- macropalette is required only for the palette-editor drop handlers (effective palette key
+-- + macro source store). Required at module scope here (mirrors Ferris); if a future
+-- circular dependency creeps in this can be flipped to a lazy `require` inside the closures.
+local macropalette = require('modules.hotbar.macropalette');
 
 local M = {};
 
@@ -75,6 +97,13 @@ end
 
 local SLOTS_PER_SIDE = 8;
 local COMBO_MODES = controller.COMBO_MODES;
+-- Full enumeration of combo-mode storage keys (used by the Edit Full Palette editor and the
+-- pet-tab filter). 'Shared' is the chord-fallback for sharedExpanded layouts where both
+-- L2+R2 and R2+L2 collapse to one set.
+local ALL_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', 'Shared' };
+-- Naming prefix on resource maps + IDs used by the Edit Full Palette draft layer so its
+-- ImGui drop zones / animation keys never collide with the live HUD's 'crossbar_*' set.
+local PAL_ED_PREFIX = 'PalEd_';
 
 -- ============================================
 -- Layout Calculation Functions
@@ -277,7 +306,14 @@ local function GetCachedCrossbarIcon(comboMode, slotIndex, slotData)
 end
 
 -- Clear crossbar icon cache
+-- iconCache rows hold the only Lua ref to D3D textures returned by actions.GetBindIcon
+-- (LoadTextureFromPath wires a gc_safe_release finalizer). Wiping mid-frame — e.g. palette
+-- deletion fires InvalidateAllVisualCachesAfterPaletteListMutation while the crossbar
+-- DrawWindow is still building this frame's ImGui draw list — lets Lua GC finalize the COM
+-- texture while AddImage still references it (CTD on Ashita 4.16). DeferRelease holds the
+-- old table alive until FlushPendingReleases runs at the top of the next d3d_present.
 local function ClearCrossbarIconCache()
+    TextureManager.DeferRelease(iconCache);
     iconCache = {};
 end
 
@@ -286,6 +322,10 @@ local function ClearCrossbarIconCacheForSlot(comboMode, slotIndex)
     -- Use effective combo mode for cache key (Shared when shared expanded bar is enabled)
     comboMode = data.GetEffectiveComboModeForStorage and data.GetEffectiveComboModeForStorage(comboMode) or comboMode;
     if iconCache[comboMode] then
+        local oldRow = iconCache[comboMode][slotIndex];
+        if oldRow ~= nil then
+            TextureManager.DeferRelease(oldRow);
+        end
         iconCache[comboMode][slotIndex] = nil;
     end
 end
@@ -328,6 +368,16 @@ local state = {
         progress = 1.0,
         wasHidden = false,
     },
+
+    -- useSharedExpandedBar bookkeeping. The shared-center layout collapses the bar to one
+    -- diamond width and forces the X anchor to screen-center every frame; without these the
+    -- normal X anchor would either get persisted as the centered narrow value (chord persists
+    -- across a save) or snap back to the leftmost saved position on chord exit. The two-step
+    -- handoff is: while in chord we stash the last "wide" window X here, then on the first
+    -- frame that exits chord we re-anchor to that stashed X so the bar returns where the
+    -- user actually placed it (rather than wherever the centered narrow bar happened to land).
+    lastWideCrossbarWindowX = nil,
+    wasSharedCenterChordLayout = false,
 };
 
 -- ============================================
@@ -376,12 +426,24 @@ end
 -- ============================================
 
 -- Determine which combo modes to display on left/right based on active combo
--- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'both', or nil)
-local function GetDisplayModes(activeCombo)
+-- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'center', 'both', or nil)
+-- When useSharedExpandedBar is enabled and the user holds a chord (L2+R2 / R2+L2), expandedSide
+-- becomes 'center': only the left column is drawn (using the 'Shared' storage key), the window
+-- shrinks to one diamond width, and DrawWindow re-centers it to screen X (a single 8-slot strip
+-- centered like the FFXIV controller bar) rather than the two-diamond wide layout.
+local function GetDisplayModes(activeCombo, settings)
+    settings = settings or (gConfig and gConfig.hotbarCrossbar);
+    local useSharedExp = settings and settings.useSharedExpandedBar == true;
     if activeCombo == COMBO_MODES.L2_THEN_R2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: L2 first, then R2 -> show L2R2 on left side only, right side dimmed (shows R2)
         return 'L2R2', 'R2', true, 'left';
     elseif activeCombo == COMBO_MODES.R2_THEN_L2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: R2 first, then L2 -> show R2L2 on right side only, left side dimmed (shows L2)
         return 'L2', 'R2L2', true, 'right';
     elseif activeCombo == 'Shared' then
@@ -585,6 +647,69 @@ local function GetSlotPositionInWindow(side, slotIndex, windowX, windowY, settin
 end
 
 -- ============================================
+-- Window-decor padding (slot-top vs window-top accounting)
+-- ============================================
+-- ImGui clips anything we draw OUTSIDE the window's content rect. The crossbar paints a
+-- lot of decoration above the slot grid (L2/R2 trigger icons, combo text, R1 cpal-anchor
+-- pulse, palette-modifier refresh glyph) and below it (palette name, action labels). To
+-- keep all of that inside the window's draw region we open the ImGui window taller than
+-- the slot grid by CROSSBAR_WINDOW_TOP_DECOR_PAD on top and `GetCrossbarWindowBottomPad`
+-- on the bottom, then offset the window-top so the SLOT GRID still lands at the user's
+-- saved (or default) Y. `state.windowY` continues to mean "slot grid top" everywhere
+-- else in this module, which lets the rest of the layout code stay unchanged.
+local CROSSBAR_WINDOW_TOP_DECOR_PAD = 80;
+
+local function GetCrossbarWindowBottomPad(settings)
+    settings = settings or {};
+    local pad = 10;
+    if settings.showActionLabels then
+        pad = pad + (settings.labelFontSize or 10) + 6 + math.max(0, tonumber(settings.actionLabelOffsetY) or 0);
+    end
+    pad = pad + math.floor(((settings.mpCostFontSize or 10) + (settings.quantityFontSize or 10)) * 0.15 + 0.5);
+    return math.min(72, math.max(10, pad));
+end
+
+-- Profile stores SLOT TOP Y (`gConfig.windowPositions.Crossbar.y`), not window-top. When
+-- we apply a saved position we subtract the decor pad so the slot grid lands where the
+-- user originally placed it. The `appliedPositions` flag keeps ImGui's drag from being
+-- overridden every frame (ImGuiCond_Always otherwise).
+local function ApplyCrossbarWindowPositionOnce()
+    if not gConfig or not gConfig.windowPositions or not gConfig.windowPositions['Crossbar'] then
+        return false;
+    end
+    if not gConfig.appliedPositions then
+        gConfig.appliedPositions = {};
+    end
+    if gConfig.appliedPositions['Crossbar'] then
+        return false;
+    end
+    local pos = gConfig.windowPositions['Crossbar'];
+    imgui.SetNextWindowPos({ pos.x, pos.y - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    gConfig.appliedPositions['Crossbar'] = true;
+    return true;
+end
+
+-- Save SLOT TOP Y, not window-top, so the saved coordinate stays meaningful even if the
+-- decor pad changes between releases (or a future patch adds more decoration above the
+-- slot grid). Skips writes when nothing changed to avoid table churn / unnecessary disk
+-- saves on every frame.
+local function SaveCrossbarWindowSlotTopPosition()
+    if not gConfig then return; end
+    local wx, wy = imgui.GetWindowPos();
+    if not gConfig.windowPositions then
+        gConfig.windowPositions = {};
+    end
+    local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+    local saved = gConfig.windowPositions['Crossbar'];
+    if not saved then
+        gConfig.windowPositions['Crossbar'] = { x = wx, y = slotTopY };
+    elseif saved.x ~= wx or saved.y ~= slotTopY then
+        saved.x = wx;
+        saved.y = slotTopY;
+    end
+end
+
+-- ============================================
 -- Initialization
 -- ============================================
 
@@ -671,12 +796,147 @@ end
 -- animOpacity: 0-1 for animation fade (default 1.0)
 -- yOffset: Y offset in pixels for animation (default 0)
 -- skillchainName: (optional) Skillchain name for WS slots
-local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName)
+-- Reusable cbInteraction sub-tables built lazily for palette-editor slots so the editor and
+-- the live crossbar each get their own slotInteraction set (different idPrefix/buttonId/
+-- dropZoneId — palette editor uses 'paled_*'; live crossbar uses 'crossbar_*'). Keeping
+-- them separate also lets the slotrenderer drop-zone-lock semantics treat them differently
+-- (paled_* are never locked; crossbar_* respect crossbarLockMovement).
+local cbInteractionPalEd = {};
+
+local function GetCbInteractionPaletteEditor(comboMode, slotIndex)
+    if not cbInteractionPalEd[comboMode] then cbInteractionPalEd[comboMode] = {}; end
+    local cached = cbInteractionPalEd[comboMode][slotIndex];
+    if cached then return cached; end
+
+    local entry = {
+        buttonId = string.format('##paled_%s_%d', comboMode, slotIndex),
+        dropZoneId = string.format('paled_%s_%d', comboMode, slotIndex),
+        pressKey = 'paled_' .. comboMode .. '_' .. slotIndex,
+        onDrop = function(payload)
+            -- Palette-editor drops go through the draft layer; Apply Draft promotes them to live.
+            -- All branches normalize through the overlay (draft falls back to live) and finalize
+            -- before writing so dual-arm macros swap correctly and empty results clear properly.
+            if payload.type == 'macro' then
+                if payload.data and payload.data.macroPaletteKey == nil then
+                    if macropalette.GetEffectivePaletteType then
+                        payload.data.macroPaletteKey = macropalette.GetEffectivePaletteType();
+                    else
+                        payload.data.macroPaletteKey = data.jobId or 1;
+                    end
+                end
+                if payload.data and macropalette.GetMacroSourceTagForDrops
+                    and payload.data.macroSourceStore == nil then
+                    payload.data.macroSourceStore = macropalette.GetMacroSourceTagForDrops();
+                end
+                local arm = {};
+                for k, v in pairs(payload.data) do arm[k] = v; end
+                if arm.macroRef == nil and payload.data.id then
+                    arm.macroRef = payload.data.id;
+                end
+                local existingRaw = data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex);
+                local existing = data.NormalizeCrossbarSlotRawForSwap(existingRaw);
+                local store = arm.macroSourceStore
+                    or (macropalette.GetMacroSourceTagForDrops and macropalette.GetMacroSourceTagForDrops())
+                    or 'profile';
+                local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                data.SetDraftSlotData(comboMode, slotIndex, built);
+            elseif payload.type == 'crossbar_slot' then
+                -- Always read source/target from overlay at drop time; payload.data was captured
+                -- at drag start and can alias stale tables after earlier moves in the same session.
+                local srcCombo = payload.comboMode;
+                local srcSlot = payload.slotIndex;
+                if srcCombo == comboMode and srcSlot == slotIndex then return; end
+                if data.BeginDraftUndoGroup then data.BeginDraftUndoGroup(); end
+                local srcRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(srcCombo, srcSlot));
+                local tgtRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+                local newTgt, newSrc = data.SwapActiveMacroArmsInPlace(srcRaw, tgtRaw);
+                local fT = data.FinalizeCrossbarRawSlotForStorage(newTgt);
+                local fS = data.FinalizeCrossbarRawSlotForStorage(newSrc);
+                if fT == nil then
+                    data.ClearDraftSlotData(comboMode, slotIndex);
+                else
+                    data.SetDraftSlotData(comboMode, slotIndex, fT);
+                end
+                if fS == nil then
+                    data.ClearDraftSlotData(srcCombo, srcSlot);
+                else
+                    data.SetDraftSlotData(srcCombo, srcSlot, fS);
+                end
+                if data.EndDraftUndoGroup then data.EndDraftUndoGroup(); end
+                -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+                -- the icon cache clear above is the only refresh needed for the source slot.
+                ClearCrossbarIconCacheForSlot(srcCombo, srcSlot);
+            elseif payload.type == 'slot' then
+                if payload.data then
+                    local c = data.FinalizeCrossbarRawSlotForStorage(data.CopyTable(payload.data));
+                    if c == nil then
+                        data.ClearDraftSlotData(comboMode, slotIndex);
+                    else
+                        data.SetDraftSlotData(comboMode, slotIndex, c);
+                    end
+                end
+            end
+            -- Visual refresh for the target slot (matches live-HUD drop behaviour).
+            -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+            -- the icon cache clear is the only refresh needed (the bind hash on next frame
+            -- naturally re-derives slot draw state — see ClearSlotIconCache notes in macropalette).
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        getDragData = function()
+            -- Use overlay (draft falling back to live) so dragging a slot that hasn't been
+            -- touched in this edit session still carries its persisted data. Reading draft-only
+            -- here would drag nil and the drop handler would clear the target slot.
+            local raw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+            return {
+                type = 'crossbar_slot',
+                comboMode = comboMode,
+                slotIndex = slotIndex,
+                data = raw,
+            };
+        end,
+        onRightClick = function()
+            data.ClearDraftSlotData(comboMode, slotIndex);
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        -- Double-click in Edit Full Palette opens the macro editor for the slot's draft
+        -- content. For empty slots that resolves to nil and macropalette.OpenEditorForSlotData
+        -- starts a fresh "creating new" session seeded with the active palette type's defaults.
+        -- The (comboMode, slotIndex) carried in the pending edit lets palettemanager auto-bind
+        -- the new macro to this slot after Save (see config/palettemanager.lua consume site).
+        -- We funnel through data.SetPendingPaletteSlotEdit so the editor opens on the NEXT
+        -- frame (consumed by config/palettemanager.lua after slots draw); opening it directly
+        -- inside this click handler would put a modal inside the hotbar's draw pass and skip
+        -- the macropalette draw-order assumptions.
+        onDoubleClick = function()
+            local slotData = data.GetDraftSlotData
+                and data.GetDraftSlotData(comboMode, slotIndex)
+                or nil;
+            data.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex);
+        end,
+    };
+    cbInteractionPalEd[comboMode][slotIndex] = entry;
+    return entry;
+end
+
+-- Palette-editor empty-slot panel tint (matches the Edit Full Palette row fill in palettemanager.lua).
+-- Lighter than the live crossbar's 0x55000000 so slot outlines read clearly against the editor row.
+local PAL_ED_EMPTY_SLOT_BG = 0xFF8E96AC;
+
+local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName, activeCombo, editorClipRect, magicBurstName)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
-    -- Get pre-created interaction closures and IDs
-    local interaction = GetCbInteraction(comboMode, slotIndex);
+    -- Edit Full Palette state: when active, this slot belongs to the editor's draft layer
+    -- rather than the live crossbar. palSk is the storage-key the editor is targeting; the
+    -- draft layer is separate per-key (so editing one palette doesn't touch the live binding).
+    local palSk = data.GetCrossbarPaletteEditSessionKey and data.GetCrossbarPaletteEditSessionKey();
+    local isEditor = palSk ~= nil;
+
+    -- Get pre-created interaction closures and IDs. Editor and live get different prefixes so
+    -- the slotrenderer drop-zone-lock policy can distinguish them (paled_* are never locked).
+    local interaction = isEditor
+        and GetCbInteractionPaletteEditor(comboMode, slotIndex)
+        or GetCbInteraction(comboMode, slotIndex);
 
     -- Apply Y offset for animation
     local drawY = y + yOffset;
@@ -687,8 +947,14 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
         iconPressScale = animation.getPressScale(interaction.pressKey, isPressed and isActive);
     end
 
-    -- Get slot data
-    local slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    -- Slot data source: editor reads from the draft layer (synced from live at session start
+    -- via data.SyncDraftSlotFromLive); live crossbar always reads the persisted binding.
+    local slotData;
+    if isEditor then
+        slotData = data.GetDraftSlotData and data.GetDraftSlotData(comboMode, slotIndex) or nil;
+    else
+        slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    end
 
     -- Get icon + cached abbreviation for this action (cached - only rebuilds when bind changes)
     local icon, cachedAbbr, cachedAbbrW = GetCachedCrossbarIcon(comboMode, slotIndex, slotData);
@@ -696,6 +962,33 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     -- Global UI scale (slotSize/x/y come in already scaled; we apply gs here to
     -- font sizes and pixel offsets that come straight from settings).
     local gs = (gConfig and gConfig.globalScale) or 1.0;
+
+    -- Diamond position: 1=Top, 2=Right, 3=Bottom, 4=Left (slots 5-8 map via -4 for face buttons).
+    -- Top-slot labels placed below would overlap the bottom slot's MP/quantity text, so the
+    -- editor (and any caller that asks for labels) flips them above for the top position.
+    local posIndex = (slotIndex <= 4) and slotIndex or (slotIndex - 4);
+    local labelAboveSlot = (posIndex == 1);
+
+    -- Dim policy. Live crossbar: inactive sides get a softer dim; when a trigger is held the
+    -- non-active half dims much harder so the active set pops. Editor: nothing is "inactive".
+    local dimFactor = 1.0;
+    if not isEditor and not isActive then
+        if activeCombo and activeCombo ~= COMBO_MODES.NONE then
+            dimFactor = settings.inactiveSideWhileTriggerDim;
+            if dimFactor == nil then dimFactor = 0.15; end
+        else
+            dimFactor = settings.inactiveSlotDim or 0.5;
+        end
+    end
+
+    -- Editor background: lighter tint behind empty editor slots so slot borders pop on the
+    -- panel row; filled editor slots use the user's normal background.
+    local slotBgColor = settings.slotBackgroundColor or 0x55000000;
+    local slotOpacity = settings.slotOpacity or 1.0;
+    if isEditor and not slotData then
+        slotBgColor = PAL_ED_EMPTY_SLOT_BG;
+        slotOpacity = 1.0;
+    end
 
     -- Update reusable params table in-place
     local p = cbParams;
@@ -707,28 +1000,30 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.cachedAbbrW = cachedAbbrW;
     p.bind = slotData;
     p.icon = icon;
-    p.slotBgColor = settings.slotBackgroundColor or 0x55000000;
-    p.slotOpacity = settings.slotOpacity or 1.0;
-    p.dimFactor = isActive and 1.0 or (settings.inactiveSlotDim or 0.5);
+    p.slotBgColor = slotBgColor;
+    p.slotOpacity = slotOpacity;
+    p.dimFactor = dimFactor;
     p.animOpacity = animOpacity;
     p.isPressed = isPressed and isActive;
     p.iconPressScale = iconPressScale;
-    p.showMpCost = settings.showMpCost ~= false;
+    p.showMpCost = isEditor and false or (settings.showMpCost ~= false);
     p.mpCostFontSize = (settings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = settings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = settings.mpCostNoMpColor or 0xFFFF4444;
     p.mpCostOffsetX = (settings.mpCostOffsetX or 0) * gs;
     p.mpCostOffsetY = (settings.mpCostOffsetY or 0) * gs;
-    p.showQuantity = settings.showQuantity ~= false;
+    p.showQuantity = isEditor and false or (settings.showQuantity ~= false);
     p.showStackQuantity = settings.showStackQuantity == true;
     p.quantityFontSize = (settings.quantityFontSize or 10) * gs;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
     p.quantityOffsetX = (settings.quantityOffsetX or 0) * gs;
     p.quantityOffsetY = (settings.quantityOffsetY or 0) * gs;
-    p.showLabel = settings.showActionLabels or false;
+    -- Editor: always show labels (on-slot abbrev with hover popup); live crossbar respects the user setting.
+    p.showLabel = isEditor and true or (settings.showActionLabels or false);
     p.labelText = slotData and (slotData.displayName or slotData.action or '') or '';
-    p.labelOffsetX = (settings.actionLabelOffsetX or 0) * gs;
-    p.labelOffsetY = ((settings.actionLabelOffsetY or 0) + 2) * gs;
+    p.labelOffsetX = isEditor and 0 or ((settings.actionLabelOffsetX or 0) * gs);
+    p.labelOffsetY = isEditor and 0 or (((settings.actionLabelOffsetY or 0) + 2) * gs);
+    p.labelAboveSlot = labelAboveSlot;
     p.labelFontSize = (settings.labelFontSize or 10) * gs;
     p.recastTimerFontSize = (settings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = settings.recastTimerFontColor or 0xFFFFFFFF;
@@ -744,10 +1039,29 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.dragType = 'crossbar_slot';
     p.getDragData = interaction.getDragData;
     p.onRightClick = interaction.onRightClick;
+    -- Editor slots: double-click opens the macro editor (empty slot = new macro seeded
+    -- with palette defaults, filled slot = edit existing). Live crossbar slots leave
+    -- onDoubleClick nil so single-click executes the action immediately.
+    p.onDoubleClick = isEditor and interaction.onDoubleClick or nil;
+    -- Editor slots don't have a "live" action to execute; suppressing the single-click
+    -- action is what enables the click-tracking pipeline in slotrenderer to detect a
+    -- second click and dispatch onDoubleClick. Live HUD keeps the default behavior.
+    p.suppressActionOnClick = isEditor and true or false;
     p.showTooltip = true;
-    -- Skillchain highlight
-    p.skillchainName = skillchainName;
+    -- Editor-only params consumed by slotrenderer Pass 2 (clip culling + on-slot multi-line label).
+    p.editorClipRect = editorClipRect;
+    p.editorMinimalView = isEditor;
+    p.labelForeground = isEditor;
+    -- Editor drops should win against the live crossbar zone underneath when the editor preview
+    -- overlaps the HUD (FlushDeferredDrops resolves overlaps by highest priority).
+    p.dropPriority = isEditor and 10 or nil;
+    -- Skillchain highlight (only on live crossbar; editor preview suppresses it).
+    p.skillchainName = (not isEditor) and skillchainName or nil;
     p.skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44;
+    -- Magic Burst highlight — same suppression rules as skillchain (editor preview has no
+    -- live target so the prediction would be meaningless / misleading there).
+    p.magicBurstName = (not isEditor) and magicBurstName or nil;
+    p.magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF;
 
     -- Render slot using shared renderer (handles ALL rendering and interactions)
     slotrenderer.DrawSlot(p);
@@ -879,8 +1193,125 @@ local function DrawTriggerIcons(activeCombo, l2GroupX, r2GroupX, groupY, groupWi
                 {0, 0}, {1, 1},
                 tintColor
             );
+
+            -- R1 return indicator: rendered above R2 when the user has set a "cpal" anchor
+            -- (via `/xiui cpal <Job>`). Pulses to draw the eye toward the return-to-anchor
+            -- shortcut. Per-scope so anchors don't leak across universal vs job-scoped views.
+            local scope = palette.GetCrossbarPaletteScope();
+            local anchor = palette.GetCpalAnchor and palette.GetCpalAnchor(scope);
+            if anchor then
+                local r1Texture = textures:GetControllerIcon('R1');
+                if r1Texture and r1Texture.image then
+                    local r1Ptr = tonumber(ffi.cast('uint32_t', r1Texture.image));
+                    if r1Ptr then
+                        local r1Width = baseIconWidth;
+                        local r1Height = baseIconHeight;
+                        local r1IconX = r2GroupX + (groupWidth / 2) - (r1Width / 2);
+                        local r1IconY = r2IconY - r1Height - 4;
+
+                        -- ~2.5 Hz size pulse (peak +30%) keeps the indicator visible without
+                        -- being distracting. Sin → abs so the icon "breathes" symmetrically.
+                        local pulse = math.abs(math.sin(os.clock() * 2.5));
+                        local sizeScale = 1.0 + 0.30 * pulse;
+                        local sw = r1Width * sizeScale;
+                        local sh = r1Height * sizeScale;
+                        local sx = r1IconX + r1Width * 0.5 - sw * 0.5;
+                        local sy = r1IconY + r1Height * 0.5 - sh * 0.5;
+
+                        -- Pill-shaped dark backdrop spans the icon + "x2" text so they read
+                        -- as a single legend regardless of the underlying scene.
+                        local textGap, textEstW, pad = 3, 14, 4;
+                        drawList:AddRectFilled(
+                            { r1IconX - pad, r1IconY - pad },
+                            { r1IconX + r1Width + textGap + textEstW + pad, r1IconY + r1Height + pad },
+                            0x99000000, 5
+                        );
+
+                        drawList:AddImage(r1Ptr, { sx, sy }, { sx + sw, sy + sh }, { 0, 0 }, { 1, 1 }, 0xFFFFFFFF);
+                        -- Gold ARGB: A=FF R=FF G=C8 B=32 → ImGui's GetColorU32 byte order is 0xAABBGGRR
+                        drawList:AddText(
+                            { r1IconX + r1Width + textGap, r1IconY + r1Height * 0.5 - 6 },
+                            0xFF32C8FF,
+                            'x2'
+                        );
+                    end
+                end
+            end
         end
     end
+end
+
+-- Shared expanded bar (useSharedExpandedBar): the L2+R2 / R2+L2 chord collapses both diamonds
+-- into a single centered 8-slot strip, so DrawTriggerIcons can't position L2 over the left group
+-- and R2 over the (now-absent) right group. This variant renders an "L2 + R2" chord glyph centred
+-- on the single visible diamond: both icons inline with a small "+" between them, tinted brighter
+-- when their trigger is part of the active combo. Same draw list as DrawTriggerIcons so the chord
+-- glyph layers with the same z-order as the regular trigger labels.
+local function DrawTriggerIconsSharedExpandedCenter(activeCombo, groupLeftX, groupY, groupWidth, settings, drawList)
+    if not settings.showTriggerLabels then return; end
+    if not drawList then return; end
+
+    local baseScale = settings.triggerIconScale or 1.0;
+    local iw = 49 * baseScale;
+    local ih = 28 * baseScale;
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    -- chordTight: pull the +/glyphs closer together as the icons shrink so the legend stays compact
+    -- (matches the spacing the editor's shared-chord glyph uses in DrawPaletteEditorL2R2TriggerGlyphs).
+    local chordTight = math.max(0.5, 0.65 * baseScale);
+    local cx = groupLeftX + groupWidth * 0.5;
+    local cy = groupY - ih * 0.5;
+
+    -- Both triggers participate in any chord / double-tap involving them, so animate accordingly.
+    local l2Active = activeCombo == COMBO_MODES.L2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.L2_DOUBLE;
+    local r2Active = activeCombo == COMBO_MODES.R2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.R2_DOUBLE;
+    if activeCombo == COMBO_MODES.NONE then
+        l2Active = false;
+        r2Active = false;
+    end
+
+    local l2PressScale = 1.0;
+    local r2PressScale = 1.0;
+    if settings.enablePressScale ~= false then
+        l2PressScale = animation.getPressScale('trigger_L2', l2Active);
+        r2PressScale = animation.getPressScale('trigger_R2', r2Active);
+    end
+
+    -- Measure the "+" once so the chord can be centered as a single unit (icon + plus + icon).
+    -- Fallback dims 10x14 keep layout sensible on builds where imgui.CalcTextSize isn't bound.
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImageScaled(texName, ix, iy, w, h, tintColor)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        drawList:AddImage(p, { ix, iy }, { ix + w, iy + h }, { 0, 0 }, { 1, 1 }, tintColor);
+    end
+
+    local ptw, pth = plusSize();
+    local lw = iw * l2PressScale;
+    local lh = ih * l2PressScale;
+    local rw = iw * r2PressScale;
+    local rh = ih * r2PressScale;
+    local total = lw + chordTight + ptw + chordTight + rw;
+    local leftX = cx - total * 0.5;
+    local l2Tint = l2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    local r2Tint = r2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    drawImageScaled('L2', leftX, cy - lh * 0.5, lw, lh, l2Tint);
+    drawList:AddText({ leftX + lw + chordTight, cy - pth * 0.5 }, textCol, '+');
+    drawImageScaled('R2', leftX + lw + chordTight + ptw + chordTight, cy - rh * 0.5, rw, rh, r2Tint);
 end
 
 -- Draw combo text in center for complex combos (L2R2, R2L2, L2x2, R2x2) or edit mode
@@ -934,7 +1365,13 @@ local function DrawComboText(activeCombo, centerX, topY, settings)
     end
 end
 
--- Draw palette name below crossbar (e.g., "Stuns (2/5)")
+-- Draw palette name below crossbar (e.g., "Stuns (2/5)"). The index/total count is
+-- restricted to ENABLED palettes (RB-cycle filtered) and is hidden entirely when there
+-- is only one cycleable palette (a 1/1 badge is just noise). For universal [G] scope,
+-- routes through GetCrossbarPaletteLabelIndexAndTotal which uses the universal cycle list
+-- instead of the per-job rows. (Lookup is microseconds at typical 1-10 palette counts; a
+-- per-frame label cache was tried and reverted because it could go stale on PaletteManager
+-- CRUD without a roster-version invalidation hook.)
 local function DrawPaletteName(centerX, bottomY, settings)
     if not settings.showPaletteName then return; end
 
@@ -943,10 +1380,14 @@ local function DrawPaletteName(centerX, bottomY, settings)
 
     local jobId = data.jobId or 1;
     local subjobId = data.subjobId or 0;
-    local index = palette.GetCrossbarPaletteIndex(paletteName, jobId, subjobId) or 1;
-    local total = palette.GetCrossbarPaletteCount(jobId, subjobId) or 1;
+    local index, total = palette.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId);
 
-    local displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    local displayText;
+    if index and total and total > 1 then
+        displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    else
+        displayText = paletteName;
+    end
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local fontSize = (settings.paletteNameFontSize or 10) * gs;
     local offsetX = (settings.paletteNameOffsetX or 0) * gs;
@@ -961,8 +1402,97 @@ local function DrawPaletteName(centerX, bottomY, settings)
     end
 end
 
--- Helper to draw just the left side
-local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- ============================================
+-- Palette scope icon (above the center divider)
+-- Shows the infinity glyph for Global/universal palettes, or the job icon for job-scoped.
+-- Lazily caches the infinity texture; the job-icon TextureManager has its own cache.
+-- ============================================
+local cachedInfinityPaletteTex = nil;
+
+local function GetInfinityPaletteIconTexture()
+    if cachedInfinityPaletteTex and cachedInfinityPaletteTex.image then
+        return cachedInfinityPaletteTex;
+    end
+    cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not cachedInfinityPaletteTex or not cachedInfinityPaletteTex.image then
+        cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    return cachedInfinityPaletteTex;
+end
+
+local function GetPaletteJobIconThemeFromSettings(settings)
+    local t = settings and settings.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+
+-- When showPaletteScopeIcon is nil (legacy profiles), the scope icon follows showPaletteName;
+-- explicit true/false overrides. Keeps the icon visible by default for existing users without
+-- forcing them through the settings menu after the upgrade.
+local function ShouldShowPaletteScopeIcon(settings)
+    if not settings then return false; end
+    if settings.showPaletteScopeIcon == false then return false; end
+    if settings.showPaletteScopeIcon == true then return true; end
+    return settings.showPaletteName == true;
+end
+
+-- Draws the scope marker (infinity for Global / universal, job icon otherwise) centred just
+-- above the divider. Only fires when a palette is actually active for the L2 group.
+local function DrawPaletteScopeIconAboveDivider(dividerX, dividerTopY, settings, drawList)
+    if not ShouldShowPaletteScopeIcon(settings) or not drawList then return; end
+
+    local paletteName = palette.GetActivePaletteForCombo('L2');
+    if not paletteName then return; end
+
+    local jobId = data.jobId or 1;
+    local iconTex;
+    if palette.GetCrossbarPaletteScope() == 'universal' then
+        iconTex = GetInfinityPaletteIconTexture();
+    else
+        iconTex = TextureManager.getJobIcon(jobId, GetPaletteJobIconThemeFromSettings(settings));
+    end
+
+    if not iconTex or not iconTex.image then return; end
+
+    local iconPtr = tonumber(ffi.cast('uint32_t', iconTex.image));
+    if not iconPtr then return; end
+
+    -- Size: explicit slider override (8..64 px) or auto-derive from palette-name font size.
+    local iconSize;
+    local explicitSize = tonumber(settings.paletteScopeIconSize);
+    if explicitSize and explicitSize > 0 then
+        iconSize = math.floor(math.max(8, math.min(64, explicitSize)) + 0.5);
+    else
+        local fontSize = settings.paletteNameFontSize or 10;
+        iconSize = math.max(12, math.min(22, math.floor(fontSize * 1.45)));
+        iconSize = math.floor(iconSize * 1.50 + 0.5);
+    end
+    local gapAboveLine = 3;
+    local scopeLiftY = tonumber(settings.paletteScopeIconOffsetY) or 6;
+    -- Clearance above the L2 / R2 combo-text strip at the top of the window.
+    local clearanceAboveComboText = 6;
+    -- Horizontally align with palette-name X offset so the icon stacks with the name.
+    local iconCenterX = dividerX + (settings.paletteNameOffsetX or 0);
+    local iconTopY = dividerTopY - gapAboveLine - iconSize - scopeLiftY - clearanceAboveComboText;
+    local leftX = iconCenterX - iconSize / 2;
+
+    drawList:AddImage(
+        iconPtr,
+        { leftX, iconTopY },
+        { leftX + iconSize, iconTopY + iconSize },
+        { 0, 0 },
+        { 1, 1 },
+        imgui.GetColorU32({ 1, 1, 1, 1 })
+    );
+end
+
+-- Helper to draw just the left side. `activeCombo` is threaded through so DrawSlot's dim
+-- policy can apply Ferris's "stronger dim on the inactive half while a trigger is held"
+-- behavior (settings.inactiveSideWhileTriggerDim, default 0.15) — without it the inactive
+-- half just gets settings.inactiveSlotDim (default 0.5) like 1.7.5/early-1.8.0.
+local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -970,15 +1500,40 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('L2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- Resolve slotData ONCE per slot so both prediction paths (skillchain + magic burst)
+        -- share the same fetch; previously the SC path re-fetched per branch. Cheap either
+        -- way, but cleaner now that two features need the same row.
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
+        -- Skillchain prediction: matches display.lua's coverage so the crossbar lights up the
+        -- same WS / Blood Pact / macro slots the keyboard hotbar does. Bloodpact slots use the
+        -- separate name->attributes map in skillchain.lua (bloodPactResonationMap); macro slots
+        -- run through macroparse to extract the primary /ws or /pet line and then route to the
+        -- matching predictor. Without the pet/macro branches, SMN ability slots and any /pet or
+        -- /ws macro would never get a skillchain icon overlay on the crossbar.
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        -- Magic Burst prediction: spells / magical pact rages / /ma|/pet-primary macros. The
+        -- single GetMagicBurstForSlot call internally routes by actionType + (for macros) the
+        -- macroparse primary line — mirrors the dispatch pattern used by display.lua.
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -989,8 +1544,9 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     end
 end
 
--- Helper to draw just the right side
-local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- Helper to draw just the right side. See DrawLeftSide above for the rationale on the
+-- trailing activeCombo / magicBurstEnabled parameters.
+local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -998,15 +1554,29 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('R2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- See DrawLeftSide for slotData / SC / MB routing rationale (identical logic).
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -1017,17 +1587,260 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     end
 end
 
--- Helper to draw a complete bar set (both sides) - used for non-animated drawing
+-- Helper to draw a complete bar set (both sides) - used for non-animated drawing.
+-- activeCombo flows from M.DrawWindow down to DrawSlot for the trigger-held dim policy.
 local function DrawBarSet(leftMode, rightMode, leftGroupX, leftGroupY, rightGroupX, rightGroupY,
                           slotSize, settings, leftActive, rightActive, pressedSlot,
-                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
-    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
-    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
+                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
+    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+end
+
+-- ============================================
+-- Double-Tap Preview Windows
+-- ============================================
+-- Reference floating windows that mirror the L2x2 / R2x2 bars at user-configurable scale
+-- and opacity. Rendered as independent ImGui windows AFTER the main crossbar so they have
+-- their own position/draw list (no shared primitives, no z-fighting). Drawn non-interactive
+-- (suppressActionOnClick) — the previews are visual reference only; actual slot activation
+-- still routes through the main bar's controller path.
+
+-- Return a shallow copy of settings with all layout-affecting fields scaled. Preserves the
+-- caller's settings unchanged so the main bar keeps its own layout numbers.
+--
+-- Result is cached on a (settings ref, scale, layout-key signature) tuple — the full
+-- shallow-copy is the dominant cost when the preview is on (8 slots × 2 windows × scaled
+-- settings every frame). Invalidates only when the caller passes a new settings table OR
+-- changes one of the geometry/scale inputs. This avoids the per-frame table-copy churn
+-- without going stale on slider drags (signature changes immediately).
+local previewSettingsCache = {
+    settingsRef = nil,
+    scale       = nil,
+    signature   = nil,
+    result      = nil,
+};
+
+local function MakePreviewSettings(settings, scale)
+    -- Cheap signature: only the fields MakePreviewSettings actually reads. Keep this in
+    -- sync with the scaled fields below — additions need a sig entry or the cache goes stale.
+    local sig = string.format('%s|%s|%s|%s|%s|%s|%s|%s|%s',
+        tostring(settings.slotSize), tostring(settings.slotGapV), tostring(settings.slotGapH),
+        tostring(settings.diamondSpacing), tostring(settings.groupSpacing),
+        tostring(settings.buttonIconSize), tostring(settings.buttonIconGapH), tostring(settings.buttonIconGapV),
+        tostring(settings.triggerIconScale));
+
+    if previewSettingsCache.settingsRef == settings
+        and previewSettingsCache.scale == scale
+        and previewSettingsCache.signature == sig then
+        return previewSettingsCache.result;
+    end
+
+    local s = {};
+    for k, v in pairs(settings) do s[k] = v; end
+    s.slotSize       = math.max(8, math.floor((settings.slotSize       or 40) * scale));
+    s.slotGapV       = math.max(1, math.floor((settings.slotGapV       or 2)  * scale));
+    s.slotGapH       = math.max(1, math.floor((settings.slotGapH       or 2)  * scale));
+    s.diamondSpacing = math.max(2, math.floor((settings.diamondSpacing or 16) * scale));
+    s.groupSpacing   = math.max(4, math.floor((settings.groupSpacing   or 24) * scale));
+    s.buttonIconSize = math.max(4, math.floor((settings.buttonIconSize or 24) * scale));
+    s.buttonIconGapH = math.max(1, math.floor((settings.buttonIconGapH or 2)  * scale));
+    s.buttonIconGapV = math.max(1, math.floor((settings.buttonIconGapV or 2)  * scale));
+    s.triggerIconScale = (settings.triggerIconScale or 1.0) * scale;
+
+    previewSettingsCache.settingsRef = settings;
+    previewSettingsCache.scale       = scale;
+    previewSettingsCache.signature   = sig;
+    previewSettingsCache.result      = s;
+    return s;
+end
+
+-- Draw one side of a double-tap preview using ImGui-only rendering (non-interactive).
+-- winX/winY    : top-left of the preview ImGui window (slot grid origin).
+-- side         : always 'L2' for single-group preview windows (slots start at window left).
+-- mode         : crossbar storage mode string ('L2x2', 'R2x2', 'L2', 'R2', etc.) whose slots to render.
+-- baseOp       : base opacity for the slot backgrounds (NOT dimmed) so frames stay visible.
+-- dimFactor    : 0-1 multiplier applied to icon/text rendering (mirrors main bar dim policy).
+-- targetServerId / skillchainEnabled / magicBurstEnabled: same per-slot SC/MB resolution
+--                inputs used by the main DrawLeftSide/DrawRightSide path. Letting the preview
+--                share them keeps the highlight calculus identical between live and preview
+--                (a slot that lights up on the live bar lights up on its preview).
+local function DrawPreviewSide(winX, winY, windowKey, side, mode, ps, baseOp, dimFactor, drawList, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize  = ps.slotSize or 40;
+    local contentOp = baseOp * dimFactor;
+
+    -- Slot background (flat rounded rect). slotrenderer's built-in bg path requires a D3D
+    -- slot primitive (we have none in preview), so paint it manually with baseOp so the
+    -- frame stays visible while icons dim with contentOp.
+    local bgArgb = ps.slotBackgroundColor or 0x55000000;
+    local bgA_raw = bit.rshift(bit.band(bgArgb, 0xFF000000), 24) / 255;
+    local bgA = math.max(bgA_raw, 0.55) * baseOp;
+    local bgR = bit.rshift(bit.band(bgArgb, 0x00FF0000), 16) / 255;
+    local bgG = bit.rshift(bit.band(bgArgb, 0x0000FF00), 8) / 255;
+    local bgB = bit.band(bgArgb, 0x000000FF) / 255;
+    local cornerR = math.max(4, math.min(10, math.floor(slotSize * 0.125 + 0.5)));
+    local bgU32 = imgui.GetColorU32({ bgR, bgG, bgB, bgA });
+
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        local slotX, slotY = GetSlotPositionInWindow(side, slotIndex, winX, winY, ps);
+
+        if drawList then
+            drawList:AddRectFilled({ slotX, slotY }, { slotX + slotSize, slotY + slotSize }, bgU32, cornerR);
+        end
+
+        local slotData = data.GetCrossbarSlotData(mode, slotIndex);
+        local icon = GetCachedCrossbarIcon(mode, slotIndex, slotData);
+
+        -- Per-slot skillchain + magic burst resolution — identical dispatch to DrawLeftSide
+        -- so a slot that highlights on the live crossbar highlights on its preview window
+        -- too. Without this the preview would silently omit both borders, hiding useful
+        -- "you could chain/MB from the other bar" cues exactly when the player is deciding
+        -- whether to commit to a double-tap.
+        local slotSkillchainName = nil;
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
+                slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
+            end
+        end
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+
+        slotrenderer.DrawSlot({
+            x    = slotX,
+            y    = slotY,
+            size = slotSize,
+            windowName = windowKey,
+            bind = slotData,
+            icon = icon,
+            slotBgColor = 0x00000000,
+            slotOpacity = 1.0,
+            dimFactor   = 1.0,
+            animOpacity = contentOp,
+            isPressed   = false,
+            iconPressScale = 1.0,
+            -- MP cost + quantity are intentionally OFF on the double-tap preview regardless of
+            -- the user's main-bar settings: the preview is a transient "what's on the other
+            -- bar" overlay, not an action-resolution surface, so a player glancing at it just
+            -- wants the icon + cooldown to decide if the next press is worth it. Showing MP /
+            -- charges duplicates the info on the live bar and crowds an already-small preview.
+            -- Cooldowns are kept (recastTimer* + flashCooldownUnder5) — they ARE useful here
+            -- because the preview's whole purpose is "should I commit to this bar".
+            showMpCost = false,
+            showQuantity = false,
+            showLabel = false,
+            recastTimerFontSize   = ps.recastTimerFontSize or 11,
+            recastTimerFontColor  = ps.recastTimerFontColor or 0xFFFFFFFF,
+            flashCooldownUnder5   = ps.flashCooldownUnder5 or false,
+            useHHMMCooldownFormat = ps.useHHMMCooldownFormat or false,
+            -- Skillchain + Magic Burst highlights. Colors fall back to the live-bar defaults
+            -- so the preview matches the main bar without requiring its own settings keys.
+            skillchainName  = slotSkillchainName,
+            skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44,
+            magicBurstName  = slotMagicBurstName,
+            magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF,
+            buttonId              = string.format('##dtprev_%s_%s_%d', windowKey, mode, slotIndex),
+            suppressActionOnClick = true,
+            forceImGuiIcon        = true,
+            drawCornerTextForeground = true,
+        });
+    end
+
+    if drawList and ps.showButtonIcons and contentOp > 0.05 then
+        DrawDiamondCenterIconsImGui('dpad', winX, winY, ps, true, drawList, contentOp);
+        DrawDiamondCenterIconsImGui('face', winX, winY, ps, true, drawList, contentOp);
+    end
+end
+
+-- Draw one double-tap preview window (L2x2 or R2x2 reference).
+-- windowKey : unique ImGui window name and persisted-position key.
+-- mode      : crossbar storage mode for the 8 slots displayed (e.g. 'L2x2', 'R2x2', 'L2', 'R2').
+-- ps        : scaled settings table (from MakePreviewSettings).
+-- baseOp    : base opacity (user slider * visibilityOpacity).
+-- dimFactor : 0-1 content dim (1.0 = at rest, inactiveSideWhileTriggerDim while any trigger held).
+-- settings  : raw crossbar settings (used for doubleTapPreviewLocked move-anchor gating).
+local function DrawDoubleTapPreviewWindow(windowKey, mode, ps, baseOp, dimFactor, activeCombo, settings, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize = ps.slotSize or 40;
+    local gw, gh = CalculateGroupDimensions(slotSize, ps.slotGapV or 2, ps.slotGapH or 2, ps.diamondSpacing or 16);
+    local totalW = gw;
+    local totalH = gh;
+
+    local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+    if savedPos then
+        imgui.SetNextWindowPos({savedPos.x, savedPos.y}, ImGuiCond_Always);
+    else
+        imgui.SetNextWindowPos({200, 200}, ImGuiCond_FirstUseEver);
+    end
+    imgui.SetNextWindowSize({totalW, totalH}, ImGuiCond_Always);
+
+    -- Preview windows intentionally omit NoBringToFrontOnFocus so they stay layered above the
+    -- main crossbar (which has that flag set). NoMove + the move anchor below gives us
+    -- explicit positioning control without ImGui drifting the window on focus.
+    local flags = bit.bor(
+        ImGuiWindowFlags_NoDecoration,
+        ImGuiWindowFlags_NoResize,
+        ImGuiWindowFlags_NoFocusOnAppearing,
+        ImGuiWindowFlags_NoNav,
+        ImGuiWindowFlags_NoBackground,
+        ImGuiWindowFlags_NoDocking,
+        ImGuiWindowFlags_NoMove
+    );
+
+    -- Zero window padding so the draw list clip rect matches the window bounds exactly.
+    -- Without this the default 8 px padding clips slots at the left/right edges (same fix
+    -- that landed for the main crossbar window in the previous smoke-test pass).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+    local didBegin = imgui.Begin(windowKey, true, flags);
+    imgui.PopStyleVar();
+
+    if didBegin then
+        local wX, wY = imgui.GetWindowPos();
+        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+        if savedPos == nil then
+            gConfig.windowPositions[windowKey] = {x = wX, y = wY};
+        end
+
+        local dl = imgui.GetWindowDrawList();
+        DrawPreviewSide(wX, wY, windowKey, 'L2', mode, ps, baseOp, dimFactor, dl, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled);
+    end
+    imgui.End();
+
+    -- Move anchor: independent lock so previews can be repositioned without unlocking the
+    -- main crossbar (and vice versa).
+    local previewLocked = settings and settings.doubleTapPreviewLocked;
+    if not previewLocked then
+        local pos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+        local anchorX = pos and pos.x or 200;
+        local anchorY = pos and pos.y or 200;
+        local newX, newY = drawing.DrawMoveAnchor(windowKey, anchorX, anchorY, {
+            anchorSide  = 'top',
+            windowWidth = totalW,
+        });
+        if newX ~= nil then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[windowKey] = {x = newX, y = newY};
+        end
+    end
 end
 
 -- Main draw function
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
+
+    -- Warm playerdata caches even when keyboard hotbars are disabled. Cheap on cache hit
+    -- (signature compare against job/level/equip ids), only does the heavy ability/WS scan
+    -- when the signature changes. See the require-site comment for the user-visible bug
+    -- this prevents (all JA/WS slots reading as unavailable on crossbar-only setups).
+    playerdata.RefreshCachedLists(data);
 
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local slotSize = (settings.slotSize or 48) * gs;
@@ -1037,34 +1850,12 @@ function M.DrawWindow(settings, moduleSettings)
     local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate dimensions using layout functions
-    local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local fullWidth, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local width = fullWidth;
 
-    -- Window flags (dummy window for positioning, like hotbar display.lua)
-    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
-
-    local windowName = 'Crossbar';
-    local defaultX, defaultY = GetDefaultPosition(settings);
-
-    -- Check if anchor is currently being dragged - if so, force position
-    local anchorDragging = drawing.IsAnchorDragging(windowName);
-    
-    if anchorDragging then
-        -- Use state position directly during drag for immediate response
-        imgui.SetNextWindowPos({state.windowX, state.windowY}, ImGuiCond_Always);
-    else
-        -- Apply saved position (once) or default
-        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-
-        if hasSaved then
-            ApplyWindowPosition(windowName);
-        else
-            imgui.SetNextWindowPos({defaultX, defaultY}, ImGuiCond_FirstUseEver);
-        end
-    end
-    
-    imgui.SetNextWindowSize({width, height}, ImGuiCond_Always);
-
-    -- Get current combo mode and pressed slot from controller
+    -- Get current combo mode and pressed slot from controller. Resolved BEFORE the window
+    -- size/position calls so the useSharedExpandedBar branch can shrink the window to a single
+    -- diamond and re-center it (a chord with useSharedExp on collapses to one 8-slot strip).
     local activeCombo = controller.GetActiveCombo();
     local pressedSlot = controller.GetPressedSlot();
 
@@ -1075,6 +1866,75 @@ function M.DrawWindow(settings, moduleSettings)
         activeCombo = editBar;
         pressedSlot = nil;  -- Don't show pressed state in edit mode
     end
+
+    -- Determine which bar set to display based on active combo. expandedSide == 'center' is
+    -- the useSharedExpandedBar branch (chord collapses both diamonds into one centered strip).
+    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo, settings);
+
+    -- useSharedExpandedBar special layout: shrink window to one diamond, re-center on screen X,
+    -- skip the right group draw + center divider/scope icon (they have no meaning when there's
+    -- only one diamond visible). Outside of chord, behaves identically to the standard 2-diamond
+    -- layout. exitingChordCenter catches the FIRST frame after the user releases the chord: we
+    -- restore the stashed wide-bar X so SaveCrossbarWindowSlotTopPosition doesn't persist the
+    -- narrow centered value.
+    local hideRightForSharedCenter = (isExpanded and expandedSide == 'center');
+    if hideRightForSharedCenter then
+        width = groupWidth;
+    end
+    local exitingChordCenter = state.wasSharedCenterChordLayout and (not hideRightForSharedCenter);
+
+    -- Window flags (dummy window for positioning, like hotbar display.lua)
+    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
+
+    local windowName = 'Crossbar';
+    local defaultX, defaultY = GetDefaultPosition(settings);
+
+    local function storedCrossbarPosY()
+        local posY = defaultY;
+        local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowName];
+        if savedPos and savedPos.y ~= nil then
+            posY = savedPos.y;
+        elseif state.windowY ~= nil then
+            posY = state.windowY;
+        end
+        return posY;
+    end
+
+    -- Check if anchor is currently being dragged - if so, force position
+    local anchorDragging = drawing.IsAnchorDragging(windowName);
+
+    -- state.windowX / state.windowY track the SLOT GRID origin. ImGui's window must open
+    -- CROSSBAR_WINDOW_TOP_DECOR_PAD pixels higher so the decoration above the slots
+    -- (L2/R2 triggers, combo text, R1 cpal-anchor pulse) stays inside the window's
+    -- content rect and doesn't get clipped.
+    if anchorDragging then
+        -- Use state position directly during drag for immediate response
+        imgui.SetNextWindowPos({ state.windowX, state.windowY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif hideRightForSharedCenter then
+        -- Shared-center chord: force X to screen-center each frame so the narrow window reads as
+        -- the FFXIV-style single 8-slot strip (Y persists from the last wide-bar position).
+        local io = imgui.GetIO();
+        local screenW = (io and io.DisplaySize and io.DisplaySize.x) or 1920;
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ (screenW - width) * 0.5, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif exitingChordCenter and state.lastWideCrossbarWindowX ~= nil then
+        -- First frame after chord release: re-anchor to the wide-bar X we stashed before the
+        -- chord, otherwise the user-visible position would briefly snap to the centered narrow X.
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ state.lastWideCrossbarWindowX, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    else
+        -- Apply saved position (once, slot-top -> window-top offset handled inside) or default
+        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+
+        if hasSaved then
+            ApplyCrossbarWindowPositionOnce();
+        else
+            imgui.SetNextWindowPos({ defaultX, defaultY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_FirstUseEver);
+        end
+    end
+
+    local bottomPad = GetCrossbarWindowBottomPad(settings);
+    imgui.SetNextWindowSize({ width, height + CROSSBAR_WINDOW_TOP_DECOR_PAD + bottomPad }, ImGuiCond_Always);
 
     -- Determine visibility for activeOnly display mode
     local leftVisible, rightVisible, crossbarVisible = GetVisibilityState(activeCombo, settings, isEditMode);
@@ -1100,8 +1960,14 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
-    -- Determine which bar set to display based on active combo
-    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo);
+    -- Menu-open dim: when a blocking game menu is open and the user has "Disable Crossbar
+    -- While In Menu" enabled, controller.lua already stops routing input — we additionally
+    -- dim everything the crossbar draws so it visually reads as "paused" rather than just
+    -- silently unresponsive. visibilityOpacity propagates into every slot via the per-slot
+    -- animOpacity param plus the background / border / trigger / divider alpha scales below.
+    if gamestate.IsMenuOpen() and settings.crossbarDisableInMenu ~= false then
+        visibilityOpacity = visibilityOpacity * 0.35;
+    end
 
     -- Check if animations are disabled - if so, force complete any in-progress animation
     if settings.enableTransitionAnimations == false and state.animation.active then
@@ -1143,7 +2009,11 @@ function M.DrawWindow(settings, moduleSettings)
     local leftActive, rightActive;
     if isExpanded then
         -- In expanded mode, only the expanded side is active, other side is dimmed
-        if expandedSide == 'left' then
+        if expandedSide == 'center' then
+            -- useSharedExpandedBar: only the left column is drawn (no right group exists this frame)
+            leftActive = true;
+            rightActive = false;
+        elseif expandedSide == 'left' then
             leftActive = true;
             rightActive = false;
         elseif expandedSide == 'right' then
@@ -1171,10 +2041,13 @@ function M.DrawWindow(settings, moduleSettings)
     -- Get draw list for ImGui-based rendering (behind config when open)
     local drawList = GetUIDrawList();
 
-    -- Get target server ID for skillchain prediction (cached for all slots)
+    -- Get target server ID for skillchain / magic burst prediction (cached for all slots).
+    -- Both features key off the same target so a single resolve+cache covers everything; the
+    -- per-slot SC and MB calls are no-ops when their respective enable flags are off.
     local targetServerId = nil;
     local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
-    if skillchainEnabled then
+    local magicBurstEnabled = gConfig.hotbarGlobal.magicBurstHighlightEnabled ~= false;
+    if skillchainEnabled or magicBurstEnabled then
         local mainTargetIdx = targetLib.GetTargets();
         if mainTargetIdx and mainTargetIdx ~= 0 then
             local targetEntity = GetEntity(mainTargetIdx);
@@ -1184,15 +2057,48 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
+    -- Zero out WindowPadding so the leftmost and rightmost diamond slots (which sit flush
+    -- against the window's content rect) aren't clipped by ImGui's default 8px padding.
+    -- Without this the left/right slots of each diamond render partially off-window and
+    -- their button hitboxes get pushed inward (slot interactions become unreliable).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
     -- Begin ImGui window - ALL slot rendering happens inside to enable interactions
     if imgui.Begin('Crossbar', true, windowFlags) then
-        -- Save position if moved (profile support)
-        SaveWindowPosition('Crossbar');
+        -- Save SLOT-TOP position if moved (decor-pad-aware; profile coordinate stays the
+        -- slot grid top so the saved value is meaningful even if decor pad changes later).
+        -- During the shared-center chord the X is force-centered each frame, so we MUST NOT
+        -- let SaveCrossbarWindowSlotTopPosition persist that narrow centered X — only sync Y.
+        if hideRightForSharedCenter then
+            if gConfig.windowPositions and gConfig.windowPositions[windowName] then
+                local wx, wy = imgui.GetWindowPos();
+                local s = gConfig.windowPositions[windowName];
+                local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+                if s.y ~= slotTopY then
+                    s.y = slotTopY;
+                end
+                -- Track the centered window X for free (used by lastWideCrossbarWindowX restore)
+                if s.x ~= wx then
+                    s.x = wx;
+                end
+            end
+        else
+            SaveCrossbarWindowSlotTopPosition();
+        end
         windowPosX, windowPosY = imgui.GetWindowPos();
 
-        -- Update stored position
+        -- Update stored position. state.windowY = slot grid top (window top + decor pad);
+        -- the rest of the layout code references state.windowY as the slot origin.
         state.windowX = windowPosX;
-        state.windowY = windowPosY;
+        state.windowY = windowPosY + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+
+        -- Stash the wide-bar X so that when the user releases the chord we can restore it
+        -- (otherwise the narrow centered X from this frame would be the "last" saved X).
+        if not hideRightForSharedCenter then
+            state.lastWideCrossbarWindowX = windowPosX;
+        end
+        -- Remember the layout for the NEXT frame so exitingChordCenter (above) can detect
+        -- the chord-release transition and re-anchor X.
+        state.wasSharedCenterChordLayout = hideRightForSharedCenter;
 
         -- Recalculate group positions with updated window position
         leftGroupX = state.windowX;
@@ -1244,35 +2150,36 @@ function M.DrawWindow(settings, moduleSettings)
                     -- Left side changed - animate it
                     if outOpacity > 0.01 then
                         DrawLeftSide(state.animation.fromLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Left side didn't change - draw at full opacity (with visibility fade)
                     DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
 
-            -- Draw RIGHT side (skip in activeOnly mode if not visible)
-            if not isActiveOnlyMode or rightVisible then
+            -- Draw RIGHT side (skip in activeOnly mode if not visible, or whenever the chord
+            -- collapsed both groups into a single centered strip — there is no right group).
+            if (not hideRightForSharedCenter) and (not isActiveOnlyMode or rightVisible) then
                 if state.animation.rightChanged then
                     -- Right side changed - animate it
                     if outOpacity > 0.01 then
                         DrawRightSide(state.animation.fromRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Right side didn't change - draw at full opacity (with visibility fade)
                     DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
         else
@@ -1281,12 +2188,16 @@ function M.DrawWindow(settings, moduleSettings)
                 -- ActiveOnly mode: draw only visible sides with visibility fade
                 if leftVisible then
                     DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
-                if rightVisible then
+                if (not hideRightForSharedCenter) and rightVisible then
                     DrawRightSide(state.currentRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
+            elseif hideRightForSharedCenter then
+                -- Shared-center chord: render only the (now-Shared) left column as one centered strip.
+                DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
+                    leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
             else
                 -- Normal mode: draw both sides at full opacity
                 DrawBarSet(
@@ -1295,17 +2206,21 @@ function M.DrawWindow(settings, moduleSettings)
                     slotSize, settings,
                     leftActive, rightActive,
                     pressedSlot, leftShowPressed, rightShowPressed,
-                    1.0, drawList, 0, targetServerId, skillchainEnabled
+                    1.0, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled
                 );
             end
         end
 
         imgui.End();
     end
+    -- Pop the WindowPadding style we pushed before Begin. Has to be unconditional (must match
+    -- the push even when Begin returns false / window is collapsed).
+    imgui.PopStyleVar();
 
-    -- Draw move anchor (only visible when config is open)
-    -- Only show when crossbar movement is NOT locked (uses global lock setting)
-    local crossbarLocked = gConfig and gConfig.hotbarLockMovement;
+    -- Draw move anchor (only visible when config is open).
+    -- Uses the crossbar-specific lock so Hotbar's lock toggle doesn't accidentally freeze
+    -- the crossbar (fixes the issue where Lock Crossbar was tied to Hotbar's setting).
+    local crossbarLocked = gConfig and gConfig.crossbarLockMovement;
     if not crossbarLocked then
         -- Use same window name as ImGui window so positions are shared
         local anchorNewX, anchorNewY = drawing.DrawMoveAnchor('Crossbar', state.windowX, state.windowY);
@@ -1323,22 +2238,36 @@ function M.DrawWindow(settings, moduleSettings)
     local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
     local showCenterElements = not isActiveOnlyMode;
 
-    -- Draw center divider (optional, hidden in activeOnly mode)
-    if settings.showDivider and drawList and showCenterElements then
-        local dividerX = state.windowX + groupWidth + (groupSpacing / 2);
-        local dividerY1 = state.windowY + 10;
-        local dividerY2 = state.windowY + height - 10;
+    -- Center decor (divider line, scope icon, combo text, palette name): all hidden in
+    -- activeOnly mode since that layout collapses to a single side and the divider has no meaning.
+    -- Shared-center chord layout: centerX is the middle of the (now single-diamond) window so the
+    -- scope icon / combo text / palette name still sit over the visible bar. The DIVIDER itself
+    -- is suppressed in chord since there's no longer a left/right split to divide.
+    local centerX;
+    if hideRightForSharedCenter then
+        centerX = state.windowX + width * 0.5;
+    else
+        centerX = state.windowX + groupWidth + (groupSpacing / 2);
+    end
+    local dividerTopY = state.windowY + 10;
 
+    if settings.showDivider and drawList and showCenterElements and (not hideRightForSharedCenter) then
+        local dividerY2 = state.windowY + height - 10;
         drawList:AddLine(
-            { dividerX, dividerY1 },
-            { dividerX, dividerY2 },
+            { centerX, dividerTopY },
+            { centerX, dividerY2 },
             imgui.GetColorU32({ 1, 1, 1, 0.3 }),
             2
         );
     end
 
+    -- Palette scope icon (infinity for Global / job icon for job-scoped) — drawn above the
+    -- divider's top endpoint. Same drawList as the divider so z-order is consistent.
+    if showCenterElements and drawList then
+        DrawPaletteScopeIconAboveDivider(centerX, dividerTopY, settings, drawList);
+    end
+
     -- Draw combo text in center for complex combos (hidden in activeOnly mode)
-    local centerX = state.windowX + groupWidth + (groupSpacing / 2);
     local topY = state.windowY - 4;  -- Above the window
     if showCenterElements then
         DrawComboText(activeCombo, centerX, topY, settings);
@@ -1350,9 +2279,15 @@ function M.DrawWindow(settings, moduleSettings)
         DrawPaletteName(centerX, bottomY, settings);
     end
 
-    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode)
+    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode). The shared-center
+    -- chord uses a different glyph (L2 + R2 chord centred on the single visible diamond) since
+    -- there's no left-vs-right group to position labels against.
     if drawList and showCenterElements then
-        DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        if hideRightForSharedCenter then
+            DrawTriggerIconsSharedExpandedCenter(activeCombo, leftGroupX, leftGroupY, groupWidth, settings, drawList);
+        else
+            DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        end
     end
 
     -- Draw palette modifier indicator (refresh icon when modifier key is held)
@@ -1380,6 +2315,41 @@ function M.DrawWindow(settings, moduleSettings)
                 );
             end
         end
+    end
+
+    -- Double-tap preview windows. Drawn AFTER the main crossbar so they end up in
+    -- separate ImGui windows with their own draw list / position, layered above the main
+    -- bar. Gated on both `enableDoubleTap` (the L2x2/R2x2 modes have to be enabled at all)
+    -- and `showDoubleTapPreview` (the per-feature visibility toggle). When the active combo
+    -- IS the matching double-tap, the preview swaps to the BASE L2/R2 slots as a reference
+    -- — the main bar is already showing the double-tap content.
+    if settings.enableDoubleTap and settings.showDoubleTapPreview then
+        local scale  = settings.doubleTapPreviewScale  or 0.60;
+        local baseOp = (settings.doubleTapPreviewOpacity or 1.0) * visibilityOpacity;
+        -- Skip the preview render path entirely when nothing would be visible (menu dim or
+        -- activeOnly hide). Saves the 16-slot DrawSlot + ImGui begin/end overhead per frame.
+        if baseOp <= 0.02 then return; end
+        local dimFact = settings.inactiveSideWhileTriggerDim;
+        if dimFact == nil then dimFact = 0.15; end
+        local ps = MakePreviewSettings(settings, scale);
+
+        local isL2xActive = (activeCombo == COMBO_MODES.L2_DOUBLE);
+        local isR2xActive = (activeCombo == COMBO_MODES.R2_DOUBLE);
+        local anyTriggerHeld = (activeCombo ~= COMBO_MODES.NONE);
+        local previewDim = anyTriggerHeld and dimFact or 1.0;
+
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewL2x2',
+            isL2xActive and 'L2' or 'L2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewR2x2',
+            isR2xActive and 'R2' or 'R2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
     end
 end
 
@@ -1467,6 +2437,11 @@ end
 -- Clear icon cache (call when job changes)
 function M.ClearIconCache()
     ClearCrossbarIconCache();
+    -- Mirror the wipe to actions.lua's negative-result cache so "no icon" decisions
+    -- pinned from a previous state don't survive into the new job/palette context.
+    if actions and actions.ClearNoIconCache then
+        actions.ClearNoIconCache();
+    end
 end
 
 -- Clear icon cache for a specific slot (call on targeted slot updates)
@@ -1487,6 +2462,187 @@ function M.ResetPositions()
     if gConfig.appliedPositions then
         gConfig.appliedPositions['Crossbar'] = nil;
     end
+end
+
+-- ============================================
+-- Edit Full Palette (called from config/palettemanager.lua's ImGui window)
+-- ============================================
+-- The editor draws a static representation of a crossbar row using the SAME DrawSlot path
+-- as the live HUD, so layout (diamond geometry, slot size, label position, MP/quantity)
+-- always matches what the user actually plays with. The editor differs from the HUD in:
+--   * Slot data is read from the draft layer (data.GetDraftSlotData) not the live binding.
+--   * MP / quantity / cooldown text are suppressed (showMpCost=false, showQuantity=false).
+--   * The action name renders ON the slot (labelForeground + editorMinimalView).
+--   * Drop zones use 'paled_*' IDs with dropPriority=10 so they win against the HUD zones
+--     underneath when the editor window overlaps the live crossbar.
+--   * Optional editorClipRect culls slots scrolled off the editor panel.
+-- These are all set by the local DrawSlot wrapper above; the public functions here just
+-- iterate the 8 slots of each diamond and call DrawSlot once per slot.
+
+-- Shared palette-editor slot row. Either or both of modeLeft (L2 group) and modeRight
+-- (R2 group) may be set; pass nil on a side to omit it (Pets tab filter renders single-sided rows).
+local function DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    if not state.initialized then return; end
+    if not modeLeft and not modeRight then return; end
+    local editorClipRect;
+    if clipMinX and clipMinY and clipMaxX and clipMaxY then
+        editorClipRect = { clipMinX, clipMinY, clipMaxX, clipMaxY };
+    end
+    local slotSize = settings.slotSize or 48;
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        if modeLeft then
+            local sx, sy = GetSlotPositionInWindow('L2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeLeft, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+        if modeRight then
+            local sx, sy = GetSlotPositionInWindow('R2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeRight, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+    end
+end
+
+function M.DrawPaletteEditorL2R2Row(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+function M.DrawPaletteEditorSingleRow(screenOriginX, screenOriginY, settings, modeOnly, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeOnly, nil, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+-- Trigger glyphs raised above the editor's slot cluster. glyphMode:
+--   'primary'     — L2 | R2 (one glyph per side, gap between d-pad and face).
+--   'doubleTap'   — L2 + "x2", R2 + "x2".
+--   'chordCombo'  — Left: L2+R2, Right: R2+L2 (with text "+" between).
+--   'sharedChord' — Single L2+R2 glyph centred over the shared diamond.
+-- Optional sides = { l=bool, r=bool } (default both true) — used by Pets-tab single-sided rows.
+function M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, glyphMode, sides)
+    local dl = imgui.GetWindowDrawList();
+    if not dl then return; end
+    glyphMode = glyphMode or 'primary';
+    local sl = (not sides or sides.l ~= false);
+    local sr = (not sides or sides.r ~= false);
+    local totalW, _, groupW, ghgt = GetCrossbarDimensions(settings);
+    local gs = totalW - 2 * groupW;
+    local slotSize = settings.slotSize or 48;
+    local scale = (settings.triggerIconScale or 1.0) * math.max(0.42, math.min(1.1, slotSize / 48));
+    local iw = 49 * scale;
+    local ih = 28 * scale;
+    local yLift = 35;
+    local cy = screenOriginY + ghgt * 0.5 - yLift;
+    local tint = imgui.GetColorU32({ 1, 1, 1, 0.88 });
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    local chordTight = math.max(0.5, 0.65 * scale);
+    local doubleTapImgGap = math.max(1, 2 * scale);
+
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImage(texName, ix, iy)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+    end
+
+    local function drawComboAtCenter(cx, firstTex, secondTex)
+        local ptw, pth = plusSize();
+        local gL, gR = chordTight, chordTight;
+        local total = iw + gL + ptw + gR + iw;
+        local leftX = cx - total * 0.5;
+        drawImage(firstTex, leftX, cy - ih * 0.5);
+        dl:AddText({ leftX + iw + gL, cy - pth * 0.5 }, textCol, '+');
+        drawImage(secondTex, leftX + iw + gL + ptw + gR, cy - ih * 0.5);
+    end
+
+    if glyphMode == 'sharedChord' then
+        drawComboAtCenter(screenOriginX + groupW * 0.5, 'L2', 'R2');
+        return;
+    end
+
+    if glyphMode == 'chordCombo' then
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then drawComboAtCenter(l2cx, 'L2', 'R2'); end
+        if sr then drawComboAtCenter(r2cx, 'R2', 'L2'); end
+        return;
+    end
+
+    if glyphMode == 'doubleTap' then
+        local x2Str = 'x2';
+        local tw, th = 18, 16;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize(x2Str);
+            if type(ts) == 'table' then
+                tw = ts[1] or ts.x or tw;
+                th = ts[2] or ts.y or th;
+            end
+        end
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then
+            local l2Tex = textures:GetControllerIcon('L2');
+            if l2Tex and l2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', l2Tex.image));
+                if p and p ~= 0 then
+                    local ix = l2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        if sr then
+            local r2Tex = textures:GetControllerIcon('R2');
+            if r2Tex and r2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', r2Tex.image));
+                if p and p ~= 0 then
+                    local ix = r2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        return;
+    end
+
+    -- primary
+    local l2cx = screenOriginX + groupW * 0.5;
+    local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+    if sl then drawImage('L2', l2cx - iw * 0.5, cy - ih * 0.5); end
+    if sr then drawImage('R2', r2cx - iw * 0.5, cy - ih * 0.5); end
+end
+
+-- Convenience wrapper used by the Shared (chord-fallback) row.
+function M.DrawPaletteEditorSharedChordTriggerGlyphs(screenOriginX, screenOriginY, settings)
+    M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, 'sharedChord');
+end
+
+-- Exposed so palettemanager.lua can size the editor row to match the live HUD dimensions
+-- without duplicating the math (slot size, gaps, diamond spacing, etc. all flow through here).
+function M.GetEditorCrossbarRowDimensions(settings)
+    return GetCrossbarDimensions(settings);
+end
+
+-- Legacy GDI hook (kept as a no-op for API compatibility with `palettemanager.lua`).
+-- Pre-1.8.0 this hid the persistent D3D/GDI primitives backing the editor's slot row when
+-- the editor window was not currently drawing. Under 1.8.0's imtext architecture there are
+-- no persistent objects to hide — un-emitted draw calls simply don't render. The function
+-- is retained so callers don't break and so the contract is documented; consider removing
+-- once palettemanager.lua's six call sites are updated.
+function M.HidePaletteEditorPrimitives()
 end
 
 return M;

--- a/XIUI/modules/hotbar/data.lua
+++ b/XIUI/modules/hotbar/data.lua
@@ -6,8 +6,42 @@
 require('common');
 
 local gameState = require('core.gamestate');
+local petregistry = require('modules.hotbar.petregistry');
+local petAllowlist = require('modules.hotbar.pet_palette_allowlist');
 
 local M = {};
+
+-- While the Crossbar "Edit Full Palette" window is open, crossbar.lua uses this key with
+-- draft functions so edits don't go live until the user confirms.
+local crossbarPaletteEditStorageKey = nil;
+local draftForStorageKey = nil;   -- persists across Begin/End cycles to guard draft re-init
+-- Multi-key draft: segment overrides read/write alternate storage keys (jobsegment:…, global:palette:…)
+local draftByKey = nil;            -- [storageKey] = { L2 = { [slot]=... }, ... }
+local draftEditJobId = nil;       -- job context for Edit Full Palette (nil = universal editor)
+local draftTouchedKeys = nil;     -- { [storageKey] = true } keys modified this session
+local draftDirty = false;
+local draftUndoStack = {};
+local draftUndoGroupActive = false;
+local DRAFT_MAX_UNDO = 30;
+-- Draft slot cell == this string means "explicitly cleared in draft". String survives deepCopyTable (undo); a table
+-- sentinel would clone to a fresh {} and break equality. Missing slot index still means "inherit live" for overlay reads.
+local DRAFT_CROSSBAR_SLOT_EMPTY = '__XIUI_DRAFT_SLOT_EMPTY__';
+
+-- Draft CRUD functions are defined after helpers (deepCopyTable, buildSlotRecord, etc.)
+-- to satisfy Lua local scoping. See "Draft Layer" section below line 1112.
+
+function M.GetCrossbarPaletteEditSessionKey()
+    return crossbarPaletteEditStorageKey;
+end
+
+--- True while crossbar draft buffers exist (Edit Full Palette session). Palette rows use draft when drawing with
+--- palSk; the gameplay HUD keeps live binds until Apply. Swap reads use GetCrossbarSlotRawForSwapOverlay when draft is open.
+function M.IsCrossbarDraftLayerOpen()
+    return draftForStorageKey ~= nil and draftByKey ~= nil;
+end
+
+-- Pet-aware slot layouts are shared across job:subjob pairs; keyed only by pet subtype
+local PETPALETTE_STORAGE_PREFIX = 'petpalette:';
 
 -- Callback for slot data changes (used by macropalette for debounced saves)
 local onSlotDataChanged = nil;
@@ -40,31 +74,111 @@ local function getPalette()
 end
 
 -- ============================================
+-- Macro palette DB: many buckets, one profile (gConfig.macroDB)
+-- ============================================
+-- Each key is a separate palette: global, items, equipment, xiui, custom:*, job id
+-- (4 = BLM), SMN composite "15:avatar:ifrit", etc. Rows in different buckets are
+-- independent: same displayName, same numeric id, or same macro text in two jobs
+-- are all valid. Hotbar/crossbar slots disambiguate with macroRef + macroPaletteKey.
+--
+-- Coherence (EnsureMacroDatabaseCoherence) only: (1) merge accidental duplicate
+-- *job* storage keys "4" and 4 for the *same* job, never other key shapes; (2) fix
+-- duplicate macro.id *within* one bucket. It does not merge distinct palettes.
+
+-- ============================================
 -- Performance: Macro ID Lookup Cache
 -- ============================================
 -- O(1) lookup instead of O(n) linear search per GetMacroById call
 -- With 197 macros and 72 slots, this reduces from ~14,184 iterations/frame to 72 lookups
+-- macroIdLookup[paletteKey] is a separate id map per bucket (see design note above)
 
 local macroIdLookup = {};  -- macroIdLookup[paletteKey][macroId] = macro
 local macroIdLookupDirty = true;
--- Identity reference of the macroDB the lookup was built against. If gConfig
--- gets reassigned (profile switch / character swap), this will no longer
--- match gConfig.macroDB and we'll rebuild automatically. This prevents the
--- "globals from old profile" bug where switching characters left stale
--- macros (e.g. Ramrock's macroDB[3]="Heel") in the lookup while the new
--- profile (Mazungu) had macroDB[3]="SendPep".
-local macroIdLookupSource = nil;
+
+-- Per gConfig in-memory: avoid re-running and avoid persisting a sentinel in profile files
+local macroDbCoherenceIdentity = nil;
+
+-- One-time (per gConfig object) repair for macroDB (see "Macro palette DB" note above):
+-- - Coalesce string job keys (JSON "4") with numeric (4) so buckets are not split.
+-- - Deduplicate macro.id within each bucket (first row keeps id) so GetMacroById matches palette grid order.
+function M.EnsureMacroDatabaseCoherence(cfg)
+    local c = cfg or gConfig;
+    if not c or macroDbCoherenceIdentity == c then
+        return;
+    end
+    macroDbCoherenceIdentity = c;
+    if not c.macroDB or type(c.macroDB) ~= 'table' then
+        return;
+    end
+    local mdb = c.macroDB;
+    -- Collect first: do not modify mdb while iterating with pairs().
+
+    -- 1) Merge "4" and 4 (pure numeric string keys only; not composite "15:avatar:ifrit")
+    local stringNumberKeys = {};
+    for k, v in pairs(mdb) do
+        if type(k) == 'string' and k:match('^%d+$') and not k:find(':') and type(v) == 'table' then
+            stringNumberKeys[k] = v;
+        end
+    end
+    for k, v in pairs(stringNumberKeys) do
+        local n = tonumber(k);
+        if n and n > 0 then
+            if mdb[n] and type(mdb[n]) == 'table' then
+                for _, m in ipairs(v) do
+                    table.insert(mdb[n], m);
+                end
+            else
+                mdb[n] = v;
+            end
+            mdb[k] = nil;
+        end
+    end
+    -- 2) Deduplicate ids per bucket (stable: first row wins, later duplicates renumbered)
+    for _, macros in pairs(mdb) do
+        if type(macros) == 'table' then
+            local seen = {};
+            local maxId = 0;
+            for _, m in ipairs(macros) do
+                if m and m.id and type(m.id) == 'number' and m.id > maxId then
+                    maxId = m.id;
+                end
+            end
+            for _, m in ipairs(macros) do
+                if m then
+                    if not m.id or type(m.id) ~= 'number' then
+                        maxId = maxId + 1;
+                        m.id = maxId;
+                        seen[m.id] = true;
+                    elseif seen[m.id] then
+                        repeat
+                            maxId = maxId + 1;
+                        until not seen[maxId];
+                        m.id = maxId;
+                        seen[m.id] = true;
+                    else
+                        seen[m.id] = true;
+                    end
+                end
+            end
+        end
+    end
+end
 
 local function RebuildMacroLookup()
+    if gConfig then
+        M.EnsureMacroDatabaseCoherence(gConfig);
+    end
     macroIdLookup = {};
-    macroIdLookupSource = (gConfig and gConfig.macroDB) or nil;
     if gConfig and gConfig.macroDB then
         for paletteKey, macros in pairs(gConfig.macroDB) do
             macroIdLookup[paletteKey] = {};
             if type(macros) == 'table' then
                 for _, macro in ipairs(macros) do
-                    if macro.id then
-                        macroIdLookup[paletteKey][macro.id] = macro;
+                    if macro and macro.id then
+                        -- First wins: matches ipairs order in macropalette M.GetMacroById
+                        if not macroIdLookup[paletteKey][macro.id] then
+                            macroIdLookup[paletteKey][macro.id] = macro;
+                        end
                     end
                 end
             end
@@ -74,14 +188,34 @@ local function RebuildMacroLookup()
 end
 
 local function GetMacroFromLookup(macroId, paletteKey)
-    -- Rebuild if explicitly dirty OR if gConfig.macroDB has been reassigned
-    -- (i.e. profile switched out from under us).
-    if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
+    if macroIdLookupDirty then
         RebuildMacroLookup();
     end
-    local paletteLookup = macroIdLookup[paletteKey];
-    if paletteLookup then
-        return paletteLookup[macroId];
+    local function try(pk)
+        local t = macroIdLookup[pk];
+        if t then
+            return t[macroId];
+        end
+        return nil;
+    end
+    local m = try(paletteKey);
+    if m then
+        return m;
+    end
+    if type(paletteKey) == 'number' and paletteKey > 0 then
+        m = try(tostring(paletteKey));
+        if m then
+            return m;
+        end
+    end
+    if type(paletteKey) == 'string' and paletteKey:match('^%d+$') then
+        local n = tonumber(paletteKey);
+        if n and n > 0 then
+            m = try(n);
+            if m then
+                return m;
+            end
+        end
     end
     return nil;
 end
@@ -93,11 +227,6 @@ end
 
 local storageKeyCache = {};  -- storageKeyCache[barIndex] = storageKey
 local storageKeyCacheDirty = true;
--- Identity reference of the gConfig the storage key cache was built against.
--- If gConfig is reassigned (profile switch) the cached keys could be stale
--- (jobSpecific / petAware / palette names are profile-specific), so we
--- detect the swap and invalidate.
-local storageKeyCacheSource = nil;
 
 -- ============================================
 -- Constants
@@ -112,6 +241,32 @@ M.PADDING = 4;
 M.BUTTON_GAP = 8;
 M.LABEL_GAP = -8;  -- Default label position offset (was 4, moved up by 12px)
 M.ROW_GAP = 6;
+
+-- ============================================
+-- Per-Bar State
+-- ============================================
+
+-- Background primitive handles (one per bar)
+M.bgHandles = {};
+
+-- Legacy GDI font/primitive tables (kept as empty placeholders for migration safety only).
+-- 1.8.0 moved all per-slot rendering to libs/imtext.lua (stateless per-frame ImGui drawing)
+-- and libs/windowbackground.lua (immediate-mode background). None of these tables are
+-- populated anymore; any leftover writes from older crossbar/macropalette code are inert.
+-- Once the Tier 3 crossbar.lua / macropalette.lua passes are complete and all GDI writes
+-- are gone, this whole block can be deleted. Reads still work (table lookups just return nil).
+M.slotPrims = {};
+M.keybindFonts = {};
+M.labelFonts = {};
+M.iconPrims = {};
+M.cooldownPrims = {};
+M.framePrims = {};
+M.timerFonts = {};
+M.mpCostFonts = {};
+M.quantityFonts = {};
+M.abbreviationFonts = {};
+M.hotbarNumberFonts = {};
+M.allFonts = nil;
 
 -- ============================================
 -- Job State
@@ -135,42 +290,34 @@ local function normalizeJobId(jobId)
     return jobId or 1;
 end
 
--- Helper to get the storage key based on jobSpecific setting
--- Returns 'global' for global mode, or '{jobId}:{subjobId}' for job-specific mode
-local function getStorageKey(barSettings, jobId, subjobId)
-    if barSettings.jobSpecific == false then
+-- Shared helper: resolve a storage key from settings that have a jobSpecific flag.
+-- Used by both hotbar bars and crossbar.
+local function resolveStorageKey(settings, jobId, subjobId)
+    if settings.jobSpecific == false then
         return GLOBAL_SLOT_KEY;
     end
-    -- Always return composite key with job:subjob
     local normalizedJobId = normalizeJobId(jobId);
     local normalizedSubjobId = normalizeJobId(subjobId or 0);
     return string.format('%d:%d', normalizedJobId, normalizedSubjobId);
 end
 
-
--- Helper to get slotActions with storage key
--- Handles: 'global' and composite keys ('15:10', '15:10:avatar:ifrit', '15:10:palette:name')
--- Falls back to base job key (jobId:0) or base palette key (jobId:0:palette:name) if exact key doesn't exist
-local function getSlotActionsForJob(slotActions, storageKey)
+-- Shared helper: look up a slotActions bucket by storage key with subjob-0 fallback.
+-- Works for both hotbar (flat per-slot) and crossbar (per-combo-mode nesting) since
+-- this only resolves the top-level key; callers index into the result as needed.
+local function getSlotActionsForKey(slotActions, storageKey)
     if not slotActions then return nil; end
-    -- Handle 'global' key specially
     if storageKey == GLOBAL_SLOT_KEY then
         return slotActions[GLOBAL_SLOT_KEY];
     end
-    -- Try exact storage key first (e.g., '3:5' for WHM/RDM, '3:5:palette:Esuna')
     local result = slotActions[storageKey];
     if result then
         return result;
     end
-    -- Fallback: try base job key (jobId:0) for imported data without subjob
-    -- This handles tHotBar imports which don't track subjobs
     local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
     if jobId and subjobId ~= '0' then
-        -- Build fallback key with subjob=0, preserving any suffix (palette, avatar, etc.)
         local fallbackKey = jobId .. ':0' .. (suffix or '');
-        result = slotActions[fallbackKey];
-        if result then
-            return result;
+        if fallbackKey ~= storageKey then
+            return slotActions[fallbackKey];
         end
     end
     return nil;
@@ -186,40 +333,898 @@ local function deepCopyTable(tbl)
     return copy;
 end
 
--- Helper to ensure slotActions structure exists for a storage key
--- Handles: 'global' and composite keys ('15:10', '15:10:avatar:ifrit')
--- IMPORTANT: When creating a new key, copies data from fallback keys to preserve slot data
-local function ensureSlotActionsStructure(barSettings, storageKey)
-    if not barSettings.slotActions then
-        barSettings.slotActions = {};
+M.CopyTable = deepCopyTable;
+
+-- Shared helper: copy the canonical set of fields from one slot data table to another.
+-- Avoids repeating the field list in every Get/Set path.
+local SLOT_DATA_FIELDS = {
+    'actionType', 'action', 'target', 'displayName', 'equipSlot',
+    'macroText', 'itemId', 'customIconType', 'customIconId', 'customIconPath',
+    'recastSourceType', 'recastSourceAction', 'recastSourceItemId',
+    'showJaBadgeOnMacro',
+    'macroRef', 'macroPaletteKey', 'macroSourceStore',
+};
+-- Dual library placement: per-slot profile vs shared binding (independent of which macro file is "live").
+M.MACRO_BIND_PROFILE_KEY = 'macroBindProfile';
+M.MACRO_BIND_SHARED_KEY = 'macroBindShared';
+local K_BIND_P = M.MACRO_BIND_PROFILE_KEY;
+local K_BIND_S = M.MACRO_BIND_SHARED_KEY;
+local function copySlotFields(src)
+    local out = {};
+    for _, k in ipairs(SLOT_DATA_FIELDS) do
+        out[k] = src[k];
     end
-    -- Handle 'global' key specially
-    if storageKey == GLOBAL_SLOT_KEY then
-        if not barSettings.slotActions[GLOBAL_SLOT_KEY] then
-            barSettings.slotActions[GLOBAL_SLOT_KEY] = {};
+    return out;
+end
+
+
+--- true when slot uses per-library macroBindProfile / macroBindShared (post-migration).
+local function isDualMacroSlotTable(slotAction)
+    return slotAction and type(slotAction) == 'table'
+        and (slotAction[K_BIND_P] ~= nil or slotAction[K_BIND_S] ~= nil);
+end
+
+--- The active library's subtable for a macro row (or legacy flat macro slot). Returns: arm, isMacro.
+local function getActiveMacroBindingFromSlot(slotAction)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local sh = gConfig and (gConfig.macroStorageScope or 'profile') == 'shared';
+        if sh then
+            return slotAction[K_BIND_S], true;
         end
-        return barSettings.slotActions[GLOBAL_SLOT_KEY];
+        return slotAction[K_BIND_P], true;
     end
-    -- All job-specific keys are composite strings (job:subjob format)
-    if not barSettings.slotActions[storageKey] then
-        -- Before creating empty table, check for fallback data to migrate
-        -- This preserves slot data when subjob changes (e.g., '1:0' -> '1:5')
+    if slotAction.macroRef and slotAction.actionType == 'macro' then
+        return slotAction, true;
+    end
+    if slotAction.macroRef then
+        return slotAction, true;
+    end
+    return nil, false;
+end
+
+M._GetActiveMacroBindingFromSlot = getActiveMacroBindingFromSlot;
+M.IsMacroSlotDualLayout = isDualMacroSlotTable;
+
+-- Shared helper: build a write-ready slot table from incoming slotData (Set operations).
+-- Adds macroRef, macroPaletteKey, macroSourceStore on top of the canonical fields.
+local function buildSlotRecord(slotData)
+    local rec = copySlotFields(slotData);
+    rec.macroRef = slotData.macroRef or slotData.id;
+    rec.macroPaletteKey = slotData.macroPaletteKey;
+    rec.macroSourceStore = slotData.macroSourceStore;
+    return rec;
+end
+
+--- Public write-ready slot builder. Two output shapes:
+---   * macro binding → { macroRef, macroPaletteKey } (the live macro is resolved at read time
+---     via the macro DB so we never persist a stale copy of the macro action/text).
+---   * everything else → full slot record with the standard action / target / customIcon / etc.
+---     fields plus the Ferris extras (macroSourceStore for dual-arm bindings).
+--- This is the 1.8.0 public API that callers like `macropalette.HandleDropOnSlot` rely on.
+--- It coexists with the local `buildSlotRecord` (which always includes the macro extras —
+--- different shape because it's used by Ferris's macro-arm builders that already know they
+--- want the full record).
+---@param slotData table|nil
+---@return table|nil
+function M.BuildSlotDataForWrite(slotData)
+    if not slotData then return nil; end
+
+    local macroRef = slotData.macroRef or slotData.id;
+    if macroRef then
+        -- Preserve dual-arm metadata (macroSourceStore: 'profile'|'shared') and the JA badge flag
+        -- when the caller supplied them. The 1.8.0 minimal {macroRef, macroPaletteKey} shape is
+        -- still the default; the extras are only added when present so untouched slot data round-
+        -- trips losslessly through this builder (i.e. swap operations keep arm identity).
+        return {
+            macroRef = macroRef,
+            macroPaletteKey = slotData.macroPaletteKey,
+            macroSourceStore = slotData.macroSourceStore,
+            showJaBadgeOnMacro = slotData.showJaBadgeOnMacro,
+        };
+    end
+
+    return {
+        actionType = slotData.actionType,
+        action = slotData.action,
+        target = slotData.target,
+        displayName = slotData.displayName,
+        equipSlot = slotData.equipSlot,
+        macroText = slotData.macroText,
+        itemId = slotData.itemId,
+        customIconType = slotData.customIconType,
+        customIconId = slotData.customIconId,
+        customIconPath = slotData.customIconPath,
+        recastSourceType = slotData.recastSourceType,
+        recastSourceAction = slotData.recastSourceAction,
+        recastSourceItemId = slotData.recastSourceItemId,
+        -- showJaBadgeOnMacro applies to macro slots too; forward when present so swap/move
+        -- operations from macropalette.lua preserve the user's per-slot badge preference.
+        showJaBadgeOnMacro = slotData.showJaBadgeOnMacro,
+    };
+end
+
+--- Build a parent macro slot with one arm set from a palette drop, preserving the other arm from existing.
+function M.BuildMacroSlotAfterDrop(armData, sourceStore, existingParentSlot)
+    -- sourceStore: 'profile' | 'shared' (GetMacroSourceTagForDrops)
+    local sh = (sourceStore or 'profile') == 'shared';
+    local arm = buildSlotRecord(armData);
+    if not sh and arm.macroSourceStore == nil then
+        arm.macroSourceStore = 'profile';
+    end
+    if sh and arm.macroSourceStore == nil then
+        arm.macroSourceStore = 'shared';
+    end
+    local out = { actionType = 'macro' };
+    if existingParentSlot and isDualMacroSlotTable(existingParentSlot) then
+        out[K_BIND_P] = existingParentSlot[K_BIND_P] and deepCopyTable(existingParentSlot[K_BIND_P]);
+        out[K_BIND_S] = existingParentSlot[K_BIND_S] and deepCopyTable(existingParentSlot[K_BIND_S]);
+    elseif existingParentSlot and existingParentSlot.macroRef and not isDualMacroSlotTable(existingParentSlot) then
+        -- migrate-on-write: one legacy binding → the appropriate arm
+        local leg = buildSlotRecord(existingParentSlot);
+        if (existingParentSlot.macroSourceStore or 'profile') == 'shared' then
+            out[K_BIND_S] = leg;
+        else
+            out[K_BIND_P] = leg;
+        end
+    else
+        out[K_BIND_P] = nil;
+        out[K_BIND_S] = nil;
+    end
+    if sh then
+        out[K_BIND_S] = arm;
+    else
+        out[K_BIND_P] = arm;
+    end
+    if out[K_BIND_P] and out[K_BIND_S] and out[K_BIND_P] == out[K_BIND_S] then
+        out[K_BIND_S] = deepCopyTable(out[K_BIND_S]);
+    end
+    return out;
+end
+
+-- Shared helper: resolve a slot's macroRef to live macro data if available.
+-- Returns a fresh table with canonical fields, the original non-macro slotAction, or nil if the
+-- slot should not display (e.g. Shared scope with no match in the shared library).
+-- macroSourceStore disambiguates profile vs global shared; in Shared scope, profile-tagged keys do not show.
+local function resolveSlotMacro(slotAction)
+    if not slotAction then
+        return nil;
+    end
+    if slotAction.cleared then
+        return nil;
+    end
+
+    local arm, isMacro = getActiveMacroBindingFromSlot(slotAction);
+    if not isMacro then
+        return slotAction;
+    end
+    if not arm or not arm.macroRef then
+        if isDualMacroSlotTable(slotAction) then
+            return nil;
+        end
+        return slotAction;
+    end
+
+    local paletteKey = arm.macroPaletteKey or (M.jobId or 1);
+    local gcfg = gConfig;
+    local scopeShared = gcfg and (gcfg.macroStorageScope or 'profile') == 'shared';
+    local mss = arm.macroSourceStore;
+    if not mss and isDualMacroSlotTable(slotAction) then
+        if scopeShared and arm == slotAction[K_BIND_S] then
+            mss = 'shared';
+        elseif not scopeShared and arm == slotAction[K_BIND_P] then
+            mss = 'profile';
+        end
+    end
+    if not mss and arm == slotAction then
+        -- Unscoped legacy hotbar/crossbar macro slots behave as profile library binds; hidden in shared scope.
+        mss = slotAction.macroSourceStore or 'profile';
+    end
+    local liveMacro;
+    if mss == 'shared' and not scopeShared then
+        local ok, sms = pcall(require, 'core.shared_macro_store');
+        if ok and sms and sms.LookupInDiskSharedFile then
+            liveMacro = sms.LookupInDiskSharedFile(arm.macroRef, paletteKey);
+        end
+    elseif mss == 'profile' and scopeShared then
+        -- Shared mode: do not show profile library binding — empty until re-drag from shared.
+        liveMacro = nil;
+    else
+        liveMacro = M.GetMacroById and M.GetMacroById(arm.macroRef, paletteKey);
+    end
+    if not liveMacro then
+        if scopeShared then
+            return nil;
+        end
+        -- Orphan macro binding: the macroRef no longer resolves to a live macro (deleted from
+        -- Macro Manager, or the draft layer still holds a stale ref the live gConfig sweep
+        -- didn't reach). Modern slots are minimal {macroRef, macroPaletteKey} records with no
+        -- fallback displayName/action — returning slotAction would render the slot with no
+        -- name and the abbreviation pass produces "?" placeholder garbage. Return nil so the
+        -- slot draws empty. Legacy slots that still carry cached displayName/action keep their
+        -- old behaviour (slotAction fallback) so partially-migrated profiles aren't wiped.
+        if isDualMacroSlotTable(slotAction) then
+            return nil;
+        end
+        if not slotAction.displayName and not slotAction.action then
+            return nil;
+        end
+        return slotAction;
+    end
+    local out = copySlotFields(liveMacro);
+    out.macroRef = arm.macroRef;
+    out.macroPaletteKey = arm.macroPaletteKey;
+    out.macroSourceStore = mss;
+    return out;
+end
+
+--- Raw crossbar blobs still hold inactive macro arms (profile vs shared) while the HUD shows empty for the other library.
+--- Swap/drag reads use raw tables — align them with what resolveSlotMacro would display so "blank" slots behave empty.
+function M.NormalizeCrossbarSlotRawForSwap(raw)
+    if raw == nil then return nil; end
+    if type(raw) ~= 'table' or raw.cleared then return nil; end
+    if resolveSlotMacro(raw) == nil then
+        return nil;
+    end
+    return raw;
+end
+
+--- In-place: legacy single macro binding -> macroBindProfile or macroBindShared.
+local function migrateOneSlotToDualMacroBindings(slot)
+    if not slot or type(slot) ~= 'table' or slot.cleared then
+        return false;
+    end
+    if isDualMacroSlotTable(slot) then
+        return false;
+    end
+    if not slot.macroRef then
+        return false;
+    end
+    if slot.actionType and slot.actionType ~= 'macro' then
+        return false;
+    end
+    local arm = copySlotFields(slot);
+    arm.macroRef = slot.macroRef or slot.id;
+    arm.macroPaletteKey = slot.macroPaletteKey;
+    arm.macroSourceStore = slot.macroSourceStore;
+    for _, k in ipairs(SLOT_DATA_FIELDS) do
+        slot[k] = nil;
+    end
+    slot.actionType = 'macro';
+    if (arm.macroSourceStore or 'profile') == 'shared' then
+        slot[K_BIND_S] = arm;
+        slot[K_BIND_P] = nil;
+    else
+        slot[K_BIND_P] = arm;
+        slot[K_BIND_S] = nil;
+    end
+    return true;
+end
+
+local function migrateHotbarSlotActionsTable(slotActions)
+    if not slotActions or type(slotActions) ~= 'table' then
+        return;
+    end
+    for _, jobSlotActions in pairs(slotActions) do
+        if type(jobSlotActions) == 'table' then
+            for _, slot in pairs(jobSlotActions) do
+                if type(slot) == 'table' then
+                    migrateOneSlotToDualMacroBindings(slot);
+                end
+            end
+        end
+    end
+end
+
+local function migrateCrossbarSlotActionsTable(slotActions)
+    if not slotActions or type(slotActions) ~= 'table' then
+        return;
+    end
+    local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+    for _, jobSlotActions in pairs(slotActions) do
+        if type(jobSlotActions) == 'table' then
+            for _, comboMode in ipairs(comboModes) do
+                local comboSlots = jobSlotActions[comboMode];
+                if type(comboSlots) == 'table' then
+                    for _, slot in pairs(comboSlots) do
+                        if type(slot) == 'table' then
+                            migrateOneSlotToDualMacroBindings(slot);
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+--- One-time per-load migration: split macro hotbar/crossbar refs into profile vs shared arms.
+function M.MigrateSlotDualMacroBindings(gConfig)
+    if not gConfig then
+        return;
+    end
+    for bar = 1, 6 do
+        local configKey = 'hotbarBar' .. bar;
+        local barSettings = gConfig[configKey];
+        if barSettings and barSettings.slotActions then
+            migrateHotbarSlotActionsTable(barSettings.slotActions);
+        end
+    end
+    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        migrateCrossbarSlotActionsTable(gConfig.hotbarCrossbar.slotActions);
+    end
+end
+
+--- Unresolved slot as stored in config (for dual-arm swap / drop merge).
+function M.GetRawHotbarSlotAction(barIndex, slotIndex)
+    if not gConfig then
+        return nil;
+    end
+    local configKey = 'hotbarBar' .. barIndex;
+    local barSettings = gConfig[configKey];
+    if not barSettings or not barSettings.slotActions then
+        return nil;
+    end
+    local storageKey = M.GetStorageKeyForBar(barIndex);
+    local jobSlotActions = getSlotActionsForKey(barSettings.slotActions, storageKey);
+    if not jobSlotActions then
+        return nil;
+    end
+    local n = tonumber(slotIndex) or slotIndex;
+    return jobSlotActions[n] or jobSlotActions[tostring(n)];
+end
+
+function M.GetRawCrossbarSlotAction(comboMode, slotIndex)
+    if not gConfig or not gConfig.hotbarCrossbar or not gConfig.hotbarCrossbar.slotActions then
+        return nil;
+    end
+    -- M.*: local GetEffectiveComboModeForStorage is defined later; bare name would read as a nil global here.
+    local effectiveComboMode = M.GetEffectiveComboModeForStorage(comboMode);
+    local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then
+        return nil;
+    end
+    return jobSlotActions[effectiveComboMode][slotIndex];
+end
+
+--- Raw slot blob for `storageKey` (palette editor segment / named palette), ignoring the HUD active palette.
+--- Same shape as GetRawCrossbarSlotAction — used when Edit Full Palette draft inherits an untouched sparse cell.
+function M.GetRawCrossbarSlotActionForStorageKey(storageKey, comboMode, slotIndex)
+    if not storageKey or not gConfig or not gConfig.hotbarCrossbar or not gConfig.hotbarCrossbar.slotActions then
+        return nil;
+    end
+    local effectiveComboMode = M.GetEffectiveComboModeForStorage(comboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then
+        return nil;
+    end
+    return jobSlotActions[effectiveComboMode][slotIndex];
+end
+
+--- Convert legacy layout to dual for swap / merge logic. nil or cleared => empty macro slot (no arms yet).
+function M.DualizeRawMacroSlotForMerge(raw)
+    if not raw or type(raw) ~= 'table' or raw.cleared then
+        return { actionType = 'macro' };
+    end
+    if isDualMacroSlotTable(raw) then
+        return deepCopyTable(raw);
+    end
+    if not raw.macroRef then
+        return deepCopyTable(raw);
+    end
+    if raw.actionType and raw.actionType ~= 'macro' then
+        return deepCopyTable(raw);
+    end
+    local arm = copySlotFields(raw);
+    arm.macroRef = raw.macroRef or raw.id;
+    arm.macroPaletteKey = raw.macroPaletteKey;
+    arm.macroSourceStore = raw.macroSourceStore;
+    local out = { actionType = 'macro' };
+    if (raw.macroSourceStore or 'profile') == 'shared' then
+        out[K_BIND_S] = arm;
+    else
+        out[K_BIND_P] = arm;
+    end
+    return out;
+end
+
+function M.FinalizeHotbarRawSlotForStorage(s)
+    if s == nil then
+        return { cleared = true };
+    end
+    if type(s) ~= 'table' then
+        return s;
+    end
+    if s.cleared then
+        return s;
+    end
+    if s.actionType == 'macro' and not s[K_BIND_P] and not s[K_BIND_S] and not s.macroRef then
+        return { cleared = true };
+    end
+    return s;
+end
+
+-- Crossbar empty slots are nil (not { cleared = true }).
+function M.FinalizeCrossbarRawSlotForStorage(s)
+    if not s or type(s) ~= 'table' then
+        return s;
+    end
+    if s.cleared then
+        return nil;
+    end
+    if s.actionType == 'macro' and not s[K_BIND_P] and not s[K_BIND_S] and not s.macroRef then
+        return nil;
+    end
+    return s;
+end
+
+local function macroPaletteKeysEqualData(a, b)
+    if a == b then
+        return true;
+    end
+    if a == nil or b == nil then
+        return false;
+    end
+    local na, nb = tonumber(a), tonumber(b);
+    if na ~= nil and nb ~= nil then
+        return na == nb;
+    end
+    return false;
+end
+
+local function macroArmMatchesDelete(arm, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    if not arm or type(arm) ~= 'table' or arm.macroRef ~= macroId then
+        return false;
+    end
+    deleteKind = deleteKind or 'profile';
+    local mss = arm.macroSourceStore;
+    if deleteKind == 'shared' then
+        if mss == 'profile' then
+            return false;
+        end
+    else
+        if mss == 'shared' then
+            return false;
+        end
+    end
+    local spk = arm.macroPaletteKey;
+    if spk ~= nil then
+        return macroPaletteKeysEqualData(spk, deletedTypeKey);
+    end
+    return onlyBucketForThisId;
+end
+
+-- Clear macro arms that refer to a deleted macro row. emptyWhenGone: hotbar { cleared = true } or crossbar nil.
+function M.ApplyMacroDeleteToSlotAction(slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, emptyWhenGone)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local out = deepCopyTable(slotAction);
+        local chg = false;
+        if macroArmMatchesDelete(out[K_BIND_P], macroId, deletedTypeKey, onlyBucketForThisId, deleteKind) then
+            out[K_BIND_P] = nil;
+            chg = true;
+        end
+        if macroArmMatchesDelete(out[K_BIND_S], macroId, deletedTypeKey, onlyBucketForThisId, deleteKind) then
+            out[K_BIND_S] = nil;
+            chg = true;
+        end
+        if not chg then
+            return nil, false;
+        end
+        if not out[K_BIND_P] and not out[K_BIND_S] then
+            return emptyWhenGone, true;
+        end
+        out.actionType = 'macro';
+        return out, true;
+    end
+    if not slotAction.macroRef or slotAction.macroRef ~= macroId then
+        return nil, false;
+    end
+    if not macroArmMatchesDelete(slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind) then
+        return nil, false;
+    end
+    return emptyWhenGone, true;
+end
+
+--- True when a macro arm should be cleared because its entire palette bucket was removed.
+local function macroArmMatchesBucketRemove(arm, removedBucketKey, deleteKind)
+    if not arm or type(arm) ~= 'table' or not arm.macroRef then
+        return false;
+    end
+    deleteKind = deleteKind or 'profile';
+    local mss = arm.macroSourceStore;
+    if deleteKind == 'shared' then
+        if mss == 'profile' then
+            return false;
+        end
+    else
+        if mss == 'shared' then
+            return false;
+        end
+    end
+    if arm.macroPaletteKey == nil then
+        return false;
+    end
+    return macroPaletteKeysEqualData(arm.macroPaletteKey, removedBucketKey);
+end
+
+-- After removing an entire custom:* (or any) macro palette bucket: clear all bindings to that key.
+-- deleteKind: 'profile' = profile-library arms, 'shared' = shared-library arms. emptyWhenGone: hotbar {cleared} / cross nil.
+function M.ApplyMacroPaletteBucketRemovedToSlotAction(slotAction, removedBucketKey, deleteKind, emptyWhenGone)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local out = deepCopyTable(slotAction);
+        local chg = false;
+        if macroArmMatchesBucketRemove(out[K_BIND_P], removedBucketKey, deleteKind) then
+            out[K_BIND_P] = nil;
+            chg = true;
+        end
+        if macroArmMatchesBucketRemove(out[K_BIND_S], removedBucketKey, deleteKind) then
+            out[K_BIND_S] = nil;
+            chg = true;
+        end
+        if not chg then
+            return nil, false;
+        end
+        if not out[K_BIND_P] and not out[K_BIND_S] then
+            return emptyWhenGone, true;
+        end
+        out.actionType = 'macro';
+        return out, true;
+    end
+    if not slotAction.macroRef then
+        return nil, false;
+    end
+    if not macroArmMatchesBucketRemove(slotAction, removedBucketKey, deleteKind) then
+        return nil, false;
+    end
+    return emptyWhenGone, true;
+end
+
+--- Compare macro palette bucket keys (job id number vs string forms, reserved string buckets).
+function M.MacroPaletteKeysEqual(a, b)
+    return macroPaletteKeysEqualData(a, b);
+end
+
+-- Arms pointing at `macroId` in `sourceKey`: explicit palette key match, or nil key only when
+-- `onlyBucketForThisId` (macro id appears in a single macroDB bucket worldwide).
+local function macroArmMatchesMoveSource(arm, macroId, sourceKey, onlyBucketForThisId)
+    if not arm or type(arm) ~= 'table' or arm.macroRef ~= macroId then
+        return false;
+    end
+    local spk = arm.macroPaletteKey;
+    if spk ~= nil then
+        return macroPaletteKeysEqualData(spk, sourceKey);
+    end
+    return onlyBucketForThisId;
+end
+
+--- Rewrite palette macro bindings after MoveMacro: same slots keep working under new macroRef + macroPaletteKey.
+function M.ApplyMacroMoveToSlotAction(slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local out = deepCopyTable(slotAction);
+        local chg = false;
+        if macroArmMatchesMoveSource(out[K_BIND_P], oldId, oldKey, onlyBucketForThisId) then
+            out[K_BIND_P].macroRef = newId;
+            out[K_BIND_P].macroPaletteKey = newKey;
+            chg = true;
+        end
+        if macroArmMatchesMoveSource(out[K_BIND_S], oldId, oldKey, onlyBucketForThisId) then
+            out[K_BIND_S].macroRef = newId;
+            out[K_BIND_S].macroPaletteKey = newKey;
+            chg = true;
+        end
+        if not chg then
+            return nil, false;
+        end
+        out.actionType = 'macro';
+        return out, true;
+    end
+    if not slotAction.macroRef or slotAction.macroRef ~= oldId then
+        return nil, false;
+    end
+    if not macroArmMatchesMoveSource(slotAction, oldId, oldKey, onlyBucketForThisId) then
+        return nil, false;
+    end
+    local out = deepCopyTable(slotAction);
+    out.macroRef = newId;
+    out.macroPaletteKey = newKey;
+    return out, true;
+end
+
+local CROSSBAR_COMBO_MODES_FOR_MACRO_SWEEP = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+
+--- Hotbars + crossbar live slot maps in cfg (typically gConfig).
+function M.RewriteMacroPaletteBindingsInConfig(cfg, oldId, oldKey, newId, newKey, onlyBucketForThisId, notifyLayouts)
+    if not cfg or not oldId or oldKey == nil or not newId or newKey == nil then
+        return false;
+    end
+    local changed = false;
+    for barIndex = 1, 6 do
+        local configKey = 'hotbarBar' .. barIndex;
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
+            for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
+                if jobSlotActions then
+                    for slotIndex, slotAction in pairs(jobSlotActions) do
+                        local newSlot, chg = M.ApplyMacroMoveToSlotAction(
+                            slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId);
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
+        for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
+            if jobSlotActions then
+                for _, comboMode in ipairs(CROSSBAR_COMBO_MODES_FOR_MACRO_SWEEP) do
+                    local comboSlots = jobSlotActions[comboMode];
+                    if comboSlots then
+                        for slotIndex, slotAction in pairs(comboSlots) do
+                            local newSlot, chg = M.ApplyMacroMoveToSlotAction(
+                                slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if changed and notifyLayouts then
+        NotifySlotDataChanged();
+    end
+    return changed;
+end
+
+--- Edit Full Palette draft crossbar blobs (if open).
+function M.RewriteMacroPaletteBindingsInDraft(oldId, oldKey, newId, newKey, onlyBucketForThisId)
+    if not draftForStorageKey or not draftByKey then
+        return false;
+    end
+    local changed = false;
+    for _, blob in pairs(draftByKey) do
+        if type(blob) == 'table' then
+            for _, comboMode in ipairs(CROSSBAR_COMBO_MODES_FOR_MACRO_SWEEP) do
+                local comboSlots = blob[comboMode];
+                if comboSlots then
+                    for slotIndex, slotAction in pairs(comboSlots) do
+                        local newSlot, chg = M.ApplyMacroMoveToSlotAction(
+                            slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId);
+                        if chg then
+                            comboSlots[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if changed then
+        draftDirty = true;
+        NotifySlotDataChanged();
+    end
+    return changed;
+end
+
+local function isLibraryMacroSlotForSwap(s)
+    if not s or type(s) ~= 'table' or s.cleared then
+        return false;
+    end
+    if s[K_BIND_P] ~= nil or s[K_BIND_S] ~= nil then
+        return true;
+    end
+    if s.macroRef and (not s.actionType or s.actionType == 'macro') then
+        return true;
+    end
+    return false;
+end
+
+-- If profile and shared arm tables are the same reference (data corruption or legacy bug), the active-arm
+-- swap can move a profile binding into the wrong key or "clone" the same row — split into two tables.
+local function disambiguateDualMacroArms(t)
+    if not t or type(t) ~= 'table' then
+        return;
+    end
+    if t[K_BIND_P] ~= nil and t[K_BIND_S] ~= nil and t[K_BIND_P] == t[K_BIND_S] then
+        t[K_BIND_S] = deepCopyTable(t[K_BIND_S]);
+    end
+end
+
+--- Exchange only the active library's arm when both slots are palette macro bindings; else swap whole slot tables.
+-- rawA = source slot (dragged from), rawB = target slot (dropped onto).
+-- Returns (value for target index, value for source index) for callers that assign:
+--   job[target] = first; job[source] = second
+function M.SwapActiveMacroArmsInPlace(rawA, rawB)
+    if isLibraryMacroSlotForSwap(rawA) and isLibraryMacroSlotForSwap(rawB) then
+        local a = M.DualizeRawMacroSlotForMerge(rawA);
+        local b = M.DualizeRawMacroSlotForMerge(rawB);
+        disambiguateDualMacroArms(a);
+        disambiguateDualMacroArms(b);
+        local sh = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared');
+        local k = sh and K_BIND_S or K_BIND_P;
+        local t = a[k];
+        a[k] = b[k];
+        b[k] = t;
+        -- Deep copy so we never return tables that still alias nested refs from the other cell or from gConfig.
+        return deepCopyTable(b), deepCopyTable(a);
+    end
+    return deepCopyTable(rawA), deepCopyTable(rawB);
+end
+
+-- Merge slot maps when migrating legacy job:subjob:petKey -> petpalette:petKey (fill empty slots only)
+local function mergeHotbarSlotActions(dst, src)
+    if type(dst) ~= 'table' or type(src) ~= 'table' then
+        return;
+    end
+    for si, action in pairs(src) do
+        if dst[si] == nil then
+            dst[si] = deepCopyTable(action);
+        elseif type(dst[si]) == 'table' and dst[si].cleared
+            and type(action) == 'table' and not action.cleared then
+            dst[si] = deepCopyTable(action);
+        end
+    end
+end
+
+local function mergeCrossbarComboSlotActions(dst, src)
+    if type(dst) ~= 'table' or type(src) ~= 'table' then
+        return;
+    end
+    for comboMode, slots in pairs(src) do
+        if type(slots) == 'table' then
+            if not dst[comboMode] then
+                dst[comboMode] = {};
+            end
+            mergeHotbarSlotActions(dst[comboMode], slots);
+        end
+    end
+end
+
+-- One-time migration: legacy '{job}:{sub}:{petKey}' -> 'petpalette:{petKey}' for pet-aware storage
+function M.MigratePetAwareSlotStorageKeys()
+    if not gConfig then
+        return false;
+    end
+    local changed = false;
+    local palPrefix = 'palette:';
+
+    local function shouldMigrateKey(remainder)
+        if not remainder or remainder == '' then
+            return false;
+        end
+        if remainder:sub(1, #palPrefix) == palPrefix then
+            return false;
+        end
+        if remainder:sub(1, #PETPALETTE_STORAGE_PREFIX) == PETPALETTE_STORAGE_PREFIX then
+            return false;
+        end
+        return petregistry.IsValidPetKey(remainder);
+    end
+
+    local function migrateFlatSlotActions(slotActions)
+        if not slotActions or type(slotActions) ~= 'table' then
+            return;
+        end
+        local moves = {};
+        for key, payload in pairs(slotActions) do
+            if type(key) == 'string' and type(payload) == 'table' then
+                local jid, sjid, remainder = key:match('^(%d+):(%d+):(.+)$');
+                if jid and sjid and shouldMigrateKey(remainder) then
+                    local newKey = PETPALETTE_STORAGE_PREFIX .. remainder;
+                    moves[key] = newKey;
+                end
+            end
+        end
+        for oldKey, newKey in pairs(moves) do
+            local oldData = slotActions[oldKey];
+            slotActions[oldKey] = nil;
+            changed = true;
+            if not slotActions[newKey] then
+                slotActions[newKey] = deepCopyTable(oldData);
+            else
+                mergeHotbarSlotActions(slotActions[newKey], oldData);
+            end
+        end
+    end
+
+    local function migrateCrossbarSlotActions(slotActions)
+        if not slotActions or type(slotActions) ~= 'table' then
+            return;
+        end
+        local moves = {};
+        for key, payload in pairs(slotActions) do
+            if type(key) == 'string' and type(payload) == 'table' then
+                local jid, sjid, remainder = key:match('^(%d+):(%d+):(.+)$');
+                if jid and sjid and shouldMigrateKey(remainder) then
+                    local newKey = PETPALETTE_STORAGE_PREFIX .. remainder;
+                    moves[key] = newKey;
+                end
+            end
+        end
+        for oldKey, newKey in pairs(moves) do
+            local oldData = slotActions[oldKey];
+            slotActions[oldKey] = nil;
+            changed = true;
+            if not slotActions[newKey] then
+                slotActions[newKey] = deepCopyTable(oldData);
+            else
+                mergeCrossbarComboSlotActions(slotActions[newKey], oldData);
+            end
+        end
+    end
+
+    for barIndex = 1, M.NUM_BARS do
+        local configKey = 'hotbarBar' .. barIndex;
+        local barSettings = gConfig[configKey];
+        if barSettings and barSettings.slotActions then
+            migrateFlatSlotActions(barSettings.slotActions);
+        end
+    end
+    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        migrateCrossbarSlotActions(gConfig.hotbarCrossbar.slotActions);
+    end
+    if changed then
+        NotifySlotDataChanged();
+    end
+    return changed;
+end
+
+-- Shared helper: ensure slotActions structure exists for a storage key.
+-- When comboMode is provided (crossbar), also ensures the combo-mode sub-table and returns it.
+-- When comboMode is nil (hotbar), returns the top-level bucket for the key.
+-- Copies from subjob-0 fallback when creating a new key to preserve data across subjob changes.
+local function ensureSlotActionsStructure(settings, storageKey, comboMode)
+    if not settings.slotActions then
+        settings.slotActions = {};
+    end
+    if storageKey == GLOBAL_SLOT_KEY then
+        if not settings.slotActions[GLOBAL_SLOT_KEY] then
+            settings.slotActions[GLOBAL_SLOT_KEY] = {};
+        end
+        local bucket = settings.slotActions[GLOBAL_SLOT_KEY];
+        if comboMode then
+            if not bucket[comboMode] then bucket[comboMode] = {}; end
+            return bucket[comboMode];
+        end
+        return bucket;
+    end
+    if not settings.slotActions[storageKey] then
         local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
         if jobId and subjobId ~= '0' then
-            -- Build fallback key with subjob=0, preserving any suffix (palette, avatar, etc.)
             local fallbackKey = jobId .. ':0' .. (suffix or '');
-            local fallbackData = barSettings.slotActions[fallbackKey];
+            local fallbackData = settings.slotActions[fallbackKey];
             if fallbackData then
-                -- Deep copy fallback data to the new key to preserve all slots
-                barSettings.slotActions[storageKey] = deepCopyTable(fallbackData);
+                settings.slotActions[storageKey] = deepCopyTable(fallbackData);
             else
-                barSettings.slotActions[storageKey] = {};
+                settings.slotActions[storageKey] = {};
             end
         else
-            barSettings.slotActions[storageKey] = {};
+            settings.slotActions[storageKey] = {};
         end
     end
-    return barSettings.slotActions[storageKey];
+    local bucket = settings.slotActions[storageKey];
+    if comboMode then
+        if not bucket[comboMode] then bucket[comboMode] = {}; end
+        return bucket[comboMode];
+    end
+    return bucket;
 end
 
 -- Keys that are always per-bar (never pulled from global)
@@ -229,11 +1234,12 @@ local PER_BAR_ONLY_KEYS = {
     columns = true,
     slots = true,
     useGlobalSettings = true,
-    keybinds = true,
+    keyBindings = true,
     slotActions = true,
     jobSpecific = true,
     petAware = true,
     showPetIndicator = true,
+    petPalettePetKeys = true,
 };
 
 -- ============================================
@@ -241,18 +1247,11 @@ local PER_BAR_ONLY_KEYS = {
 -- ============================================
 
 -- Build full storage key for a bar, considering job, subjob, pet awareness, and general palettes
--- Returns: 'global', '{jobId}:{subjobId}' (base), '{jobId}:{subjobId}:{petKey}' (pet), or '{jobId}:{subjobId}:palette:{name}' (palette)
+-- Returns: 'global', '{jobId}:{subjobId}' (base), 'petpalette:{petKey}' (pet), or '{jobId}:{subjobId}:palette:{name}' (palette)
 -- Priority: global > pet-aware > general palette > base
 -- NOTE: Palettes can be subjob-specific or shared (subjob 0), with fallback to shared if no subjob-specific exist
 -- OPTIMIZED: Results are cached to avoid 72+ string allocations per frame
 function M.GetStorageKeyForBar(barIndex)
-    -- If gConfig was swapped out (profile change), invalidate.
-    if storageKeyCacheSource ~= gConfig then
-        storageKeyCache = {};
-        storageKeyCacheDirty = true;
-        storageKeyCacheSource = gConfig;
-    end
-
     -- Check cache first (major optimization for runtime rendering)
     if not storageKeyCacheDirty and storageKeyCache[barIndex] then
         return storageKeyCache[barIndex];
@@ -287,11 +1286,14 @@ function M.GetStorageKeyForBar(barIndex)
             if pp then
                 -- Check for manual override or auto-detected pet
                 petKey = pp.GetEffectivePetKey(barIndex);
+                if petKey and not petAllowlist.Allows(barSettings, petKey) then
+                    petKey = nil;
+                end
             end
         end
 
         if petKey then
-            result = string.format('%s:%s', baseKey, petKey);
+            result = PETPALETTE_STORAGE_PREFIX .. petKey;
         else
             -- Check for general palette (user-defined named palettes)
             -- Palettes use subjob-aware keys with fallback to shared (subjob 0) if no subjob-specific exist
@@ -347,7 +1349,9 @@ function M.GetAvailablePalettes(barIndex)
         if pp then
             local petPalettes = pp.GetAvailablePalettes(barIndex, jobId, subjobId);
             for _, p in ipairs(petPalettes) do
-                table.insert(palettes, p);
+                if p.key == nil or petAllowlist.Allows(barSettings, p.key) then
+                    table.insert(palettes, p);
+                end
             end
         end
     end
@@ -380,9 +1384,12 @@ function M.GetCurrentPaletteDisplayName(barIndex)
     if barSettings and barSettings.petAware then
         local pp = getPetPalette();
         if pp then
-            local petDisplayName = pp.GetPaletteDisplayName(barIndex, jobId);
-            if petDisplayName and petDisplayName ~= 'Base' then
-                return petDisplayName;
+            local ek = pp.GetEffectivePetKey(barIndex);
+            if ek and petAllowlist.Allows(barSettings, ek) then
+                local petDisplayName = pp.GetPaletteDisplayName(barIndex, jobId);
+                if petDisplayName and petDisplayName ~= 'Base' then
+                    return petDisplayName;
+                end
             end
         end
     end
@@ -426,13 +1433,147 @@ end
 -- Expose for external use (e.g., crossbar icon caching)
 M.GetEffectiveComboModeForStorage = GetEffectiveComboModeForStorage;
 
+-- Job-wide shared segment storage (Edit Full Palette: Job-Shared override). effectiveComboMode = GetEffectiveComboModeForStorage(mode).
+function M.BuildJobSegmentSharedStorageKey(jobId, effectiveComboMode)
+    local j = normalizeJobId(jobId);
+    local m = effectiveComboMode or 'L2x2';
+    return string.format('jobsegment:%d:%s', j, m);
+end
+
+-- FFXI main jobs 1..22 — segment override rows are keyed per job; Global [G] redirects must resolve for the *current* job id in-game.
+local SEGMENT_OVERRIDE_FALLBACK_JOB_MAX = 22;
+
+local function GetSegmentOverrideEntry(jobId, comboMode)
+    local cross = gConfig and gConfig.hotbarCrossbar;
+    if not cross or not cross.segmentOverrides then
+        return nil;
+    end
+    local eff = GetEffectiveComboModeForStorage(comboMode);
+    if eff == 'L2' or eff == 'R2' then
+        return nil;
+    end
+    local jidStr = tostring(normalizeJobId(jobId));
+    local modes = cross.segmentOverrides[jidStr];
+    local seg = modes and modes[eff];
+    if seg and seg.scope == 'jobShared' then
+        return seg, eff;
+    end
+    if seg and seg.scope == 'global' and type(seg.globalPalette) == 'string' and seg.globalPalette ~= '' then
+        return seg, eff;
+    end
+    -- Legacy / partial saves: Global was only stored on the job row open in Edit Full Palette; other job ids had no entry.
+    if not seg or not seg.scope then
+        local anyJobShared = false;
+        local globalPaletteName;
+        for j = 1, SEGMENT_OVERRIDE_FALLBACK_JOB_MAX do
+            local candidate = cross.segmentOverrides[tostring(j)] and cross.segmentOverrides[tostring(j)][eff];
+            if candidate and candidate.scope == 'jobShared' then
+                anyJobShared = true;
+            elseif candidate and candidate.scope == 'global' and type(candidate.globalPalette) == 'string' and candidate.globalPalette ~= '' then
+                globalPaletteName = candidate.globalPalette;
+            end
+        end
+        if not anyJobShared and globalPaletteName then
+            return { scope = 'global', globalPalette = globalPaletteName }, eff;
+        end
+    end
+    return nil;
+end
+
+-- Resolved slotActions key when a Job-Shared / Global segment override is active (nil if none).
+function M.GetSegmentOverrideResolvedStorageKey(jobId, comboMode)
+    local seg, eff = GetSegmentOverrideEntry(jobId, comboMode);
+    if not seg or not seg.scope then
+        return nil;
+    end
+    if seg.scope == 'jobShared' then
+        return M.BuildJobSegmentSharedStorageKey(jobId, eff);
+    end
+    if seg.scope == 'global' and type(seg.globalPalette) == 'string' and seg.globalPalette ~= '' then
+        return getPalette().BuildUniversalCrossbarStorageKey(seg.globalPalette);
+    end
+    return nil;
+end
+
+-- For Edit Full Palette warnings: { scope, globalPalette?, effectiveMode } or nil
+function M.GetSegmentOverrideDescriptorForJob(jobId, comboMode)
+    local seg, eff = GetSegmentOverrideEntry(jobId, comboMode);
+    if not seg or not seg.scope then
+        return nil;
+    end
+    return {
+        scope = seg.scope,
+        globalPalette = seg.globalPalette,
+        effectiveMode = eff,
+    };
+end
+
 -- ============================================
 -- Crossbar Storage Key Resolution (GLOBAL Palette)
 -- ============================================
 
+-- Per combo *segment* (L2, R2, …) pet type filter: comboModeSettings[mode].petPalettePetKeys, or fallback
+-- hotbarCrossbar.petPalettePetKeys, or nil = all. Not per named [J] palette.
+local function getCrossbarPetTypeKeysForMode(crossbarSettings, mode)
+    if not crossbarSettings or not mode then
+        return nil;
+    end
+    local cm = crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[mode];
+    if cm and cm.petPalettePetKeys ~= nil then
+        return cm.petPalettePetKeys;
+    end
+    if crossbarSettings.petPalettePetKeys ~= nil then
+        return crossbarSettings.petPalettePetKeys;
+    end
+    return nil;
+end
+
+-- Merge Crossbar defaults with optional per-named-palette overrides (Job [J] scope only)
+local function GetMergedCrossbarComboModeSettings(comboMode)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local base = crossbarSettings and crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[comboMode];
+    if not base then
+        base = { petAware = false, universalOverridePalette = nil };
+    end
+    local merged = {
+        petAware = base.petAware == true,
+        universalOverridePalette = base.universalOverridePalette,
+        petPalettePetKeys = getCrossbarPetTypeKeysForMode(crossbarSettings, comboMode),
+    };
+    local p = getPalette();
+    if not crossbarSettings or not p or not crossbarSettings.namedPaletteComboModeSettings then
+        return merged;
+    end
+    if crossbarSettings.enableUniversalCrossbarPalettes and p.GetCrossbarPaletteScope() == 'universal' then
+        return merged;
+    end
+    local jobId = M.jobId or 1;
+    local subjobId = M.subjobId or 0;
+    local palName = p.GetActivePaletteForCombo('L2');
+    if not palName or palName == '' then
+        return merged;
+    end
+    local tier = subjobId;
+    if subjobId ~= 0 and p.GetCrossbarActivePaletteStorageSubjobForResolution then
+        tier = p.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, subjobId);
+    end
+    local storageKey = p.BuildPaletteStorageKey(jobId, tier, palName);
+    local byPal = crossbarSettings.namedPaletteComboModeSettings[storageKey];
+    local ovr = byPal and byPal[comboMode];
+    if not ovr then
+        return merged;
+    end
+    -- Pet palette on/off and pet-type allowlist are job-wide, not per named palette.
+    if ovr.universalOverridePalette ~= nil then
+        local u = ovr.universalOverridePalette;
+        merged.universalOverridePalette = (type(u) == 'string' and u ~= '') and u or nil;
+    end
+    return merged;
+end
+
 -- Build full storage key for a crossbar combo mode, considering job, subjob, pet awareness, and palettes
--- NOTE: Crossbar now uses a SINGLE global palette for all combo modes (not per-combo-mode)
--- Returns: 'global', '{jobId}:{subjobId}' (base), '{jobId}:{subjobId}:{petKey}' (pet), or '{jobId}:{subjobId}:palette:{name}' (palette)
+-- Returns: 'global', 'global:palette:{name}', '{jobId}:{subjobId}', 'petpalette:{petKey}',
+--   or '{jobId}:{subjobId}:palette:{name}'
 function M.GetCrossbarStorageKeyForCombo(comboMode)
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
     if not crossbarSettings then
@@ -444,51 +1585,71 @@ function M.GetCrossbarStorageKeyForCombo(comboMode)
     local normalizedJobId = normalizeJobId(jobId);
     local normalizedSubjobId = normalizeJobId(subjobId);
 
-    -- Global mode (non-job-specific)
+    -- Global mode (non-job-specific single flat slot map)
     if crossbarSettings.jobSpecific == false then
         return GLOBAL_SLOT_KEY;
     end
 
-    -- Build base job:subjob key (used for base slots - subjob-specific)
     local baseKey = string.format('%d:%d', normalizedJobId, normalizedSubjobId);
+    local modeSettings = GetMergedCrossbarComboModeSettings(comboMode);
+    local p = getPalette();
 
-    -- Get per-combo-mode settings (still used for pet-aware, but not for palette)
-    local modeSettings = crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[comboMode];
+    -- [G] L1+R1 scope: all combos use all-jobs storage keys; pet never applies (including per-combo [G] attach)
+    if crossbarSettings.enableUniversalCrossbarPalettes and p and p.GetCrossbarPaletteScope() == 'universal' then
+        if modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+            return p.BuildUniversalCrossbarStorageKey(modeSettings.universalOverridePalette);
+        end
+        local uName = p.GetActiveUniversalCrossbarPalette();
+        if uName and uName ~= '' then
+            return p.BuildUniversalCrossbarStorageKey(uName);
+        end
+        return baseKey;
+    end
 
-    -- Check pet-aware mode for this combo mode
+    -- Temporary /xiui cpal summon: another job's named palette (flat layout; skips pet, segment overrides, per-mode [G] attach).
+    if p and p.GetCrossbarCliPreview then
+        local pv = p.GetCrossbarCliPreview();
+        if pv and pv.paletteName and pv.jobId then
+            local sfx = p.GetPaletteKeySuffix(pv.paletteName);
+            if sfx then
+                return string.format('%d:%d:%s', pv.jobId, pv.storageSubjob or 0, sfx);
+            end
+        end
+    end
+
+    -- [J] scope: pet can override job-tier storage, including when a combo uses an attached [G] palette name
     if modeSettings and modeSettings.petAware then
         local pp = getPetPalette();
         if pp then
             local effectivePetKey = pp.GetEffectivePetKeyForCombo(comboMode);
-            if effectivePetKey then
-                return string.format('%s:%s', baseKey, effectivePetKey);
+            if effectivePetKey and petAllowlist.Allows(modeSettings, effectivePetKey) then
+                return PETPALETTE_STORAGE_PREFIX .. effectivePetKey;
             end
         end
     end
 
-    -- Check for GLOBAL crossbar palette (shared across all combo modes)
-    -- Palettes use subjob-aware keys with fallback to shared (subjob 0) if no subjob-specific exist
-    local p = getPalette();
+    -- Per-job segment override (Edit Full Palette): Job-Shared bucket or Global [G] palette source — supersedes legacy per-palette [G] attach below
+    local segOvrKey = M.GetSegmentOverrideResolvedStorageKey(normalizedJobId, comboMode);
+    if segOvrKey then
+        return segOvrKey;
+    end
+
+    if p and modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+        return p.BuildUniversalCrossbarStorageKey(modeSettings.universalOverridePalette);
+    end
+
+    -- Named job / job+subjob crossbar palettes
     if p then
         local paletteSuffix = p.GetEffectivePaletteKeySuffixForCombo(comboMode);
         if paletteSuffix then
-            -- Determine which subjobId to use: check if using fallback to shared palettes
-            local effectiveSubjobId = normalizedSubjobId;
-            -- Use crossbar-specific fallback check
-            if p.IsUsingFallbackPalettes then
-                -- Check crossbar palettes specifically
-                local crossbarPalettes = p.GetCrossbarAvailablePalettes(normalizedJobId, normalizedSubjobId);
-                -- If no palettes found and we're not at subjob 0, we're likely using fallback
-                if #crossbarPalettes == 0 or (normalizedSubjobId ~= 0 and p.IsUsingFallbackPalettes(normalizedJobId, normalizedSubjobId)) then
-                    effectiveSubjobId = 0;  -- Use shared palette key
-                end
+            local tierSubjob = normalizedSubjobId;
+            if normalizedSubjobId ~= 0 and p.GetCrossbarActivePaletteStorageSubjobForResolution then
+                tierSubjob = p.GetCrossbarActivePaletteStorageSubjobForResolution(normalizedJobId, normalizedSubjobId);
             end
-            -- NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
-            return string.format('%d:%d:%s', normalizedJobId, effectiveSubjobId, paletteSuffix);
+            return string.format('%d:%d:%s', normalizedJobId, tierSubjob, paletteSuffix);
         end
     end
 
-    -- No pet or palette - fall back to base job:subjob key
     return baseKey;
 end
 
@@ -497,22 +1658,60 @@ end
 -- NOTE: Now uses GLOBAL crossbar palette instead of per-combo-mode
 function M.GetCrossbarPaletteDisplayName(comboMode)
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
-    local modeSettings = crossbarSettings and crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[comboMode];
+    local modeSettings = GetMergedCrossbarComboModeSettings(comboMode);
     local jobId = M.jobId or 1;
+    local p = getPalette();
 
-    -- Check pet palette first (if pet-aware - still per-combo-mode)
+    -- [G] scope: universal keys only (no pet)
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes and p and p.GetCrossbarPaletteScope() == 'universal' then
+        if modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+            return modeSettings.universalOverridePalette;
+        end
+        local u = p.GetActiveUniversalCrossbarPalette();
+        if u and u ~= '' then
+            return u;
+        end
+    end
+
+    if p and p.GetCrossbarCliPreview and p.GetCrossbarPaletteScope() == 'job' then
+        local pv = p.GetCrossbarCliPreview();
+        if pv and pv.paletteName then
+            return pv.paletteName .. ' (preview)';
+        end
+    end
+
+    -- [J] scope: pet wins over attached [G] palette name and job palette
     if modeSettings and modeSettings.petAware then
         local pp = getPetPalette();
         if pp then
-            local petDisplayName = pp.GetCrossbarPaletteDisplayName(comboMode, jobId);
-            if petDisplayName and petDisplayName ~= 'Base' then
-                return petDisplayName;
+            local ek = pp.GetEffectivePetKeyForCombo(comboMode);
+            if ek and petAllowlist.Allows(modeSettings, ek) then
+                local petDisplayName = pp.GetCrossbarPaletteDisplayName(comboMode, jobId);
+                if petDisplayName and petDisplayName ~= 'Base' then
+                    return petDisplayName;
+                end
             end
         end
     end
 
-    -- Check GLOBAL crossbar palette (shared across all combo modes)
-    local p = getPalette();
+    local segDesc = M.GetSegmentOverrideDescriptorForJob(jobId, comboMode);
+    if segDesc then
+        if segDesc.scope == 'global' and type(segDesc.globalPalette) == 'string' and segDesc.globalPalette ~= '' then
+            return segDesc.globalPalette;
+        end
+        if segDesc.scope == 'jobShared' then
+            local n = p and p.GetActivePaletteForCombo('L2');
+            if n and n ~= '' then
+                return n .. ' (job-shared)';
+            end
+            return 'Job-shared';
+        end
+    end
+
+    if modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+        return modeSettings.universalOverridePalette;
+    end
+
     if p then
         local paletteName = p.GetActivePaletteForCombo(comboMode);
         if paletteName then
@@ -668,40 +1867,23 @@ function M.GetKeybindDisplay(barIndex, slotIndex)
     return '';
 end
 
--- Helper to look up a macro from macroDB by id
--- paletteKey can be a job ID (number) or composite key (string like "15:avatar:ifrit")
--- OPTIMIZED: Uses O(1) lookup map instead of linear search
--- Falls back to scanning all palettes for legacy slots that don't have macroPaletteKey set
+-- Look up a macro row: macroId is unique only within the given paletteKey bucket
+-- (not across jobs or global). paletteKey: job id, global/items/equipment/xiui/custom:*, or
+-- composite (e.g. "15:avatar:ifrit"). OPTIMIZED: O(1) via lookup + string/number key alias.
 local function GetMacroById(macroId, paletteKey)
     if not gConfig or not gConfig.macroDB then return nil; end
 
     -- Try the specific palette key first using O(1) lookup
-    if paletteKey ~= nil then
-        local macro = GetMacroFromLookup(macroId, paletteKey);
-        if macro then
-            return macro;
-        end
-
-        -- If paletteKey is a composite key and macro not found, try base job palette
-        if type(paletteKey) == 'string' then
-            local baseJobId = tonumber(paletteKey:match('^(%d+)'));
-            if baseJobId then
-                macro = GetMacroFromLookup(macroId, baseJobId);
-                if macro then
-                    return macro;
-                end
-            end
-        end
+    local macro = GetMacroFromLookup(macroId, paletteKey);
+    if macro then
+        return macro;
     end
 
-    -- Fallback for legacy slots missing macroPaletteKey: scan all palettes
-    -- (rebuild lookup if dirty OR if gConfig.macroDB was swapped under us)
-    if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
-        RebuildMacroLookup();
-    end
-    for key, paletteLookup in pairs(macroIdLookup) do
-        if key ~= paletteKey then
-            local macro = paletteLookup[macroId];
+    -- If paletteKey is a composite key and macro not found, try base job palette
+    if type(paletteKey) == 'string' then
+        local baseJobId = tonumber(paletteKey:match('^(%d+)'));
+        if baseJobId then
+            macro = GetMacroFromLookup(macroId, baseJobId);
             if macro then
                 return macro;
             end
@@ -711,6 +1893,9 @@ local function GetMacroById(macroId, paletteKey)
     return nil;
 end
 
+-- O(1) macro row lookup (paletteKey = job id, global key, or composite pet key)
+M.GetMacroById = GetMacroById;
+
 -- Get action assignment for a specific bar and slot
 function M.GetKeybindForSlot(barIndex, slotIndex)
     -- First check for custom slot actions in per-bar settings
@@ -719,56 +1904,29 @@ function M.GetKeybindForSlot(barIndex, slotIndex)
         local barSettings = gConfig[configKey];
         -- Use pet-aware storage key (handles global, job-specific, and pet palettes)
         local storageKey = M.GetStorageKeyForBar(barIndex);
-        local jobSlotActions = getSlotActionsForJob(barSettings.slotActions, storageKey);
+        local jobSlotActions = getSlotActionsForKey(barSettings.slotActions, storageKey);
 
         -- NOTE: Do NOT fall back to base job when pet palette is active
         -- If user has a pet out and petAware enabled, show the pet-specific palette (even if empty)
         -- This prevents the base job summon macros from showing when an avatar is summoned
         if jobSlotActions then
-            -- Handle both numeric and string keys (JSON serialization converts numeric keys to strings)
             local numericSlot = tonumber(slotIndex) or slotIndex;
             local slotAction = jobSlotActions[numericSlot] or jobSlotActions[tostring(numericSlot)];
             if slotAction then
-                -- Check for "cleared" marker - slot was explicitly emptied
                 if slotAction.cleared then
-                    return nil;  -- Don't fall back to defaults
+                    return nil;
                 end
 
-                -- If this slot has a macro reference, the macroDB is the single source of truth.
-                -- Old configs may have duplicated macro fields cached on the slot - we ignore them.
-                -- If the live lookup fails (orphaned macro), the slot is treated as unavailable.
-                local macroData;
-                if slotAction.macroRef then
-                    local paletteKey = slotAction.macroPaletteKey or M.jobId;
-                    macroData = GetMacroById(slotAction.macroRef, paletteKey);
-                    if not macroData then
-                        return nil;  -- Macro reference is orphaned
-                    end
-                else
-                    -- Custom non-macro slot - use inline fields directly
-                    macroData = slotAction;
+                local resolved = resolveSlotMacro(slotAction);
+                if not resolved then
+                    return nil;
                 end
-
-                -- Return slot action in the same format as parsed keybinds
-                return {
-                    context = 'battle',
-                    hotbar = barIndex,
-                    slot = slotIndex,
-                    actionType = macroData.actionType,
-                    action = macroData.action,
-                    target = macroData.target,
-                    displayName = macroData.displayName or macroData.action,
-                    equipSlot = macroData.equipSlot,
-                    macroText = macroData.macroText,
-                    itemId = macroData.itemId,
-                    customIconType = macroData.customIconType,
-                    customIconId = macroData.customIconId,
-                    customIconPath = macroData.customIconPath,
-                    -- Recast source override (for macros showing cooldown from different action)
-                    recastSourceType = macroData.recastSourceType,
-                    recastSourceAction = macroData.recastSourceAction,
-                    recastSourceItemId = macroData.recastSourceItemId,
-                };
+                local out = copySlotFields(resolved);
+                out.context = 'battle';
+                out.hotbar = barIndex;
+                out.slot = slotIndex;
+                out.displayName = out.displayName or resolved.action;
+                return out;
             end
         end
     end
@@ -780,69 +1938,7 @@ end
 -- Crossbar Slot Data Helpers
 -- ============================================
 
--- Helper to get the crossbar storage key based on jobSpecific setting
--- Returns 'global' or '{jobId}:{subjobId}' format
-local function getCrossbarStorageKey(crossbarSettings, jobId, subjobId)
-    if crossbarSettings.jobSpecific == false then
-        return GLOBAL_SLOT_KEY;
-    end
-    -- Always return composite key with job:subjob
-    local normalizedJobId = normalizeJobId(jobId);
-    local normalizedSubjobId = normalizeJobId(subjobId or 0);
-    return string.format('%d:%d', normalizedJobId, normalizedSubjobId);
-end
-
--- Helper to get crossbar slotActions with storage key
--- Handles: 'global' and composite keys ('15:10', '15:10:palette:Stuns', '15:10:avatar:ifrit')
--- Falls back to base job key (jobId:0) preserving any suffix if full job:subjob key doesn't exist
-local function getCrossbarSlotActionsForJob(slotActions, storageKey)
-    if not slotActions then return nil; end
-    -- Handle 'global' key specially
-    if storageKey == GLOBAL_SLOT_KEY then
-        return slotActions[GLOBAL_SLOT_KEY];
-    end
-    -- Try exact storage key first (e.g., '3:5' for WHM/RDM, '3:5:palette:Stuns')
-    local result = slotActions[storageKey];
-    if result then
-        return result;
-    end
-    -- Fallback: try base job key (jobId:0) for imported data without subjob
-    -- IMPORTANT: Preserve any suffix (palette:X, avatar:Y) in the fallback key
-    local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
-    if jobId and subjobId ~= '0' then
-        local fallbackKey = jobId .. ':0' .. (suffix or '');
-        if fallbackKey ~= storageKey then
-            return slotActions[fallbackKey];
-        end
-    end
-    return nil;
-end
-
--- Helper to ensure crossbar slotActions structure exists for a storage key and combo mode
--- Handles: 'global' and composite keys ('15:10')
-local function ensureCrossbarSlotActionsStructure(crossbarSettings, storageKey, comboMode)
-    if not crossbarSettings.slotActions then
-        crossbarSettings.slotActions = {};
-    end
-    -- Handle 'global' key specially
-    if storageKey == GLOBAL_SLOT_KEY then
-        if not crossbarSettings.slotActions[GLOBAL_SLOT_KEY] then
-            crossbarSettings.slotActions[GLOBAL_SLOT_KEY] = {};
-        end
-        if not crossbarSettings.slotActions[GLOBAL_SLOT_KEY][comboMode] then
-            crossbarSettings.slotActions[GLOBAL_SLOT_KEY][comboMode] = {};
-        end
-        return crossbarSettings.slotActions[GLOBAL_SLOT_KEY][comboMode];
-    end
-    -- All job-specific keys are composite strings (job:subjob format)
-    if not crossbarSettings.slotActions[storageKey] then
-        crossbarSettings.slotActions[storageKey] = {};
-    end
-    if not crossbarSettings.slotActions[storageKey][comboMode] then
-        crossbarSettings.slotActions[storageKey][comboMode] = {};
-    end
-    return crossbarSettings.slotActions[storageKey][comboMode];
-end
+-- (Crossbar uses the same shared helpers: resolveStorageKey, getSlotActionsForKey, ensureSlotActionsStructure with comboMode)
 
 -- Get slot data for a crossbar slot
 -- comboMode: 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', or 'Shared'
@@ -858,77 +1954,12 @@ function M.GetCrossbarSlotData(comboMode, slotIndex)
 
     -- Use per-combo-mode storage key (considers pet-aware and palette settings per combo)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
-    local jobSlotActions = getCrossbarSlotActionsForJob(gConfig.hotbarCrossbar.slotActions, storageKey);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
     if not jobSlotActions then return nil; end
     if not jobSlotActions[effectiveComboMode] then return nil; end
 
     local slotAction = jobSlotActions[effectiveComboMode][slotIndex];
-    if not slotAction then return nil; end
-
-    -- If this slot has a macro reference, the macroDB is the single source of truth.
-    -- Old configs may have duplicated macro fields cached on the slot - we ignore them.
-    -- If the live lookup fails (orphaned macro), the slot is treated as unavailable.
-    if slotAction.macroRef then
-        local paletteKey = slotAction.macroPaletteKey or jobId;
-        local liveMacro = GetMacroById(slotAction.macroRef, paletteKey);
-        if not liveMacro then
-            return nil;  -- Macro reference is orphaned
-        end
-        return {
-            actionType = liveMacro.actionType,
-            action = liveMacro.action,
-            target = liveMacro.target,
-            displayName = liveMacro.displayName,
-            equipSlot = liveMacro.equipSlot,
-            macroText = liveMacro.macroText,
-            itemId = liveMacro.itemId,
-            customIconType = liveMacro.customIconType,
-            customIconId = liveMacro.customIconId,
-            customIconPath = liveMacro.customIconPath,
-            macroRef = slotAction.macroRef,
-            macroPaletteKey = slotAction.macroPaletteKey,
-            -- Recast source override (for macros showing cooldown from different action)
-            recastSourceType = liveMacro.recastSourceType,
-            recastSourceAction = liveMacro.recastSourceAction,
-            recastSourceItemId = liveMacro.recastSourceItemId,
-        };
-    end
-
-    -- Custom non-macro slot - return inline data directly
-    return slotAction;
-end
-
--- Build the persisted form of slot data.
--- When the slot references a macro (macroRef or id), only the reference is stored;
--- the macroDB is the single source of truth for action/macroText/displayName/etc.
--- When the slot has no macro reference, inline fields are stored as-is (custom slots).
--- This is exposed on M so external writers (macropalette, migrations) can reuse it.
-function M.BuildSlotDataForWrite(slotData)
-    if not slotData then return nil; end
-
-    local macroRef = slotData.macroRef or slotData.id;
-    if macroRef then
-        return {
-            macroRef = macroRef,
-            macroPaletteKey = slotData.macroPaletteKey,
-        };
-    end
-
-    return {
-        actionType = slotData.actionType,
-        action = slotData.action,
-        target = slotData.target,
-        displayName = slotData.displayName,
-        equipSlot = slotData.equipSlot,
-        macroText = slotData.macroText,
-        itemId = slotData.itemId,
-        customIconType = slotData.customIconType,
-        customIconId = slotData.customIconId,
-        customIconPath = slotData.customIconPath,
-        recastSourceType = slotData.recastSourceType,
-        recastSourceAction = slotData.recastSourceAction,
-        recastSourceItemId = slotData.recastSourceItemId,
-    };
+    return resolveSlotMacro(slotAction);
 end
 
 -- Set slot data for a crossbar slot
@@ -951,12 +1982,15 @@ function M.SetCrossbarSlotData(comboMode, slotIndex, slotData)
     -- Map L2R2/R2L2 to Shared when shared expanded bar is enabled
     local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
 
-    -- Use per-combo-mode storage key (considers pet-aware and palette settings per combo)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
-    local comboSlots = ensureCrossbarSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
+    local comboSlots = ensureSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
 
-    comboSlots[slotIndex] = M.BuildSlotDataForWrite(slotData);
-
+    if isDualMacroSlotTable(slotData) then
+        comboSlots[slotIndex] = slotData;
+    else
+        comboSlots[slotIndex] = buildSlotRecord(slotData);
+    end
+    M.SyncDraftSlotFromLive(comboMode, slotIndex);
     NotifySlotDataChanged();
 end
 
@@ -970,16 +2004,408 @@ function M.ClearCrossbarSlotData(comboMode, slotIndex)
     -- Map L2R2/R2L2 to Shared when shared expanded bar is enabled
     local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
 
-    -- Use per-combo-mode storage key (considers pet-aware and palette settings per combo)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
-    local jobSlotActions = getCrossbarSlotActionsForJob(gConfig.hotbarCrossbar.slotActions, storageKey);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
     if not jobSlotActions then return; end
     if not jobSlotActions[effectiveComboMode] then return; end
 
-    -- Clear the slot
-    jobSlotActions[effectiveComboMode][slotIndex] = nil;
-
+    local raw = jobSlotActions[effectiveComboMode][slotIndex];
+    if isDualMacroSlotTable(raw) then
+        local sh = (gConfig.macroStorageScope or 'profile') == 'shared';
+        if sh then
+            raw[K_BIND_S] = nil;
+        else
+            raw[K_BIND_P] = nil;
+        end
+        if not raw[K_BIND_P] and not raw[K_BIND_S] then
+            jobSlotActions[effectiveComboMode][slotIndex] = nil;
+        else
+            raw.actionType = 'macro';
+        end
+    else
+        jobSlotActions[effectiveComboMode][slotIndex] = nil;
+    end
+    M.SyncDraftSlotFromLive(comboMode, slotIndex);
     NotifySlotDataChanged();
+end
+
+-- Direct read/write for a fixed storage key (palette editor / Edit Full Palette). Does not call GetCrossbarStorageKeyForCombo.
+function M.GetCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex)
+    if not gConfig or not gConfig.hotbarCrossbar or not storageKey then
+        return nil;
+    end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then
+        return nil;
+    end
+    return resolveSlotMacro(jobSlotActions[effectiveComboMode][slotIndex]);
+end
+
+function M.SetCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex, slotData)
+    if not storageKey then return; end
+    if not slotData then
+        M.ClearCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex);
+        return;
+    end
+    if not gConfig.hotbarCrossbar then
+        gConfig.hotbarCrossbar = {};
+    end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    local comboSlots = ensureSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
+    if isDualMacroSlotTable(slotData) then
+        comboSlots[slotIndex] = slotData;
+    else
+        comboSlots[slotIndex] = buildSlotRecord(slotData);
+    end
+    NotifySlotDataChanged();
+end
+
+function M.ClearCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex)
+    if not gConfig.hotbarCrossbar or not storageKey then return; end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then return; end
+    jobSlotActions[effectiveComboMode][slotIndex] = nil;
+    NotifySlotDataChanged();
+end
+
+-- ============================================
+-- Draft Layer (Edit Full Palette)
+-- ============================================
+-- Edits stay in a draft buffer until the user clicks Apply. deepCopyTable, buildSlotRecord,
+-- resolveSlotMacro, and GetEffectiveComboModeForStorage are all defined above by this point.
+-- draftByKey can hold multiple storage keys when Job-Shared / Global segment overrides redirect combo modes.
+
+local function resolveDraftStorageKeyForCombo(comboMode)
+    if not draftForStorageKey or not draftByKey then
+        return nil;
+    end
+    if draftEditJobId then
+        local sk = M.GetSegmentOverrideResolvedStorageKey(draftEditJobId, comboMode);
+        if sk then
+            return sk;
+        end
+    end
+    return draftForStorageKey;
+end
+
+local function ensureDraftBucket(resolvedKey)
+    if not resolvedKey or not draftByKey then
+        return nil;
+    end
+    if not draftByKey[resolvedKey] then
+        if gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+            draftByKey[resolvedKey] = deepCopyTable(gConfig.hotbarCrossbar.slotActions[resolvedKey]) or {};
+        else
+            draftByKey[resolvedKey] = {};
+        end
+    end
+    return draftByKey[resolvedKey];
+end
+
+--- After live `gConfig` crossbar mutations while Edit Full Palette draft is open, copy the affected slot into the draft
+--- blob so the palette row matches HUD (HUD stays authoritative for gameplay binds during the session).
+--- When the HUD is showing a different palette than `rk`, skips — otherwise active-palette hops overwrite the draft.
+function M.SyncDraftSlotFromLive(comboMode, slotIndex)
+    if not draftForStorageKey or not draftByKey then
+        return;
+    end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then
+        return;
+    end
+    local effectiveComboModeForHud = M.GetEffectiveComboModeForStorage(comboMode);
+    local liveKey = M.GetCrossbarStorageKeyForCombo(effectiveComboModeForHud);
+    if liveKey ~= rk then
+        return;
+    end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then
+        return;
+    end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then
+        bucket[effectiveComboMode] = {};
+    end
+    draftTouchedKeys[rk] = true;
+    local liveRaw = M.GetRawCrossbarSlotAction(comboMode, slotIndex);
+    if liveRaw == nil then
+        bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+    else
+        bucket[effectiveComboMode][slotIndex] = deepCopyTable(liveRaw);
+    end
+    draftDirty = true;
+end
+
+--- Dual macro slots: clearing only the active arm can leave the inactive arm in the bucket while resolveSlotMacro shows empty.
+--- Only dual-layout blobs need this — never run on freshly written single-arm macros (profile vs shared visibility differs).
+local function scrubDraftBucketSlotIfInvisible(bucket, rk, effectiveComboMode, slotIndex)
+    if not bucket or not bucket[effectiveComboMode] then
+        return false;
+    end
+    local raw = bucket[effectiveComboMode][slotIndex];
+    if raw == nil or not isDualMacroSlotTable(raw) then
+        return false;
+    end
+    if resolveSlotMacro(raw) ~= nil then
+        return false;
+    end
+    bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+    draftTouchedKeys[rk] = true;
+    return true;
+end
+
+local function pushDraftUndo()
+    if draftUndoGroupActive then return; end
+    if not draftByKey then return; end
+    local touchedCopy = {};
+    if draftTouchedKeys then
+        for k, v in pairs(draftTouchedKeys) do
+            touchedCopy[k] = v;
+        end
+    end
+    table.insert(draftUndoStack, {
+        blob = deepCopyTable(draftByKey),
+        touched = touchedCopy,
+    });
+    if #draftUndoStack > DRAFT_MAX_UNDO then
+        table.remove(draftUndoStack, 1);
+    end
+end
+
+function M.BeginDraftUndoGroup()
+    pushDraftUndo();
+    draftUndoGroupActive = true;
+end
+
+function M.EndDraftUndoGroup()
+    draftUndoGroupActive = false;
+end
+
+function M.BeginCrossbarPaletteEditSession(storageKey, editJobId)
+    crossbarPaletteEditStorageKey = storageKey;
+    local ej = editJobId;
+    if draftForStorageKey == storageKey and draftByKey and draftEditJobId == ej then
+        return;
+    end
+    draftForStorageKey = storageKey;
+    draftEditJobId = ej;
+    draftDirty = false;
+    draftUndoStack = {};
+    draftTouchedKeys = {};
+    draftByKey = {};
+    if gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions and storageKey then
+        draftByKey[storageKey] = deepCopyTable(gConfig.hotbarCrossbar.slotActions[storageKey]) or {};
+    elseif storageKey then
+        draftByKey[storageKey] = {};
+    end
+end
+
+-- Segment override toggles used to clear draftForStorageKey here; that breaks GetDraftSlotData for the
+-- rest of the frame and forces a full draft re-init next frame (scroll jumps, wrong row heights, data risk).
+-- Resolved storage keys already update via GetSegmentOverrideResolvedStorageKey + ensureDraftBucket.
+function M.InvalidateCrossbarDraftLayout()
+end
+
+function M.EndCrossbarPaletteEditSession()
+    crossbarPaletteEditStorageKey = nil;
+end
+
+function M.FullyClosePaletteEditSession()
+    crossbarPaletteEditStorageKey = nil;
+    draftForStorageKey = nil;
+    draftEditJobId = nil;
+    draftByKey = nil;
+    draftTouchedKeys = nil;
+    draftDirty = false;
+    draftUndoStack = {};
+end
+
+function M.GetDraftSlotData(comboMode, slotIndex)
+    if not draftByKey then return nil; end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return nil; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return nil; end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then return nil; end
+    local cell = bucket[effectiveComboMode][slotIndex];
+    if cell == DRAFT_CROSSBAR_SLOT_EMPTY then
+        return nil;
+    end
+    return resolveSlotMacro(cell);
+end
+
+function M.GetDraftRawSlotData(comboMode, slotIndex)
+    if not draftByKey then return nil; end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return nil; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return nil; end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then return nil; end
+    local v = bucket[effectiveComboMode][slotIndex];
+    if v == DRAFT_CROSSBAR_SLOT_EMPTY then
+        return nil;
+    end
+    return v;
+end
+
+--- Swap/drag reads: draft cell wins when present; explicit draft empty beats inherit; missing cell inherits
+--- persisted `gConfig` for the palette being edited (`rk`), not the HUD active palette (see GetRawCrossbarSlotAction).
+function M.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex)
+    if not draftForStorageKey or not draftByKey then
+        return M.GetRawCrossbarSlotAction(comboMode, slotIndex);
+    end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then
+        return M.GetRawCrossbarSlotAction(comboMode, slotIndex);
+    end
+    local blob = draftByKey[rk];
+    if not blob then
+        return M.GetRawCrossbarSlotActionForStorageKey(rk, comboMode, slotIndex);
+    end
+    local eff = GetEffectiveComboModeForStorage(comboMode);
+    local row = blob[eff];
+    if not row then
+        return M.GetRawCrossbarSlotActionForStorageKey(rk, comboMode, slotIndex);
+    end
+    local v = row[slotIndex];
+    if v == DRAFT_CROSSBAR_SLOT_EMPTY then
+        return nil;
+    end
+    if v ~= nil then
+        return v;
+    end
+    return M.GetRawCrossbarSlotActionForStorageKey(rk, comboMode, slotIndex);
+end
+
+function M.SetDraftSlotData(comboMode, slotIndex, slotData)
+    if not draftByKey then return; end
+    if not slotData then
+        M.ClearDraftSlotData(comboMode, slotIndex);
+        return;
+    end
+    pushDraftUndo();
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return; end
+    draftTouchedKeys[rk] = true;
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then
+        bucket[effectiveComboMode] = {};
+    end
+    if isDualMacroSlotTable(slotData) then
+        bucket[effectiveComboMode][slotIndex] = slotData;
+    else
+        bucket[effectiveComboMode][slotIndex] = buildSlotRecord(slotData);
+    end
+    draftDirty = true;
+end
+
+function M.ClearDraftSlotData(comboMode, slotIndex)
+    if not draftByKey then return; end
+    pushDraftUndo();
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return; end
+    draftTouchedKeys[rk] = true;
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then return; end
+    local raw = bucket[effectiveComboMode][slotIndex];
+    if isDualMacroSlotTable(raw) then
+        local sh = gConfig and (gConfig.macroStorageScope or 'profile') == 'shared';
+        if sh then
+            raw[K_BIND_S] = nil;
+        else
+            raw[K_BIND_P] = nil;
+        end
+        if not raw[K_BIND_P] and not raw[K_BIND_S] then
+            bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+        else
+            raw.actionType = 'macro';
+        end
+    else
+        bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+    end
+    scrubDraftBucketSlotIfInvisible(bucket, rk, effectiveComboMode, slotIndex);
+    draftDirty = true;
+end
+
+function M.UndoDraft()
+    if #draftUndoStack == 0 then return false; end
+    local prev = table.remove(draftUndoStack);
+    draftByKey = prev.blob;
+    draftTouchedKeys = prev.touched or {};
+    draftDirty = #draftUndoStack > 0;
+    return true;
+end
+
+function M.CanUndoDraft()
+    return #draftUndoStack > 0;
+end
+
+local function prepareDraftBlobForApply(blob)
+    local out = {};
+    for comboMode, row in pairs(blob) do
+        out[comboMode] = {};
+        for slotIndex, cell in pairs(row) do
+            if cell ~= DRAFT_CROSSBAR_SLOT_EMPTY then
+                out[comboMode][slotIndex] = deepCopyTable(cell);
+            end
+        end
+    end
+    return out;
+end
+
+function M.ApplyDraft()
+    if not draftForStorageKey or not draftByKey then return; end
+    if not gConfig.hotbarCrossbar then gConfig.hotbarCrossbar = {}; end
+    if not gConfig.hotbarCrossbar.slotActions then gConfig.hotbarCrossbar.slotActions = {}; end
+    for key, _ in pairs(draftTouchedKeys or {}) do
+        local blob = draftByKey[key];
+        if blob then
+            gConfig.hotbarCrossbar.slotActions[key] = prepareDraftBlobForApply(blob);
+        end
+    end
+    draftDirty = false;
+    draftUndoStack = {};
+    draftTouchedKeys = {};
+    M.InvalidateStorageKeyCache();
+    NotifySlotDataChanged();
+end
+
+function M.DiscardDraft()
+    local key = crossbarPaletteEditStorageKey or draftForStorageKey;
+    if not key then return; end
+    draftByKey = {};
+    draftTouchedKeys = {};
+    if gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        draftByKey[key] = deepCopyTable(gConfig.hotbarCrossbar.slotActions[key]) or {};
+    else
+        draftByKey[key] = {};
+    end
+    draftDirty = false;
+    draftUndoStack = {};
+end
+
+function M.IsDraftDirty()
+    return draftDirty;
+end
+
+local pendingPaletteSlotEdit = nil;
+
+function M.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex)
+    pendingPaletteSlotEdit = { slotData = slotData, comboMode = comboMode, slotIndex = slotIndex };
+end
+
+function M.ConsumePendingPaletteSlotEdit()
+    local edit = pendingPaletteSlotEdit;
+    pendingPaletteSlotEdit = nil;
+    return edit;
 end
 
 -- Clear all slot actions for a hotbar (used when switching between job-specific and global modes)
@@ -1014,9 +2440,12 @@ function M.SetSlotData(barIndex, slotIndex, slotData)
     local jobSlotActions = ensureSlotActionsStructure(barSettings, storageKey);
 
     if slotData then
-        jobSlotActions[slotIndex] = M.BuildSlotDataForWrite(slotData);
+        if isDualMacroSlotTable(slotData) then
+            jobSlotActions[slotIndex] = slotData;
+        else
+            jobSlotActions[slotIndex] = buildSlotRecord(slotData);
+        end
     else
-        -- Mark as explicitly cleared
         jobSlotActions[slotIndex] = { cleared = true };
     end
 
@@ -1030,11 +2459,33 @@ function M.ClearSlotData(barIndex, slotIndex)
 
     local barSettings = gConfig[configKey];
     local storageKey = M.GetStorageKeyForBar(barIndex);
-    local jobSlotActions = getSlotActionsForJob(barSettings.slotActions, storageKey);
+    local jobSlotActions = getSlotActionsForKey(barSettings.slotActions, storageKey);
 
     if jobSlotActions then
-        -- Mark as explicitly cleared
-        jobSlotActions[slotIndex] = { cleared = true };
+        local num = tonumber(slotIndex) or slotIndex;
+        local raw = jobSlotActions[num] or jobSlotActions[tostring(num)];
+        if isDualMacroSlotTable(raw) then
+            local sh = (gConfig.macroStorageScope or 'profile') == 'shared';
+            if sh then
+                raw[K_BIND_S] = nil;
+            else
+                raw[K_BIND_P] = nil;
+            end
+            if not raw[K_BIND_P] and not raw[K_BIND_S] then
+                jobSlotActions[num] = { cleared = true };
+                if jobSlotActions[tostring(num)] then
+                    jobSlotActions[tostring(num)] = { cleared = true };
+                end
+            else
+                raw.actionType = 'macro';
+                jobSlotActions[num] = raw;
+            end
+        else
+            jobSlotActions[num] = { cleared = true };
+            if jobSlotActions[tostring(num)] then
+                jobSlotActions[tostring(num)] = { cleared = true };
+            end
+        end
         NotifySlotDataChanged();
     end
 end
@@ -1059,6 +2510,32 @@ function M.InvalidateStorageKeyCache()
     storageKeyCache = {};
 end
 
+-- Call whenever the global gConfig table is replaced (profile switch, settings reload, reset).
+-- macroIdLookup holds references into gConfig.macroDB; if gConfig is swapped without invalidating,
+-- lookups can return macro rows from the previous profile in memory (wrong name/icon for macroRef).
+function M.InvalidateConfigDerivedCaches()
+    macroIdLookupDirty = true;
+    macroDbCoherenceIdentity = nil;
+    M.InvalidateStorageKeyCache();
+end
+
+-- ============================================
+-- Font Visibility Helpers
+-- ============================================
+-- REMOVED in 1.8.0 (and intentionally preserved-deleted here during migration):
+--   M.RebuildAllFonts, M.SetAllFontsVisible, M.SetBarFontsVisible
+-- These managed the GDI font lifecycle (`primitives` + `FontManager`) for per-slot keybind/
+-- label/timer/MP/quantity/abbreviation text. 1.8.0 replaced the entire rendering pipeline
+-- with libs/imtext.lua which is stateless per-frame — no font objects to create, hide,
+-- or rebuild. The old per-bar font tables (M.keybindFonts / M.labelFonts / M.timerFonts /
+-- M.mpCostFonts / M.quantityFonts / M.abbreviationFonts / M.hotbarNumberFonts / M.allFonts)
+-- are no longer populated; any lingering refs would also be obsolete.
+--
+-- Any caller of the dropped functions should be considered dead code from 1.7.5; the
+-- imtext path needs no per-bar visibility toggling because un-emitted draw calls don't
+-- render. If a caller still exists in macropalette.lua / crossbar.lua, it should be
+-- removed when that file is migrated (no replacement needed).
+
 -- ============================================
 -- Preview Mode (stub for compatibility)
 -- ============================================
@@ -1070,6 +2547,57 @@ function M.ClearPreview()
 end
 
 function M.ClearError()
+end
+
+-- ============================================
+-- Profile duplicate (no macro library): strip bar binds to palette macros
+-- ============================================
+
+-- Clears actionType == 'macro' slots in settings (in-memory copy) so a duplicated profile
+-- that dropped the macro library does not show ghost bindings to missing macroRef rows.
+function M.StripPaletteMacroBindsFromSettings(settings)
+    if not settings or type(settings) ~= 'table' then
+        return;
+    end
+    local function isPaletteMacro(slot)
+        if not slot or type(slot) ~= 'table' or slot.cleared then
+            return false;
+        end
+        if isDualMacroSlotTable(slot) then
+            return slot.actionType == 'macro' or slot[K_BIND_P] ~= nil or slot[K_BIND_S] ~= nil;
+        end
+        return slot.actionType == 'macro';
+    end
+    for bar = 1, 6 do
+        local configKey = 'hotbarBar' .. bar;
+        local barSettings = settings[configKey];
+        if barSettings and type(barSettings.slotActions) == 'table' then
+            for _, jobSlotActions in pairs(barSettings.slotActions) do
+                if type(jobSlotActions) == 'table' then
+                    for si, slot in pairs(jobSlotActions) do
+                        if isPaletteMacro(slot) then
+                            jobSlotActions[si] = { cleared = true };
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if settings.hotbarCrossbar and type(settings.hotbarCrossbar.slotActions) == 'table' then
+        for _, jobSlotActions in pairs(settings.hotbarCrossbar.slotActions) do
+            if type(jobSlotActions) == 'table' then
+                for _, comboSlots in pairs(jobSlotActions) do
+                    if type(comboSlots) == 'table' then
+                        for si, slot in pairs(comboSlots) do
+                            if isPaletteMacro(slot) then
+                                comboSlots[si] = nil;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
 end
 
 -- ============================================
@@ -1097,6 +2625,10 @@ function M.SetPlayerJob()
     -- Invalidate caches if job changed
     if M.jobId ~= currentJobId or M.subjobId ~= currentSubjobId then
         M.InvalidateStorageKeyCache();
+        local okPal, palMod = pcall(require, 'modules.hotbar.palette');
+        if okPal and palMod and palMod.ClearCrossbarCliPreview then
+            palMod.ClearCrossbarCliPreview();
+        end
     end
 
     M.jobId = currentJobId;
@@ -1111,6 +2643,19 @@ end
 -- Cleanup (call on addon unload)
 function M.Cleanup()
     M.Clear();
+    M.bgHandles = {};
+    M.slotPrims = {};
+    M.iconPrims = {};
+    M.cooldownPrims = {};
+    M.framePrims = {};
+    M.keybindFonts = {};
+    M.labelFonts = {};
+    M.timerFonts = {};
+    M.mpCostFonts = {};
+    M.quantityFonts = {};
+    M.abbreviationFonts = {};
+    M.hotbarNumberFonts = {};
+    M.allFonts = nil;
 end
 
 return M;

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -35,6 +35,7 @@
 
 require('common');
 require('handlers.helpers');
+local gameState = require('core.gamestate');
 local dragdrop = require('libs.dragdrop');
 local imtext = require('libs.imtext');
 
@@ -75,6 +76,17 @@ M.visible = true;
 -- Track hotbar enable/disable state for transitions
 local wasHotbarEnabled = nil;
 
+-- Crossbar controller "Disable XI Macros" is shared with Hotbar -> Disable XI Macros (hotbarGlobal.disableMacroBars).
+-- Wrapper exists so the call sites read as crossbar-specific intent.
+local function GetCrossbarDisableXiMacrosEffective()
+    local hg = gConfig and gConfig.hotbarGlobal;
+    return hg and hg.disableMacroBars == true;
+end
+
+-- Palette change dedup: SetActivePalette / SetActivePaletteForCombo fire one callback per bar (1-6)
+-- or per combo mode (6x). Without deduping, display/slot cache clears run 6x per logical palette change.
+local lastPaletteVisualRefreshSig = nil;
+
 -- True if any hotbar bar or crossbar combo-mode has petAware enabled.
 -- Used to short-circuit the pet-change callback's cache wipes when no
 -- bar would actually rebind its slots in response.
@@ -113,6 +125,11 @@ function M.Initialize(settings)
 
     -- Initialize data module (sets player job)
     data.Initialize();
+    -- Migrate any legacy non-pet-aware storage keys + invalidate cache after migration.
+    if data.MigratePetAwareSlotStorageKeys then
+        data.MigratePetAwareSlotStorageKeys();
+    end
+    data.InvalidateStorageKeyCache();
 
     -- Validate palettes on reload (not just on job change packets)
     -- Helper function to validate palettes once job is ready
@@ -121,7 +138,14 @@ function M.Initialize(settings)
         local maxAttempts = 20;
 
         if data.SetPlayerJob() then
-            palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+            -- Honor pending "profile loaded before job was readable" (char select / logout)
+            -- so the default crossbar palette scope applies on first job-ready frame.
+            local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+                and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+                or nil;
+            palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+                applyDefaultCrossbarScope = pending,
+            });
             macropalette.SyncToCurrentJob();
             display.ClearIconCache();
             slotrenderer.ClearAllCache();
@@ -138,7 +162,12 @@ function M.Initialize(settings)
     end
 
     if data.jobId then
-        palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+        local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+            and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+            or nil;
+        palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+            applyDefaultCrossbarScope = pending,
+        });
     else
         -- Job not ready yet, start retry loop
         ashita.tasks.once(0.3, function()
@@ -177,16 +206,28 @@ function M.Initialize(settings)
         macropalette.ClearPetCommandsCache();
     end);
 
-    -- Register palette change callback to clear caches
+    -- Register palette change callback to clear caches.
+    -- Dedupe identical logical palette switches: SetActivePalette / SetActivePaletteForCombo
+    -- fire one callback per bar (1-6) or per combo mode (6x), so a single user palette change
+    -- triggers 6+ identical cache flushes if unguarded.
+    -- For no-op refreshes (same name -> same name, e.g. JSON import) include barIdentifier so
+    -- every bar/combo still runs; otherwise only the first callback fires and the UI stays blank.
     palette.OnPaletteChanged(function(barIdentifier, oldPaletteName, newPaletteName)
-        -- Invalidate storage key cache (palette change affects storage keys)
+        local sig;
+        if oldPaletteName == newPaletteName then
+            sig = tostring(barIdentifier) .. '\0' .. tostring(oldPaletteName) .. '\0' .. tostring(newPaletteName);
+        else
+            sig = tostring(oldPaletteName) .. '\0' .. tostring(newPaletteName);
+        end
+        if sig == lastPaletteVisualRefreshSig then
+            return;
+        end
+        lastPaletteVisualRefreshSig = sig;
         data.InvalidateStorageKeyCache();
-        -- Clear crossbar icon cache when any palette changes (hotbar or crossbar)
+        display.ClearIconCache();
         if crossbarInitialized then
             crossbar.ClearIconCache();
         end
-        -- Clear ONLY slot rendering cache (not availability/MP/item caches)
-        -- OPTIMIZED: Selective invalidation avoids unnecessary recalculation cascade
         slotrenderer.ClearSlotRenderingCache();
     end);
 
@@ -204,11 +245,10 @@ function M.Initialize(settings)
     end
     -- If checkbox is OFF, macrofix is already applied by initialize_patches()
 
-    -- Initialize crossbar if mode includes crossbar
-    -- Defensive: validate gConfig.hotbarCrossbar is a table before accessing
+    -- Initialize crossbar when enabled (independent flag, not mode-based).
+    -- Defensive: validate gConfig.hotbarCrossbar is a table before accessing.
     local crossbarConfig = gConfig and type(gConfig.hotbarCrossbar) == 'table' and gConfig.hotbarCrossbar or nil;
-    local crossbarMode = crossbarConfig and crossbarConfig.mode or 'hotbar';
-    local crossbarNeeded = crossbarMode == 'crossbar' or crossbarMode == 'both';
+    local crossbarNeeded = gConfig and gConfig.crossbarEnabled ~= false;
     if crossbarNeeded and crossbarConfig then
         crossbar.Initialize(crossbarConfig, gAdjustedSettings.crossbarSettings);
         
@@ -231,8 +271,8 @@ function M.Initialize(settings)
         controller.SetSlotActivateCallback(function(comboMode, slotIndex)
             crossbar.ActivateSlot(comboMode, slotIndex);
         end);
-        -- Set controller blocking enabled state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Set controller blocking enabled state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
         crossbarInitialized = true;
     end
 
@@ -271,9 +311,8 @@ function M.UpdateVisuals(settings)
         macrosLib.set_controller_hold_to_show(holdToShow);
     end
 
-    -- Handle crossbar enable/disable based on mode
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    local crossbarNeeded = crossbarMode == 'crossbar' or crossbarMode == 'both';
+    -- Handle crossbar enable/disable (independent flag, not mode-based)
+    local crossbarNeeded = gConfig and gConfig.crossbarEnabled ~= false;
 
     if crossbarNeeded and not crossbarInitialized then
         -- Initialize crossbar when newly needed
@@ -290,8 +329,8 @@ function M.UpdateVisuals(settings)
         controller.SetSlotActivateCallback(function(comboMode, slotIndex)
             crossbar.ActivateSlot(comboMode, slotIndex);
         end);
-        -- Set controller blocking enabled state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Set controller blocking enabled state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
         crossbarInitialized = true;
     elseif not crossbarNeeded and crossbarInitialized then
         -- Cleanup crossbar when no longer needed
@@ -312,8 +351,8 @@ function M.UpdateVisuals(settings)
             customMapping = gConfig.hotbarCrossbar.customControllerMappings.dinput;
         end
         controller.SetControllerScheme(gConfig.hotbarCrossbar.controllerScheme, customMapping);
-        -- Update controller blocking state (crossbar-specific)
-        controller.SetBlockingEnabled(disableMacroBars);
+        -- Update controller blocking state (crossbar-specific; shares the hotbar flag).
+        controller.SetBlockingEnabled(GetCrossbarDisableXiMacrosEffective());
     end
 
     -- Update state tracking for hotbar enable/disable
@@ -339,38 +378,50 @@ function M.DrawWindow(settings)
         texturesInitialized = true;
     end
 
-    if gConfig and gConfig.hotbarEnabled == false then
-        display.HideWindow();
-        if crossbarInitialized then
-            crossbar.SetHidden(true);
-        end
-        return;
-    end
+    -- Hotbar and crossbar are independent; either, both, or neither can be on. Menu-hide
+    -- is evaluated here per-system so keyboard hotbars and the crossbar can have different
+    -- hideOnMenuFocus behaviors (they previously shared `hotbarHideOnMenuFocus`).
+    local menuOpen = gameState.IsMenuOpen();
+    local hideKbOnMenu = gConfig.hotbarHideOnMenuFocus == true;
+    local hideXbOnMenu = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.crossbarHideOnMenuFocus == true;
+    local showHotbar = gConfig
+        and gConfig.hotbarEnabled ~= false
+        and not (menuOpen and hideKbOnMenu);
+    local showCrossbar = gConfig
+        and gConfig.crossbarEnabled ~= false
+        and not (menuOpen and hideXbOnMenu);
 
-    -- Determine what to draw based on mode
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    local showHotbar = crossbarMode == 'hotbar' or crossbarMode == 'both';
-    local showCrossbar = crossbarMode == 'crossbar' or crossbarMode == 'both';
-
-    -- Draw hotbar if mode includes it
+    -- Draw keyboard hotbars when enabled
     if showHotbar then
         display.DrawWindow(settings);
     else
         display.HideWindow();
     end
 
-    -- Draw crossbar if mode includes it
+    -- Draw crossbar when enabled
     if showCrossbar and crossbarInitialized then
         crossbar.DrawWindow(gConfig.hotbarCrossbar, gAdjustedSettings.crossbarSettings);
     elseif crossbarInitialized then
         crossbar.SetHidden(true);
     end
 
-    -- Always draw macro palette and keybind modal (regardless of mode)
+    -- Always draw macro palette and keybind modal (regardless of enabled state)
     macropalette.DrawPalette();
     hotbarConfig.DrawKeybindModal();
 
-    -- Render drag preview (must be called at end of frame, after all drop zones)
+    -- Drop previews / deferred overlaps happen in M.FinalizeFrame() — XIUI.lua calls it
+    -- after palettemanager.Draw so the floating palette can win when its DropZone overlaps
+    -- the HUD crossbar / Edit Full Palette preview.
+end
+
+-- Called by XIUI.lua at the very end of d3d_present, after palettemanager.Draw().
+-- Resolves overlapping DropZone hits via FlushDeferredDrops (highest dropPriority wins)
+-- and then renders the drag preview overlay.
+function M.FinalizeFrame()
+    if not M.initialized then return; end
+
+    -- Resolve overlapping DropZones (HUD crossbar vs. Edit Full Palette preview, etc.)
+    dragdrop.FlushDeferredDrops();
     dragdrop.Render();
 
     -- Handle slot dragged outside (remove the action)
@@ -381,9 +432,13 @@ function M.DrawWindow(settings)
                 -- Standard hotbar slot was dragged outside - clear it
                 macropalette.ClearSlot(lastPayload.barIndex, lastPayload.slotIndex);
             elseif lastPayload.type == 'crossbar_slot' then
-                -- Crossbar slot was dragged outside - clear it
-                data.ClearCrossbarSlotData(lastPayload.comboMode, lastPayload.slotIndex);
-                -- Clear icon cache for this slot (targeted - fast)
+                -- Crossbar slot dragged outside: distinguish a draft slot (Edit Full Palette
+                -- editing buffer) from a live HUD slot so we don't blow away the wrong store.
+                if lastPayload.paletteEditStorageKey and data.ClearDraftSlotData then
+                    data.ClearDraftSlotData(lastPayload.comboMode, lastPayload.slotIndex);
+                else
+                    data.ClearCrossbarSlotData(lastPayload.comboMode, lastPayload.slotIndex);
+                end
                 if crossbarInitialized then
                     crossbar.ClearIconCacheForSlot(lastPayload.comboMode, lastPayload.slotIndex);
                 end
@@ -437,6 +492,12 @@ function M.HandleZonePacket()
     petpalette.ClearPetState();
     -- Clear availability cache since player state is invalid during zone
     slotrenderer.ClearAvailabilityCache();
+    -- Universal 2hr glow state can hold a stale subtarget arm across zones.
+    -- Defensive require: module may not be merged yet in intermediate states.
+    local okU, uth = pcall(require, 'modules.hotbar.universal_two_hour');
+    if okU and uth and uth.ResetUniversalTwoHourSubtargetGlowArm then
+        uth.ResetUniversalTwoHourSubtargetGlowArm();
+    end
 end
 
 function M.HandleJobChangePacket(e)
@@ -445,9 +506,26 @@ function M.HandleJobChangePacket(e)
         local maxAttempts = 20;
 
         if data.SetPlayerJob() then
-            -- Job successfully read - proceed with refresh
+            -- Job successfully read - proceed with refresh.
+            -- Reset universal 2hr subtarget glow arm; it can carry stale state across job change.
+            local okU, uth = pcall(require, 'modules.hotbar.universal_two_hour');
+            if okU and uth and uth.ResetUniversalTwoHourSubtargetGlowArm then
+                uth.ResetUniversalTwoHourSubtargetGlowArm();
+            end
             macropalette.SyncToCurrentJob();
-            palette.ValidatePalettesForJob(data.jobId, data.subjobId);
+            -- Universal 2hr global row mirrors the current job's 2hr ability; resync after job change.
+            local okMg, macroGlobalDefaults = pcall(require, 'modules.hotbar.macro_global_defaults');
+            if okMg and macroGlobalDefaults and macroGlobalDefaults.SyncUniversalTwoHourGlobalRow and gConfig then
+                macroGlobalDefaults.SyncUniversalTwoHourGlobalRow(gConfig);
+            end
+            -- Honor pending "profile loaded before job was readable" (char select / logout) so
+            -- Default Palette Type on Profile Load applies on first job-ready frame.
+            local pending = palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile
+                and palette.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+                or nil;
+            palette.ValidatePalettesForJob(data.jobId, data.subjobId, {
+                applyDefaultCrossbarScope = pending,
+            });
             display.ClearIconCache();
             actions.ClearNoIconCache();
             if crossbarInitialized then
@@ -524,10 +602,8 @@ function M.HandleKey(event)
 end
 
 function M.HandleXInputState(e)
+    -- Controller events go through crossbar regardless of keyboard hotbar enable state.
     if not crossbarInitialized then return; end
-    if gConfig and gConfig.hotbarEnabled == false then return; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return; end
     controller.HandleXInputState(e);
 end
 
@@ -535,9 +611,6 @@ end
 -- Returns true if the button should be blocked
 function M.HandleXInputButton(e)
     if not crossbarInitialized then return false; end
-    if gConfig and gConfig.hotbarEnabled == false then return false; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return false; end
     return controller.HandleXInputButton(e);
 end
 
@@ -545,18 +618,12 @@ end
 -- Returns true if the button should be blocked
 function M.HandleDInputButton(e)
     if not crossbarInitialized then return false; end
-    if gConfig and gConfig.hotbarEnabled == false then return false; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return false; end
     return controller.HandleDInputButton(e);
 end
 
 -- Handle DirectInput state event (for D-pad POV)
 function M.HandleDInputState(e)
     if not crossbarInitialized then return; end
-    if gConfig and gConfig.hotbarEnabled == false then return; end
-    local crossbarMode = gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-    if crossbarMode ~= 'crossbar' and crossbarMode ~= 'both' then return; end
     controller.HandleDInputState(e);
 end
 

--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 * XIUI Hotbar - Macro Palette Module
 * Provides a visual grid of user-created macros that can be dragged to hotbar slots
 ]]--
@@ -18,11 +18,142 @@ local petpalette = require('modules.hotbar.petpalette');
 local petregistry = require('modules.hotbar.petregistry');
 local playerdata = require('modules.hotbar.playerdata');
 local actiondb = require('modules.hotbar.actiondb');
+local iconmatch = require('modules.hotbar.iconmatch');
+local macroBuckets = require('modules.hotbar.macro_palette_buckets');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
+local profileManager = require('core.profile_manager');
+local sharedMacroStore = require('core.shared_macro_store');
 -- display and crossbar are loaded lazily to avoid circular dependencies
 local display = nil;
 local crossbar = nil;
 
 local M = {};
+
+-- Bundle for macropalette_macroeditor.lua (Lua 5.1: max 60 upvalues per function).
+local MP = {};
+
+MP.editingMacro = nil;
+MP.isCreatingNew = false;
+MP.currentPalettePage = 1;
+MP.editorPaletteKey = nil;
+MP.editorAutoLabel = nil;
+MP.editorAutoIconKey = nil;
+MP.editorDidInitialIconPick = false;
+MP.editorIconAutoSource = 'all';
+MP.editorCustomIconCategory = 'all';
+MP.selectedPaletteType = nil;
+MP.selectedAvatarPalette = nil;
+-- SMN only: when true, macro grid lists Base SMN + every avatar bucket together.
+MP.smnShowAllAvatarSubsets = false;
+-- BST: jug-family subset (movesKey from petregistry), nil = Base BST bucket.
+MP.selectedBstJugMovesKey = nil;
+-- BST: when true, macro grid lists Base BST + every jug:* macro bucket together.
+MP.bstShowAllJugSubsets = false;
+MP.cachedPetCommands = nil;
+MP.petAvatarFilter = 1;
+MP.searchFilter = { '' };
+-- Macro Palette window: filter tiles by display/action name (not icon-picker search).
+MP.macroPaletteSearchName = { '' };
+MP.macroNewCategoryBuf = { '' };
+MP.macroCustomRenameBuf = { '' };
+MP.macroCustomRenameTargetKey = nil; -- 'custom:N' for MacroCustomRename modal
+MP.macroCustomDeleteKey = nil; -- pending delete: confirm modal
+MP.macroCustomDeleteLabel = nil;
+MP.macroCustomDeleteN = 0;
+MP.macroMoveSourceKey = nil;
+MP.macroMoveMacroId = nil;
+MP.macroMoveDestKey = nil;
+MP._macroSearchPaletteKey = nil;
+MP._lastMacroPaletteSearch = nil;
+-- Which scope switch confirmation is open (single non-modal BeginPopup, no full-screen dim).
+MP.macroScopeConfirmKind = nil; -- 'toShared' | 'toProfile' while 'MacroScopeSwitch##xiui' is open
+MP.showAllMode = false;
+MP.showAllPetMode = false;
+MP.wsWeaponFilter = 'All';
+MP.spellTypeFilter = 'All';
+MP.abilityJobFilter = 0;
+MP.petTypeOverride = 0;
+MP.iconPickerTargetIsJaBadge = false;
+MP.iconPickerOpen = false;
+MP.iconPickerFilter = { '' };
+MP.iconPickerTab = 1;
+MP.iconPickerPage = { 1, 1, 1 };
+MP.iconPickerLastFilter = { '', '', '' };
+MP.iconPickerSpellType = 'All';
+MP.iconPickerItemType = 0;
+MP.editorImplicitActionIconDone = false;
+MP.editorIconManuallySet = false;
+-- When true, JA badge icon is not replaced by implicit /ja resolution; use "Sync JA badge" to refresh.
+MP.editorJaBadgeManuallySet = false;
+MP.editorIconPrefsHydrated = false;
+
+
+
+-- Palette / editor: GetBindIcon + ResolveMacroJaBadgeIcon do real work (macroparse, DB, texture lookup).
+-- The macro grid calls them once per tile per frame â€” cache by stable keys; clear when palette type changes.
+local PALETTE_ICON_NONE = {};
+local PALETTE_JA_NONE = {};
+
+local paletteMainIconCache = {};
+local paletteJaBadgeIconCache = {};
+local paletteIconCacheDbKey = nil;
+
+local editorPreviewIconKey = nil;
+local editorPreviewCachedIcon = nil;
+
+local function ClearEditorPreviewIconCache()
+    editorPreviewIconKey = nil;
+    editorPreviewCachedIcon = nil;
+end
+
+local function ClearPaletteJaBadgeIconCache()
+    for k in pairs(paletteJaBadgeIconCache) do
+        paletteJaBadgeIconCache[k] = nil;
+    end
+end
+
+local function BuildMacroMainIconCacheKey(macro)
+    if not macro then
+        return 'nil';
+    end
+    return table.concat({
+        tostring(macro.id or 0),
+        macro.actionType or '',
+        macro.action or '',
+        macro.target or '',
+        macro.macroText or '',
+        macro.customIconType or '',
+        tostring(macro.customIconId or ''),
+        macro.customIconPath or '',
+        macro.itemId and tostring(macro.itemId) or '',
+        tostring(macro.macroRef or ''),
+    }, '|');
+end
+
+local function BuildMacroJaBadgeCacheKey(macro)
+    if not macro then
+        return '';
+    end
+    return table.concat({
+        tostring(macro.id or 0),
+        macro.macroText or '',
+        tostring(macro.jaBadgeCustomIconType or ''),
+        tostring(macro.jaBadgeCustomIconId or ''),
+        macro.jaBadgeCustomIconPath or '',
+        tostring(macro.showJaBadgeOnMacro ~= false),
+    }, '|');
+end
+
+local function GetCachedPaletteMainIcon(macro)
+    local k = BuildMacroMainIconCacheKey(macro);
+    local hit = paletteMainIconCache[k];
+    if hit ~= nil then
+        return hit == PALETTE_ICON_NONE and nil or hit;
+    end
+    local icon = actions.GetBindIcon(macro);
+    paletteMainIconCache[k] = icon or PALETTE_ICON_NONE;
+    return icon;
+end
 
 -- ============================================
 -- Constants
@@ -30,11 +161,13 @@ local M = {};
 
 local INPUT_BUFFER_SIZE = 64;
 local MACRO_BUFFER_SIZE = 512;  -- 8 lines * ~60 chars each
-local PALETTE_COLUMNS = 6;
+local PALETTE_COLUMNS = 7;
 local PALETTE_ROWS = 6;
-local PALETTE_MACROS_PER_PAGE = PALETTE_COLUMNS * PALETTE_ROWS;  -- 36 macros per page
+local PALETTE_MACROS_PER_PAGE = PALETTE_COLUMNS * PALETTE_ROWS;  -- 42 macros per page
 local PALETTE_TILE_SIZE = 48;
 local PALETTE_TILE_GAP = 4;
+-- Slightly rounded macro grid tiles (ImGui button shape; icons draw square on top).
+local PALETTE_TILE_ROUNDING = 6;
 local PALETTE_PADDING = 8;
 
 -- XIUI Color Scheme (from components.TAB_STYLE)
@@ -70,10 +203,20 @@ end
 -- If preferAction is true, prioritize action name over displayName (for previews)
 local function GetActionAbbreviation(macro, preferAction)
     local name;
+    -- Macros: never abbreviate from raw `action` (it may be the full multiline buffer â€” yields garbage like /"S<).
+    if macro and macro.actionType == 'macro' and macro.macroText and macro.macroText ~= '' then
+        local mp = require('modules.hotbar.macroparse');
+        local _, pName = mp.GetMacroPrimaryAndJaBadge(macro.macroText);
+        if pName and pName ~= '' then
+            name = pName;
+        end
+    end
+    if not name or name == '' then
     if preferAction then
         name = macro.action or macro.displayName or '';
     else
         name = macro.displayName or macro.action or '';
+        end
     end
     if name == '' then return '?'; end
 
@@ -131,17 +274,17 @@ local function ClearAllIconCaches()
     if slotrenderer and slotrenderer.ClearSlotRenderingCache then
         slotrenderer.ClearSlotRenderingCache();
     end
-    -- Edits that change a macro's action leave the old actionType:action entry
-    -- orphaned in mpCostCache / availabilityCache. Functionally fine (the new key
-    -- naturally misses), but bounds memory across many edits.
+    -- 1.8.0 additions: edits that change a macro's action leave the old actionType:action
+    -- entry orphaned in the MP cost / availability caches. Functionally fine (the new key
+    -- naturally misses) but unbounded across many edits, so flush both during full clears.
     if slotrenderer and slotrenderer.ClearMPCostCache then
         slotrenderer.ClearMPCostCache();
     end
     if slotrenderer and slotrenderer.ClearAvailabilityCache then
         slotrenderer.ClearAvailabilityCache();
     end
-    -- Clear the icon-resolution negative cache so newly-added custom icons
-    -- on edited macros are picked up next frame.
+    -- Drop the icon-resolution negative cache so newly-added custom icons on edited
+    -- macros are picked up on the next frame instead of remaining "no icon".
     if actions and actions.ClearNoIconCache then
         actions.ClearNoIconCache();
     end
@@ -162,6 +305,8 @@ local function ClearSlotIconCache(barIndex, slotIndex)
     if display and display.ClearIconCacheForSlot then
         display.ClearIconCacheForSlot(barIndex, slotIndex);
     end
+    -- Note: per-slot slotrenderer.InvalidateSlotByKey was removed in 1.8.0. Slot rendering is
+    -- immediate-mode (no persistent prim cache); the per-frame bind hash naturally re-derives.
 end
 
 -- Helper to clear icon cache for a single crossbar slot (targeted - fast)
@@ -179,6 +324,7 @@ local function ClearCrossbarSlotIconCache(comboMode, slotIndex)
     if crossbar and crossbar.ClearIconCacheForSlot then
         crossbar.ClearIconCacheForSlot(comboMode, slotIndex);
     end
+    -- Note: per-slot slotrenderer.InvalidateSlotByKey was removed in 1.8.0. See ClearSlotIconCache above.
 end
 
 -- Action type constants (needed by DrawMacroTile and DrawMacroEditor)
@@ -187,11 +333,14 @@ local ACTION_TYPE_LABELS = {
     ma = 'Spell (ma)',
     ja = 'Ability (ja)',
     ws = 'Weaponskill (ws)',
-    item = 'Item',
+    item = 'Items',
     equip = 'Equip',
     macro = 'Macro',
     pet = 'Pet Command',
 };
+
+-- Items palette bucket: Action Type combo offers only these (order: Item, Macro, Equip).
+local ACTION_TYPES_ITEMS_BUCKET = { 'item', 'macro', 'equip' };
 
 -- Recast source types for macros (allows displaying cooldown from a different action)
 local RECAST_SOURCE_TYPES = { 'none', 'ma', 'ja', 'item', 'pet' };
@@ -240,8 +389,39 @@ local EQUIP_SLOT_MASKS = {
 -- Special key for global (non-job-specific) slot storage
 local GLOBAL_SLOT_KEY = 'global';
 
--- Special key for global macros (shared across all jobs)
-local GLOBAL_MACRO_KEY = 'global';
+-- Macro palette bucket keys (see macro_palette_buckets.lua)
+local GLOBAL_MACRO_KEY = macroBuckets.GLOBAL;
+local ITEMS_MACRO_KEY = macroBuckets.ITEMS;
+local EQUIPMENT_MACRO_KEY = macroBuckets.EQUIPMENT;
+local XIUI_MACRO_KEY = macroBuckets.XIUI;
+
+local function DefaultNewMacroBodyForPaletteKey(paletteKey)
+    if data.MacroPaletteKeysEqual(paletteKey, ITEMS_MACRO_KEY) then
+        return {
+            actionType = 'item',
+            action = '',
+            target = 't',
+            displayName = '',
+            customIconType = 'xiui_default',
+            customIconPath = 'item',
+        }, 'xiui_default::item';
+    end
+    return {
+        actionType = 'ma',
+        action = '',
+        target = 't',
+        displayName = '',
+        customIconType = 'xiui_default',
+        customIconPath = 'ma',
+    }, 'xiui_default::ma';
+end
+
+local function IsSharedJobAgnosticMacroSelection(sel)
+    if sel == GLOBAL_MACRO_KEY or sel == ITEMS_MACRO_KEY or sel == EQUIPMENT_MACRO_KEY or sel == XIUI_MACRO_KEY then
+        return true;
+    end
+    return macroBuckets.isCustomCategoryKey(sel);
+end
 
 -- Helper to deep copy a table (for migrating slot data)
 local function deepCopyTable(tbl)
@@ -293,30 +473,15 @@ end
 -- State
 -- ============================================
 
-local paletteOpen = false;
-local selectedMacroIndex = nil;
-local editingMacro = nil;
-local isCreatingNew = false;
-local currentPalettePage = 1;  -- Current page in macro palette (1-indexed)
-
--- Selected job for viewing/editing macros (nil = use current player job)
-local selectedPaletteType = nil;  -- Can be GLOBAL_MACRO_KEY or a job ID
-local selectedAvatarPalette = nil;  -- For SMN: nil = base, or avatar name like 'Ifrit'
-
--- Cached pet commands (managed locally, not in shared module)
-local cachedPetCommands = nil;
-local petAvatarFilter = 1;  -- 1 = All, 2+ = specific avatar index
-
--- Search filter for dropdowns
-local searchFilter = { '' };
-
--- Icon picker state
-local iconPickerOpen = false;
-local iconPickerFilter = { '' };
-local iconPickerTab = 1;  -- 1 = Spells, 2 = Items, 3 = Custom
-local iconPickerPage = { 1, 1, 1 };  -- Current page for each tab [spells, items, custom]
-local iconPickerLastFilter = { '', '', '' };  -- Track filter changes to reset page
-local iconPickerSpellType = 'All';  -- Current spell type filter
+-- Palette open state (table: avoids extra upvalues when palette draw uses MacroPaletteDrawEnv).
+local paletteUi = { open = false, selectedMacroIndex = nil };
+local ICON_AUTO_SOURCES = { 'all', 'spells', 'items', 'custom' };
+local ICON_AUTO_SOURCE_LABELS = {
+    ['all'] = 'All',
+    ['spells'] = 'Spells',
+    ['items'] = 'Items',
+    ['custom'] = 'Custom',
+};
 
 -- Spell type display names and order
 local SPELL_TYPE_ORDER = {
@@ -404,7 +569,6 @@ local ITEM_TYPE_ICONS = {
     [8] = 4096,   -- Fire Crystal
     [10] = 6232,  -- Furnishing item
 };
-local iconPickerItemType = 0;  -- 0 = All
 
 -- Custom icon categories (subdirectories in assets/hotbar/custom/)
 local CUSTOM_ICON_CATEGORIES = {};  -- Populated by scanning directory
@@ -432,6 +596,8 @@ local filteredSpellsCache = nil;
 local filteredSpellsCacheKey = nil;  -- "filter:type" key for cache invalidation
 local filteredItemsCache = nil;
 local filteredItemsCacheKey = nil;  -- "filter" key for cache invalidation
+local filteredCustomIconsCache = nil;
+local filteredCustomIconsCacheKey = nil;  -- filter + category for custom tab
 
 -- Icon picker grid constants
 local ICON_GRID_COLUMNS_DEFAULT = 12;  -- Default columns, recalculated based on window width
@@ -486,7 +652,7 @@ local function RefreshCachedLists()
     playerdata.RefreshCachedLists(data);
     -- Clear local pet commands cache when job changes
     if playerdata.GetCacheJobId() ~= data.jobId then
-        cachedPetCommands = nil;
+        MP.cachedPetCommands = nil;
     end
 end
 
@@ -734,8 +900,262 @@ local function LoadCustomIcons()
         if b == 'all' then return false; end
         return a:lower() < b:lower();
     end);
+
+    -- LoadCustomIcons replaces CUSTOM_ICON_CATEGORIES with a new table; keep MP.* in sync for the macro editor sub-module.
+    MP.CUSTOM_ICON_CATEGORIES = CUSTOM_ICON_CATEGORIES;
+    MP.CUSTOM_ICON_LABELS = CUSTOM_ICON_LABELS;
     
     return customIconsCache;
+end
+
+local function HydrateMacroEditorIconPrefs()
+    if not gConfig or not gConfig.macroEditorIconPrefs then
+        return;
+    end
+    local p = gConfig.macroEditorIconPrefs;
+    local src = p.iconAutoSource;
+    if src == 'all' or src == 'spells' or src == 'items' or src == 'custom' then
+        MP.editorIconAutoSource = src;
+    end
+    if type(p.customIconFolder) == 'string' and p.customIconFolder ~= '' then
+        MP.editorCustomIconCategory = p.customIconFolder;
+    end
+end
+
+local function ValidateEditorCustomIconCategoryAgainstScan()
+    LoadCustomIcons();
+    local cat = MP.editorCustomIconCategory or 'all';
+    if cat == 'all' then
+        return;
+    end
+    local found = false;
+    for _, c in ipairs(CUSTOM_ICON_CATEGORIES or {}) do
+        if c == cat then
+            found = true;
+            break;
+        end
+    end
+    if not found then
+        MP.editorCustomIconCategory = 'all';
+    end
+end
+
+local function PersistMacroEditorIconPrefs()
+    if not gConfig then
+        return;
+    end
+    if not gConfig.macroEditorIconPrefs then
+        gConfig.macroEditorIconPrefs = {};
+    end
+    gConfig.macroEditorIconPrefs.iconAutoSource = MP.editorIconAutoSource;
+    gConfig.macroEditorIconPrefs.customIconFolder = MP.editorCustomIconCategory;
+    if SaveSettingsToDisk then
+        SaveSettingsToDisk();
+    end
+end
+
+-- Rescan custom/ PNG lists (new files, addon reload) without restarting the game client.
+local function InvalidateCustomIconScanCaches()
+    customIconsCache = nil;
+    customIconsByCategoryCache = nil;
+    customCategoryIconCache = {};
+    filteredCustomIconsCache = nil;
+    filteredCustomIconsCacheKey = nil;
+    local ok, cir = pcall(require, 'modules.hotbar.customiconresolve');
+    if ok and cir and cir.InvalidateScanCache then
+        cir.InvalidateScanCache();
+    end
+end
+
+-- Normalized relative path compare for saved custom icon paths (mixed slashes).
+local function NormalizeCustomIconRelPath(p)
+    if not p then
+        return '';
+    end
+    return tostring(p):gsub('/', '\\'):gsub('^%s+', ''):gsub('%s+$', '');
+end
+
+--- Find scanned custom icon entry by path saved on a macro (path relative to assets/hotbar/custom/).
+local function FindCustomIconEntryBySavedPath(savedPath)
+    savedPath = NormalizeCustomIconRelPath(savedPath);
+    if savedPath == '' then
+        return nil;
+    end
+    LoadCustomIcons();
+    local sle = savedPath:lower();
+    for _, icon in ipairs(customIconsCache or {}) do
+        if icon.path and NormalizeCustomIconRelPath(icon.path):lower() == sle then
+            return icon;
+        end
+    end
+    local leaf = savedPath:match('[^\\/]+$') or savedPath;
+    leaf = leaf:gsub('%.png$', ''):lower();
+    for _, icon in ipairs(customIconsCache or {}) do
+        if icon.path then
+            local il = (icon.path:match('[^\\/]+$') or icon.path):gsub('%.png$', ''):lower();
+            if il == leaf then
+                return icon;
+            end
+        end
+    end
+    return nil;
+end
+
+-- Same normalization as macro editor auto-pick (matches TryAutoPickCustomIcon).
+local function PaletteNormalizeIconMatchText(s)
+    if not s then
+        return '';
+    end
+    s = tostring(s):lower();
+    s = s:gsub('^%s+', ''):gsub('%s+$', '');
+    s = s:gsub('[\r\n\t]', ' ');
+    s = s:gsub('[%p%c%s]', '');
+    return s;
+end
+
+local function PaletteBuildIconMatchNeedles(actionName)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return {};
+    end
+
+    local needles = {};
+    local function add(n)
+        n = PaletteNormalizeIconMatchText(n);
+        if n ~= '' then
+            needles[n] = true;
+        end
+    end
+
+    local fullNorm = PaletteNormalizeIconMatchText(actionName);
+    add(actionName);
+    local rhs = actionName:match(':%s*(.+)$');
+    if rhs then
+        add(rhs);
+    end
+    local paren = actionName:match('%(([^)]+)%)');
+    if paren then
+        add(paren);
+    end
+    local lastWord = actionName:match('([^%s]+)%s*$');
+    if lastWord then
+        local lwNorm = PaletteNormalizeIconMatchText(lastWord);
+        -- Do not add a last-word needle when it is only a tail of the full normalized name
+        -- (e.g. "Attack" for "Sneak Attack" â†’ sneakattack) â€” exact match would pick generic Attack.png
+        -- before fuzzy matching can prefer Sneak_Attack_*.
+        if lwNorm ~= '' and lwNorm ~= fullNorm then
+            local weakTail = (#lwNorm < 9 and #fullNorm > #lwNorm + 4 and fullNorm:sub(-#lwNorm) == lwNorm);
+            if not weakTail then
+                add(lastWord);
+            end
+        end
+    end
+
+    local arr = {};
+    for n, _ in pairs(needles) do
+        table.insert(arr, n);
+    end
+    table.sort(arr, function(a, b)
+        return #a > #b;
+    end);
+    return arr;
+end
+
+--- Best custom icon match for an action name (same rules as TryAutoPickCustomIcon). Returns icon entry or nil.
+local function ResolveBestCustomIconMatchForActionName(actionName, categoryFilter)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return nil;
+    end
+    LoadCustomIcons();
+    local category = categoryFilter or 'all';
+    local list = customIconsByCategoryCache and (customIconsByCategoryCache[category] or customIconsByCategoryCache['all']) or nil;
+    if not list or #list == 0 then
+        return nil;
+    end
+
+    local needles = PaletteBuildIconMatchNeedles(actionName);
+    if #needles == 0 then
+        return nil;
+    end
+
+    for _, icon in ipairs(list) do
+        if icon and icon.name and icon.path then
+            local iconNorm = PaletteNormalizeIconMatchText(icon.name);
+            for _, needle in ipairs(needles) do
+                if iconNorm == needle then
+                    return icon;
+                end
+            end
+        end
+    end
+
+    -- Fuzzy round: collect all decent matches, then prefer the most specific (longest normalized stem)
+    -- so short substrings don't steal the pick when several PNGs could match.
+    local fuzzy = {};
+    for _, icon in ipairs(list) do
+        if icon and icon.name and icon.path and iconmatch.IsDecentIconNameMatch(actionName, icon.name) then
+            table.insert(fuzzy, icon);
+        end
+    end
+    if #fuzzy == 1 then
+        return fuzzy[1];
+    end
+    if #fuzzy > 1 then
+        table.sort(fuzzy, function(x, y)
+            local sx = iconmatch.MatchQualityScore(actionName, x.name);
+            local sy = iconmatch.MatchQualityScore(actionName, y.name);
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return #iconmatch.NormalizeIconKey(x.name) > #iconmatch.NormalizeIconKey(y.name);
+        end);
+        return fuzzy[1];
+    end
+
+    return nil;
+end
+
+-- Icon picker search: collapse spaces, underscores, punctuation so "Sneak Attack", "sneak_attack",
+-- and "sneakattack" match the same assets (multi-word spell/ability/file names).
+local function normalizeIconPickerNameKey(s)
+    if not s then
+        return '';
+    end
+    return tostring(s):lower():gsub('[^a-z0-9]', '');
+end
+
+local function iconPickerNameMatchesFilter(name, filter)
+    if not filter or filter == '' then
+        return true;
+    end
+    if not name or name == '' then
+        return false;
+    end
+    local normName = normalizeIconPickerNameKey(name);
+    local normAll = normalizeIconPickerNameKey(filter);
+    if normAll == '' then
+        return true;
+    end
+    if normName:find(normAll, 1, true) then
+        return true;
+    end
+    local tokens = {};
+    for w in tostring(filter):gmatch('%S+') do
+        local t = normalizeIconPickerNameKey(w);
+        if t ~= '' then
+            table.insert(tokens, t);
+        end
+    end
+    if #tokens <= 1 then
+        return false;
+    end
+    for _, t in ipairs(tokens) do
+        if not normName:find(t, 1, true) then
+            return false;
+        end
+    end
+    return true;
 end
 
 -- Get custom icons filtered by category
@@ -749,24 +1169,31 @@ local function GetCustomIconsFiltered(category, filter)
         sourceList = customIconsByCategoryCache[category] or {};
     end
     
-    -- Apply text filter if any
+    -- Apply text filter if any (best matches first: full-name embed beats loose substring)
     if filter and filter ~= '' then
         local filtered = {};
-        filter = filter:lower();
         for _, icon in ipairs(sourceList) do
-            if icon.name:lower():find(filter, 1, true) then
+            if iconPickerNameMatchesFilter(icon.name or '', filter) then
                 table.insert(filtered, icon);
             end
         end
+        table.sort(filtered, function(x, y)
+            local sx = iconmatch.MatchQualityScore(filter, x.name or '');
+            local sy = iconmatch.MatchQualityScore(filter, y.name or '');
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return (x.name or '') < (y.name or '');
+        end);
         return filtered;
     end
     
     return sourceList;
 end
 
--- Load a custom icon texture by relative path (uses TextureManager with LRU caching)
+-- Load a custom icon texture by relative path (same cache as hotbar; avoids duplicate VRAM + TextureManager LRU thrash)
 local function LoadCustomIconTexture(relativePath)
-    return TextureManager.getCustomIcon(relativePath);
+    return actions.GetCustomHotbarIconTexture(relativePath);
 end
 
 -- Create a new custom icon folder
@@ -903,10 +1330,51 @@ local function PopComboStyle()
     imgui.PopStyleColor(11);
 end
 
+-- Status tier colors for "Show All" mode
+local STATUS_COLORS = {
+    ['have']        = { 0.35, 0.85, 0.35, 1.0 },
+    ['learnable']   = { 0.95, 0.78, 0.25, 1.0 },
+    ['unavailable'] = { 0.75, 0.30, 0.30, 1.0 },
+};
+
+-- Base colors per magic type (full brightness = STATUS_HAVE)
+local SPELL_TYPE_COLORS = {
+    WhiteMagic   = { 0.96, 0.92, 0.78, 1.0 },  -- eggshell/holy white
+    BlackMagic   = { 0.75, 0.50, 0.90, 1.0 },  -- purple
+    BardSong     = { 0.50, 0.80, 1.00, 1.0 },  -- light blue
+    Ninjutsu     = { 0.78, 0.60, 0.38, 1.0 },  -- scroll brown
+    SummonerPact = { 0.50, 0.75, 0.38, 1.0 },  -- moss green
+    BlueMagic    = { 0.30, 0.70, 0.95, 1.0 },  -- steel blue
+    Geomancy     = { 0.60, 0.85, 0.45, 1.0 },  -- earthy green
+    Trust        = { 0.80, 0.80, 0.80, 1.0 },  -- silver
+};
+
+-- Human-readable headers for each spell type
+local SPELL_TYPE_HEADERS = {
+    WhiteMagic   = 'White Magic',
+    BlackMagic   = 'Black Magic',
+    BardSong     = 'Songs',
+    Ninjutsu     = 'Ninjutsu',
+    SummonerPact = 'Summoning',
+    BlueMagic    = 'Blue Magic',
+    Geomancy     = 'Geomancy',
+    Trust        = 'Trust',
+};
+
+-- Canonical type display order
+local SPELL_TYPE_ORDER = {
+    'WhiteMagic', 'BlackMagic', 'BardSong', 'Ninjutsu',
+    'SummonerPact', 'BlueMagic', 'Geomancy', 'Trust',
+};
+local SPELL_TYPE_RANK = {};
+for i, t in ipairs(SPELL_TYPE_ORDER) do SPELL_TYPE_RANK[t] = i; end
+
+
 -- Draw a searchable dropdown combo box with XIUI styling
 -- showIcons: if true, will attempt to load and display item icons
 -- equipSlotFilter: if provided, only show items that can be equipped in this slot (e.g., 'main', 'head')
-local function DrawSearchableCombo(label, items, currentValue, onSelect, showIcons, equipSlotFilter)
+-- useStatusColors: if true, color text by item.status (have/learnable/unavailable)
+local function DrawSearchableCombo(label, items, currentValue, onSelect, showIcons, equipSlotFilter, itemWidth, useStatusColors)
     local displayText = currentValue ~= '' and currentValue or 'Select...';
 
     -- Get the slot mask for filtering if provided
@@ -915,16 +1383,17 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
     -- Apply XIUI styling to combo popup
     PushComboStyle();
 
-    imgui.SetNextItemWidth(220);
+    local comboW = (type(itemWidth) == 'number' and itemWidth > 0) and itemWidth or 220;
+    imgui.SetNextItemWidth(comboW);
     -- Use HeightLargest so popup fits our child window without its own scrollbar
     if imgui.BeginCombo(label, displayText, ImGuiComboFlags_HeightLargest) then
         -- Search input at top (fixed, not scrollable)
-        imgui.SetNextItemWidth(200);
+        imgui.SetNextItemWidth(math.max(80, comboW - 20));
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
-        imgui.InputText('##search' .. label, searchFilter, INPUT_BUFFER_SIZE);
+        imgui.InputText('##search' .. label, MP.searchFilter, INPUT_BUFFER_SIZE);
         imgui.PopStyleColor();
 
-        if searchFilter[1] == '' then
+        if MP.searchFilter[1] == '' then
             -- Show placeholder hint
             local inputPos = {imgui.GetItemRectMin()};
             imgui.SetCursorScreenPos({inputPos[1] + 6, inputPos[2] + 3});
@@ -937,9 +1406,13 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
         local childHeight = 200;
         imgui.BeginChild('##comboScroll' .. label, {0, childHeight}, false);
 
-        local filter = searchFilter[1]:lower();
+        local filter = MP.searchFilter[1];
         local matchCount = 0;
         local iconSize = 16;
+        local GOLD_STAR_COLOR = {1.0, 0.88, 0.12, 1.0};
+        local PINK_STAR_COLOR = {1.0, 0.45, 0.72, 1.0};
+        local lastType = nil;
+        local isSearching = filter ~= '';
 
         for _, item in ipairs(items) do
             local itemName = item.name or '';
@@ -950,48 +1423,195 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
                 passesSlotFilter = bit.band(item.slots, slotMask) ~= 0;
             end
 
-            if passesSlotFilter and (filter == '' or itemName:lower():find(filter, 1, true)) then
+            if passesSlotFilter and iconPickerNameMatchesFilter(itemName, filter) then
                 matchCount = matchCount + 1;
+
+                -- Insert type group header when type changes (only when not searching)
+                if not isSearching and item.type and item.type ~= lastType then
+                    if lastType ~= nil then
+                        imgui.Separator();
+                    end
+                    local headerLabel = SPELL_TYPE_HEADERS[item.type] or item.type;
+                    local headerColor = SPELL_TYPE_COLORS[item.type] or COLORS.textDim;
+                    imgui.TextColored(headerColor, headerLabel);
+                    lastType = item.type;
+                end
+
                 local isSelected = currentValue == itemName;
+                local uid = item.id or matchCount;
+                local isSpellWithType = item.type and SPELL_TYPE_COLORS[item.type] ~= nil;
 
-                -- Determine text color: gold if selected, blue if usable, default otherwise
-                local textColor = nil;
-                if isSelected then
-                    textColor = COLORS.gold;
-                elseif item.usable then
-                    textColor = COLORS.usable;
-                end
+                if isSpellWithType and not isSelected then
+                    -- â”€â”€ Two-color spell rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+                    -- [level] â†’ magic type color; name â†’ status color.
+                    -- Use one hit target (InvisibleButton): overlapping Selectable + Text ate clicks.
+                    local levelColor = SPELL_TYPE_COLORS[item.type];
+                    local nameColor = (item.status and STATUS_COLORS[item.status]) or COLORS.text;
+                    local rowW = math.max(60, comboW - 24);
+                    local padY = 2;
+                    local lineH = imgui.GetTextLineHeight();
+                    local rowH = lineH + padY * 2;
 
-                if textColor then
-                    imgui.PushStyleColor(ImGuiCol_Text, textColor);
-                end
+                    imgui.InvisibleButton('##item' .. uid, {rowW, rowH});
+                    local clicked = imgui.IsItemClicked();
+                    local hovered = imgui.IsItemHovered();
 
-                -- Show icon if enabled and item has an id
-                if showIcons and item.id then
-                    -- Use memory-only loading (no PNG creation) for browsing
-                    local icon = actions.GetItemIconForBrowsing(item.id);
-                    if icon and icon.image then
-                        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
-                        if iconPtr then
-                            imgui.Image(iconPtr, {iconSize, iconSize});
-                            imgui.SameLine();
+                    local dl = imgui.GetWindowDrawList();
+                    local rmin = {imgui.GetItemRectMin()};
+                    local tx = rmin[1] + 6;
+                    local ty = rmin[2] + padY;
+                    local curX = tx;
+                    if item.level then
+                        local lvlStr = '[' .. tostring(item.level) .. '] ';
+                        dl:AddText({curX, ty}, imgui.GetColorU32(levelColor), lvlStr);
+                        local lw = imgui.CalcTextSize(lvlStr);
+                        curX = curX + ((type(lw) == 'table' and (lw[1] or lw.x)) or lw);
+                    end
+                    dl:AddText({curX, ty}, imgui.GetColorU32(nameColor), itemName);
+                    local nw = imgui.CalcTextSize(itemName);
+                    curX = curX + ((type(nw) == 'table' and (nw[1] or nw.x)) or nw);
+
+                    local starCol, starTip = nil, nil;
+                    if item.pinkStarTooltip then
+                        starCol = PINK_STAR_COLOR;
+                        starTip = item.pinkStarTooltip;
+                    elseif item.familyVarianceReason then
+                        starCol = GOLD_STAR_COLOR;
+                        starTip = item.familyVarianceReason;
+                    end
+                    if starCol then
+                        dl:AddText({curX + 4, ty}, imgui.GetColorU32(starCol), '*');
+                    end
+
+                    if hovered then
+                        if starTip then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(starTip);
+                            imgui.EndTooltip();
+                        elseif item.reason then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(item.reason);
+                            imgui.EndTooltip();
                         end
                     end
-                end
 
-                local itemLabel = item.level and string.format('[%d] %s', item.level, itemName) or itemName;
-                -- Add quantity for items with count > 1
-                if item.count and item.count > 1 then
-                    itemLabel = itemLabel .. ' x' .. item.count;
-                end
-                if imgui.Selectable(itemLabel .. '##item' .. (item.id or matchCount), isSelected) then
-                    onSelect(item);
-                    searchFilter[1] = '';
-                    imgui.CloseCurrentPopup();
-                end
+                    if clicked then
+                        onSelect(item);
+                        MP.searchFilter[1] = '';
+                        imgui.CloseCurrentPopup();
+                    end
+                else
+                    -- â”€â”€ Standard single-color rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+                    local textColor = nil;
+                    if isSelected then
+                        textColor = COLORS.gold;
+                    elseif useStatusColors and item.status and STATUS_COLORS[item.status] then
+                        textColor = STATUS_COLORS[item.status];
+                    elseif item.usable then
+                        textColor = COLORS.usable;
+                    end
 
-                if textColor then
-                    imgui.PopStyleColor();
+                    local starCol, starTip = nil, nil;
+                    if item.familyVarianceReason then
+                        starCol = GOLD_STAR_COLOR;
+                        starTip = item.familyVarianceReason;
+                    elseif item.pinkStarTooltip then
+                        starCol = PINK_STAR_COLOR;
+                        starTip = item.pinkStarTooltip;
+                    end
+
+                    if starCol and starTip then
+                        local baseCol = isSelected and COLORS.gold or (textColor or COLORS.text);
+                        local rowW = math.max(60, comboW - 24);
+                        local rowH = math.max(iconSize + 4, imgui.GetTextLineHeight() + 6);
+
+                        imgui.InvisibleButton('##item' .. uid, {rowW, rowH});
+                        local clicked = imgui.IsItemClicked();
+                        local hovered = imgui.IsItemHovered();
+
+                        local dl = imgui.GetWindowDrawList();
+                        local rmin = {imgui.GetItemRectMin()};
+                        local curX = rmin[1] + 4;
+                        local curY = rmin[2] + 2;
+
+                        if showIcons and item.id then
+                            local icon = actions.GetItemIconForBrowsing(item.id);
+                            if icon and icon.image then
+                                local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+                                if iconPtr then
+                                    dl:AddImage(iconPtr, {curX, curY}, {curX + iconSize, curY + iconSize});
+                                    curX = curX + iconSize + 6;
+                                end
+                            end
+                        end
+
+                        local labelMain = itemName;
+                        if item.level then
+                            labelMain = string.format('[%d] %s', item.level, itemName);
+                        elseif item.reqStr then
+                            labelMain = string.format('%s  (%s)', itemName, item.reqStr);
+                        end
+                        if item.count and item.count > 1 then
+                            labelMain = labelMain .. ' x' .. item.count;
+                        end
+
+                        local ty = curY + math.max(0, (rowH - imgui.GetTextLineHeight()) / 2 - 2);
+                        dl:AddText({curX, ty}, imgui.GetColorU32(baseCol), labelMain);
+                        local lw = imgui.CalcTextSize(labelMain);
+                        curX = curX + ((type(lw) == 'table' and (lw[1] or lw.x)) or lw);
+                        dl:AddText({curX + 4, ty}, imgui.GetColorU32(starCol), '*');
+
+                        if hovered then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(starTip);
+                            imgui.EndTooltip();
+                        end
+
+                        if clicked then
+                            onSelect(item);
+                            MP.searchFilter[1] = '';
+                            imgui.CloseCurrentPopup();
+                        end
+                    else
+                        if textColor then imgui.PushStyleColor(ImGuiCol_Text, textColor); end
+
+                        -- Show icon if enabled and item has an id
+                        if showIcons and item.id then
+                            local icon = actions.GetItemIconForBrowsing(item.id);
+                            if icon and icon.image then
+                                local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+                                if iconPtr then
+                                    imgui.Image(iconPtr, {iconSize, iconSize});
+                                    imgui.SameLine();
+                                end
+                            end
+                        end
+
+                        local itemLabel;
+                        if item.level then
+                            itemLabel = string.format('[%d] %s', item.level, itemName);
+                        elseif item.reqStr then
+                            itemLabel = string.format('%s  (%s)', itemName, item.reqStr);
+                        else
+                            itemLabel = itemName;
+                        end
+                        if item.count and item.count > 1 then
+                            itemLabel = itemLabel .. ' x' .. item.count;
+                        end
+                        if imgui.Selectable(itemLabel .. '##item' .. uid, isSelected) then
+                            onSelect(item);
+                            MP.searchFilter[1] = '';
+                            imgui.CloseCurrentPopup();
+                        end
+
+                        if item.reason and imgui.IsItemHovered() then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(item.reason);
+                            imgui.EndTooltip();
+                        end
+
+                        if textColor then imgui.PopStyleColor(); end
+                    end
                 end
             end
         end
@@ -1013,34 +1633,127 @@ end
 -- Macro Database Functions
 -- ============================================
 
+-- Clear SMN avatar / BST jug subset palette UI state (when switching macro type or job bucket).
+local function ClearSmnMacroSubsetUi()
+    MP.selectedAvatarPalette = nil;
+    MP.smnShowAllAvatarSubsets = false;
+end
+
+local function ClearBstJugMacroSubsetUi()
+    MP.selectedBstJugMovesKey = nil;
+    MP.bstShowAllJugSubsets = false;
+end
+
+local function ResetPetJobMacroPaletteSubsets()
+    ClearSmnMacroSubsetUi();
+    ClearBstJugMacroSubsetUi();
+end
+
 -- Get current effective type for the palette (selected type or player's current job)
--- Returns GLOBAL_MACRO_KEY for global macros, a job ID, or a composite key like "15:avatar:ifrit"
+-- Returns GLOBAL_MACRO_KEY, ITEMS_MACRO_KEY, a job ID, or a composite key like "15:avatar:ifrit"
 local function GetEffectivePaletteType()
-    if selectedPaletteType then
+    if MP.selectedPaletteType then
         -- If Global is selected, return the global key
-        if selectedPaletteType == GLOBAL_MACRO_KEY then
+        if MP.selectedPaletteType == GLOBAL_MACRO_KEY then
             return GLOBAL_MACRO_KEY;
         end
+        if MP.selectedPaletteType == ITEMS_MACRO_KEY then
+            return ITEMS_MACRO_KEY;
+        end
+        if MP.selectedPaletteType == EQUIPMENT_MACRO_KEY then
+            return EQUIPMENT_MACRO_KEY;
+        end
+        if MP.selectedPaletteType == XIUI_MACRO_KEY then
+            return XIUI_MACRO_KEY;
+        end
+        if type(MP.selectedPaletteType) == 'string' and macroBuckets.isCustomCategoryKey(MP.selectedPaletteType) then
+            return MP.selectedPaletteType;
+        end
         -- If a valid job ID is selected
-        if type(selectedPaletteType) == 'number' and selectedPaletteType > 0 then
+        if type(MP.selectedPaletteType) == 'number' and MP.selectedPaletteType > 0 then
             -- Check for SMN avatar-specific palette
-            if selectedPaletteType == petregistry.JOB_SMN and selectedAvatarPalette then
-                local avatarKey = petregistry.avatars[selectedAvatarPalette];
+            if MP.selectedPaletteType == petregistry.JOB_SMN and MP.selectedAvatarPalette then
+                local avatarKey = petregistry.avatars[MP.selectedAvatarPalette];
                 if avatarKey then
-                    return string.format('%d:avatar:%s', selectedPaletteType, avatarKey);
+                    return string.format('%d:avatar:%s', MP.selectedPaletteType, avatarKey);
                 end
             end
-            return selectedPaletteType;
+            if MP.selectedPaletteType == petregistry.JOB_BST and MP.selectedBstJugMovesKey then
+                return petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(MP.selectedBstJugMovesKey);
+            end
+            return MP.selectedPaletteType;
         end
     end
     -- Default to current player job
     return data.jobId or 1;
+end
+-- Exposed for crossbar drop: must match fallbacks in HandleDropOnSlot (not raw job id for Global/items/etc.)
+M.GetEffectivePaletteType = GetEffectivePaletteType;
+
+--- True when macros are being saved under the Items palette bucket (`macroDB.items`).
+function M.EditorMacroPaletteKeyIsItems(saveKey)
+    local k = saveKey;
+    if k == nil then
+        k = MP.editorPaletteKey;
+    end
+    if k == nil then
+        k = GetEffectivePaletteType();
+    end
+    return data.MacroPaletteKeysEqual(k, ITEMS_MACRO_KEY);
+end
+
+--- Restrict editor to item/macro/equip types when Saving To (or editing) Items palette; coerce illegal types to Item.
+function M.ClampMacroEditorForItemsPalette()
+    if not MP.editingMacro then
+        return;
+    end
+    if not M.EditorMacroPaletteKeyIsItems(MP.editorPaletteKey) then
+        return;
+    end
+    local allowed = { item = true, macro = true, equip = true };
+    local at = MP.editingMacro.actionType or 'item';
+    if not allowed[at] then
+        MP.editingMacro.actionType = 'item';
+        MP.editingMacro.action = '';
+        MP.editorFields.action[1] = '';
+        MP.searchFilter[1] = '';
+        MP.editingMacro.recastSourceType = nil;
+        MP.editingMacro.recastSourceAction = nil;
+        MP.editingMacro.recastSourceItemId = nil;
+        MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES, 'none');
+        MP.editorFields.recastSourceAction[1] = '';
+        MP.editingMacro.showJaBadgeOnMacro = nil;
+        MP.editingMacro.customIconType = 'xiui_default';
+        MP.editingMacro.customIconPath = 'item';
+        MP.editorAutoIconKey = 'xiui_default::item';
+        MP.editorImplicitActionIconDone = false;
+    end
+    MP.editorFields.actionType[1] = MP.FindIndex(ACTION_TYPES, MP.editingMacro.actionType or 'item');
 end
 
 -- Get display name for a palette type key
 local function GetPaletteDisplayName(typeKey)
     if typeKey == GLOBAL_MACRO_KEY then
         return 'Global';
+    end
+    if typeKey == ITEMS_MACRO_KEY then
+        return 'Items';
+    end
+    if typeKey == EQUIPMENT_MACRO_KEY then
+        return 'Equipment';
+    end
+    if typeKey == XIUI_MACRO_KEY then
+        return 'XIUI Commands';
+    end
+    if type(typeKey) == 'string' and macroBuckets.isCustomCategoryKey(typeKey) then
+        if gConfig and gConfig.macroCustomCategories then
+            for _, entry in ipairs(gConfig.macroCustomCategories) do
+                if entry.key == typeKey then
+                    return entry.label or typeKey;
+                end
+            end
+        end
+        return typeKey;
     end
     if type(typeKey) == 'number' then
         return jobs[typeKey] or 'Unknown';
@@ -1055,45 +1768,355 @@ local function GetPaletteDisplayName(typeKey)
                     return string.format('%s (%s)', jobs[tonumber(jobId)] or 'SMN', name);
                 end
             end
+        elseif jobId and petType == petregistry.PET_TYPE_JUG and petId then
+            local petLabel = petregistry.GetDisplayNameForKey(petregistry.PET_TYPE_JUG .. ':' .. petId);
+            return string.format('%s (%s)', jobs[tonumber(jobId)] or 'BST', petLabel);
         end
     end
     return tostring(typeKey);
 end
 
+local function CountMacrosInPalette(paletteKey)
+    if gConfig and gConfig.macroDB and gConfig.macroDB[paletteKey] then
+        return #gConfig.macroDB[paletteKey];
+    end
+    return 0;
+end
+
+-- Cache key so search/icon caches reset when toggling SMN "all subsets" view.
+local SMN_ALL_SUBSETS_VIEW_TAG = '__all_subsets__';
+local BST_ALL_SUBSETS_VIEW_TAG = '__bst_all_jug_subsets__';
+
+local function IsSmnAllSubsetsPaletteView()
+    return MP.selectedPaletteType == petregistry.JOB_SMN and MP.smnShowAllAvatarSubsets;
+end
+
+local function IsBstAllSubsetsPaletteView()
+    return MP.selectedPaletteType == petregistry.JOB_BST and MP.bstShowAllJugSubsets;
+end
+
+--- Stable jug subset rows: picker families (deduped by slug) then extra jug:* keys (e.g. Lynx, Arctic).
+local function BstJugSubsetEntriesOrdered()
+    local rows = {};
+    local seen = {};
+    local jid = petregistry.JOB_BST;
+    for _, row in ipairs(petregistry.GetBstJugReadyFamilyPickerList()) do
+        local slug = row.movesKey:lower();
+        if not seen[slug] then
+            seen[slug] = true;
+            table.insert(rows, {
+                movesKey = row.movesKey,
+                label = row.name,
+                fullKey = petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(row.movesKey),
+            });
+        end
+    end
+    local extras = {};
+    for _, pk in ipairs(petregistry.GetAvailablePetKeys(jid)) do
+        local slug = pk:match('^jug:(.+)$');
+        if slug and not seen[slug] then
+            local mk = petregistry.MovesKeyFromBstMacroPaletteSlug(slug);
+            if mk then
+                seen[slug] = true;
+                table.insert(extras, {
+                    movesKey = mk,
+                    label = petregistry.GetDisplayNameForKey(pk),
+                    fullKey = string.format('%d:%s:%s', jid, petregistry.PET_TYPE_JUG, slug),
+                });
+            end
+        end
+    end
+    table.sort(extras, function(a, b)
+        return (a.label or '') < (b.label or '');
+    end);
+    for _, e in ipairs(extras) do
+        table.insert(rows, e);
+    end
+    return rows;
+end
+
+local function CountBstAllJugSubsetsMacros()
+    local n = CountMacrosInPalette(petregistry.JOB_BST);
+    for _, ent in ipairs(BstJugSubsetEntriesOrdered()) do
+        n = n + CountMacrosInPalette(ent.fullKey);
+    end
+    return n;
+end
+
+local function BuildBstAllJugSubsetsRows()
+    local out = {};
+    local jid = petregistry.JOB_BST;
+    if not gConfig or not gConfig.macroDB then
+        return out;
+    end
+    local baseDb = gConfig.macroDB[jid];
+    if baseDb then
+        for _, m in ipairs(baseDb) do
+            table.insert(out, { macro = m, paletteKey = jid, subsetLabel = 'Base BST' });
+        end
+    end
+    for _, ent in ipairs(BstJugSubsetEntriesOrdered()) do
+        local adb = gConfig.macroDB[ent.fullKey];
+        if adb then
+            for _, m in ipairs(adb) do
+                table.insert(out, { macro = m, paletteKey = ent.fullKey, subsetLabel = ent.label });
+            end
+        end
+    end
+    return out;
+end
+
+local function CountSmnAllSubsetsMacros()
+    local n = 0;
+    local jid = petregistry.JOB_SMN;
+    if not gConfig or not gConfig.macroDB then
+        return 0;
+    end
+    local base = gConfig.macroDB[jid];
+    if base then
+        n = n + #base;
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local ak = petregistry.avatars[avatar];
+        if ak then
+            local fk = string.format('%d:avatar:%s', jid, ak);
+            local adb = gConfig.macroDB[fk];
+            if adb then
+                n = n + #adb;
+            end
+        end
+    end
+    return n;
+end
+
+--- Flatten Base SMN + each avatar macro bucket (order: base, then avatars list order).
+local function BuildSmnAllSubsetsRows()
+    local rows = {};
+    local jid = petregistry.JOB_SMN;
+    if not gConfig or not gConfig.macroDB then
+        return rows;
+    end
+    local baseDb = gConfig.macroDB[jid];
+    if baseDb then
+        for _, m in ipairs(baseDb) do
+            table.insert(rows, { macro = m, paletteKey = jid, subsetLabel = 'Base SMN' });
+        end
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local ak = petregistry.avatars[avatar];
+        if ak then
+            local fk = string.format('%d:avatar:%s', jid, ak);
+            local adb = gConfig.macroDB[fk];
+            if adb then
+                for _, m in ipairs(adb) do
+                    table.insert(rows, { macro = m, paletteKey = fk, subsetLabel = avatar });
+                end
+            end
+        end
+    end
+    return rows;
+end
+
+local function EnsureMacroCustomCategoriesList()
+    if not gConfig.macroCustomCategories then
+        gConfig.macroCustomCategories = {};
+    end
+    if not gConfig.macroCustomNextSeq or gConfig.macroCustomNextSeq < 1 then
+        gConfig.macroCustomNextSeq = 1;
+    end
+end
+
+local function AddMacroCustomCategory(displayLabel)
+    EnsureMacroCustomCategoriesList();
+    local label = tostring(displayLabel or ''):match('^%s*(.-)%s*$') or '';
+    if label == '' then
+        return nil;
+    end
+    local key = macroBuckets.CUSTOM_PREFIX .. tostring(gConfig.macroCustomNextSeq);
+    gConfig.macroCustomNextSeq = gConfig.macroCustomNextSeq + 1;
+    table.insert(gConfig.macroCustomCategories, { key = key, label = label });
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    if not gConfig.macroDB[key] then
+        gConfig.macroDB[key] = {};
+    end
+    return key;
+end
+
+local function RemoveMacroCustomCategory(remKey)
+    if not gConfig.macroCustomCategories then
+        return;
+    end
+    for i, e in ipairs(gConfig.macroCustomCategories) do
+        if e.key == remKey then
+            table.remove(gConfig.macroCustomCategories, i);
+            break;
+        end
+    end
+    if gConfig.macroDB and gConfig.macroDB[remKey] then
+        gConfig.macroDB[remKey] = nil;
+    end
+end
+
+--- Numeric job id from a save key (Global â†’ nil; composite SMN avatar keys â†’ job id).
+local function EditorSaveKeyToJobId(saveKey)
+    if saveKey == GLOBAL_MACRO_KEY or saveKey == ITEMS_MACRO_KEY or saveKey == EQUIPMENT_MACRO_KEY or saveKey == XIUI_MACRO_KEY then
+        return nil;
+    end
+    if type(saveKey) == 'string' and macroBuckets.isCustomCategoryKey(saveKey) then
+        return nil;
+    end
+    if type(saveKey) == 'number' then
+        return saveKey;
+    end
+    if type(saveKey) == 'string' then
+        local jid = saveKey:match('^(%d+):');
+        if jid then
+            return tonumber(jid);
+        end
+    end
+    return nil;
+end
+
+-- While creating an SMN macro, set Save Sub Type to match Avatar Filter when filter is a specific avatar (not "All").
+local function SyncSaveSubTypeFromPetAvatarFilter()
+    if not MP.isCreatingNew then
+        return;
+    end
+    local saveJid = EditorSaveKeyToJobId(MP.editorPaletteKey);
+    if saveJid ~= petregistry.JOB_SMN then
+        return;
+    end
+    if MP.petAvatarFilter <= 1 then
+        return;
+    end
+    local avatarList = petregistry.GetAvatarList();
+    local avatar = avatarList[MP.petAvatarFilter - 1];
+    if not avatar then
+        return;
+    end
+    local avatarKey = petregistry.avatars[avatar];
+    if not avatarKey then
+        return;
+    end
+    MP.editorPaletteKey = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
+end
+
+-- Align create-macro Avatar Filter with "Saving To" / "Save Sub Type" for SMN (independent of Macro Palette window avatar).
+local function SyncPetAvatarFilterFromSaveSubType()
+    local key = MP.editorPaletteKey;
+    if not key then
+        return;
+    end
+    local jid = EditorSaveKeyToJobId(key);
+    if jid ~= petregistry.JOB_SMN then
+        return;
+    end
+    if type(key) == 'number' and key == petregistry.JOB_SMN then
+        MP.petAvatarFilter = 1;
+        MP.cachedPetCommands = nil;
+        return;
+    end
+    if type(key) == 'string' then
+        local jobId, petType, petId = key:match('^(%d+):([^:]+):(.+)$');
+        if jobId and tonumber(jobId) == petregistry.JOB_SMN and petType == 'avatar' and petId then
+            local avatarList = petregistry.GetAvatarList();
+            for i, name in ipairs(avatarList) do
+                if petregistry.avatars[name] == petId then
+                    MP.petAvatarFilter = i + 1;
+                    MP.cachedPetCommands = nil;
+                    return;
+                end
+            end
+        end
+    end
+end
+
+local function SyncBstJugFamilyFromSaveSubType()
+    local key = MP.editorPaletteKey;
+    if not MP.editingMacro then
+        return;
+    end
+    if not key or type(key) ~= 'string' then
+        return;
+    end
+    local jobId, petType, petId = key:match('^(%d+):([^:]+):(.+)$');
+    if not jobId or tonumber(jobId) ~= petregistry.JOB_BST then
+        return;
+    end
+    if petType ~= petregistry.PET_TYPE_JUG then
+        return;
+    end
+    local mk = petregistry.MovesKeyFromBstMacroPaletteSlug(petId);
+    if not mk then
+        return;
+    end
+    MP.editingMacro.bstJugReadyMovesKey = mk;
+    MP.editingMacro.bstJugReadyFamilyLabel = nil;
+    for _, row in ipairs(petregistry.GetBstJugReadyFamilyPickerList()) do
+        if row.movesKey == mk then
+            MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+            break;
+        end
+    end
+end
+
+-- While creating a BST Ready (Use) macro, align Save Sub Type with the picked jug family (SMN avatar parity).
+local function SyncSaveSubTypeFromBstJugFamily()
+    if not MP.isCreatingNew then
+        return;
+    end
+    if EditorSaveKeyToJobId(MP.editorPaletteKey) ~= petregistry.JOB_BST then
+        return;
+    end
+    local mk = MP.editingMacro and MP.editingMacro.bstJugReadyMovesKey;
+    if not mk or mk == '' then
+        return;
+    end
+    MP.editorPaletteKey = petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(mk);
+end
+
+local function SyncMacroEditorSubtypeFieldsFromSaveKey()
+    SyncPetAvatarFilterFromSaveSubType();
+    SyncBstJugFamilyFromSaveSubType();
+end
+
 -- Sync palette to current player job (call on job change)
 function M.SyncToCurrentJob()
-    -- Only sync if not viewing Global - preserve Global selection across job changes
-    if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+    -- Only sync when viewing a job bucket â€” preserve shared/custom macro categories across job changes
+    if not IsSharedJobAgnosticMacroSelection(MP.selectedPaletteType) then
+        MP.selectedPaletteType = data.jobId or 1;
     end
     -- Clear spell/ability/item caches so they rebuild for new job
     playerdata.ClearCache();
-    cachedPetCommands = nil;
-    petAvatarFilter = 1;
-    selectedAvatarPalette = nil;
+    MP.cachedPetCommands = nil;
+    MP.petAvatarFilter = 1;
+    ResetPetJobMacroPaletteSubsets();
     -- Close editor window if open (spells/abilities are job-specific)
-    if editingMacro then
-        editingMacro = nil;
-        isCreatingNew = false;
-        searchFilter[1] = '';
-        iconPickerOpen = false;
+    if MP.editingMacro then
+        MP.editingMacro = nil;
+        MP.isCreatingNew = false;
+        MP.searchFilter[1] = '';
+        MP.iconPickerOpen = false;
+        ClearEditorPreviewIconCache();
     end
     -- Clear macro selection (macros are per-type)
-    selectedMacroIndex = nil;
+    paletteUi.selectedMacroIndex = nil;
     -- If palette is open, immediately refresh the caches
-    if paletteOpen then
+    if paletteUi.open then
         RefreshCachedLists();
     end
 end
 
 -- Clear pet commands cache (call on pet change for BST)
 function M.ClearPetCommandsCache()
-    cachedPetCommands = nil;
+    MP.cachedPetCommands = nil;
 end
 
 -- Get the macro database for selected type (Global or job-specific)
-function M.GetMacroDatabase()
-    local typeKey = GetEffectivePaletteType();
+function M.GetMacroDatabase(typeKeyOverride)
+    local typeKey = typeKeyOverride or GetEffectivePaletteType();
 
     if not gConfig.macroDB then
         gConfig.macroDB = {};
@@ -1106,20 +2129,42 @@ function M.GetMacroDatabase()
     return gConfig.macroDB[typeKey], typeKey;
 end
 
--- Add a new macro to the database
-function M.AddMacro(macroData)
-    local db, _ = M.GetMacroDatabase();
+local function markSharedMacroLibraryDirtyIfNeeded()
+    if gConfig and sharedMacroStore.IsSharedScope(gConfig) then
+        sharedMacroStore.MarkSharedLibraryDirty();
+    end
+end
 
-    -- Generate unique ID
+-- Add a new macro to the database
+function M.AddMacro(macroData, typeKeyOverride)
+    local db, typeKey = M.GetMacroDatabase(typeKeyOverride);
+
+    if typeKey == macroBuckets.GLOBAL and macroGlobalDefaults.IsUniversalTwoHourMacro(macroData) then
+        for _, ex in ipairs(db) do
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(ex) then
+                return nil;
+            end
+        end
+    end
+
+    -- Generate unique ID (per palette bucket). In Shared scope, also consider the frozen profile
+    -- library so new ids never collide with profile hotbar macroRef values in the same bucket.
     local maxId = 0;
     for _, macro in ipairs(db) do
         if macro.id and macro.id > maxId then
             maxId = macro.id;
         end
     end
+    if gConfig and sharedMacroStore.IsSharedScope(gConfig) then
+        local fmax = sharedMacroStore.GetMaxMacroIdInFrozenProfileBucket(typeKey);
+        if fmax > maxId then
+            maxId = fmax;
+        end
+    end
 
     macroData.id = maxId + 1;
     table.insert(db, macroData);
+    markSharedMacroLibraryDirtyIfNeeded();
     SaveSettingsToDisk();
     data.MarkMacroLookupDirty();
 
@@ -1127,13 +2172,17 @@ function M.AddMacro(macroData)
 end
 
 -- Update an existing macro
-function M.UpdateMacro(macroId, macroData)
-    local db = M.GetMacroDatabase();
+function M.UpdateMacro(macroId, macroData, typeKeyOverride)
+    local db = M.GetMacroDatabase(typeKeyOverride);
 
     for i, macro in ipairs(db) do
         if macro.id == macroId then
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                return false;
+            end
             macroData.id = macroId;  -- Preserve ID
             db[i] = macroData;
+            markSharedMacroLibraryDirtyIfNeeded();
             SaveSettingsToDisk();
             -- Clear icon cache so hotbar slots referencing this macro update
             ClearAllIconCaches();
@@ -1145,43 +2194,64 @@ function M.UpdateMacro(macroId, macroData)
     return false;
 end
 
--- Clear all hotbar/crossbar slots that reference a specific macro ID
--- For Global macros, clears from ALL jobs' slot actions
-local function ClearSlotsReferencingMacro(macroId, typeKey)
-    local isGlobalMacro = (typeKey == GLOBAL_MACRO_KEY);
+-- Macro IDs are unique only within one macroDB[typeKey] table; the same numeric id can exist
+-- in Global and in each job palette. Clearing by macroRef alone removed unrelated slots.
+local function CountPaletteBucketsWithMacroId(macroId)
+    if not gConfig or not gConfig.macroDB then
+        return 0;
+    end
+    local n = 0;
+    for _, macros in pairs(gConfig.macroDB) do
+        if type(macros) == 'table' then
+            for _, m in ipairs(macros) do
+                if m.id == macroId then
+                    n = n + 1;
+                    break;
+                end
+            end
+        end
+    end
+    return n;
+end
 
-    -- Clear from all hotbars (1-6)
+-- deletedTypeKey / onlyBucketForThisId / deleteKind: see data.ApplyMacroDeleteToSlotAction
+local function ClearMacroSlotsInConfigTable(cfg, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    if not cfg then
+        return false;
+    end
+    local changed = false;
     for barIndex = 1, 6 do
         local configKey = 'hotbarBar' .. barIndex;
-        if gConfig[configKey] and gConfig[configKey].slotActions then
-            local barSettings = gConfig[configKey];
-
-            -- Clear from ALL storage keys (macro could be on any job:subjob combination)
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
             for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
                 if jobSlotActions then
                     for slotIndex, slotAction in pairs(jobSlotActions) do
-                        if slotAction and slotAction.macroRef == macroId then
-                            jobSlotActions[slotIndex] = { cleared = true };
+                        local newSlot, chg = data.ApplyMacroDeleteToSlotAction(
+                            slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, { cleared = true });
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
                         end
                     end
                 end
             end
         end
     end
-
-    -- Clear from crossbar (all combo modes, all storage keys)
-    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
-        local crossbarSettings = gConfig.hotbarCrossbar;
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
         local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
-
         for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
             if jobSlotActions then
                 for _, comboMode in ipairs(comboModes) do
                     local comboSlots = jobSlotActions[comboMode];
                     if comboSlots then
                         for slotIndex, slotAction in pairs(comboSlots) do
-                            if slotAction and slotAction.macroRef == macroId then
-                                comboSlots[slotIndex] = nil;
+                            local newSlot, chg = data.ApplyMacroDeleteToSlotAction(
+                                slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, nil);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
                             end
                         end
                     end
@@ -1189,18 +2259,207 @@ local function ClearSlotsReferencingMacro(macroId, typeKey)
             end
         end
     end
+    return changed;
 end
 
--- Delete a macro from the database
-function M.DeleteMacro(macroId)
-    local db, typeKey = M.GetMacroDatabase();
+-- Clear every slot that references a removed macroDB bucket (entire key deleted).
+local function ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, removedBucketKey, deleteKind)
+    if not cfg or removedBucketKey == nil then
+        return false;
+    end
+    local changed = false;
+    for barIndex = 1, 6 do
+        local configKey = 'hotbarBar' .. barIndex;
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
+            for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
+                if jobSlotActions then
+                    for slotIndex, slotAction in pairs(jobSlotActions) do
+                        local newSlot, chg = data.ApplyMacroPaletteBucketRemovedToSlotAction(
+                            slotAction, removedBucketKey, deleteKind, { cleared = true });
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
+        local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+        for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
+            if jobSlotActions then
+                for _, comboMode in ipairs(comboModes) do
+                    local comboSlots = jobSlotActions[comboMode];
+                    if comboSlots then
+                        for slotIndex, slotAction in pairs(comboSlots) do
+                            local newSlot, chg = data.ApplyMacroPaletteBucketRemovedToSlotAction(
+                                slotAction, removedBucketKey, deleteKind, nil);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return changed;
+end
+
+local function RemoveCustomCategoryFromProfileMeta(cfg, remKey)
+    if not cfg or not cfg.macroCustomCategories or not remKey then
+        return false;
+    end
+    for i, e in ipairs(cfg.macroCustomCategories) do
+        if e.key == remKey then
+            table.remove(cfg.macroCustomCategories, i);
+            return true;
+        end
+    end
+    return false;
+end
+
+-- Shared library: the bucket is global; other profiles' layouts may still list it or have slots. Sync metadata and slots.
+local function SweepOtherProfilesForSharedCustomCategoryDelete(remKey, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg then
+                local chg = ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, remKey, 'profile');
+                if ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, remKey, 'shared') then
+                    chg = true;
+                end
+                if RemoveCustomCategoryFromProfileMeta(cfg, remKey) then
+                    chg = true;
+                end
+                if chg then
+                    profileManager.SaveProfileSettings(name, cfg);
+                end
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Display label only; storage key stays 'custom:N' (macro data and hotbar macroPaletteKey refs unchanged).
+local function ApplyRenameMacroCustomCategory(catKey, newLabel)
+    if not catKey or not macroBuckets.isCustomCategoryKey(catKey) then
+        return false;
+    end
+    local label = tostring(newLabel or ''):match('^%s*(.-)%s*$') or '';
+    if label == '' then
+        return false;
+    end
+    EnsureMacroCustomCategoriesList();
+    for _, e in ipairs(gConfig.macroCustomCategories) do
+        if e.key == catKey then
+            e.label = label;
+            return true;
+        end
+    end
+    return false;
+end
+
+-- Remove a custom bucket: clear all hotbar/crossbar slot refs, delete macro rows, and sync other profiles in shared mode.
+local function DeleteMacroCustomCategoryCompletely(remKey)
+    if not remKey or not macroBuckets.isCustomCategoryKey(remKey) then
+        return false;
+    end
+    local inShared = (gConfig.macroStorageScope or 'profile') == 'shared';
+    -- Custom buckets use one palette key, but a slot may have profile+shared library arms; clear both.
+    ClearMacroSlotsInConfigForRemovedPaletteBucket(gConfig, remKey, 'profile');
+    ClearMacroSlotsInConfigForRemovedPaletteBucket(gConfig, remKey, 'shared');
+    RemoveMacroCustomCategory(remKey);
+    if inShared and config and config.currentProfile then
+        SweepOtherProfilesForSharedCustomCategoryDelete(remKey, config.currentProfile);
+    end
+    markSharedMacroLibraryDirtyIfNeeded();
+    if MP.selectedPaletteType == remKey then
+        MP.selectedPaletteType = GLOBAL_MACRO_KEY;
+    end
+    ResetPetJobMacroPaletteSubsets();
+    paletteUi.selectedMacroIndex = nil;
+    MP.currentPalettePage = 1;
+    MP.macroCustomRenameTargetKey = nil;
+    playerdata.ClearCache();
+    MP.cachedPetCommands = nil;
+    MP.petAvatarFilter = 1;
+    SaveSettingsToDisk();
+    ClearAllIconCaches();
+    data.InvalidateConfigDerivedCaches();
+    data.MarkMacroLookupDirty();
+    return true;
+end
+
+-- After deleting a global shared macro: clear that ref on all other profile files (current gConfig was already cleared + saved)
+local function SweepOtherProfilesForSharedMacroDelete(macroId, typeKey, onlyBucket, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg and ClearMacroSlotsInConfigTable(cfg, macroId, typeKey, onlyBucket, 'shared') then
+                profileManager.SaveProfileSettings(name, cfg);
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Shared macro library: update bindings on other profiles after MoveMacro (same as delete sweep, but rewrite refs).
+local function SweepOtherProfilesForSharedMacroMove(oldId, oldKey, newId, newKey, onlyBucket, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg and data.RewriteMacroPaletteBindingsInConfig(cfg, oldId, oldKey, newId, newKey, onlyBucket, false) then
+                profileManager.SaveProfileSettings(name, cfg);
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Clear hotbar/crossbar live config (gConfig). Edit Full Palette draft buffers are not scanned here;
+-- dead macroRef in an open draft fixes on Apply (resolve) or when the user edits the slot.
+local function ClearSlotsReferencingMacro(macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    ClearMacroSlotsInConfigTable(gConfig, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind);
+end
+
+-- Delete a macro from the database (optional typeKeyOverride targets a specific macroDB bucket).
+function M.DeleteMacro(macroId, typeKeyOverride)
+    local db, typeKey = M.GetMacroDatabase(typeKeyOverride);
+    local deleteKind = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') and 'shared' or 'profile';
 
     for i, macro in ipairs(db) do
         if macro.id == macroId then
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                return false;
+            end
+            local onlyBucketForThisId = (CountPaletteBucketsWithMacroId(macroId) == 1);
             table.remove(db, i);
-            -- Clear any hotbar/crossbar slots referencing this macro
-            ClearSlotsReferencingMacro(macroId, typeKey);
+            ClearSlotsReferencingMacro(macroId, typeKey, onlyBucketForThisId, deleteKind);
+            markSharedMacroLibraryDirtyIfNeeded();
             SaveSettingsToDisk();
+            if deleteKind == 'shared' and config and config.currentProfile then
+                SweepOtherProfilesForSharedMacroDelete(macroId, typeKey, onlyBucketForThisId, config.currentProfile);
+            end
             -- Clear icon cache so hotbar slots update immediately
             ClearAllIconCaches();
             data.MarkMacroLookupDirty();
@@ -1209,6 +2468,56 @@ function M.DeleteMacro(macroId)
     end
 
     return false;
+end
+
+--- Copy a macro row into destPaletteKey with a new id, rewrite bindings that pointed at (macroId, sourcePaletteKey), then remove the source row.
+--- Profile + shared arms are both updated on current layout; other profiles are swept when macro storage is shared.
+function M.MoveMacroToPalette(macroId, sourcePaletteKey, destPaletteKey)
+    if not gConfig or not gConfig.macroDB or not macroId or sourcePaletteKey == nil or destPaletteKey == nil then
+        return false;
+    end
+    if data.MacroPaletteKeysEqual(sourcePaletteKey, destPaletteKey) then
+        return false;
+    end
+    local dbSrc = gConfig.macroDB[sourcePaletteKey];
+    if type(dbSrc) ~= 'table' then
+        return false;
+    end
+    local macroRow = nil;
+    local macroIdx = nil;
+    for i, m in ipairs(dbSrc) do
+        if m.id == macroId then
+            macroRow = m;
+            macroIdx = i;
+            break;
+        end
+    end
+    if not macroRow then
+        return false;
+    end
+    if macroGlobalDefaults.IsUniversalTwoHourMacro(macroRow) then
+        return false;
+    end
+    local copy = deepCopyTable(macroRow);
+    copy.id = nil;
+    local newId = M.AddMacro(copy, destPaletteKey);
+    if not newId then
+        return false;
+    end
+    local onlyBucketForThisId = (CountPaletteBucketsWithMacroId(macroId) == 1);
+    data.RewriteMacroPaletteBindingsInConfig(gConfig, macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId, true);
+    data.RewriteMacroPaletteBindingsInDraft(macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId);
+    local deleteKind = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') and 'shared' or 'profile';
+    if deleteKind == 'shared' and config and config.currentProfile then
+        SweepOtherProfilesForSharedMacroMove(macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId, config.currentProfile);
+    end
+    table.remove(dbSrc, macroIdx);
+    markSharedMacroLibraryDirtyIfNeeded();
+    SaveSettingsToDisk();
+    ClearAllIconCaches();
+    data.InvalidateConfigDerivedCaches();
+    data.MarkMacroLookupDirty();
+    return true;
 end
 
 -- Get a macro by ID
@@ -1224,19 +2533,103 @@ function M.GetMacroById(macroId)
     return nil;
 end
 
+-- opts.bindTargetSlot = { comboMode = string, slotIndex = number } — when present AND the
+-- editor enters "creating new" mode (slotData nil), the first successful Save will write the
+-- new macro's binding into that crossbar draft slot. Consumed exactly once on first Save;
+-- cleared on Cancel/close to prevent stale binds carrying over to unrelated sessions.
+function M.OpenEditorForSlotData(slotData, opts)
+    ClearEditorPreviewIconCache();
+    MP.editorDidInitialIconPick = false;
+    MP.editorImplicitActionIconDone = false;
+    MP.editorIconManuallySet = false;
+    MP.editorJaBadgeManuallySet = false;
+    MP.showAllMode = false;
+    MP.showAllPetMode = false;
+    MP.spellTypeFilter = 'All';
+    MP.abilityJobFilter = 0;
+    MP.petTypeOverride = 0;
+    MP.editorIconPrefsHydrated = false;
+    MP.pendingNewMacroBindTarget = nil;
+
+    if slotData and slotData.macroRef then
+        local paletteKey = slotData.macroPaletteKey or data.jobId or 1;
+        local macro = data.GetMacroById(slotData.macroRef, paletteKey);
+        if macro then
+            MP.editingMacro = deep_copy_table(macro);
+            MP.isCreatingNew = false;
+            MP.editorPaletteKey = paletteKey;
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            RefreshCachedLists();
+            return;
+        end
+    end
+
+    if slotData then
+        MP.editingMacro = deep_copy_table(slotData);
+        MP.isCreatingNew = false;
+        MP.editorPaletteKey = slotData.macroPaletteKey or GetEffectivePaletteType();
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+    else
+        MP.isCreatingNew = true;
+        MP.editorPaletteKey = GetEffectivePaletteType();
+        local body, autoKey = DefaultNewMacroBodyForPaletteKey(MP.editorPaletteKey);
+        MP.editingMacro = body;
+        MP.editorAutoIconKey = autoKey;
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+        if opts and opts.bindTargetSlot and opts.bindTargetSlot.comboMode and opts.bindTargetSlot.slotIndex then
+            MP.pendingNewMacroBindTarget = {
+                comboMode = opts.bindTargetSlot.comboMode,
+                slotIndex = opts.bindTargetSlot.slotIndex,
+            };
+        end
+    end
+    RefreshCachedLists();
+end
+
+-- Open the macro editor as a new macro pre-filled with a raw macro text command.
+-- The palette window is opened automatically; the user can choose where to save.
+function M.OpenNewMacroWithText(macroText, displayName)
+    M.OpenPalette();
+    ClearEditorPreviewIconCache();
+    MP.isCreatingNew              = true;
+    MP.editorDidInitialIconPick   = false;
+    MP.editorImplicitActionIconDone = false;
+    MP.editorIconManuallySet      = false;
+    MP.editorJaBadgeManuallySet   = false;
+    MP.editingMacro = {
+        actionType  = 'macro',
+        macroText   = macroText,
+        displayName = displayName or '',
+        action      = '',
+    };
+    if MP.editorFields and MP.FindIndex then
+        MP.editorFields.actionType[1]       = MP.FindIndex(MP.ACTION_TYPES or {}, 'macro');
+        MP.editorFields.action[1]           = '';
+        MP.editorFields.target[1]           = MP.FindIndex(MP.TARGET_OPTIONS or {}, 't');
+        MP.editorFields.displayName[1]      = displayName or '';
+        MP.editorFields.macroText[1]        = macroText;
+        MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES or {}, 'none');
+        MP.editorFields.recastSourceAction[1] = '';
+    end
+end
+
 -- ============================================
 -- Drag & Drop Functions (using dragdrop library)
 -- ============================================
 
 -- Start dragging a macro from the palette
-function M.StartDragMacro(macroIndex, macroData)
+function M.StartDragMacro(macroIndex, macroData, macroPaletteKeyOverride)
     -- Get icon for this macro
     local icon = actions.GetBindIcon(macroData);
 
     -- Include palette key in data so crossbar drops know which palette the macro came from
     local dragData = {};
     for k, v in pairs(macroData) do dragData[k] = v; end
-    dragData.macroPaletteKey = GetEffectivePaletteType();
+    dragData.macroPaletteKey = macroPaletteKeyOverride or GetEffectivePaletteType();
+    dragData.macroSourceStore = M.GetMacroSourceTagForDrops();
 
     dragdrop.StartDrag('macro', {
         data = dragData,
@@ -1248,22 +2641,32 @@ end
 
 -- Start dragging from a hotbar slot
 function M.StartDragSlot(barIndex, slotIndex, slotData)
-    -- Empty/orphaned slot - nothing to drag
+    -- 1.8.0 defensive guard: empty/orphaned slots have nothing to drag; dragdrop.StartDrag
+    -- with a nil payload bypassed the displayName fallback below and started a "ghost" drag
+    -- in 1.7.5 that confused the drop-zone logic. Bail early instead.
     if not slotData then return; end
-
     -- Get icon for this slot
     local icon = actions.GetBindIcon(slotData);
-
+    -- Raw slot preserves dual profile/shared macro arms (resolved slotData is flattened)
+    local raw = data.GetRawHotbarSlotAction(barIndex, slotIndex);
     dragdrop.StartDrag('slot', {
-        data = slotData,
+        data = raw,
         barIndex = barIndex,
         slotIndex = slotIndex,
-        label = slotData.displayName or slotData.action or 'Slot',
+        label = slotData and (slotData.displayName or slotData.action) or 'Slot',
         icon = icon,
     });
 end
 
 -- Clear drag state
+-- 'shared' | 'profile' â€” which library new hotbar/crossbar binds refer to (for delete + cross-scope resolution)
+function M.GetMacroSourceTagForDrops()
+    if gConfig and (gConfig.macroStorageScope or 'profile') == 'shared' then
+        return 'shared';
+    end
+    return 'profile';
+end
+
 function M.ClearDrag()
     dragdrop.CancelDrag();
 end
@@ -1313,53 +2716,58 @@ function M.HandleDropOnSlot(payload, targetBarIndex, targetSlotIndex)
     local jobSlotActions = ensureSlotActionsStructure(gConfig[configKey], storageKey);
 
     if payload.type == 'macro' then
-        -- Dragging from palette to slot - store only the macro reference.
-        -- macroDB is the single source of truth for action/macroText/displayName/etc.
+        -- Dragging from palette to slot
         local macroData = payload.data;
         if macroData then
-            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite({
-                macroRef = macroData.id,
-                macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType(),
-            });
+            local macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType();
+            local arm = {};
+            for k, v in pairs(macroData) do arm[k] = v; end
+            arm.macroPaletteKey = macroPaletteKey;
+            arm.macroRef = macroData.id;
+            local existing = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+            local store = arm.macroSourceStore or M.GetMacroSourceTagForDrops();
+            local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+            jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(built);
             MarkHotbarDirty();
         end
 
     elseif payload.type == 'slot' then
-        -- Dragging from slot to slot (swap or move)
+        -- Dragging from slot to slot (swap)
         local sourceBarIndex = payload.barIndex;
         local sourceSlotIndex = payload.slotIndex;
-        local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
-
-        local sourceData = data.BuildSlotDataForWrite(payload.data);
-
-        -- Get target slot data
-        local targetBind = data.GetKeybindForSlot(targetBarIndex, targetSlotIndex);
-        local targetData;
-        if targetBind then
-            targetData = data.BuildSlotDataForWrite(targetBind);
-        else
-            -- Target slot is empty - mark as cleared
-            targetData = { cleared = true };
+        if sourceBarIndex == targetBarIndex and sourceSlotIndex == targetSlotIndex then
+            return false;
         end
-
-        -- Ensure source config structure exists
+        local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
         if not gConfig[sourceConfigKey] then
             gConfig[sourceConfigKey] = {};
         end
-        -- Use pet-aware storage key for source bar
         local sourceStorageKey = data.GetStorageKeyForBar(sourceBarIndex);
         local sourceJobSlotActions = ensureSlotActionsStructure(gConfig[sourceConfigKey], sourceStorageKey);
-
-        -- Swap the slots
-        jobSlotActions[targetSlotIndex] = sourceData;
-        sourceJobSlotActions[sourceSlotIndex] = targetData;
-
+        local sourceRaw = data.GetRawHotbarSlotAction(sourceBarIndex, sourceSlotIndex);
+        local targetRaw = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+        local newTarget, newSource = data.SwapActiveMacroArmsInPlace(sourceRaw, targetRaw);
+        jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(newTarget);
+        sourceJobSlotActions[sourceSlotIndex] = data.FinalizeHotbarRawSlotForStorage(newSource);
         MarkHotbarDirty();
 
     elseif payload.type == 'crossbar_slot' then
         -- Dragging from crossbar to hotbar (one-way copy, doesn't clear source)
-        if payload.data then
-            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite(payload.data);
+        local crossRaw = payload.data;
+        if crossRaw and not crossRaw.cleared then
+            local existing = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+            local isMacro = data.IsMacroSlotDualLayout(crossRaw)
+                or (crossRaw.macroRef and (not crossRaw.actionType or crossRaw.actionType == 'macro'));
+            if isMacro then
+                local arm = select(1, data._GetActiveMacroBindingFromSlot(crossRaw));
+                if arm and arm.macroRef then
+                    local store = arm.macroSourceStore or M.GetMacroSourceTagForDrops();
+                    local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                    jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(built);
+                end
+            else
+                jobSlotActions[targetSlotIndex] = deepCopyTable(crossRaw);
+            end
             MarkHotbarDirty();
         end
     end
@@ -1386,14 +2794,15 @@ end
 -- ============================================
 
 function M.OpenPalette()
-    paletteOpen = true;
-    selectedMacroIndex = nil;
-    editingMacro = nil;
-    isCreatingNew = false;
+    paletteUi.open = true;
+    paletteUi.selectedMacroIndex = nil;
+    MP.editingMacro = nil;
+    MP.isCreatingNew = false;
+    ClearEditorPreviewIconCache();
 
-    -- Sync to current player job when opening (unless Global was selected)
-    if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+    -- Sync to current player job when opening (unless a shared or custom category was selected)
+    if not IsSharedJobAgnosticMacroSelection(MP.selectedPaletteType) then
+        MP.selectedPaletteType = data.jobId or 1;
     end
 
     -- Refresh spell/ability/weaponskill caches
@@ -1406,19 +2815,30 @@ function M.ClosePalette()
         SaveSettingsToDisk();
         hotbarDataDirty = false;
     end
-    paletteOpen = false;
-    selectedMacroIndex = nil;
-    editingMacro = nil;
-    isCreatingNew = false;
-    currentPalettePage = 1;  -- Reset to page 1
+    paletteUi.open = false;
+    paletteUi.selectedMacroIndex = nil;
+    MP.editingMacro = nil;
+    MP.isCreatingNew = false;
+    MP.currentPalettePage = 1;  -- Reset to page 1
+    if MP.macroPaletteSearchName then
+        MP.macroPaletteSearchName[1] = '';
+    end
+    MP._lastMacroPaletteSearch = nil;
+    MP.editorDidInitialIconPick = false;
+    MP.editorIconManuallySet = false;
+    MP.editorJaBadgeManuallySet = false;
+    ClearEditorPreviewIconCache();
+    paletteMainIconCache = {};
+    ClearPaletteJaBadgeIconCache();
+    paletteIconCacheDbKey = nil;
 end
 
 function M.IsPaletteOpen()
-    return paletteOpen;
+    return paletteUi.open;
 end
 
 function M.TogglePalette()
-    if paletteOpen then
+    if paletteUi.open then
         M.ClosePalette();
     else
         M.OpenPalette();
@@ -1427,7 +2847,7 @@ end
 
 -- Draw a single macro tile (used in palette)
 local function DrawMacroTile(macro, index, x, y, size)
-    local isSelected = selectedMacroIndex == index;
+    local isSelected = paletteUi.selectedMacroIndex == index;
     local isHovered = false;
 
     -- Set cursor position
@@ -1446,13 +2866,13 @@ local function DrawMacroTile(macro, index, x, y, size)
         imgui.PushStyleColor(ImGuiCol_ButtonActive, COLORS.bgLight);
     end
 
-    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4);
+    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, PALETTE_TILE_ROUNDING);
     imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
     imgui.PushStyleColor(ImGuiCol_Border, isSelected and COLORS.gold or COLORS.border);
 
     local buttonId = string.format('##macrotile%d', index);
     if imgui.Button(buttonId, {size, size}) then
-        selectedMacroIndex = index;
+        paletteUi.selectedMacroIndex = index;
     end
 
     imgui.PopStyleColor(4);
@@ -1508,17 +2928,21 @@ local function DrawMacroTile(macro, index, x, y, size)
         imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {8, 6});
         imgui.BeginTooltip();
-        imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
-        imgui.Spacing();
-        imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
-        if macro.actionType ~= 'macro' and macro.target then
-            local formattedTarget = FormatTargetForDisplay(macro.target);
-            if formattedTarget then
-                imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+        if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+            imgui.TextColored(COLORS.gold, '2-Hour Ability');
+        else
+            imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
+            if macro.actionType ~= 'macro' and macro.target then
+                local formattedTarget = FormatTargetForDisplay(macro.target);
+                if formattedTarget then
+                    imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                end
             end
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
         end
-        imgui.Spacing();
-        imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
         imgui.EndTooltip();
         imgui.PopStyleVar();
         imgui.PopStyleColor(2);
@@ -1572,43 +2996,353 @@ for i, job in ipairs(JOB_LIST) do
     JOB_ID_MAP[job.id] = i;
 end
 
--- Draw the palette window
-function M.DrawPalette()
-    if not paletteOpen then
+local function PickDefaultMacroMoveDestination(sourceKey)
+    local order = { GLOBAL_MACRO_KEY, ITEMS_MACRO_KEY, EQUIPMENT_MACRO_KEY, XIUI_MACRO_KEY };
+    for _, k in ipairs(order) do
+        if not data.MacroPaletteKeysEqual(k, sourceKey) then
+            return k;
+        end
+    end
+    EnsureMacroCustomCategoriesList();
+    for _, cat in ipairs(gConfig and gConfig.macroCustomCategories or {}) do
+        local k = cat.key;
+        if not data.MacroPaletteKeysEqual(k, sourceKey) then
+            return k;
+        end
+    end
+    for _, job in ipairs(JOB_LIST) do
+        if not data.MacroPaletteKeysEqual(job.id, sourceKey) then
+            return job.id;
+        end
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local avatarKey = petregistry.avatars[avatar];
+        if avatarKey then
+            local fk = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
+            if not data.MacroPaletteKeysEqual(fk, sourceKey) then
+                return fk;
+            end
+        end
+    end
+    for _, pk in ipairs(petregistry.GetAvailablePetKeys(petregistry.JOB_BST)) do
+        local slug = pk:match('^jug:(.+)$');
+        if slug then
+            local fk = string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug);
+            if not data.MacroPaletteKeysEqual(fk, sourceKey) then
+                return fk;
+            end
+        end
+    end
+    return GLOBAL_MACRO_KEY;
+end
+
+-- Bottom-right /ja badge on macro tiles (same corner style as small status icons on slots).
+-- Declared before M.DrawPalette so palette grid can call it (Lua local scope).
+local function DrawMacroJaBadgeOverlay(drawList, macro, x, y, boxSize)
+    if not drawList or not macro or macro.actionType ~= 'macro' or not macro.macroText then
         return;
     end
+    if macro.showJaBadgeOnMacro == false then
+        return;
+    end
+    local jaName = actions.GetMacroJaBadgeAbilityName(macro.macroText);
+    if not jaName or jaName == '' then
+        return;
+    end
+    local jbKey = BuildMacroJaBadgeCacheKey(macro);
+    local jaIcon = paletteJaBadgeIconCache[jbKey];
+    if jaIcon == nil then
+        jaIcon = actions.ResolveMacroJaBadgeIcon(macro) or PALETTE_JA_NONE;
+        paletteJaBadgeIconCache[jbKey] = jaIcon;
+    end
+    if jaIcon == PALETTE_JA_NONE or not jaIcon.image then
+        return;
+    end
+    local iconPtr = tonumber(ffi.cast('uint32_t', jaIcon.image));
+    if not iconPtr or iconPtr == 0 then
+        return;
+    end
+    local iconSize = math.max(10, math.floor(boxSize * 0.35));
+    local padding = 2;
+    local iconX = x + boxSize - iconSize - padding;
+    local iconY = y + boxSize - iconSize - padding;
+    drawList:AddImage(iconPtr, {iconX, iconY}, {iconX + iconSize, iconY + iconSize});
+end
+
+-- Draw icon preview box with current icon (macro editor); must be above DrawIconButton users.
+local function DrawIconPreview(macro, x, y, size)
+    local drawList = imgui.GetWindowDrawList();
+    if not drawList then return; end
+
+    local bgColor = imgui.GetColorU32({0.1, 0.09, 0.08, 0.95});
+    local borderColor = imgui.GetColorU32(COLORS.border);
+    drawList:AddRectFilled({x, y}, {x + size, y + size}, bgColor, 4);
+    drawList:AddRect({x, y}, {x + size, y + size}, borderColor, 4, 0, 1);
+
+    local pvKey = BuildMacroMainIconCacheKey(macro);
+    if pvKey ~= editorPreviewIconKey then
+        editorPreviewIconKey = pvKey;
+        editorPreviewCachedIcon = actions.GetBindIcon(macro);
+    end
+    local icon = editorPreviewCachedIcon;
+    if icon and icon.image then
+        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+        if iconPtr then
+            local padding = 4;
+            drawList:AddImage(
+                iconPtr,
+                {x + padding, y + padding},
+                {x + size - padding, y + size - padding}
+            );
+        end
+    else
+        local abbr = GetActionAbbreviation(macro, true);
+        local textSize = imgui.CalcTextSize(abbr);
+        local textX = x + (size - textSize) / 2;
+        local textY = y + (size - 14) / 2;
+        local textColor = imgui.GetColorU32(COLORS.gold);
+        drawList:AddText({textX, textY}, textColor, abbr);
+    end
+
+    DrawMacroJaBadgeOverlay(drawList, macro, x, y, size);
+end
+
+-- Draw the palette window (Lua 5.1: max 60 upvalues per function; heavy body uses MacroPaletteDrawEnv.)
+local MacroPaletteDrawEnv = {};
+
+local function InitMacroPaletteDrawEnv()
+    local E = MacroPaletteDrawEnv;
+    E.imgui = imgui;
+    E.ffi = ffi;
+    E.data = data;
+    E.actions = actions;
+    E.textures = textures;
+    E.dragdrop = dragdrop;
+    E.petregistry = petregistry;
+    E.playerdata = playerdata;
+    E.petpalette = petpalette;
+    E.sharedMacroStore = sharedMacroStore;
+    E.macroBuckets = macroBuckets;
+    E.COLORS = COLORS;
+    E.MP = MP;
+    E.M = M;
+    E.paletteUi = paletteUi;
+    E.JOB_LIST = JOB_LIST;
+    E.INPUT_BUFFER_SIZE = INPUT_BUFFER_SIZE;
+    E.GLOBAL_MACRO_KEY = GLOBAL_MACRO_KEY;
+    E.ITEMS_MACRO_KEY = ITEMS_MACRO_KEY;
+    E.EQUIPMENT_MACRO_KEY = EQUIPMENT_MACRO_KEY;
+    E.XIUI_MACRO_KEY = XIUI_MACRO_KEY;
+    E.PALETTE_COLUMNS = PALETTE_COLUMNS;
+    E.PALETTE_ROWS = PALETTE_ROWS;
+    E.PALETTE_MACROS_PER_PAGE = PALETTE_MACROS_PER_PAGE;
+    E.PALETTE_TILE_SIZE = PALETTE_TILE_SIZE;
+    E.PALETTE_TILE_GAP = PALETTE_TILE_GAP;
+    E.PALETTE_TILE_ROUNDING = PALETTE_TILE_ROUNDING;
+    E.SMN_ALL_SUBSETS_VIEW_TAG = SMN_ALL_SUBSETS_VIEW_TAG;
+    E.BST_ALL_SUBSETS_VIEW_TAG = BST_ALL_SUBSETS_VIEW_TAG;
+    E.ACTION_TYPE_LABELS = ACTION_TYPE_LABELS;
+    E.RefreshCachedLists = RefreshCachedLists;
+    E.BuildSmnAllSubsetsRows = BuildSmnAllSubsetsRows;
+    E.BuildBstAllJugSubsetsRows = BuildBstAllJugSubsetsRows;
+    E.IsSmnAllSubsetsPaletteView = IsSmnAllSubsetsPaletteView;
+    E.IsBstAllSubsetsPaletteView = IsBstAllSubsetsPaletteView;
+    E.GetPaletteDisplayName = GetPaletteDisplayName;
+    E.PushWindowStyle = PushWindowStyle;
+    E.PopWindowStyle = PopWindowStyle;
+    E.PushComboStyle = PushComboStyle;
+    E.PopComboStyle = PopComboStyle;
+    E.ClearAllIconCaches = ClearAllIconCaches;
+    E.ResetPetJobMacroPaletteSubsets = ResetPetJobMacroPaletteSubsets;
+    E.EnsureMacroCustomCategoriesList = EnsureMacroCustomCategoriesList;
+    E.AddMacroCustomCategory = AddMacroCustomCategory;
+    E.markSharedMacroLibraryDirtyIfNeeded = markSharedMacroLibraryDirtyIfNeeded;
+    E.ApplyRenameMacroCustomCategory = ApplyRenameMacroCustomCategory;
+    E.DeleteMacroCustomCategoryCompletely = DeleteMacroCustomCategoryCompletely;
+    E.CountMacrosInPalette = CountMacrosInPalette;
+    E.CountSmnAllSubsetsMacros = CountSmnAllSubsetsMacros;
+    E.CountBstAllJugSubsetsMacros = CountBstAllJugSubsetsMacros;
+    E.GetEffectivePaletteType = GetEffectivePaletteType;
+    E.ClearBstJugMacroSubsetUi = ClearBstJugMacroSubsetUi;
+    E.ClearSmnMacroSubsetUi = ClearSmnMacroSubsetUi;
+    E.BstJugSubsetEntriesOrdered = BstJugSubsetEntriesOrdered;
+    E.SyncMacroEditorSubtypeFieldsFromSaveKey = SyncMacroEditorSubtypeFieldsFromSaveKey;
+    E.GetCachedPaletteMainIcon = GetCachedPaletteMainIcon;
+    E.DrawMacroJaBadgeOverlay = DrawMacroJaBadgeOverlay;
+    E.FormatTargetForDisplay = FormatTargetForDisplay;
+    E.ClearEditorPreviewIconCache = ClearEditorPreviewIconCache;
+end
+
+InitMacroPaletteDrawEnv();
+
+local function DrawPaletteBody()
+    local E = MacroPaletteDrawEnv;
+    local imgui = E.imgui;
+    local ffi = E.ffi;
+    local data = E.data;
+    local actions = E.actions;
+    local textures = E.textures;
+    local dragdrop = E.dragdrop;
+    local petregistry = E.petregistry;
+    local playerdata = E.playerdata;
+    local petpalette = E.petpalette;
+    local sharedMacroStore = E.sharedMacroStore;
+    local macroBuckets = E.macroBuckets;
+    local COLORS = E.COLORS;
+    local MP = E.MP;
+    local M = E.M;
+    local paletteUi = E.paletteUi;
+    local JOB_LIST = E.JOB_LIST;
+    local INPUT_BUFFER_SIZE = E.INPUT_BUFFER_SIZE;
+    local GLOBAL_MACRO_KEY = E.GLOBAL_MACRO_KEY;
+    local ITEMS_MACRO_KEY = E.ITEMS_MACRO_KEY;
+    local EQUIPMENT_MACRO_KEY = E.EQUIPMENT_MACRO_KEY;
+    local XIUI_MACRO_KEY = E.XIUI_MACRO_KEY;
+    local PALETTE_COLUMNS = E.PALETTE_COLUMNS;
+    local PALETTE_ROWS = E.PALETTE_ROWS;
+    local PALETTE_MACROS_PER_PAGE = E.PALETTE_MACROS_PER_PAGE;
+    local PALETTE_TILE_SIZE = E.PALETTE_TILE_SIZE;
+    local PALETTE_TILE_GAP = E.PALETTE_TILE_GAP;
+    local PALETTE_TILE_ROUNDING = E.PALETTE_TILE_ROUNDING;
+    local SMN_ALL_SUBSETS_VIEW_TAG = E.SMN_ALL_SUBSETS_VIEW_TAG;
+    local BST_ALL_SUBSETS_VIEW_TAG = E.BST_ALL_SUBSETS_VIEW_TAG;
+    local ACTION_TYPE_LABELS = E.ACTION_TYPE_LABELS;
+    local RefreshCachedLists = E.RefreshCachedLists;
+    local BuildSmnAllSubsetsRows = E.BuildSmnAllSubsetsRows;
+    local BuildBstAllJugSubsetsRows = E.BuildBstAllJugSubsetsRows;
+    local IsSmnAllSubsetsPaletteView = E.IsSmnAllSubsetsPaletteView;
+    local IsBstAllSubsetsPaletteView = E.IsBstAllSubsetsPaletteView;
+    local GetPaletteDisplayName = E.GetPaletteDisplayName;
+    local PushWindowStyle = E.PushWindowStyle;
+    local PopWindowStyle = E.PopWindowStyle;
+    local PushComboStyle = E.PushComboStyle;
+    local PopComboStyle = E.PopComboStyle;
+    local ClearAllIconCaches = E.ClearAllIconCaches;
+    local ResetPetJobMacroPaletteSubsets = E.ResetPetJobMacroPaletteSubsets;
+    local EnsureMacroCustomCategoriesList = E.EnsureMacroCustomCategoriesList;
+    local AddMacroCustomCategory = E.AddMacroCustomCategory;
+    local markSharedMacroLibraryDirtyIfNeeded = E.markSharedMacroLibraryDirtyIfNeeded;
+    local ApplyRenameMacroCustomCategory = E.ApplyRenameMacroCustomCategory;
+    local DeleteMacroCustomCategoryCompletely = E.DeleteMacroCustomCategoryCompletely;
+    local CountMacrosInPalette = E.CountMacrosInPalette;
+    local CountSmnAllSubsetsMacros = E.CountSmnAllSubsetsMacros;
+    local CountBstAllJugSubsetsMacros = E.CountBstAllJugSubsetsMacros;
+    local GetEffectivePaletteType = E.GetEffectivePaletteType;
+    local ClearBstJugMacroSubsetUi = E.ClearBstJugMacroSubsetUi;
+    local ClearSmnMacroSubsetUi = E.ClearSmnMacroSubsetUi;
+    local BstJugSubsetEntriesOrdered = E.BstJugSubsetEntriesOrdered;
+    local SyncMacroEditorSubtypeFieldsFromSaveKey = E.SyncMacroEditorSubtypeFieldsFromSaveKey;
+    local GetCachedPaletteMainIcon = E.GetCachedPaletteMainIcon;
+    local DrawMacroJaBadgeOverlay = E.DrawMacroJaBadgeOverlay;
+    local FormatTargetForDisplay = E.FormatTargetForDisplay;
+    local ClearEditorPreviewIconCache = E.ClearEditorPreviewIconCache;
 
     -- Continuously check for job changes while palette is open
     -- This catches cases where job changed but cache wasn't refreshed properly
     RefreshCachedLists();
 
-    -- Initialize selectedPaletteType to current job if not set
-    if not selectedPaletteType then
-        selectedPaletteType = data.jobId or 1;
+    -- Initialize MP.selectedPaletteType to current job if not set
+    if not MP.selectedPaletteType then
+        MP.selectedPaletteType = data.jobId or 1;
     end
 
-    local db, typeKey = M.GetMacroDatabase();
+    local smnMergeMeta = nil;
+    local bstMergeMeta = nil;
+    local db;
+    local typeKey;
+    if IsSmnAllSubsetsPaletteView() then
+        smnMergeMeta = BuildSmnAllSubsetsRows();
+        db = {};
+        for i, row in ipairs(smnMergeMeta) do
+            db[i] = row.macro;
+        end
+        typeKey = petregistry.JOB_SMN;
+    elseif IsBstAllSubsetsPaletteView() then
+        bstMergeMeta = BuildBstAllJugSubsetsRows();
+        db = {};
+        for i, row in ipairs(bstMergeMeta) do
+            db[i] = row.macro;
+        end
+        typeKey = petregistry.JOB_BST;
+    else
+        db, typeKey = M.GetMacroDatabase();
+    end
+
+    local paletteViewCacheKey = smnMergeMeta and (tostring(petregistry.JOB_SMN) .. ':' .. SMN_ALL_SUBSETS_VIEW_TAG)
+        or (bstMergeMeta and (tostring(petregistry.JOB_BST) .. ':' .. BST_ALL_SUBSETS_VIEW_TAG))
+        or typeKey;
+    if MP._macroSearchPaletteKey ~= paletteViewCacheKey then
+        MP._macroSearchPaletteKey = paletteViewCacheKey;
+        MP.macroPaletteSearchName[1] = '';
+        MP._lastMacroPaletteSearch = nil;
+    end
+    if paletteIconCacheDbKey ~= paletteViewCacheKey then
+        paletteMainIconCache = {};
+        paletteJaBadgeIconCache = {};
+        paletteIconCacheDbKey = paletteViewCacheKey;
+    end
     local isGlobal = (typeKey == GLOBAL_MACRO_KEY);
+    local isItems = (typeKey == ITEMS_MACRO_KEY);
+    local isEquipment = (typeKey == EQUIPMENT_MACRO_KEY);
+    local isXiui = (typeKey == XIUI_MACRO_KEY);
+    local isCustomMacroBucket = macroBuckets.isCustomCategoryKey(typeKey);
+    local isSharedMacroPalette = isGlobal or isItems or isEquipment or isXiui or isCustomMacroBucket;
     local typeName = GetPaletteDisplayName(typeKey);
     local currentPlayerJob = data.jobId or 1;
-    -- For SMN with avatar selected, check base job ID
     local baseJobId = type(typeKey) == 'number' and typeKey or tonumber(tostring(typeKey):match('^(%d+)'));
-    local isViewingCurrentJob = (not isGlobal and baseJobId == currentPlayerJob);
+    local isViewingCurrentJob = (not isSharedMacroPalette and baseJobId == currentPlayerJob);
 
-    -- Calculate pagination
-    local totalMacros = #db;
+    -- Name filter (substring match on display name or action name; case-insensitive)
+    local needleRaw = (MP.macroPaletteSearchName[1] or ''):match('^%s*(.-)%s*$') or '';
+    if MP._lastMacroPaletteSearch ~= needleRaw then
+        MP._lastMacroPaletteSearch = needleRaw;
+        MP.currentPalettePage = 1;
+    end
+
+    local filteredIndices = {};
+    if needleRaw == '' then
+        for i = 1, #db do
+            filteredIndices[i] = i;
+        end
+    else
+        local needle = needleRaw:lower();
+        for i = 1, #db do
+            local m = db[i];
+            local disp = (m.displayName or ''):lower();
+            local act = (m.action or ''):lower();
+            if disp:find(needle, 1, true) or act:find(needle, 1, true) then
+                table.insert(filteredIndices, i);
+            end
+        end
+    end
+
+    if paletteUi.selectedMacroIndex then
+        local selOk = false;
+        for _, fi in ipairs(filteredIndices) do
+            if fi == paletteUi.selectedMacroIndex then
+                selOk = true;
+                break;
+            end
+        end
+        if not selOk then
+            paletteUi.selectedMacroIndex = nil;
+        end
+    end
+
+    -- Calculate pagination (filtered list)
+    local totalMacros = #filteredIndices;
     local totalPages = math.max(1, math.ceil(totalMacros / PALETTE_MACROS_PER_PAGE));
 
     -- Clamp current page to valid range
-    if currentPalettePage > totalPages then
-        currentPalettePage = totalPages;
+    if MP.currentPalettePage > totalPages then
+        MP.currentPalettePage = totalPages;
     end
-    if currentPalettePage < 1 then
-        currentPalettePage = 1;
+    if MP.currentPalettePage < 1 then
+        MP.currentPalettePage = 1;
     end
 
     -- Calculate how many macros/rows on this page
-    local startIdx = (currentPalettePage - 1) * PALETTE_MACROS_PER_PAGE + 1;
+    local startIdx = (MP.currentPalettePage - 1) * PALETTE_MACROS_PER_PAGE + 1;
     local endIdx = math.min(startIdx + PALETTE_MACROS_PER_PAGE - 1, totalMacros);
     local macrosOnPage = math.max(0, endIdx - startIdx + 1);
     local rowsOnPage = math.max(1, math.ceil(macrosOnPage / PALETTE_COLUMNS));
@@ -1629,9 +3363,161 @@ function M.DrawPalette()
     PushWindowStyle();
 
     if imgui.Begin('Macro Palette###MacroPalette', isOpen, windowFlags) then
-        -- Header with gold accent
-        imgui.TextColored(COLORS.gold, 'Drag macros to your hotbar slots');
-        imgui.Spacing();
+        -- Header: instruction (left) + macro source toggle (right, S = Shared, P = Profile)
+        do
+            local scopeShared = (gConfig.macroStorageScope or 'profile') == 'shared';
+            local scopeBtnSize = 22;
+            imgui.TextColored(COLORS.gold, 'Drag macros to your hotbar slots');
+            imgui.SameLine();
+            -- GetContentRegionAvail: use (w,h) or table [1]/[2]; do not use .x â€” sugar Vector can error (see palettemanager GetContentRegionAvailHeight).
+            local availW, availH = imgui.GetContentRegionAvail();
+            if type(availW) == 'table' then
+                availW = availW[1] or 0;
+            end
+            availW = tonumber(availW) or 0;
+            imgui.SetCursorPosX(imgui.GetCursorPosX() + availW - scopeBtnSize);
+            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, scopeBtnSize * 0.5);
+            imgui.PushStyleVar(ImGuiStyleVar_FramePadding, { 0, 0 });
+            if scopeShared then
+                imgui.PushStyleColor(ImGuiCol_Button, { 0.35, 0.30, 0.18, 0.95 });
+                imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.50, 0.44, 0.28, 1.0 });
+                imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.45, 0.40, 0.24, 1.0 });
+            else
+                imgui.PushStyleColor(ImGuiCol_Button, { 0.14, 0.13, 0.11, 0.95 });
+                imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.22, 0.20, 0.16, 1.0 });
+                imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.18, 0.16, 0.13, 1.0 });
+            end
+            local scopeLabel = scopeShared and 'S##MacroScopeToggle' or 'P##MacroScopeToggle';
+            if imgui.Button(scopeLabel, { scopeBtnSize, scopeBtnSize }) then
+                if scopeShared then
+                    MP.macroScopeConfirmKind = 'toProfile';
+                else
+                    MP.macroScopeConfirmKind = 'toShared';
+                end
+                imgui.OpenPopup('MacroScopeSwitch##xiui');
+            end
+            imgui.PopStyleColor(3);
+            imgui.PopStyleVar(2);
+            if imgui.IsItemHovered() then
+                imgui.BeginTooltip();
+                imgui.PushTextWrapPos(400);
+                local profName = (GetCurrentProfileName and GetCurrentProfileName()) or (config and config.currentProfile) or 'current';
+                if scopeShared then
+                    imgui.TextColored(COLORS.gold, 'Shared is active (S)');
+                    imgui.Spacing();
+                    imgui.TextWrapped('This macro set is available here and is shared with all XIUI profiles that use Shared (SharedMacros.lua). Click the button to edit this character\'s profile-only macros instead.');
+                else
+                    imgui.TextColored(COLORS.text, 'Profile is active (P)');
+                    imgui.Spacing();
+                    imgui.TextWrapped('This macro set is available on the "' .. tostring(profName) .. '" profile only. Click the button to use the shared macro list instead (all profiles on Shared).');
+                end
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'Your hotbar/crossbar layout is not removed when you switch. Icons and actions use the active library; a slot that pointed at the other library may look empty until you switch back or re-drag a macro. The palette and bars refresh when you change mode.');
+                imgui.PopTextWrapPos();
+                imgui.EndTooltip();
+            end
+        end
+
+        -- Macro scope confirm: non-modal BeginPopup (palettemanager copy flow) = no full-screen dim; anchor to this window.
+        do
+            imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+            imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+            imgui.PushStyleColor(ImGuiCol_TitleBg, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_TitleBgActive, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_FrameBg, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLORS.bgLight);
+            imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+
+            local SCOPE_MODAL_W = 420;
+            local estPopupH = 200;
+            local aboveGap = 6;
+            imgui.SetNextWindowSize({ SCOPE_MODAL_W, 0 }, ImGuiCond_Appearing);
+            local wx, wy = imgui.GetWindowPos();
+            local wiw, wih = imgui.GetWindowSize();
+            if type(wx) == 'table' then
+                local t = wx;
+                wx, wy = tonumber(t[1]) or 0, tonumber(t[2] or 0) or 0;
+            else
+                wx, wy = tonumber(wx) or 0, tonumber(wy) or 0;
+            end
+            if type(wiw) == 'table' then
+                local t = wiw;
+                wiw, wih = tonumber(t[1]) or 0, tonumber(t[2] or 0) or 0;
+            else
+                wiw, wih = tonumber(wiw) or 0, tonumber(wih) or 0;
+            end
+            local posX = wx + (wiw - SCOPE_MODAL_W) * 0.5;
+            if posX < 2 then
+                posX = 2;
+            end
+            -- Prefer just above the palette; if that would be off-screen, sit on the top of the palette (overlaps header strip).
+            local posY = wy - aboveGap - estPopupH;
+            if posY < 2 then
+                posY = wy + 6;
+            end
+            imgui.SetNextWindowPos({ posX, posY }, ImGuiCond_Always);
+
+            if imgui.BeginPopup('MacroScopeSwitch##xiui') then
+                local function closeScopePopup()
+                    MP.macroScopeConfirmKind = nil;
+                    imgui.CloseCurrentPopup();
+                end
+
+                if MP.macroScopeConfirmKind == 'toShared' then
+                    imgui.TextColored(COLORS.gold, 'Switch to shared macros?');
+                    imgui.TextWrapped('You will use the global list (SharedMacros.lua) for every profile set to Shared. Your profile-only macros stay saved in this .lua if you switch back.');
+                    imgui.Spacing();
+                    imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
+                    if imgui.Button('Switch##ssok', { 100, 24 }) then
+                        sharedMacroStore.ApplySwitchToShared(gConfig);
+                        data.InvalidateConfigDerivedCaches();
+                        SaveSettingsToDisk();
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        RefreshCachedLists();
+                        ClearAllIconCaches();
+                        closeScopePopup();
+                    end
+                    imgui.PopStyleColor();
+                    imgui.SameLine();
+                    if imgui.Button('Cancel##sscancel', { 100, 24 }) then
+                        closeScopePopup();
+                    end
+                elseif MP.macroScopeConfirmKind == 'toProfile' then
+                    imgui.TextColored(COLORS.gold, 'Switch to profile-only macros?');
+                    imgui.TextWrapped('You will use only this profile file again. The shared file is not changed.');
+                    imgui.Spacing();
+                    imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
+                    if imgui.Button('Switch##spok', { 100, 24 }) then
+                        if (gConfig.macroStorageScope or 'profile') == 'shared' then
+                            SaveSettingsToDisk();
+                        end
+                        sharedMacroStore.ApplySwitchToProfile(gConfig);
+                        data.InvalidateConfigDerivedCaches();
+                        SaveSettingsToDisk();
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        RefreshCachedLists();
+                        ClearAllIconCaches();
+                        closeScopePopup();
+                    end
+                    imgui.PopStyleColor();
+                    imgui.SameLine();
+                    if imgui.Button('Cancel##spcancel', { 100, 24 }) then
+                        closeScopePopup();
+                    end
+                else
+                    closeScopePopup();
+                end
+                imgui.EndPopup();
+            end
+
+            imgui.PopStyleColor(9);
+        end
+
+        imgui.Dummy({ 0, 4 });
 
         -- Type selector row
         imgui.TextColored(COLORS.textDim, 'Type:');
@@ -1639,7 +3525,7 @@ function M.DrawPalette()
 
         -- Style the combo popup
         PushComboStyle();
-        imgui.PushItemWidth(100);
+        imgui.PushItemWidth(148);
 
         -- Helper to get macro count for a type (Global or job ID)
         local function getMacroCount(key)
@@ -1649,8 +3535,8 @@ function M.DrawPalette()
             return 0;
         end
 
-        -- Build display label with macro count
-        local macroCount = getMacroCount(typeKey);
+        -- Build display label with macro count (uses current grid, including SMN / BST "all subsets" merge)
+        local macroCount = #db;
         local displayLabel = macroCount > 0 and string.format('%s (%d)', typeName, macroCount) or typeName;
 
         if imgui.BeginCombo('##TypeSelect', displayLabel, ImGuiComboFlags_None) then
@@ -1671,15 +3557,15 @@ function M.DrawPalette()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
             end
 
-            if imgui.Selectable(globalLabel, globalSelected) then
-                selectedPaletteType = GLOBAL_MACRO_KEY;
-                selectedAvatarPalette = nil;
-                selectedMacroIndex = nil;
-                currentPalettePage = 1;
+                if imgui.Selectable(globalLabel, globalSelected) then
+                    MP.selectedPaletteType = GLOBAL_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
                 -- Clear caches to force refresh
                 playerdata.ClearCache();
-                cachedPetCommands = nil;
-                petAvatarFilter = 1;
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
             end
             imgui.PopStyleColor();
 
@@ -1687,12 +3573,140 @@ function M.DrawPalette()
                 imgui.SetItemDefaultFocus();
             end
 
-            -- Separator between Global and jobs
+            -- Items bucket (gear / consumables â€” not tied to a job)
+            local itemsSelected = isItems;
+            local itemsMacroCount = getMacroCount(ITEMS_MACRO_KEY);
+            local itemsLabel = 'Items';
+            if itemsMacroCount > 0 then
+                itemsLabel = string.format('Items (%d)', itemsMacroCount);
+            end
+
+            if itemsMacroCount > 0 and not itemsSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif itemsSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(itemsLabel, itemsSelected) then
+                    MP.selectedPaletteType = ITEMS_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if itemsSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- Equipment bucket (gear swap macros, all jobs)
+            local equipSelected = isEquipment;
+            local equipMacroCount = getMacroCount(EQUIPMENT_MACRO_KEY);
+            local equipLabel = 'Equipment';
+            if equipMacroCount > 0 then
+                equipLabel = string.format('Equipment (%d)', equipMacroCount);
+            end
+
+            if equipMacroCount > 0 and not equipSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif equipSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(equipLabel, equipSelected) then
+                    MP.selectedPaletteType = EQUIPMENT_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if equipSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- XIUI slash-command shortcuts (seeded defaults; editable like any macro bucket)
+            local xiuiSelected = isXiui;
+            local xiuiMacroCount = getMacroCount(XIUI_MACRO_KEY);
+            local xiuiLabel = 'XIUI Commands';
+            if xiuiMacroCount > 0 then
+                xiuiLabel = string.format('XIUI Commands (%d)', xiuiMacroCount);
+            end
+
+            if xiuiMacroCount > 0 and not xiuiSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif xiuiSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(xiuiLabel, xiuiSelected) then
+                    MP.selectedPaletteType = XIUI_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if xiuiSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- Player-defined categories (keys under macroDB["custom:N"])
+            EnsureMacroCustomCategoriesList();
+            for _, cat in ipairs(gConfig.macroCustomCategories) do
+                local cKey = cat.key;
+                local cSel = (MP.selectedPaletteType == cKey);
+                local cCount = getMacroCount(cKey);
+                local cLabel = cat.label or cKey;
+                if cCount > 0 then
+                    cLabel = string.format('%s (%d)', cLabel, cCount);
+                end
+
+                if cCount > 0 and not cSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                elseif cSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+
+                if imgui.Selectable(cLabel, cSel) then
+                    MP.selectedPaletteType = cKey;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    playerdata.ClearCache();
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
+                end
+                imgui.PopStyleColor();
+
+                if cSel then
+                    imgui.SetItemDefaultFocus();
+                end
+            end
+
+            -- Separator between non-job buckets and jobs
             imgui.Separator();
 
             -- Job options
             for i, job in ipairs(JOB_LIST) do
-                local isSelected = (not isGlobal and job.id == typeKey);
+                local isSelected = (not isSharedMacroPalette and MP.selectedPaletteType == job.id);
                 local jobMacroCount = getMacroCount(job.id);
 
                 -- Build label with indicators
@@ -1723,14 +3737,14 @@ function M.DrawPalette()
                 end
 
                 if imgui.Selectable(label, isSelected) then
-                    selectedPaletteType = job.id;
-                    selectedAvatarPalette = nil;  -- Clear avatar selection when switching jobs
-                    selectedMacroIndex = nil;  -- Clear selection when switching types
-                    currentPalettePage = 1;    -- Reset to page 1 when switching types
+                    MP.selectedPaletteType = job.id;
+                    ResetPetJobMacroPaletteSubsets(); -- Clear avatar / jug subset selection when switching jobs
+                    paletteUi.selectedMacroIndex = nil;  -- Clear selection when switching types
+                    MP.currentPalettePage = 1;    -- Reset to page 1 when switching types
                     -- Clear caches to force refresh
                     playerdata.ClearCache();
-                    cachedPetCommands = nil;
-                    petAvatarFilter = 1;
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
                 end
 
                 imgui.PopStyleColor();
@@ -1744,28 +3758,298 @@ function M.DrawPalette()
         imgui.PopItemWidth();
         PopComboStyle();
 
-        -- Avatar sub-palette dropdown (only for SMN)
-        -- Use selectedPaletteType (the job ID) not typeKey (which may be composite like "15:avatar:ifrit")
-        if not isGlobal and selectedPaletteType == petregistry.JOB_SMN then
+        local catAddBtnSize = (imgui.GetFrameHeight and imgui.GetFrameHeight()) or 24;
+        imgui.SameLine(0, 6);
+        if imgui.Button('+##macroCatAddBtn', { catAddBtnSize, catAddBtnSize }) then
+            imgui.OpenPopup('MacroAddCustomCategory##xiui');
+        end
+        if imgui.IsItemHovered() then
+            imgui.BeginTooltip();
+            imgui.Text('Add a custom type.');
+            imgui.EndTooltip();
+        end
+
+        if isCustomMacroBucket and typeKey then
+            imgui.SameLine(0, 8);
+            imgui.PushStyleColor(ImGuiCol_Button, { 0.62, 0.12, 0.1, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.78, 0.2, 0.16, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.7, 0.16, 0.12, 1.0 });
+            if imgui.Button('-##macroCatDelToolbar', { catAddBtnSize, catAddBtnSize }) then
+                MP.macroCustomDeleteKey = typeKey;
+                MP.macroCustomDeleteLabel = GetPaletteDisplayName(typeKey);
+                MP.macroCustomDeleteN = CountMacrosInPalette(typeKey);
+                imgui.OpenPopup('MacroCustomCatDelete##xiui');
+            end
+            imgui.PopStyleColor(3);
+            if imgui.IsItemHovered() then
+                imgui.BeginTooltip();
+                imgui.Text('Delete this custom type. Macros in the group are removed; any hotbar or crossbar slot that holds one of those macros reverts to an empty slot. Other slots are unchanged.');
+                imgui.EndTooltip();
+            end
+            imgui.SameLine(0, 8);
+            if imgui.SmallButton('Rename##macroCatRenToolbar') then
+                MP.macroCustomRenameTargetKey = typeKey;
+                MP.macroCustomRenameBuf[1] = GetPaletteDisplayName(typeKey);
+                imgui.OpenPopup('MacroCustomRename##xiui');
+            end
+        end
+
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroAddCustomCategory##xiui') then
+            imgui.TextColored(COLORS.textDim, 'New category name');
+            imgui.SetNextItemWidth(240);
+            imgui.InputText('##macroNewCatPopup', MP.macroNewCategoryBuf, INPUT_BUFFER_SIZE);
+            imgui.Spacing();
+            if imgui.Button('Add##macroCatAddPopup', { 100, 24 }) then
+                local nk = AddMacroCustomCategory(MP.macroNewCategoryBuf[1]);
+                if nk then
+                    MP.selectedPaletteType = nk;
+                    ResetPetJobMacroPaletteSubsets();
+                    MP.macroNewCategoryBuf[1] = '';
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    playerdata.ClearCache();
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
+                    markSharedMacroLibraryDirtyIfNeeded();
+                    SaveSettingsToDisk();
+                    data.MarkMacroLookupDirty();
+                    imgui.CloseCurrentPopup();
+                end
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Rename custom type (modal; opened from toolbar)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroCustomRename##xiui') then
+            local rk = MP.macroCustomRenameTargetKey;
+            if rk and macroBuckets.isCustomCategoryKey(rk) then
+                imgui.TextColored(COLORS.textDim, 'Display name (macros and slot data keep the same type key).');
+                imgui.SetNextItemWidth(300);
+                imgui.InputText('##mcrenfield', MP.macroCustomRenameBuf, INPUT_BUFFER_SIZE);
+                imgui.Spacing();
+                if imgui.Button('Apply##mcrenconf', { 100, 24 }) then
+                    if ApplyRenameMacroCustomCategory(rk, MP.macroCustomRenameBuf[1]) then
+                        markSharedMacroLibraryDirtyIfNeeded();
+                        SaveSettingsToDisk();
+                        MP.macroCustomRenameTargetKey = nil;
+                        imgui.CloseCurrentPopup();
+                    end
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##mcrencan', { 100, 24 }) then
+                    MP.macroCustomRenameTargetKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            else
+                MP.macroCustomRenameTargetKey = nil;
+                imgui.CloseCurrentPopup();
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Confirm delete for a custom type (modal; opened from red - button)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroCustomCatDelete##xiui') then
+            local dk = MP.macroCustomDeleteKey;
+            if dk and macroBuckets.isCustomCategoryKey(dk) then
+                local n = tonumber(MP.macroCustomDeleteN) or 0;
+                local lab = tostring(MP.macroCustomDeleteLabel or dk);
+                imgui.TextColored(COLORS.gold, 'Delete this custom type?');
+                imgui.PushTextWrapPos(440);
+                local macroW = n == 1 and '1 macro' or (string.format('%d macros', n));
+                imgui.TextWrapped(string.format('This permanently removes %s saved under "%s" (macro text, icons, and palette data for that type).', macroW, lab));
+                imgui.TextWrapped('On every hotbar and crossbar, any slot that contains a macro from this type reverts to an empty slot. All other slots are unchanged.');
+                if (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') then
+                    imgui.TextWrapped('Shared macro mode: the type is removed from the shared library, and other XIUI profiles get the same per-slot updates anywhere their bars referenced these macros.');
+                end
+                imgui.PopTextWrapPos();
+                imgui.Spacing();
+                if imgui.Button('Delete##mcdelconf', { 100, 24 }) then
+                    DeleteMacroCustomCategoryCompletely(dk);
+                    MP.macroCustomDeleteKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##mcdelcan', { 100, 24 }) then
+                    MP.macroCustomDeleteKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            else
+                MP.macroCustomDeleteKey = nil;
+                imgui.CloseCurrentPopup();
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Move macro to another palette bucket (modal)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroMoveToPalette##xiui') then
+            local srcK = MP.macroMoveSourceKey;
+            local mid = MP.macroMoveMacroId;
+            if not srcK or not mid then
+                MP.macroMoveSourceKey = nil;
+                MP.macroMoveMacroId = nil;
+                MP.macroMoveDestKey = nil;
+                imgui.CloseCurrentPopup();
+            else
+                imgui.TextColored(COLORS.gold, 'Move macro');
+                imgui.PushTextWrapPos(440);
+                imgui.TextWrapped(
+                    'Creates a copy in the destination palette with a new internal id, removes it from the source palette, '
+                        .. 'and updates hotbar and crossbar bindings so slots that already use this macro keep working.');
+                imgui.PopTextWrapPos();
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'From');
+                imgui.SameLine(0, 8);
+                imgui.Text(GetPaletteDisplayName(srcK));
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'To');
+                imgui.SameLine(0, 8);
+                PushComboStyle();
+                imgui.SetNextItemWidth(360);
+                if imgui.BeginCombo('##macroMoveDest', GetPaletteDisplayName(MP.macroMoveDestKey), ImGuiComboFlags_None) then
+                    local function offerMoveDest(key)
+                        if data.MacroPaletteKeysEqual(key, srcK) then
+                            return;
+                        end
+                        local cnt = CountMacrosInPalette(key);
+                        local lab = GetPaletteDisplayName(key);
+                        if cnt > 0 then
+                            lab = string.format('%s (%d)', lab, cnt);
+                        end
+                        local sel = data.MacroPaletteKeysEqual(key, MP.macroMoveDestKey);
+                        if sel then
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                        elseif cnt > 0 then
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                        else
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                        end
+                        if imgui.Selectable(lab, sel) then
+                            MP.macroMoveDestKey = key;
+                        end
+                        imgui.PopStyleColor();
+                    end
+                    offerMoveDest(GLOBAL_MACRO_KEY);
+                    offerMoveDest(ITEMS_MACRO_KEY);
+                    offerMoveDest(EQUIPMENT_MACRO_KEY);
+                    offerMoveDest(XIUI_MACRO_KEY);
+                    EnsureMacroCustomCategoriesList();
+                    for _, cat in ipairs(gConfig.macroCustomCategories or {}) do
+                        offerMoveDest(cat.key);
+                    end
+                    imgui.Separator();
+                    for _, job in ipairs(JOB_LIST) do
+                        offerMoveDest(job.id);
+                    end
+                    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+                        local avatarKey = petregistry.avatars[avatar];
+                        if avatarKey then
+                            offerMoveDest(string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey));
+                        end
+                    end
+                    for _, pk in ipairs(petregistry.GetAvailablePetKeys(petregistry.JOB_BST)) do
+                        local slug = pk:match('^jug:(.+)$');
+                        if slug then
+                            offerMoveDest(string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug));
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                PopComboStyle();
+                imgui.Spacing();
+                local canApply = MP.macroMoveDestKey ~= nil and not data.MacroPaletteKeysEqual(MP.macroMoveDestKey, srcK);
+                if not canApply then
+                    imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.45);
+                end
+                if imgui.Button('Move##macroMoveApply', {100, 26}) and canApply then
+                    if M.MoveMacroToPalette(mid, srcK, MP.macroMoveDestKey) then
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.macroMoveSourceKey = nil;
+                        MP.macroMoveMacroId = nil;
+                        MP.macroMoveDestKey = nil;
+                        imgui.CloseCurrentPopup();
+                    end
+                end
+                if not canApply then
+                    imgui.PopStyleVar();
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##macroMoveCancel', {100, 26}) then
+                    MP.macroMoveSourceKey = nil;
+                    MP.macroMoveMacroId = nil;
+                    MP.macroMoveDestKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- SMN: base / all avatars merged / single avatar (own row so the window stays narrow)
+        if not isSharedMacroPalette and MP.selectedPaletteType == petregistry.JOB_SMN then
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Sub-type:');
             imgui.SameLine();
             local avatarList = petregistry.GetAvatarList();
-            local avatarLabel = selectedAvatarPalette or 'Base SMN';
-
-            -- Count macros for current avatar selection
-            local avatarMacroCount = 0;
-            local currentAvatarKey = GetEffectivePaletteType();
-            if gConfig.macroDB and gConfig.macroDB[currentAvatarKey] then
-                avatarMacroCount = #gConfig.macroDB[currentAvatarKey];
-            end
-            if avatarMacroCount > 0 then
-                avatarLabel = string.format('%s (%d)', avatarLabel, avatarMacroCount);
+            local allSubCount = CountSmnAllSubsetsMacros();
+            local avatarLabel;
+            if MP.smnShowAllAvatarSubsets then
+                avatarLabel = allSubCount > 0 and string.format('All subsets (%d)', allSubCount) or 'All subsets';
+            else
+                avatarLabel = MP.selectedAvatarPalette or 'Base SMN';
+                local avatarMacroCount = 0;
+                local currentAvatarKey = GetEffectivePaletteType();
+                if gConfig.macroDB and gConfig.macroDB[currentAvatarKey] then
+                    avatarMacroCount = #gConfig.macroDB[currentAvatarKey];
+                end
+                if avatarMacroCount > 0 then
+                    avatarLabel = string.format('%s (%d)', avatarLabel, avatarMacroCount);
+                end
             end
 
             PushComboStyle();
-            imgui.SetNextItemWidth(140);
+            imgui.SetNextItemWidth(148);
             if imgui.BeginCombo('##AvatarPalette', avatarLabel, ImGuiComboFlags_None) then
-                -- Base SMN option
-                local isBaseSelected = selectedAvatarPalette == nil;
+                -- All subsets: one grid with Base SMN + every avatar bucket
+                local allSubLabel = allSubCount > 0 and string.format('All subsets (%d)', allSubCount) or 'All subsets';
+                local allSubSel = MP.smnShowAllAvatarSubsets;
+                if allSubSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif allSubCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+                if imgui.Selectable(allSubLabel, allSubSel) then
+                    ClearBstJugMacroSubsetUi();
+                    MP.smnShowAllAvatarSubsets = true;
+                    MP.selectedAvatarPalette = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+                if allSubSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                local isBaseSelected = (not MP.smnShowAllAvatarSubsets and MP.selectedAvatarPalette == nil);
                 local baseMacroCount = 0;
                 if gConfig.macroDB and gConfig.macroDB[petregistry.JOB_SMN] then
                     baseMacroCount = #gConfig.macroDB[petregistry.JOB_SMN];
@@ -1781,10 +4065,12 @@ function M.DrawPalette()
                 end
 
                 if imgui.Selectable(baseLabel, isBaseSelected) then
-                    selectedAvatarPalette = nil;
-                    selectedMacroIndex = nil;
-                    currentPalettePage = 1;
-                    cachedPetCommands = nil;  -- Refresh pet commands for new avatar
+                    ClearBstJugMacroSubsetUi();
+                    MP.smnShowAllAvatarSubsets = false;
+                    MP.selectedAvatarPalette = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
                 end
                 imgui.PopStyleColor();
 
@@ -1794,9 +4080,8 @@ function M.DrawPalette()
 
                 imgui.Separator();
 
-                -- Avatar options
                 for _, avatar in ipairs(avatarList) do
-                    local isSelected = selectedAvatarPalette == avatar;
+                    local isSelected = (not MP.smnShowAllAvatarSubsets and MP.selectedAvatarPalette == avatar);
                     local avatarKey = petregistry.avatars[avatar];
                     local fullKey = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
                     local macroCount = 0;
@@ -1814,10 +4099,12 @@ function M.DrawPalette()
                     end
 
                     if imgui.Selectable(label, isSelected) then
-                        selectedAvatarPalette = avatar;
-                        selectedMacroIndex = nil;
-                        currentPalettePage = 1;
-                        cachedPetCommands = nil;  -- Refresh pet commands for new avatar
+                        ClearBstJugMacroSubsetUi();
+                        MP.smnShowAllAvatarSubsets = false;
+                        MP.selectedAvatarPalette = avatar;
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        MP.cachedPetCommands = nil;
                     end
                     imgui.PopStyleColor();
 
@@ -1830,10 +4117,134 @@ function M.DrawPalette()
             PopComboStyle();
         end
 
+        -- BST: Base / all jug families merged / single jug family (parity with SMN Sub-type)
+        if not isSharedMacroPalette and MP.selectedPaletteType == petregistry.JOB_BST then
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Sub-type:');
+            imgui.SameLine();
+            local bstJugList = BstJugSubsetEntriesOrdered();
+            local allBstSubCount = CountBstAllJugSubsetsMacros();
+            local bstSubLabel;
+            if MP.bstShowAllJugSubsets then
+                bstSubLabel = allBstSubCount > 0 and string.format('All subsets (%d)', allBstSubCount) or 'All subsets';
+            else
+                bstSubLabel = 'Base BST';
+                if MP.selectedBstJugMovesKey ~= nil then
+                    bstSubLabel = MP.selectedBstJugMovesKey;
+                    for _, ent in ipairs(bstJugList) do
+                        if ent.movesKey == MP.selectedBstJugMovesKey then
+                            bstSubLabel = ent.label;
+                            break;
+                        end
+                    end
+                end
+                local curBstKey = GetEffectivePaletteType();
+                local bstFamMacroCount = 0;
+                if gConfig.macroDB and gConfig.macroDB[curBstKey] then
+                    bstFamMacroCount = #gConfig.macroDB[curBstKey];
+                end
+                if bstFamMacroCount > 0 then
+                    bstSubLabel = string.format('%s (%d)', bstSubLabel, bstFamMacroCount);
+                end
+            end
+
+            PushComboStyle();
+            imgui.SetNextItemWidth(148);
+            if imgui.BeginCombo('##BstJugPalette', bstSubLabel, ImGuiComboFlags_None) then
+                local allBstLabel = allBstSubCount > 0 and string.format('All subsets (%d)', allBstSubCount) or 'All subsets';
+                local allBstSel = MP.bstShowAllJugSubsets;
+                if allBstSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif allBstSubCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+                if imgui.Selectable(allBstLabel, allBstSel) then
+                    ClearSmnMacroSubsetUi();
+                    MP.bstShowAllJugSubsets = true;
+                    MP.selectedBstJugMovesKey = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+                if allBstSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                local bstBaseSel = (not MP.bstShowAllJugSubsets and MP.selectedBstJugMovesKey == nil);
+                local bstBaseMacroCount = 0;
+                if gConfig.macroDB and gConfig.macroDB[petregistry.JOB_BST] then
+                    bstBaseMacroCount = #gConfig.macroDB[petregistry.JOB_BST];
+                end
+                local bstBaseLabel = bstBaseMacroCount > 0 and string.format('Base BST (%d)', bstBaseMacroCount) or 'Base BST';
+
+                if bstBaseSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif bstBaseMacroCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+
+                if imgui.Selectable(bstBaseLabel, bstBaseSel) then
+                    ClearSmnMacroSubsetUi();
+                    MP.bstShowAllJugSubsets = false;
+                    MP.selectedBstJugMovesKey = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+
+                if bstBaseSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                for _, ent in ipairs(bstJugList) do
+                    local jugSel = (not MP.bstShowAllJugSubsets and MP.selectedBstJugMovesKey == ent.movesKey);
+                    local jugMc = 0;
+                    if gConfig.macroDB and gConfig.macroDB[ent.fullKey] then
+                        jugMc = #gConfig.macroDB[ent.fullKey];
+                    end
+                    local jugLab = jugMc > 0 and string.format('%s (%d)', ent.label, jugMc) or ent.label;
+
+                    if jugSel then
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                    elseif jugMc > 0 then
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                    else
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                    end
+
+                    if imgui.Selectable(jugLab, jugSel) then
+                        ClearSmnMacroSubsetUi();
+                        MP.bstShowAllJugSubsets = false;
+                        MP.selectedBstJugMovesKey = ent.movesKey;
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        MP.cachedPetCommands = nil;
+                    end
+                    imgui.PopStyleColor();
+
+                    if jugSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            PopComboStyle();
+        end
+
         -- Pet Palette section (only show if selected palette type is a pet job AND any bar has petAware enabled)
         local isPetJob = false;
-        if selectedPaletteType and type(selectedPaletteType) == 'number' then
-            isPetJob = petregistry.IsPetJob(selectedPaletteType);
+        if MP.selectedPaletteType and type(MP.selectedPaletteType) == 'number' then
+            isPetJob = petregistry.IsPetJob(MP.selectedPaletteType);
         end
 
         local hasPetAwareBar = false;
@@ -1934,8 +4345,8 @@ function M.DrawPalette()
 
                         imgui.Separator();
 
-                        -- Spirits section
-                        imgui.TextColored(COLORS.textDim, 'Spirits');
+                        -- Elementals (SMN spirit pets)
+                        imgui.TextColored(COLORS.textDim, 'Elementals');
                         for _, summon in ipairs(allSummons) do
                             if summon.category == 'spirit' then
                                 local petKey = petregistry.GetPetKeyForSummon(summon.name);
@@ -1969,6 +4380,36 @@ function M.DrawPalette()
         end
 
         imgui.Spacing();
+        imgui.TextColored(COLORS.textDim, 'Search by name:');
+        imgui.SetNextItemWidth(math.min(180, gridWidth));
+        imgui.InputText('##MacroPaletteNameSearch', MP.macroPaletteSearchName, INPUT_BUFFER_SIZE);
+        imgui.ShowHelp('Filters the macro grid by display name or action name (case-insensitive).');
+
+        imgui.Spacing();
+
+        local function rowPaletteKeyForGridIdx(idx)
+            if smnMergeMeta and smnMergeMeta[idx] then
+                return smnMergeMeta[idx].paletteKey;
+            end
+            if bstMergeMeta and bstMergeMeta[idx] then
+                return bstMergeMeta[idx].paletteKey;
+            end
+            return typeKey;
+        end
+        local function rowSubsetLabelForGridIdx(idx)
+            if smnMergeMeta and smnMergeMeta[idx] then
+                return smnMergeMeta[idx].subsetLabel;
+            end
+            if bstMergeMeta and bstMergeMeta[idx] then
+                return bstMergeMeta[idx].subsetLabel;
+            end
+            return nil;
+        end
+
+        local hasSelection = paletteUi.selectedMacroIndex and db[paletteUi.selectedMacroIndex];
+        local universalLocked = hasSelection and macroGlobalDefaults.IsUniversalTwoHourMacro(db[paletteUi.selectedMacroIndex]);
+        local copyEnabled = hasSelection and not universalLocked;
+        local editDelEnabled = hasSelection and not universalLocked;
 
         -- Button row with XIUI button styling
         imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
@@ -1979,14 +4420,67 @@ function M.DrawPalette()
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
 
         if imgui.Button('+ New Macro', {115, 26}) then
-            isCreatingNew = true;
-            editingMacro = {
-                actionType = 'ma',
-                action = '',
-                target = 't',
-                displayName = '',
-            };
-            selectedMacroIndex = nil;
+            MP.isCreatingNew = true;
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
+            paletteUi.selectedMacroIndex = nil;
+            MP.editorPaletteKey = GetEffectivePaletteType();
+            local body, autoKey = DefaultNewMacroBodyForPaletteKey(MP.editorPaletteKey);
+            MP.editingMacro = body;
+            MP.editorAutoIconKey = autoKey;
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+        end
+
+        imgui.SameLine();
+
+        if not copyEnabled then
+            imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
+        end
+        if imgui.Button('Copy', {60, 26}) and copyEnabled then
+            MP.editingMacro = deep_copy_table(db[paletteUi.selectedMacroIndex]);
+            MP.editingMacro.id = nil;
+            MP.isCreatingNew = true;
+            MP.editorPaletteKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
+            ClearEditorPreviewIconCache();
+        end
+        if not copyEnabled then
+            imgui.PopStyleVar();
+        end
+
+        imgui.SameLine();
+
+        if not copyEnabled then
+            imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
+        end
+        if imgui.Button('Move', {52, 26}) and copyEnabled then
+            MP.macroMoveSourceKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            MP.macroMoveMacroId = db[paletteUi.selectedMacroIndex].id;
+            MP.macroMoveDestKey = PickDefaultMacroMoveDestination(MP.macroMoveSourceKey);
+            imgui.OpenPopup('MacroMoveToPalette##xiui');
+        end
+        if not copyEnabled then
+            imgui.PopStyleVar();
         end
 
         imgui.PopStyleColor(5);
@@ -1994,37 +4488,48 @@ function M.DrawPalette()
 
         imgui.SameLine();
 
-        -- Edit/Delete buttons (always visible, disabled when no selection)
-        local hasSelection = selectedMacroIndex and db[selectedMacroIndex];
-
-        if not hasSelection then
+        -- Edit/Delete buttons (always visible, disabled when no selection or Universal 2Hr locked)
+        if not editDelEnabled then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
         end
 
-        if imgui.Button('Edit', {60, 26}) and hasSelection then
-            editingMacro = deep_copy_table(db[selectedMacroIndex]);
-            isCreatingNew = false;
+        if imgui.Button('Edit', {60, 26}) and editDelEnabled then
+            MP.editingMacro = deep_copy_table(db[paletteUi.selectedMacroIndex]);
+            MP.isCreatingNew = false;
+            MP.editorPaletteKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
         end
 
         imgui.SameLine();
 
         -- Delete button with danger styling (or dimmed when disabled)
-        if hasSelection then
+        if editDelEnabled then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.dangerDim);
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.danger);
             imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.9, 0.35, 0.35, 1.0});
         end
 
-        if imgui.Button('Delete', {60, 26}) and hasSelection then
-            M.DeleteMacro(db[selectedMacroIndex].id);
-            selectedMacroIndex = nil;
+        if imgui.Button('Delete', {60, 26}) and editDelEnabled then
+            M.DeleteMacro(db[paletteUi.selectedMacroIndex].id, rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex));
+            paletteUi.selectedMacroIndex = nil;
         end
 
-        if hasSelection then
+        if editDelEnabled then
             imgui.PopStyleColor(3);
         end
 
-        if not hasSelection then
+        if not editDelEnabled then
             imgui.PopStyleVar();
         end
 
@@ -2036,12 +4541,16 @@ function M.DrawPalette()
         if #db == 0 then
             imgui.TextColored(COLORS.textDim, 'No macros yet.');
             imgui.TextColored(COLORS.textMuted, 'Click "+ New Macro" to create one.');
+        elseif totalMacros == 0 then
+            imgui.TextColored(COLORS.textDim, 'No macros match your search.');
+            imgui.TextColored(COLORS.textMuted, 'Clear the search field or try different text.');
         else
             -- Draw grid row by row using standard ImGui layout
             for row = 0, rowsOnPage - 1 do
                 for col = 0, PALETTE_COLUMNS - 1 do
-                    local idx = startIdx + row * PALETTE_COLUMNS + col;
-                    if idx <= endIdx then
+                    local pos = startIdx + row * PALETTE_COLUMNS + col;
+                    if pos <= endIdx then
+                        local idx = filteredIndices[pos];
                         local macro = db[idx];
                         if macro then
                             if col > 0 then
@@ -2049,7 +4558,7 @@ function M.DrawPalette()
                             end
 
                             -- Draw the tile inline
-                            local isSelected = selectedMacroIndex == idx;
+                            local isSelected = paletteUi.selectedMacroIndex == idx;
 
                             if isSelected then
                                 imgui.PushStyleColor(ImGuiCol_Button, {0.15, 0.13, 0.08, 0.95});
@@ -2061,7 +4570,7 @@ function M.DrawPalette()
                                 imgui.PushStyleColor(ImGuiCol_ButtonActive, COLORS.bgLight);
                             end
 
-                            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4);
+                            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, PALETTE_TILE_ROUNDING);
                             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
                             imgui.PushStyleColor(ImGuiCol_Border, isSelected and COLORS.gold or COLORS.border);
 
@@ -2069,18 +4578,17 @@ function M.DrawPalette()
                             local buttonPos = {imgui.GetCursorScreenPos()};
 
                             if imgui.Button(buttonId, {PALETTE_TILE_SIZE, PALETTE_TILE_SIZE}) then
-                                selectedMacroIndex = idx;
+                                paletteUi.selectedMacroIndex = idx;
                             end
 
                             imgui.PopStyleColor(4);
                             imgui.PopStyleVar(2);
 
                             -- Draw icon on top of button, or abbreviation if no icon
-                            local icon = actions.GetBindIcon(macro);
-                            local iconRendered = false;
-                            if icon and icon.image then
                                 local drawList = imgui.GetWindowDrawList();
-                                if drawList then
+                            local icon = GetCachedPaletteMainIcon(macro);
+                            local iconRendered = false;
+                            if icon and icon.image and drawList then
                                     local iconSize = PALETTE_TILE_SIZE - 8;
                                     local iconX = buttonPos[1] + 4;
                                     local iconY = buttonPos[2] + 4;
@@ -2090,6 +4598,8 @@ function M.DrawPalette()
                                         iconRendered = true;
                                     end
                                 end
+                            if drawList then
+                                DrawMacroJaBadgeOverlay(drawList, macro, buttonPos[1], buttonPos[2], PALETTE_TILE_SIZE);
                             end
 
                             -- No icon - show abbreviated action name
@@ -2108,7 +4618,7 @@ function M.DrawPalette()
                             -- Handle drag
                             if imgui.IsItemActive() and imgui.IsMouseDragging(0, 3) then
                                 if not dragdrop.IsDragging() and not dragdrop.IsDragPending() then
-                                    M.StartDragMacro(idx, macro);
+                                    M.StartDragMacro(idx, macro, rowPaletteKeyForGridIdx(idx));
                                 end
                             end
 
@@ -2118,17 +4628,25 @@ function M.DrawPalette()
                                 imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
                                 imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {8, 6});
                                 imgui.BeginTooltip();
-                                imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
-                                imgui.Spacing();
-                                imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
-                                if macro.actionType ~= 'macro' and macro.target then
-                                    local formattedTarget = FormatTargetForDisplay(macro.target);
-                                    if formattedTarget then
-                                        imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                                if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                                    imgui.TextColored(COLORS.gold, '2-Hour Ability');
+                                else
+                                    imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
+                                    local subLbl = rowSubsetLabelForGridIdx(idx);
+                                    if subLbl then
+                                        imgui.TextColored(COLORS.textMuted, 'Subset: ' .. subLbl);
                                     end
+                                    imgui.Spacing();
+                                    imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
+                                    if macro.actionType ~= 'macro' and macro.target then
+                                        local formattedTarget = FormatTargetForDisplay(macro.target);
+                                        if formattedTarget then
+                                            imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                                        end
+                                    end
+                                    imgui.Spacing();
+                                    imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
                                 end
-                                imgui.Spacing();
-                                imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
                                 imgui.EndTooltip();
                                 imgui.PopStyleVar();
                                 imgui.PopStyleColor(2);
@@ -2156,13 +4674,13 @@ function M.DrawPalette()
         imgui.SetCursorPosX(paginationStartX);
 
         -- Previous button (disabled when on first page)
-        local canGoPrev = currentPalettePage > 1;
+        local canGoPrev = MP.currentPalettePage > 1;
         if not canGoPrev then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.3);
         end
         if imgui.Button('<##PrevPage', {30, 22}) and canGoPrev then
-            currentPalettePage = currentPalettePage - 1;
-            selectedMacroIndex = nil;
+            MP.currentPalettePage = MP.currentPalettePage - 1;
+            paletteUi.selectedMacroIndex = nil;
         end
         if not canGoPrev then
             imgui.PopStyleVar();
@@ -2171,7 +4689,7 @@ function M.DrawPalette()
         imgui.SameLine();
 
         -- Page indicator
-        local pageText = string.format('Page %d / %d', currentPalettePage, totalPages);
+        local pageText = string.format('Page %d / %d', MP.currentPalettePage, totalPages);
         local textWidth = imgui.CalcTextSize(pageText);
         imgui.SetCursorPosX(paginationStartX + (paginationWidth - textWidth) / 2);
         imgui.TextColored(COLORS.textDim, pageText);
@@ -2180,13 +4698,13 @@ function M.DrawPalette()
         imgui.SetCursorPosX(paginationStartX + paginationWidth - 30);
 
         -- Next button (disabled when on last page)
-        local canGoNext = currentPalettePage < totalPages;
+        local canGoNext = MP.currentPalettePage < totalPages;
         if not canGoNext then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.3);
         end
         if imgui.Button('>##NextPage', {30, 22}) and canGoNext then
-            currentPalettePage = currentPalettePage + 1;
-            selectedMacroIndex = nil;
+            MP.currentPalettePage = MP.currentPalettePage + 1;
+            paletteUi.selectedMacroIndex = nil;
         end
         if not canGoNext then
             imgui.PopStyleVar();
@@ -2202,9 +4720,22 @@ function M.DrawPalette()
     end
 
     -- Draw macro editor popup if needed
-    if editingMacro then
+    if MP.editingMacro then
         M.DrawMacroEditor();
     end
+end
+
+function M.DrawPalette()
+    -- Macro editor must draw even when the palette list is closed (e.g. opened from Edit Full Palette
+    -- via double-click); otherwise MP.editingMacro is set but no window is ever drawn.
+    if not paletteUi.open then
+        if MP.editingMacro then
+            RefreshCachedLists();
+            M.DrawMacroEditor();
+        end
+        return;
+    end
+    DrawPaletteBody();
 end
 
 -- ============================================
@@ -2269,40 +4800,6 @@ local function FindIndex(array, value)
     return 1;
 end
 
--- Draw icon preview box with current icon
-local function DrawIconPreview(macro, x, y, size)
-    local drawList = imgui.GetWindowDrawList();
-    if not drawList then return; end
-
-    -- Draw background box
-    local bgColor = imgui.GetColorU32({0.1, 0.09, 0.08, 0.95});
-    local borderColor = imgui.GetColorU32(COLORS.border);
-    drawList:AddRectFilled({x, y}, {x + size, y + size}, bgColor, 4);
-    drawList:AddRect({x, y}, {x + size, y + size}, borderColor, 4, 0, 1);
-
-    -- Draw icon if available
-    local icon = actions.GetBindIcon(macro);
-    if icon and icon.image then
-        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
-        if iconPtr then
-            local padding = 4;
-            drawList:AddImage(
-                iconPtr,
-                {x + padding, y + padding},
-                {x + size - padding, y + size - padding}
-            );
-        end
-    else
-        -- No icon - show abbreviated action name (prefer action for preview)
-        local abbr = GetActionAbbreviation(macro, true);
-        local textSize = imgui.CalcTextSize(abbr);
-        local textX = x + (size - textSize) / 2;
-        local textY = y + (size - 14) / 2;
-        local textColor = imgui.GetColorU32(COLORS.gold);
-        drawList:AddText({textX, textY}, textColor, abbr);
-    end
-end
-
 -- Helper to draw an icon button (works around ImageButton signature issues)
 local function DrawIconButton(id, icon, size, isSelected, tooltipText)
     local clicked = false;
@@ -2357,12 +4854,12 @@ end
 
 -- Draw the icon picker popup
 local function DrawIconPicker()
-    if not iconPickerOpen or not editingMacro then
+    if not MP.iconPickerOpen or not MP.editingMacro then
         return;
     end
 
     -- Start item loading when items tab is selected
-    if iconPickerTab == 2 then
+    if MP.iconPickerTab == 2 then
         StartItemIconLoading();
         LoadItemIconBatch();  -- Load a batch each frame
     end
@@ -2389,7 +4886,7 @@ local function DrawIconPicker()
         local tabWidth = 70;
 
         -- Spells tab
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2397,7 +4894,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Spells', {tabWidth, 24}) then
-            iconPickerTab = 1;
+            MP.iconPickerTab = 1;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2405,7 +4902,7 @@ local function DrawIconPicker()
         imgui.SameLine();
 
         -- Items tab
-        if iconPickerTab == 2 then
+        if MP.iconPickerTab == 2 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2413,7 +4910,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Items', {tabWidth, 24}) then
-            iconPickerTab = 2;
+            MP.iconPickerTab = 2;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2421,7 +4918,7 @@ local function DrawIconPicker()
         imgui.SameLine();
 
         -- Custom tab
-        if iconPickerTab == 3 then
+        if MP.iconPickerTab == 3 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2429,7 +4926,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Custom', {tabWidth, 24}) then
-            iconPickerTab = 3;
+            MP.iconPickerTab = 3;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2441,10 +4938,18 @@ local function DrawIconPicker()
         imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.danger);
         imgui.PushStyleColor(ImGuiCol_Border, COLORS.danger);
         if imgui.Button('Clear', {50, 24}) then
-            editingMacro.customIconType = nil;
-            editingMacro.customIconId = nil;
-            editingMacro.customIconPath = nil;
-            iconPickerOpen = false;
+            if MP.iconPickerTargetIsJaBadge then
+                MP.editingMacro.jaBadgeCustomIconType = nil;
+                MP.editingMacro.jaBadgeCustomIconId = nil;
+                MP.editingMacro.jaBadgeCustomIconPath = nil;
+                MP.editorJaBadgeManuallySet = false;
+            else
+                MP.editingMacro.customIconType = nil;
+                MP.editingMacro.customIconId = nil;
+                MP.editingMacro.customIconPath = nil;
+            end
+            MP.editorAutoIconKey = nil;
+            MP.iconPickerOpen = false;
         end
         imgui.PopStyleColor(3);
 
@@ -2456,10 +4961,10 @@ local function DrawIconPicker()
         imgui.TextColored(COLORS.goldDim, 'Search:');
         imgui.SameLine();
         imgui.SetNextItemWidth(200);
-        imgui.InputText('##iconSearch', iconPickerFilter, INPUT_BUFFER_SIZE);
+        imgui.InputText('##iconSearch', MP.iconPickerFilter, INPUT_BUFFER_SIZE);
 
         -- Show loading status for items tab (count shown near page navigation)
-        if iconPickerTab == 2 and itemIconLoadState.loading then
+        if MP.iconPickerTab == 2 and itemIconLoadState.loading then
             imgui.SameLine();
             imgui.TextColored(COLORS.textMuted, string.format('Loading... %d%%', GetItemLoadProgress()));
         end
@@ -2467,7 +4972,7 @@ local function DrawIconPicker()
         imgui.Spacing();
 
         -- Spell type filter buttons with icons (only for spells tab)
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             local filterIconSize = 24;
             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
             imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {3, 3});
@@ -2475,7 +4980,7 @@ local function DrawIconPicker()
 
             for i, spellType in ipairs(SPELL_TYPE_ORDER) do
                 local tooltip = SPELL_TYPE_LABELS[spellType] or spellType;
-                local isSelected = iconPickerSpellType == spellType;
+                local isSelected = MP.iconPickerSpellType == spellType;
 
                 if isSelected then
                     imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
@@ -2492,8 +4997,8 @@ local function DrawIconPicker()
 
                 -- Use DrawIconButton which works on all Ashita versions
                 if DrawIconButton('##spellFilter' .. i, icon, filterIconSize, isSelected, tooltip) then
-                    iconPickerSpellType = spellType;
-                    iconPickerPage[1] = 1;
+                    MP.iconPickerSpellType = spellType;
+                    MP.iconPickerPage[1] = 1;
                 end
 
                 if i < #SPELL_TYPE_ORDER then
@@ -2506,7 +5011,7 @@ local function DrawIconPicker()
         end
 
         -- Item type filter buttons with icons (only for items tab)
-        if iconPickerTab == 2 then
+        if MP.iconPickerTab == 2 then
             local filterIconSize = 24;
             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
             imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {3, 3});
@@ -2514,7 +5019,7 @@ local function DrawIconPicker()
 
             for i, itemType in ipairs(ITEM_TYPE_ORDER) do
                 local tooltip = ITEM_TYPE_LABELS[itemType] or tostring(itemType);
-                local isSelected = iconPickerItemType == itemType;
+                local isSelected = MP.iconPickerItemType == itemType;
                 local itemId = ITEM_TYPE_ICONS[itemType];
 
                 -- Get item icon texture
@@ -2522,8 +5027,8 @@ local function DrawIconPicker()
 
                 -- Use DrawIconButton which works on all Ashita versions
                 if DrawIconButton('##itemFilter' .. i, icon, filterIconSize, isSelected, tooltip) then
-                    iconPickerItemType = itemType;
-                    iconPickerPage[2] = 1;
+                    MP.iconPickerItemType = itemType;
+                    MP.iconPickerPage[2] = 1;
                 end
 
                 if i < #ITEM_TYPE_ORDER then
@@ -2536,7 +5041,7 @@ local function DrawIconPicker()
         end
 
         -- Custom icon category filter buttons (only for custom tab)
-        if iconPickerTab == 3 then
+        if MP.iconPickerTab == 3 then
             -- Load categories if not loaded
             LoadCustomIcons();
             
@@ -2569,7 +5074,7 @@ local function DrawIconPicker()
                     imgui.PushStyleColor(ImGuiCol_Text, COLORS.goldDim);
                     if imgui.Button(letter .. '##customFilter' .. i, {filterIconSize, filterIconSize}) then
                         customIconCategory = category;
-                        iconPickerPage[3] = 1;
+                        MP.iconPickerPage[3] = 1;
                         customIconsCacheKey = nil;
                     end
                     imgui.PopStyleColor(3);
@@ -2582,7 +5087,7 @@ local function DrawIconPicker()
                     -- Use DrawIconButton for categories with icons
                     if DrawIconButton('##customFilter' .. i, categoryIcon, filterIconSize, isSelected, tooltip) then
                         customIconCategory = category;
-                        iconPickerPage[3] = 1;
+                        MP.iconPickerPage[3] = 1;
                         customIconsCacheKey = nil;  -- Invalidate cache
                     end
                 end
@@ -2629,7 +5134,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
             
-            if imgui.BeginPopupModal('Create Custom Folder##newFolderPopup', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+            if imgui.BeginPopup('Create Custom Folder##newFolderPopup') then
                 imgui.TextColored(COLORS.goldDim, 'Folder name:');
                 imgui.SetNextItemWidth(250);
                 imgui.InputText('##newFolderInput', newFolderName, 64);
@@ -2656,60 +5161,62 @@ local function DrawIconPicker()
             imgui.PopStyleColor(9);
         end
 
-        local filter = iconPickerFilter[1]:lower();
-        local currentPage = iconPickerPage[iconPickerTab];
+        local filter = MP.iconPickerFilter[1];
+        local currentPage = MP.iconPickerPage[MP.iconPickerTab];
 
         -- Build cache key for filtered results
         local cacheKey;
-        if iconPickerTab == 1 then
-            cacheKey = filter .. ':spell:' .. iconPickerSpellType;
-        elseif iconPickerTab == 2 then
-            cacheKey = filter .. ':item:' .. tostring(iconPickerItemType);
-        elseif iconPickerTab == 3 then
+        if MP.iconPickerTab == 1 then
+            cacheKey = filter .. ':spell:' .. MP.iconPickerSpellType;
+        elseif MP.iconPickerTab == 2 then
+            cacheKey = filter .. ':item:' .. tostring(MP.iconPickerItemType);
+        elseif MP.iconPickerTab == 3 then
             cacheKey = filter .. ':custom:' .. customIconCategory;
         end
 
         -- Reset page and invalidate cache if filter/type changed
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             if cacheKey ~= filteredSpellsCacheKey then
-                iconPickerPage[1] = 1;
+                MP.iconPickerPage[1] = 1;
                 currentPage = 1;
                 filteredSpellsCache = nil;
                 filteredSpellsCacheKey = cacheKey;
             end
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             if cacheKey ~= filteredItemsCacheKey then
-                iconPickerPage[2] = 1;
+                MP.iconPickerPage[2] = 1;
                 currentPage = 1;
                 filteredItemsCache = nil;
                 filteredItemsCacheKey = cacheKey;
             end
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             if cacheKey ~= customIconsCacheKey then
-                iconPickerPage[3] = 1;
+                MP.iconPickerPage[3] = 1;
                 currentPage = 1;
                 customIconsCacheKey = cacheKey;
+                filteredCustomIconsCache = nil;
+                filteredCustomIconsCacheKey = nil;
             end
         end
 
         -- Build filtered list (with caching to avoid rebuilding every frame)
         local filteredItems = {};
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             if filteredSpellsCache then
                 filteredItems = filteredSpellsCache;
             else
                 local allSpells = GetAllSpells();
                 for _, spell in ipairs(allSpells) do
                     local spellName = spell.name or '';
-                    local matchesFilter = (filter == '' or spellName:lower():find(filter, 1, true));
-                    local matchesType = (iconPickerSpellType == 'All' or spell.type == iconPickerSpellType);
+                    local matchesFilter = iconPickerNameMatchesFilter(spellName, filter);
+                    local matchesType = (MP.iconPickerSpellType == 'All' or spell.type == MP.iconPickerSpellType);
                     if matchesFilter and matchesType then
                         table.insert(filteredItems, spell);
                     end
                 end
                 filteredSpellsCache = filteredItems;
             end
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             -- Only use cache if: cache exists, not loading, and cache has items (or items DB is empty)
             local cacheValid = filteredItemsCache
                 and not itemIconLoadState.loading
@@ -2720,8 +5227,8 @@ local function DrawIconPicker()
             else
                 -- Use pre-filtered type list if available and a specific type is selected
                 local sourceItems;
-                if iconPickerItemType ~= 0 and itemIconLoadState.itemsByType[iconPickerItemType] then
-                    sourceItems = itemIconLoadState.itemsByType[iconPickerItemType];
+                if MP.iconPickerItemType ~= 0 and itemIconLoadState.itemsByType[MP.iconPickerItemType] then
+                    sourceItems = itemIconLoadState.itemsByType[MP.iconPickerItemType];
                 else
                     sourceItems = itemIconLoadState.items;
                 end
@@ -2735,7 +5242,7 @@ local function DrawIconPicker()
                         -- Apply text filter
                         for _, item in ipairs(sourceItems) do
                             local itemName = item.name or '';
-                            if itemName:lower():find(filter, 1, true) then
+                            if iconPickerNameMatchesFilter(itemName, filter) then
                                 table.insert(filteredItems, item);
                             end
                         end
@@ -2747,23 +5254,28 @@ local function DrawIconPicker()
                     filteredItemsCache = filteredItems;
                 end
             end
-        elseif iconPickerTab == 3 then
-            -- Custom icons - use pre-filtered category list
+        elseif MP.iconPickerTab == 3 then
+            if filteredCustomIconsCache and filteredCustomIconsCacheKey == cacheKey then
+                filteredItems = filteredCustomIconsCache;
+            else
             filteredItems = GetCustomIconsFiltered(customIconCategory, filter);
+                filteredCustomIconsCache = filteredItems;
+                filteredCustomIconsCacheKey = cacheKey;
+            end
         end
 
         local totalItems = #filteredItems;
         local totalPages = math.max(1, math.ceil(totalItems / ICONS_PER_PAGE));
 
         -- Show filtered count for spells and custom (items count shown near page navigation only)
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             local allSpells = GetAllSpells();
             local countText = string.format('%d of %d spells', totalItems, #allSpells);
-            if iconPickerSpellType ~= 'All' then
-                countText = countText .. ' (' .. (SPELL_TYPE_LABELS[iconPickerSpellType] or iconPickerSpellType) .. ')';
+            if MP.iconPickerSpellType ~= 'All' then
+                countText = countText .. ' (' .. (SPELL_TYPE_LABELS[MP.iconPickerSpellType] or MP.iconPickerSpellType) .. ')';
             end
             imgui.TextColored(COLORS.textMuted, countText);
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             local allCustom = LoadCustomIcons();
             local countText = string.format('%d of %d custom icons', totalItems, #allCustom);
             if customIconCategory ~= 'all' then
@@ -2790,16 +5302,10 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Text, COLORS.goldDim);
             if imgui.Button('Refresh##refreshCustom', {60, 18}) then
-                -- Clear all caches to force rescan
-                customIconsCache = nil;
-                customIconsByCategoryCache = {};
-                customCategoryIconCache = {};
+                InvalidateCustomIconScanCaches();
                 customIconsCacheKey = nil;
-                -- Clear TextureManager custom icons cache
-                TextureManager.clearCategory('custom_icons');
-                -- Also clear the action module's custom icon cache
                 actions.ClearCustomIconCache();
-                -- Reset progressive loading
+                TextureManager.clearCategory('custom_icons');
                 ResetIconLoading();
             end
             imgui.PopStyleColor(3);
@@ -2813,7 +5319,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgMedium);
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             
-            if imgui.BeginPopupModal('Delete Folder##deleteFolderPopup', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+            if imgui.BeginPopup('Delete Folder##deleteFolderPopup') then
                 local categoryLabel = CUSTOM_ICON_LABELS[deleteFolderTarget] or deleteFolderTarget or '';
                 local iconCount = customIconsByCategoryCache[deleteFolderTarget] and #customIconsByCategoryCache[deleteFolderTarget] or 0;
                 
@@ -2857,7 +5363,7 @@ local function DrawIconPicker()
         -- Clamp current page
         if currentPage > totalPages then
             currentPage = totalPages;
-            iconPickerPage[iconPickerTab] = currentPage;
+            MP.iconPickerPage[MP.iconPickerTab] = currentPage;
         end
 
         -- Page navigation UI
@@ -2873,7 +5379,7 @@ local function DrawIconPicker()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textMuted);
             end
             if imgui.Button('<##prevPage', {30, 22}) and canGoPrev then
-                iconPickerPage[iconPickerTab] = currentPage - 1;
+                MP.iconPickerPage[MP.iconPickerTab] = currentPage - 1;
             end
             if not canGoPrev then
                 imgui.PopStyleColor(3);
@@ -2894,7 +5400,7 @@ local function DrawIconPicker()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textMuted);
             end
             if imgui.Button('>##nextPage', {30, 22}) and canGoNext then
-                iconPickerPage[iconPickerTab] = currentPage + 1;
+                MP.iconPickerPage[MP.iconPickerTab] = currentPage + 1;
             end
             if not canGoNext then
                 imgui.PopStyleColor(3);
@@ -2928,7 +5434,7 @@ local function DrawIconPicker()
 
         local displayedCount = 0;
 
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             -- Spell icons - render current page from filtered list
             if totalItems == 0 then
                 imgui.TextColored(COLORS.textMuted, 'No matching spells found');
@@ -2961,11 +5467,25 @@ local function DrawIconPicker()
                                 tooltipText = spell.name .. ' (' .. (SPELL_TYPE_LABELS[spell.type] or spell.type) .. ')';
                             end
 
-                            local isSelected = editingMacro.customIconType == 'spell' and editingMacro.customIconId == spell.id;
+                            local isSelected;
+                            if MP.iconPickerTargetIsJaBadge then
+                                isSelected = MP.editingMacro.jaBadgeCustomIconType == 'spell' and MP.editingMacro.jaBadgeCustomIconId == spell.id;
+                            else
+                                isSelected = MP.editingMacro.customIconType == 'spell' and MP.editingMacro.customIconId == spell.id;
+                            end
                             if DrawIconButton('##spell' .. spell.id, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                                editingMacro.customIconType = 'spell';
-                                editingMacro.customIconId = spell.id;
-                                iconPickerOpen = false;
+                                if MP.iconPickerTargetIsJaBadge then
+                                    MP.editingMacro.jaBadgeCustomIconType = 'spell';
+                                    MP.editingMacro.jaBadgeCustomIconId = spell.id;
+                                    MP.editingMacro.jaBadgeCustomIconPath = nil;
+                                    MP.editorJaBadgeManuallySet = true;
+                                else
+                                    MP.editingMacro.customIconType = 'spell';
+                                    MP.editingMacro.customIconId = spell.id;
+                                    MP.editingMacro.customIconPath = nil;
+                                end
+                                MP.editorAutoIconKey = nil;
+                                MP.iconPickerOpen = false;
                             end
 
                             displayedCount = displayedCount + 1;
@@ -2974,7 +5494,7 @@ local function DrawIconPicker()
                 end
             end
 
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             -- Item icons - render current page from filtered list with progressive loading
             if itemIconLoadState.loading and #itemIconLoadState.items == 0 then
                 imgui.TextColored(COLORS.textMuted, 'Loading item database...');
@@ -2985,7 +5505,7 @@ local function DrawIconPicker()
                 local loadCacheKey = cacheKey .. ':' .. tostring(currentPage);
                 if iconLoadState.currentCacheKey ~= loadCacheKey then
                     iconLoadState.currentPage = currentPage;
-                    iconLoadState.currentTab = iconPickerTab;
+                    iconLoadState.currentTab = MP.iconPickerTab;
                     iconLoadState.currentCacheKey = loadCacheKey;
                     iconLoadState.loadedCount = 0;
                     iconLoadState.pageIconCache = {};
@@ -3046,11 +5566,25 @@ local function DrawIconPicker()
                             tooltipText = item.name .. ' (' .. typeLabel .. ')';
                         end
 
-                        local isSelected = editingMacro.customIconType == 'item' and editingMacro.customIconId == item.id;
-                        if DrawIconButton('##item' .. item.id, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                            editingMacro.customIconType = 'item';
-                            editingMacro.customIconId = item.id;
-                            iconPickerOpen = false;
+                        local isSelectedItem;
+                        if MP.iconPickerTargetIsJaBadge then
+                            isSelectedItem = MP.editingMacro.jaBadgeCustomIconType == 'item' and MP.editingMacro.jaBadgeCustomIconId == item.id;
+                        else
+                            isSelectedItem = MP.editingMacro.customIconType == 'item' and MP.editingMacro.customIconId == item.id;
+                        end
+                        if DrawIconButton('##item' .. item.id, icon, ICON_GRID_SIZE, isSelectedItem, tooltipText) then
+                            if MP.iconPickerTargetIsJaBadge then
+                                MP.editingMacro.jaBadgeCustomIconType = 'item';
+                                MP.editingMacro.jaBadgeCustomIconId = item.id;
+                                MP.editingMacro.jaBadgeCustomIconPath = nil;
+                                MP.editorJaBadgeManuallySet = true;
+                            else
+                                MP.editingMacro.customIconType = 'item';
+                                MP.editingMacro.customIconId = item.id;
+                                MP.editingMacro.customIconPath = nil;
+                            end
+                            MP.editorAutoIconKey = nil;
+                            MP.iconPickerOpen = false;
                         end
 
                         displayedCount = displayedCount + 1;
@@ -3058,7 +5592,7 @@ local function DrawIconPicker()
                 end
             end
         
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             -- Custom icons - render from custom directory with progressive loading
             if totalItems == 0 then
                 if customIconCategory ~= 'all' then
@@ -3098,9 +5632,9 @@ local function DrawIconPicker()
             else
                 -- Check if page/tab/filter changed - reset icon cache
                 local loadCacheKey = cacheKey .. ':' .. tostring(currentPage);
-                if iconLoadState.currentCacheKey ~= loadCacheKey or iconLoadState.currentTab ~= iconPickerTab then
+                if iconLoadState.currentCacheKey ~= loadCacheKey or iconLoadState.currentTab ~= MP.iconPickerTab then
                     iconLoadState.currentPage = currentPage;
-                    iconLoadState.currentTab = iconPickerTab;
+                    iconLoadState.currentTab = MP.iconPickerTab;
                     iconLoadState.currentCacheKey = loadCacheKey;
                     iconLoadState.loadedCount = 0;
                     iconLoadState.pageIconCache = {};
@@ -3159,12 +5693,25 @@ local function DrawIconPicker()
                             tooltipText = customIcon.name .. ' (' .. categoryLabel .. ')';
                         end
 
-                        local isSelected = editingMacro.customIconType == 'custom' and editingMacro.customIconPath == customIcon.path;
-                        if DrawIconButton('##custom' .. itemIdx, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                            editingMacro.customIconType = 'custom';
-                            editingMacro.customIconPath = customIcon.path;
-                            editingMacro.customIconId = nil;
-                            iconPickerOpen = false;
+                        local isSelectedCust;
+                        if MP.iconPickerTargetIsJaBadge then
+                            isSelectedCust = MP.editingMacro.jaBadgeCustomIconType == 'custom' and MP.editingMacro.jaBadgeCustomIconPath == customIcon.path;
+                        else
+                            isSelectedCust = MP.editingMacro.customIconType == 'custom' and MP.editingMacro.customIconPath == customIcon.path;
+                        end
+                        if DrawIconButton('##custom' .. itemIdx, icon, ICON_GRID_SIZE, isSelectedCust, tooltipText) then
+                            if MP.iconPickerTargetIsJaBadge then
+                                MP.editingMacro.jaBadgeCustomIconType = 'custom';
+                                MP.editingMacro.jaBadgeCustomIconPath = customIcon.path;
+                                MP.editingMacro.jaBadgeCustomIconId = nil;
+                                MP.editorJaBadgeManuallySet = true;
+                            else
+                                MP.editingMacro.customIconType = 'custom';
+                                MP.editingMacro.customIconPath = customIcon.path;
+                                MP.editingMacro.customIconId = nil;
+                            end
+                            MP.editorAutoIconKey = nil;
+                            MP.iconPickerOpen = false;
                         end
 
                         displayedCount = displayedCount + 1;
@@ -3181,12 +5728,13 @@ local function DrawIconPicker()
     PopWindowStyle();
 
     if not isOpen[1] then
-        iconPickerOpen = false;
-        iconPickerFilter[1] = '';
-        iconPickerPage = { 1, 1, 1 };  -- Reset pages
-        iconPickerLastFilter = { '', '', '' };
-        iconPickerSpellType = 'All';  -- Reset spell type filter
-        iconPickerItemType = 0;  -- Reset item type filter (0 = All)
+        MP.iconPickerOpen = false;
+        MP.iconPickerTargetIsJaBadge = false;
+        MP.iconPickerFilter[1] = '';
+        MP.iconPickerPage = { 1, 1, 1 };  -- Reset pages
+        MP.iconPickerLastFilter = { '', '', '' };
+        MP.iconPickerSpellType = 'All';  -- Reset spell type filter
+        MP.iconPickerItemType = 0;  -- Reset item type filter (0 = All)
         customIconCategory = 'all';  -- Reset custom category filter
         -- Clear filter caches when picker closes
         filteredSpellsCache = nil;
@@ -3194,626 +5742,570 @@ local function DrawIconPicker()
         filteredItemsCache = nil;
         filteredItemsCacheKey = nil;
         customIconsCacheKey = nil;
+        filteredCustomIconsCache = nil;
+        filteredCustomIconsCacheKey = nil;
         -- Reset progressive icon loading
         ResetIconLoading();
     end
 end
 
-function M.DrawMacroEditor()
-    if not editingMacro then
+-- When opening the icon picker (Change), align tab / filters with the resolved icon; search text is always the
+-- primary action name (what auto-pick matched against), not the resolved spell/item/custom label.
+-- Implemented on M (not a file-local) so M.DrawMacroEditor does not gain an extra upvalue (Lua 5.1 limit: 60).
+function M.ApplyIconPickerContextFromEditor(forJaBadgeArg)
+    if not MP.editingMacro then
         return;
     end
 
-    -- Initialize editor fields from editing macro
-    editorFields.actionType[1] = FindIndex(ACTION_TYPES, editingMacro.actionType or 'ma');
-    editorFields.action[1] = editingMacro.action or '';
-    editorFields.target[1] = FindIndex(TARGET_OPTIONS, editingMacro.target or 't');
-    editorFields.displayName[1] = editingMacro.displayName or '';
-    editorFields.equipSlot[1] = FindIndex(EQUIP_SLOTS, editingMacro.equipSlot or 'main');
-    editorFields.macroText[1] = editingMacro.macroText or '';
-    editorFields.recastSourceType[1] = FindIndex(RECAST_SOURCE_TYPES, editingMacro.recastSourceType or 'none');
-    editorFields.recastSourceAction[1] = editingMacro.recastSourceAction or '';
+    local forJaBadge = forJaBadgeArg and true or false;
+    MP.iconPickerTargetIsJaBadge = forJaBadge;
 
-    local title = isCreatingNew and 'Create Macro###MacroEditor' or 'Edit Macro###MacroEditor';
-    local isOpen = { true };
+    local pType;
+    local pName;
+    local jaBadgeName;
 
-    imgui.SetNextWindowSize({420, 480}, ImGuiCond_FirstUseEver);
+    if MP.editingMacro.actionType == 'macro' then
+        local mp = require('modules.hotbar.macroparse');
+        pType, pName, jaBadgeName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+    else
+        pType = MP.editingMacro.actionType;
+        pName = MP.editingMacro.action;
+    end
 
-    -- Apply XIUI styling
-    PushWindowStyle();
-
-    if imgui.Begin(title, isOpen, ImGuiWindowFlags_NoCollapse) then
-        -- Icon preview section at the top right (uses window-relative positioning for scrolling)
-        local iconPreviewSize = 64;
-        local contentWidth = imgui.GetContentRegionAvail();
-        local iconPreviewX = contentWidth - iconPreviewSize - 10;
-
-        -- Draw icon preview and Change button together
-        local startCursorY = imgui.GetCursorPosY();
-        imgui.SetCursorPosX(iconPreviewX);
-
-        -- Get screen position for icon preview (DrawIconPreview needs screen coords)
-        local screenPos = {imgui.GetCursorScreenPos()};
-        DrawIconPreview(editingMacro, screenPos[1], screenPos[2], iconPreviewSize);
-
-        -- Change Icon button below preview (use window-relative SetCursorPos for scroll support)
-        imgui.SetCursorPos({iconPreviewX - 10, startCursorY + iconPreviewSize + 8});
-        imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
-        imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
-        if imgui.Button('Change', {iconPreviewSize + 20, 22}) then
-            iconPickerOpen = true;
-            iconPickerFilter[1] = '';
+    if forJaBadge then
+        if not jaBadgeName or jaBadgeName == '' then
+            return;
         end
-        imgui.PopStyleColor();
-        imgui.PopStyleVar();
+        pType = 'ja';
+        pName = jaBadgeName;
+    end
 
-        -- Reset cursor for main content (left side, use window-relative positioning)
-        imgui.SetCursorPos({8, startCursorY});
+    if pName then
+        pName = tostring(pName);
+        pName = pName:match('^%s*(.-)%s*$') or pName;
+        if pName == '' then
+            pName = nil;
+        end
+    end
 
-        -- Action Type dropdown with label
-        imgui.TextColored(COLORS.goldDim, 'Action Type');
-        PushComboStyle();
-        imgui.SetNextItemWidth(240);
-        local currentType = ACTION_TYPES[editorFields.actionType[1]];
-        if imgui.BeginCombo('##actionType', ACTION_TYPE_LABELS[currentType] or 'Select...') then
-            for i, actionType in ipairs(ACTION_TYPES) do
-                local isSelected = editorFields.actionType[1] == i;
-                if isSelected then
-                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
-                end
-                if imgui.Selectable(ACTION_TYPE_LABELS[actionType], isSelected) then
-                    editorFields.actionType[1] = i;
-                    editingMacro.actionType = actionType;
-                    -- Clear action when type changes
-                    editingMacro.action = '';
-                    editorFields.action[1] = '';
-                    searchFilter[1] = '';
-                    -- Clear recast source fields when changing away from macro type
-                    if actionType ~= 'macro' then
-                        editingMacro.recastSourceType = nil;
-                        editingMacro.recastSourceAction = nil;
-                        editingMacro.recastSourceItemId = nil;
-                        editorFields.recastSourceType[1] = 1;  -- Reset to 'none'
-                        editorFields.recastSourceAction[1] = '';
+    local ct = forJaBadge and MP.editingMacro.jaBadgeCustomIconType or MP.editingMacro.customIconType;
+    local cid = forJaBadge and MP.editingMacro.jaBadgeCustomIconId or MP.editingMacro.customIconId;
+    local cp = forJaBadge and MP.editingMacro.jaBadgeCustomIconPath or MP.editingMacro.customIconPath;
+
+    local src = MP.editorIconAutoSource or 'all';
+
+    -- Custom XIUI icon actually on the macro, or the same match auto-pick would use first (/pet before spell, etc.).
+    local customEntryForPicker = nil;
+    if ct == 'custom' and cp and tostring(cp) ~= '' then
+        customEntryForPicker = FindCustomIconEntryBySavedPath(cp);
+        if not customEntryForPicker then
+            local base = tostring(cp):match('[^\\/]+$') or '';
+            base = base:gsub('%.png$', '');
+            if base ~= '' then
+                customEntryForPicker = { name = base, category = 'all' };
+            end
+        end
+    elseif ct ~= 'spell' and ct ~= 'item' and pName then
+        -- Match AutoPick order: item id â†’ spell id (for /ma) before inferring a custom PNG.
+        local exactItemId = (MP.editingMacro.itemId and tonumber(MP.editingMacro.itemId)) or actiondb.GetItemId(pName);
+        local maSpellId = (pType == 'ma' and pName) and actions.GetSpellIdByEnglishName(pName, 'ma') or nil;
+        local tryInfer = (pType == 'pet' or pType == 'ja' or pType == 'ws')
+            or (src == 'custom' and pType == 'ma')
+            or (pType == 'ma' and pName and not maSpellId and (src == 'all' or src == 'custom'))
+            or ((pType == 'item' or pType == 'equip') and (not exactItemId or exactItemId == 0));
+        if tryInfer then
+            customEntryForPicker = ResolveBestCustomIconMatchForActionName(pName, MP.editorCustomIconCategory or 'all');
                     end
                 end
-                if isSelected then
-                    imgui.PopStyleColor();
+
+    if customEntryForPicker then
+        MP.iconPickerTab = 3;
+    elseif src == 'items' then
+        MP.iconPickerTab = 2;
+    elseif src == 'custom' then
+        MP.iconPickerTab = 3;
+    elseif src == 'spells' then
+        MP.iconPickerTab = 1;
+    else
+        if pType == 'item' or pType == 'equip' then
+            MP.iconPickerTab = 2;
+        else
+            MP.iconPickerTab = 1;
+                end
+            end
+
+    MP.iconPickerPage[1] = 1;
+    MP.iconPickerPage[2] = 1;
+    MP.iconPickerPage[3] = 1;
+
+    filteredSpellsCache = nil;
+    filteredSpellsCacheKey = nil;
+    filteredItemsCache = nil;
+    filteredItemsCacheKey = nil;
+    customIconsCacheKey = nil;
+    filteredCustomIconsCache = nil;
+    filteredCustomIconsCacheKey = nil;
+    ResetIconLoading();
+
+    local function mapHorizonTypeToSpellFilter(dbType)
+        if not dbType or dbType == 'All' then
+            return nil;
+        end
+        if dbType == 'BloodPact' then
+            return 'SummonerPact';
+        end
+        for _, st in ipairs(SPELL_TYPE_ORDER) do
+            if st == dbType then
+                return dbType;
+            end
+        end
+        return nil;
+    end
+
+    if MP.iconPickerTab == 2 then
+        MP.iconPickerSpellType = 'All';
+        -- Search shows the action text auto-pick matched against, not the resolved item's canonical name.
+        if pName and (pType == 'item' or pType == 'equip') then
+            MP.iconPickerFilter[1] = pName;
+        else
+            MP.iconPickerFilter[1] = '';
+        end
+        return;
+    end
+
+    if MP.iconPickerTab == 3 then
+        MP.iconPickerSpellType = 'All';
+        -- Same: search = user/primary-line text that drove matching; folder still reflects the picked asset.
+        MP.iconPickerFilter[1] = pName or '';
+        if customEntryForPicker then
+            if customEntryForPicker.category and customEntryForPicker.category ~= 'root' then
+                customIconCategory = customEntryForPicker.category;
+            else
+                customIconCategory = 'all';
+            end
+        end
+        return;
+    end
+
+    -- Spells tab: spell-type filter from resolved id/row; search = primary action text (what matching used).
+    do
+        local horizonSpells = require('modules.hotbar.database.horizonspells');
+        local hid;
+
+        if ct == 'spell' and cid then
+            hid = tonumber(cid);
+        elseif not forJaBadge then
+            local at = tostring(MP.editingMacro.actionType or '');
+            local maOrPet = false;
+            if at == 'macro' then
+                local mp = require('modules.hotbar.macroparse');
+                local pt = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+                maOrPet = (pt == 'ma' or pt == 'pet');
+            elseif at == 'ma' or at == 'pet' then
+                maOrPet = true;
+            end
+            if maOrPet then
+                local _, rid = actions.GetBindIcon(MP.editingMacro);
+                if rid and type(rid) == 'number' and horizonSpells[rid] and horizonSpells[rid].en then
+                    hid = rid;
+                end
+            end
+        end
+
+        if hid then
+            local h = horizonSpells[hid];
+            if h and h.en then
+                local bt = mapHorizonTypeToSpellFilter(h.type);
+                if bt then
+                    MP.iconPickerSpellType = bt;
+                else
+                    MP.iconPickerSpellType = 'All';
+                end
+                MP.iconPickerFilter[1] = pName or '';
+                return;
+            end
+        end
+    end
+
+    local spellRow = nil;
+    if pName and (pType == 'ma' or pType == 'pet') then
+        spellRow = actions.GetHorizonSpellForIconResolution(pName, pType);
+    end
+
+    local bestType = spellRow and mapHorizonTypeToSpellFilter(spellRow.type) or nil;
+
+    if bestType then
+        MP.iconPickerSpellType = bestType;
+        MP.iconPickerFilter[1] = pName or '';
+    elseif pType == 'ma' or pType == 'pet' then
+        MP.iconPickerSpellType = 'All';
+        MP.iconPickerFilter[1] = pName or '';
+    else
+        MP.iconPickerSpellType = 'All';
+        MP.iconPickerFilter[1] = pName or '';
+    end
+end
+
+-- Title-bar display name for the macro editor (e.g. "WHM", "Global", "SMN (Ifrit)").
+function M.GetEditorSaveDisplayName()
+    local saveKey = MP.editorPaletteKey or GetEffectivePaletteType();
+    return GetPaletteDisplayName(saveKey);
+end
+
+-- Compact save-target toolbar drawn just below the title bar in create mode.
+function M.DrawMacroEditorSaveToSection(creatingNew, contentWidth)
+    local function applyEditorSaveKey(newKey)
+        MP.editorPaletteKey = newKey;
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+    end
+
+    local saveKey = MP.editorPaletteKey or GetEffectivePaletteType();
+    local currentPlayerJob = data.jobId or 1;
+
+    if not creatingNew then
+        return;
+    end
+
+    local function mc(k)
+        return CountMacrosInPalette(k);
+    end
+    local function labelTextWidth(str)
+        local sz = imgui.CalcTextSize(tostring(str or ''));
+        if type(sz) == 'table' then
+            return sz[1] or sz.x or 0;
+        end
+        return tonumber(sz) or 0;
+    end
+
+    imgui.TextColored(COLORS.textDim, 'Saving To');
+    imgui.SameLine(0, 6);
+
+    local maxOptW = labelTextWidth(GetPaletteDisplayName(saveKey));
+    local gCount = mc(GLOBAL_MACRO_KEY);
+    local gLabel = gCount > 0 and string.format('Global (%d)', gCount) or 'Global';
+    maxOptW = math.max(maxOptW, labelTextWidth(gLabel));
+    local iCount = mc(ITEMS_MACRO_KEY);
+    local iLabel = iCount > 0 and string.format('Items (%d)', iCount) or 'Items';
+    maxOptW = math.max(maxOptW, labelTextWidth(iLabel));
+    local eCount = mc(EQUIPMENT_MACRO_KEY);
+    local eLabel = eCount > 0 and string.format('Equipment (%d)', eCount) or 'Equipment';
+    maxOptW = math.max(maxOptW, labelTextWidth(eLabel));
+    local xCount = mc(XIUI_MACRO_KEY);
+    local xLabel = xCount > 0 and string.format('XIUI Commands (%d)', xCount) or 'XIUI Commands';
+    maxOptW = math.max(maxOptW, labelTextWidth(xLabel));
+    EnsureMacroCustomCategoriesList();
+    for _, cat in ipairs(gConfig.macroCustomCategories) do
+        local ck = cat.key;
+        local cCount = mc(ck);
+        local cLab = cat.label or ck;
+        if cCount > 0 then
+            cLab = string.format('%s (%d)', cLab, cCount);
+        end
+        maxOptW = math.max(maxOptW, labelTextWidth(cLab));
+    end
+    for _, job in ipairs(JOB_LIST) do
+        local jCount = mc(job.id);
+        local label = job.name;
+        if jCount > 0 then
+            label = string.format('%s (%d)', label, jCount);
+        end
+        if job.id == currentPlayerJob then
+            label = label .. '  *';
+        end
+        if job.id == data.subjobId then
+            label = label .. '  /sub';
+        end
+        maxOptW = math.max(maxOptW, labelTextWidth(label));
+    end
+    local fp = imgui.GetStyle().FramePadding;
+    local fpX = (type(fp) == 'table' and (fp.x or fp[1])) or 8;
+    local comboW = maxOptW + (fpX * 2) + 28;
+    comboW = math.max(80, math.min(comboW, contentWidth * 0.4));
+
+    PushComboStyle();
+    imgui.SetNextItemWidth(comboW);
+    if imgui.BeginCombo('##macroEditorSavePalette', GetPaletteDisplayName(saveKey), ImGuiComboFlags_None) then
+        local gSel = (saveKey == GLOBAL_MACRO_KEY);
+        if gSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif gCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(gLabel, gSel) then
+            applyEditorSaveKey(GLOBAL_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local itemsSel = (saveKey == ITEMS_MACRO_KEY);
+        if itemsSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif iCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(iLabel, itemsSel) then
+            applyEditorSaveKey(ITEMS_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local equipSel = (saveKey == EQUIPMENT_MACRO_KEY);
+        if equipSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif eCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(eLabel, equipSel) then
+            applyEditorSaveKey(EQUIPMENT_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local xiuiSel = (saveKey == XIUI_MACRO_KEY);
+        if xiuiSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif xCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(xLabel, xiuiSel) then
+            applyEditorSaveKey(XIUI_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        for _, cat in ipairs(gConfig.macroCustomCategories) do
+            local ck = cat.key;
+            local cCount = mc(ck);
+            local cLab = cat.label or ck;
+            if cCount > 0 then
+                cLab = string.format('%s (%d)', cLab, cCount);
+            end
+            local cSel = (saveKey == ck);
+            if cSel then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            elseif cCount > 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+            if imgui.Selectable(cLab, cSel) then
+                applyEditorSaveKey(ck);
+            end
+            imgui.PopStyleColor();
+        end
+
+        imgui.Separator();
+
+        for _, job in ipairs(JOB_LIST) do
+            local jCount = mc(job.id);
+            local label = job.name;
+            if jCount > 0 then
+                label = string.format('%s (%d)', label, jCount);
+            end
+            if job.id == currentPlayerJob then
+                label = label .. '  *';
+            end
+            if job.id == data.subjobId then
+                label = label .. '  /sub';
+            end
+            local jSel = (EditorSaveKeyToJobId(saveKey) == job.id);
+            if jSel then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            elseif jCount > 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+            if imgui.Selectable(label, jSel) then
+                applyEditorSaveKey(job.id);
+            end
+            imgui.PopStyleColor();
+        end
+        imgui.EndCombo();
+    end
+    PopComboStyle();
+
+    -- SMN sub-type combo on the same line
+    if EditorSaveKeyToJobId(saveKey) == petregistry.JOB_SMN then
+        imgui.SameLine(0, 10);
+        imgui.TextColored(COLORS.textDim, '/');
+        imgui.SameLine(0, 10);
+
+        local avatarList = petregistry.GetAvatarList();
+        local currentLabel = 'Base SMN';
+        if type(saveKey) == 'string' then
+            local jobId, petType, petId = saveKey:match('^(%d+):([^:]+):(.+)$');
+            if jobId and tonumber(jobId) == petregistry.JOB_SMN and petType == 'avatar' and petId then
+                for name, key in pairs(petregistry.avatars) do
+                    if key == petId then
+                        currentLabel = name;
+                        break;
+                    end
+                end
+            end
+        end
+
+        local subMaxW = labelTextWidth('Base SMN');
+        for _, av in ipairs(avatarList) do
+            subMaxW = math.max(subMaxW, labelTextWidth(av));
+        end
+        local subComboW = subMaxW + (fpX * 2) + 28;
+        subComboW = math.max(80, math.min(subComboW, contentWidth * 0.35));
+
+        PushComboStyle();
+        imgui.SetNextItemWidth(subComboW);
+        if imgui.BeginCombo('##SaveAvatarPalette', currentLabel, ImGuiComboFlags_None) then
+            local isBaseSelected = (type(saveKey) == 'number' and saveKey == petregistry.JOB_SMN);
+            if imgui.Selectable('Base SMN', isBaseSelected) then
+                applyEditorSaveKey(petregistry.JOB_SMN);
+            end
+            imgui.Separator();
+            for _, avatar in ipairs(avatarList) do
+                local avatarKey = petregistry.avatars[avatar];
+                local fullKey = avatarKey and string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey) or nil;
+                local isSelected = (fullKey ~= nil and saveKey == fullKey);
+                if imgui.Selectable(avatar, isSelected) then
+                    applyEditorSaveKey(fullKey);
                 end
             end
             imgui.EndCombo();
         end
         PopComboStyle();
-
-        imgui.Spacing();
-        imgui.Spacing();
-
-        -- Dynamic fields based on action type
-        currentType = ACTION_TYPES[editorFields.actionType[1]];
-
-        if currentType == 'ma' then
-            -- Spell: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Spell');
-            local spells = GetCachedSpells();
-            if spells and #spells > 0 then
-                DrawSearchableCombo('##spellCombo', spells, editingMacro.action or '', function(spell)
-                    editingMacro.action = spell.name;
-                    editorFields.action[1] = spell.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = spell.name;
-                        editorFields.displayName[1] = spell.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No spells available for this job');
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'ja' then
-            -- Ability: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Ability');
-            local abilities = GetCachedAbilities();
-            if abilities and #abilities > 0 then
-                DrawSearchableCombo('##abilityCombo', abilities, editingMacro.action or '', function(ability)
-                    editingMacro.action = ability.name;
-                    editorFields.action[1] = ability.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = ability.name;
-                        editorFields.displayName[1] = ability.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No abilities available');
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'ws' then
-            -- Weaponskill: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Weaponskill');
-            local weaponskills = GetCachedWeaponskills();
-            if weaponskills and #weaponskills > 0 then
-                DrawSearchableCombo('##wsCombo', weaponskills, editingMacro.action or '', function(ws)
-                    editingMacro.action = ws.name;
-                    editorFields.action[1] = ws.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = ws.name;
-                        editorFields.displayName[1] = ws.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No weaponskills available');
-            end
-
-            -- Target dropdown (default to <t>)
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'item' then
-            -- Item: Searchable dropdown or manual input
-            imgui.TextColored(COLORS.goldDim, 'Item');
-            local items = GetCachedItems();
-            if items and #items > 0 then
-                DrawSearchableCombo('##itemCombo', items, editingMacro.action or '', function(item)
-                    editingMacro.action = item.name;
-                    editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
-                    editorFields.action[1] = item.name;
-                    editingMacro.displayName = item.name;
-                    editorFields.displayName[1] = item.name;
-                end, true);  -- Show icons
-                imgui.SameLine();
-                imgui.TextColored(COLORS.textMuted, '(' .. #items .. ')');
-            else
-                imgui.TextColored(COLORS.textMuted, 'No items found in storage');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type item name:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##itemName', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'equip' then
-            -- Equipment slot dropdown
-            imgui.TextColored(COLORS.goldDim, 'Equipment Slot');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##equipSlot', EQUIP_SLOT_LABELS[EQUIP_SLOTS[editorFields.equipSlot[1]]] or 'Select...') then
-                for i, slot in ipairs(EQUIP_SLOTS) do
-                    local isSelected = editorFields.equipSlot[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(EQUIP_SLOT_LABELS[slot], isSelected) then
-                        editorFields.equipSlot[1] = i;
-                        editingMacro.equipSlot = slot;
-                        -- Clear item selection when slot changes (old item may not fit new slot)
-                        editingMacro.action = '';
-                        editingMacro.itemId = nil;
-                        editingMacro.displayName = '';
-                        editorFields.action[1] = '';
-                        editorFields.displayName[1] = '';
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-            -- Item: Searchable dropdown or manual input (filtered by selected equipment slot)
-            imgui.Spacing();
-            local selectedSlot = EQUIP_SLOTS[editorFields.equipSlot[1]];
-            imgui.TextColored(COLORS.goldDim, 'Item (' .. EQUIP_SLOT_LABELS[selectedSlot] .. ')');
-            local equipItems = GetCachedItems();
-            if equipItems and #equipItems > 0 then
-                DrawSearchableCombo('##equipItemCombo', equipItems, editingMacro.action or '', function(item)
-                    editingMacro.action = item.name;
-                    editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
-                    editorFields.action[1] = item.name;
-                    editingMacro.displayName = item.name;
-                    editorFields.displayName[1] = item.name;
-                end, true, selectedSlot);  -- Show icons, filter by selected slot
-                imgui.SameLine();
-                imgui.TextColored(COLORS.textMuted, '(' .. #equipItems .. ')');
-            else
-                imgui.TextColored(COLORS.textMuted, 'No items found in storage');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type item name:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##equipItemName', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-        elseif currentType == 'macro' then
-            -- Raw macro command (8 lines like native FFXI macro editor)
-            imgui.TextColored(COLORS.goldDim, 'Macro Commands (8 lines)');
-
-            -- Style the multiline input
-            imgui.PushStyleColor(ImGuiCol_FrameBg, COLORS.bgMedium);
-            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLORS.bgLight);
-            imgui.PushStyleColor(ImGuiCol_FrameBgActive, COLORS.bgLight);
-
-            -- 8 rows * ~16px line height + padding
-            local lineHeight = imgui.GetTextLineHeight();
-            local inputHeight = (lineHeight * 8) + 8;
-
-            if imgui.InputTextMultiline('##macroText', editorFields.macroText, MACRO_BUFFER_SIZE, {280, inputHeight}) then
-                editingMacro.macroText = editorFields.macroText[1];
-                editingMacro.action = editorFields.macroText[1];
-            end
-
-            imgui.PopStyleColor(3);
-            imgui.ShowHelp('Enter commands, one per line (e.g., /ma "Cure" <stpc>)');
-
-            -- Recast Source section (optional)
-            imgui.Spacing();
-            imgui.Spacing();
-            if imgui.TreeNode('Recast Source (Optional)##recastSource') then
-                imgui.TextColored(COLORS.textMuted, 'Show cooldown from a different action');
-                imgui.Spacing();
-
-                -- Recast source type dropdown
-                imgui.TextColored(COLORS.goldDim, 'Source Type');
-                PushComboStyle();
-                imgui.SetNextItemWidth(240);
-                local currentRecastType = RECAST_SOURCE_TYPES[editorFields.recastSourceType[1]] or 'none';
-                if imgui.BeginCombo('##recastSourceType', RECAST_SOURCE_LABELS[currentRecastType] or 'None') then
-                    for i, sourceType in ipairs(RECAST_SOURCE_TYPES) do
-                        local isSelected = editorFields.recastSourceType[1] == i;
-                        if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                        if imgui.Selectable(RECAST_SOURCE_LABELS[sourceType], isSelected) then
-                            editorFields.recastSourceType[1] = i;
-                            if sourceType == 'none' then
-                                editingMacro.recastSourceType = nil;
-                                editingMacro.recastSourceAction = nil;
-                                editingMacro.recastSourceItemId = nil;
-                            else
-                                editingMacro.recastSourceType = sourceType;
-                            end
-                            -- Clear action when type changes
-                            editingMacro.recastSourceAction = nil;
-                            editingMacro.recastSourceItemId = nil;
-                            editorFields.recastSourceAction[1] = '';
-                        end
-                        if isSelected then imgui.PopStyleColor(); end
-                    end
-                    imgui.EndCombo();
-                end
-                PopComboStyle();
-
-                -- Show action selector based on recast source type
-                currentRecastType = RECAST_SOURCE_TYPES[editorFields.recastSourceType[1]] or 'none';
-
-                if currentRecastType == 'ma' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Spell');
-                    local spells = GetCachedSpells();
-                    if spells and #spells > 0 then
-                        DrawSearchableCombo('##recastSpellCombo', spells, editingMacro.recastSourceAction or '', function(spell)
-                            editingMacro.recastSourceAction = spell.name;
-                            editorFields.recastSourceAction[1] = spell.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No spells available');
-                    end
-
-                elseif currentRecastType == 'ja' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Ability');
-                    local abilities = GetCachedAbilities();
-                    if abilities and #abilities > 0 then
-                        DrawSearchableCombo('##recastAbilityCombo', abilities, editingMacro.recastSourceAction or '', function(ability)
-                            editingMacro.recastSourceAction = ability.name;
-                            editorFields.recastSourceAction[1] = ability.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No abilities available');
-                    end
-
-                elseif currentRecastType == 'item' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Item');
-                    local items = GetCachedItems();
-                    if items and #items > 0 then
-                        DrawSearchableCombo('##recastItemCombo', items, editingMacro.recastSourceAction or '', function(item)
-                            editingMacro.recastSourceAction = item.name;
-                            editingMacro.recastSourceItemId = item.id;
-                            editorFields.recastSourceAction[1] = item.name;
-                        end, true);  -- Show icons
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No items available');
-                    end
-
-                elseif currentRecastType == 'pet' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Pet Command');
-                    -- Use current job for pet commands
-                    local viewedJobId = selectedPaletteType;
-                    if type(viewedJobId) ~= 'number' then
-                        viewedJobId = playerdata.GetCacheJobId() or 0;
-                    end
-                    local petCommands = GetPetCommandsForJob(viewedJobId, selectedAvatarPalette, nil);
-                    if petCommands and #petCommands > 0 then
-                        DrawSearchableCombo('##recastPetCombo', petCommands, editingMacro.recastSourceAction or '', function(cmd)
-                            editingMacro.recastSourceAction = cmd.name;
-                            editorFields.recastSourceAction[1] = cmd.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No pet commands available');
-                    end
-                end
-
-                imgui.TreePop();
-            end
-
-        elseif currentType == 'pet' then
-            -- For SMN, show avatar filter dropdown
-            -- Use the VIEWED palette's job, not necessarily the player's current job
-            local viewedJobId = selectedPaletteType;
-            if type(viewedJobId) ~= 'number' then
-                viewedJobId = playerdata.GetCacheJobId() or 0;
-            end
-            local avatarList = petregistry.GetAvatarList();
-
-            if viewedJobId == petregistry.JOB_SMN then
-                imgui.TextColored(COLORS.goldDim, 'Avatar Filter');
-                PushComboStyle();
-                imgui.SetNextItemWidth(240);
-                local filterLabel = petAvatarFilter == 1 and 'All Avatars' or avatarList[petAvatarFilter - 1];
-                if imgui.BeginCombo('##avatarFilter', filterLabel) then
-                    -- "All" option
-                    local isAllSelected = petAvatarFilter == 1;
-                    if isAllSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable('All Avatars', isAllSelected) then
-                        petAvatarFilter = 1;
-                        cachedPetCommands = nil;  -- Clear cache to rebuild
-                    end
-                    if isAllSelected then imgui.PopStyleColor(); end
-
-                    imgui.Separator();
-
-                    -- Individual avatars
-                    for i, avatar in ipairs(avatarList) do
-                        local isSelected = petAvatarFilter == i + 1;
-                        if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                        if imgui.Selectable(avatar, isSelected) then
-                            petAvatarFilter = i + 1;
-                            cachedPetCommands = nil;  -- Clear cache to rebuild
-                        end
-                        if isSelected then imgui.PopStyleColor(); end
-                    end
-                    imgui.EndCombo();
-                end
-                PopComboStyle();
-                imgui.Spacing();
-            end
-
-            -- Build pet commands cache if needed
-            if not cachedPetCommands then
-                local avatarName = nil;
-                local activePetName = nil;
-                if viewedJobId == petregistry.JOB_SMN then
-                    -- Prefer the macro palette's avatar selection, then the filter
-                    if selectedAvatarPalette then
-                        avatarName = selectedAvatarPalette;
-                    elseif petAvatarFilter > 1 then
-                        avatarName = avatarList[petAvatarFilter - 1];
-                    end
-                elseif viewedJobId == petregistry.JOB_BST then
-                    -- Get the active pet's entity name for BST ready moves
-                    activePetName = petpalette.GetCurrentPetEntityName();
-                end
-                cachedPetCommands = GetPetCommandsForJob(viewedJobId, avatarName, activePetName);
-            end
-
-            -- Pet command dropdown
-            imgui.TextColored(COLORS.goldDim, 'Pet Command');
-            if cachedPetCommands and #cachedPetCommands > 0 then
-                DrawSearchableCombo('##petCommandCombo', cachedPetCommands, editingMacro.action or '', function(cmd)
-                    editingMacro.action = cmd.name;
-                    editorFields.action[1] = cmd.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = cmd.name;
-                        editorFields.displayName[1] = cmd.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No pet commands available for this job');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type command:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##petCommandManual', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-        end
-
-        -- Slot Label input (for all types)
-        imgui.Spacing();
-        imgui.Spacing();
-        imgui.TextColored(COLORS.goldDim, 'Slot Label');
-        imgui.SetNextItemWidth(240);
-        if imgui.InputText('##displayName', editorFields.displayName, 32) then
-            editingMacro.displayName = editorFields.displayName[1];
-        end
-        if currentType ~= 'macro' then
-            imgui.ShowHelp('Short label shown on the slot (e.g., "Cure3"). Leave empty to use action name.');
-        else
-            imgui.ShowHelp('Label shown on the slot for this macro.');
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Save button with success styling
-        imgui.PushStyleColor(ImGuiCol_Button, COLORS.success);
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.5, 0.8, 0.5, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.6, 0.9, 0.6, 1.0});
-        imgui.PushStyleColor(ImGuiCol_Text, {0.1, 0.1, 0.1, 1.0});
-
-        if imgui.Button('Save', {90, 28}) then
-            -- Validate before saving
-            local canSave = false;
-
-            if currentType == 'macro' then
-                canSave = (editingMacro.macroText or '') ~= '';
-                if canSave and (editingMacro.displayName or '') == '' then
-                    editingMacro.displayName = 'Macro';
-                end
-                -- Clear target for macro type (targets are embedded in macro text)
-                editingMacro.target = nil;
-            else
-                canSave = (editingMacro.action or '') ~= '';
-                if canSave and (editingMacro.displayName or '') == '' then
-                    editingMacro.displayName = editingMacro.action;
-                end
-            end
-
-            if canSave then
-                -- Look up itemId for item/equip macros if not already set
-                -- This handles cases where user typed item name manually instead of selecting from dropdown
-                if (currentType == 'item' or currentType == 'equip') and not editingMacro.itemId and editingMacro.action then
-                    editingMacro.itemId = actiondb.GetItemId(editingMacro.action);
-                end
-
-                if isCreatingNew then
-                    M.AddMacro(editingMacro);
-                    -- Navigate to last page to show the new macro
-                    local db = M.GetMacroDatabase();
-                    currentPalettePage = math.max(1, math.ceil(#db / PALETTE_MACROS_PER_PAGE));
-                else
-                    M.UpdateMacro(editingMacro.id, editingMacro);
-                end
-                editingMacro = nil;
-                isCreatingNew = false;
-                searchFilter[1] = '';
-                iconPickerOpen = false;
-                iconPickerFilter[1] = '';
-            end
-        end
-
-        imgui.PopStyleColor(4);
-
-        imgui.SameLine();
-
-        -- Cancel button
-        if imgui.Button('Cancel', {90, 28}) then
-            editingMacro = nil;
-            isCreatingNew = false;
-            searchFilter[1] = '';
-            iconPickerOpen = false;
-            iconPickerFilter[1] = '';
-        end
     end
 
-    imgui.End();
-    PopWindowStyle();
+    if EditorSaveKeyToJobId(saveKey) == petregistry.JOB_BST then
+        imgui.SameLine(0, 10);
+        imgui.TextColored(COLORS.textDim, '/');
+        imgui.SameLine(0, 10);
 
-    if not isOpen[1] then
-        editingMacro = nil;
-        isCreatingNew = false;
-        searchFilter[1] = '';
-        iconPickerOpen = false;
-        iconPickerFilter[1] = '';
+        local currentJugLabel = 'Base BST';
+        if type(saveKey) == 'string' then
+            local jobId, petType, petId = saveKey:match('^(%d+):([^:]+):(.+)$');
+            if jobId and tonumber(jobId) == petregistry.JOB_BST and petType == petregistry.PET_TYPE_JUG and petId then
+                currentJugLabel = petregistry.GetDisplayNameForKey(petregistry.PET_TYPE_JUG .. ':' .. petId);
+            end
+        end
+
+        local subMaxW = labelTextWidth('Base BST');
+        local bstPetKeys = petregistry.GetAvailablePetKeys(petregistry.JOB_BST);
+        for _, pk in ipairs(bstPetKeys) do
+            local slug = pk:match('^jug:(.+)$');
+            if slug then
+                subMaxW = math.max(subMaxW, labelTextWidth(petregistry.GetDisplayNameForKey(pk)));
+            end
+        end
+        local subComboW = subMaxW + (fpX * 2) + 28;
+        subComboW = math.max(80, math.min(subComboW, contentWidth * 0.35));
+
+        PushComboStyle();
+        imgui.SetNextItemWidth(subComboW);
+        if imgui.BeginCombo('##SaveBstJugPalette', currentJugLabel, ImGuiComboFlags_None) then
+            local isBaseSelected = (type(saveKey) == 'number' and saveKey == petregistry.JOB_BST);
+            if imgui.Selectable('Base BST', isBaseSelected) then
+                applyEditorSaveKey(petregistry.JOB_BST);
+            end
+            imgui.Separator();
+            for _, pk in ipairs(bstPetKeys) do
+                local slug = pk:match('^jug:(.+)$');
+                if slug then
+                    local fullKey = string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug);
+                    local label = petregistry.GetDisplayNameForKey(pk);
+                    local isSelected = (saveKey == fullKey);
+                    if imgui.Selectable(label, isSelected) then
+                        applyEditorSaveKey(fullKey);
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        PopComboStyle();
     end
 
-    -- Draw icon picker if open
-    DrawIconPicker();
+    imgui.SameLine(0, 6);
+    imgui.ShowHelp('Palette this macro is saved to.');
+    imgui.Separator();
+    imgui.Spacing();
 end
+
+-- Macro editor: macropalette_macroeditor.lua (Lua 5.1 max 60 upvalues per function).
+do
+    MP.M = M;
+    MP.imgui = imgui;
+    MP.ffi = ffi;
+    MP.actions = actions;
+    MP.data = data;
+    MP.textures = textures;
+    MP.petregistry = petregistry;
+    MP.actiondb = actiondb;
+    MP.playerdata = playerdata;
+    MP.petpalette = petpalette;
+    MP.components = components;
+    MP.COLORS = COLORS;
+    MP.jobs = jobs;
+    MP.ACTION_TYPES = ACTION_TYPES;
+    MP.ACTION_TYPES_ITEMS_BUCKET = ACTION_TYPES_ITEMS_BUCKET;
+    MP.ACTION_TYPE_LABELS = ACTION_TYPE_LABELS;
+    MP.RECAST_SOURCE_TYPES = RECAST_SOURCE_TYPES;
+    MP.RECAST_SOURCE_LABELS = RECAST_SOURCE_LABELS;
+    MP.TARGET_OPTIONS = TARGET_OPTIONS;
+    MP.TARGET_LABELS = TARGET_LABELS;
+    MP.EQUIP_SLOTS = EQUIP_SLOTS;
+    MP.EQUIP_SLOT_LABELS = EQUIP_SLOT_LABELS;
+    MP.ICON_AUTO_SOURCES = ICON_AUTO_SOURCES;
+    MP.ICON_AUTO_SOURCE_LABELS = ICON_AUTO_SOURCE_LABELS;
+    MP.INPUT_BUFFER_SIZE = INPUT_BUFFER_SIZE;
+    MP.MACRO_BUFFER_SIZE = MACRO_BUFFER_SIZE;
+    MP.PALETTE_MACROS_PER_PAGE = PALETTE_MACROS_PER_PAGE;
+    MP.SPELL_TYPE_ORDER = SPELL_TYPE_ORDER;
+    MP.SPELL_TYPE_LABELS = SPELL_TYPE_LABELS;
+    MP.SPELL_TYPE_JOB_ICONS = SPELL_TYPE_JOB_ICONS;
+    MP.editorFields = editorFields;
+    MP.CUSTOM_ICON_CATEGORIES = CUSTOM_ICON_CATEGORIES;
+    MP.CUSTOM_ICON_LABELS = CUSTOM_ICON_LABELS;
+    MP.FindIndex = FindIndex;
+    MP.DrawSearchableCombo = DrawSearchableCombo;
+    MP.DrawIconButton = DrawIconButton;
+    MP.DrawIconPreview = DrawIconPreview;
+    MP.PushComboStyle = PushComboStyle;
+    MP.PopComboStyle = PopComboStyle;
+    MP.PushWindowStyle = PushWindowStyle;
+    MP.PopWindowStyle = PopWindowStyle;
+    MP.LoadCustomIcons = LoadCustomIcons;
+    MP.InvalidateCustomIconScanCaches = InvalidateCustomIconScanCaches;
+    MP.GetCachedSpells = GetCachedSpells;
+    MP.GetCachedAbilities = GetCachedAbilities;
+    MP.GetCachedWeaponskills = GetCachedWeaponskills;
+    MP.GetCachedItems = GetCachedItems;
+    MP.GetPetCommandsForJob = GetPetCommandsForJob;
+    MP.EditorSaveKeyToJobId = EditorSaveKeyToJobId;
+    MP.ITEMS_MACRO_KEY = ITEMS_MACRO_KEY;
+    MP.EQUIPMENT_MACRO_KEY = EQUIPMENT_MACRO_KEY;
+    MP.XIUI_MACRO_KEY = XIUI_MACRO_KEY;
+    MP.ResolveBestCustomIconMatchForActionName = ResolveBestCustomIconMatchForActionName;
+    MP.SyncSaveSubTypeFromPetAvatarFilter = SyncSaveSubTypeFromPetAvatarFilter;
+    MP.SyncSaveSubTypeFromBstJugFamily = SyncSaveSubTypeFromBstJugFamily;
+    MP.SyncPetAvatarFilterFromSaveSubType = SyncPetAvatarFilterFromSaveSubType;
+    MP.ClearEditorPreviewIconCache = ClearEditorPreviewIconCache;
+    MP.ClearPaletteJaBadgeIconCache = ClearPaletteJaBadgeIconCache;
+    MP.HydrateMacroEditorIconPrefs = HydrateMacroEditorIconPrefs;
+    MP.ValidateEditorCustomIconCategoryAgainstScan = ValidateEditorCustomIconCategoryAgainstScan;
+    MP.PersistMacroEditorIconPrefs = PersistMacroEditorIconPrefs;
+    MP.DrawIconPicker = DrawIconPicker;
+    MP.paletteMainIconCache = paletteMainIconCache;
+    MP.paletteJaBadgeIconCache = paletteJaBadgeIconCache;
+end
+
+local runMacroEditor = require('modules.hotbar.macropalette_macroeditor')(MP);
+
+function M.DrawMacroEditor()
+    runMacroEditor();
+end
+
 
 -- ============================================
 -- Dragdrop Library Accessors (for display.lua)
@@ -3857,3 +6349,4 @@ end
 data.SetSlotDataChangedCallback(MarkHotbarDirty);
 
 return M;
+

--- a/XIUI/modules/hotbar/macropalette_macroeditor.lua
+++ b/XIUI/modules/hotbar/macropalette_macroeditor.lua
@@ -1,0 +1,1787 @@
+return function(MP)
+    return function()
+    if not MP.editingMacro then
+        return;
+    end
+
+    if not MP.editorIconPrefsHydrated then
+        MP.HydrateMacroEditorIconPrefs();
+        MP.ValidateEditorCustomIconCategoryAgainstScan();
+        MP.editorIconPrefsHydrated = true;
+    end
+
+    -- Legacy: `action` was set to the full multiline buffer; normalize to the parsed primary name.
+    if MP.editingMacro.actionType == 'macro' and MP.editingMacro.macroText and MP.editingMacro.macroText ~= '' then
+        local a = tostring(MP.editingMacro.action or '');
+        local looksLikeFullMacro = (a:find('\n') or a:find('\r') or a:match('^%s*/'));
+        if looksLikeFullMacro or a == '' then
+            local mp = require('modules.hotbar.macroparse');
+            local _, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText);
+            if pName and pName ~= '' then
+                MP.editingMacro.action = pName;
+            end
+        end
+    end
+
+    -- Initialize editor fields from editing macro
+    MP.editorFields.actionType[1] = MP.FindIndex(MP.ACTION_TYPES, MP.editingMacro.actionType or 'ma');
+    MP.editorFields.action[1] = MP.editingMacro.action or '';
+    MP.editorFields.target[1] = MP.FindIndex(MP.TARGET_OPTIONS, MP.editingMacro.target or 't');
+    MP.editorFields.displayName[1] = MP.editingMacro.displayName or '';
+    MP.editorFields.equipSlot[1] = MP.FindIndex(MP.EQUIP_SLOTS, MP.editingMacro.equipSlot or 'main');
+    MP.editorFields.macroText[1] = MP.editingMacro.macroText or '';
+    MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES, MP.editingMacro.recastSourceType or 'none');
+    MP.editorFields.recastSourceAction[1] = MP.editingMacro.recastSourceAction or '';
+
+    MP.M.ClampMacroEditorForItemsPalette();
+
+    local saveDisplayName = MP.M.GetEditorSaveDisplayName and MP.M.GetEditorSaveDisplayName() or nil;
+    local titlePrefix = MP.isCreatingNew and 'Create Macro' or 'Edit Macro';
+    local title;
+    if saveDisplayName and saveDisplayName ~= '' then
+        title = titlePrefix .. ' - ' .. saveDisplayName .. '###MacroEditor';
+    else
+        title = titlePrefix .. '###MacroEditor';
+    end
+    local isOpen = { true };
+
+    -- Track whether the Slot Label is currently "auto" (same as action). This lets new selections refresh it.
+    do
+        local dn = (MP.editingMacro.displayName or '');
+        local act = (MP.editingMacro.action or '');
+        if dn ~= '' and act ~= '' and dn == act then
+            MP.editorAutoLabel = dn;
+        end
+    end
+
+    local function AutoSetDisplayName(newLabel)
+        if not newLabel or newLabel == '' then return; end
+        local current = (MP.editingMacro.displayName or '');
+        if current == '' or (MP.editorAutoLabel and current == MP.editorAutoLabel) then
+            MP.editingMacro.displayName = newLabel;
+            MP.editorFields.displayName[1] = newLabel;
+            MP.editorAutoLabel = newLabel;
+        end
+    end
+
+    local function ApplyDefaultEditorTargetForJaAbility(abilityName)
+        if abilityName == 'Reward' or abilityName == 'Call Beast' then
+            MP.editorFields.target[1] = MP.FindIndex(MP.TARGET_OPTIONS, 'me');
+            MP.editingMacro.target = 'me';
+        end
+    end
+
+    local function ApplyDefaultEditorTargetForPetCommand(commandName)
+        if commandName == 'Ready'
+            or commandName == 'Ready (Recast)'
+            or commandName == 'Ready (Use)' then
+            MP.editorFields.target[1] = MP.FindIndex(MP.TARGET_OPTIONS, 'me');
+            MP.editingMacro.target = 'me';
+        end
+    end
+
+    --- Primary Pet Command combo shows synthetic Ready rows when jug progression is enabled; map saved macro.action back to the visible row label.
+    local function BstPetPrimaryComboCurrentLabel(macro, viewedPetJobId)
+        if (macro.actionType or '') ~= 'pet' then
+            return macro.action or '';
+        end
+        if viewedPetJobId ~= MP.petregistry.JOB_BST or not MP.petregistry.IsBstJugReadyMovesEnabled() then
+            return macro.action or '';
+        end
+        local act = macro.action or '';
+        if act == 'Ready' then
+            return 'Ready (Recast)';
+        end
+        if macro.bstReadyMode == 'use' and act == '' then
+            return 'Ready (Use)';
+        end
+        if MP.petregistry.IsBstJugReadyMoveName(act) then
+            return 'Ready (Use)';
+        end
+        return act;
+    end
+
+    -- Pet commands follow "Saving To" + Avatar Filter in the editor, not the separate Macro Palette avatar.
+    local function GetEditorPetJobId()
+        if MP.editorPaletteKey and MP.EditorSaveKeyToJobId then
+            local jid = MP.EditorSaveKeyToJobId(MP.editorPaletteKey);
+            if jid then
+                return jid;
+            end
+        end
+        local viewedJobId = MP.selectedPaletteType;
+        if type(viewedJobId) == 'number' then
+            return viewedJobId;
+        end
+        return MP.playerdata.GetCacheJobId() or 0;
+    end
+
+    local function SmnAvatarNameFromEditorFilter(avatarList)
+        if MP.petAvatarFilter <= 1 then
+            return nil;
+        end
+        return avatarList[MP.petAvatarFilter - 1];
+    end
+
+    local function GetCurrentActionNameForIcon()
+        local t = tostring(MP.editingMacro.actionType or '');
+        if t == '' then return nil; end
+        if t == 'macro' then return nil; end
+        local name = tostring(MP.editingMacro.action or '');
+        if name == '' then return nil; end
+        return name;
+    end
+
+    -- Implicit auto-pick (no force): only when no icon is stored yet, and not already synced to MP.editorAutoIconKey.
+    -- Matching MP.editorAutoIconKey means "already applied"; re-pick only via Sync (force=true) or first-open block.
+    local function ShouldAllowImplicitAutoIconPick()
+        local t = MP.editingMacro.customIconType;
+        local id = MP.editingMacro.customIconId;
+        local p = MP.editingMacro.customIconPath;
+        local curKey = tostring(t or '') .. ':' .. tostring(id or '') .. ':' .. tostring(p or '');
+        if MP.editorAutoIconKey and curKey == MP.editorAutoIconKey then
+            return false;
+        end
+        if t == nil and id == nil and (p == nil or p == '') then
+            return true;
+        end
+        return false;
+    end
+
+    local function SetIconSpell(spellId)
+        if not spellId then return; end
+        MP.editingMacro.customIconType = 'spell';
+        MP.editingMacro.customIconId = spellId;
+        MP.editingMacro.customIconPath = nil;
+        MP.editorAutoIconKey = 'spell:' .. tostring(spellId) .. ':';
+    end
+
+    local function SetIconItem(itemId)
+        if not itemId then return; end
+        MP.editingMacro.customIconType = 'item';
+        MP.editingMacro.customIconId = itemId;
+        MP.editingMacro.customIconPath = nil;
+        MP.editorAutoIconKey = 'item:' .. tostring(itemId) .. ':';
+    end
+
+    local function SetIconCustom(customPath)
+        if not customPath or customPath == '' then return; end
+        MP.editingMacro.customIconType = 'custom';
+        MP.editingMacro.customIconPath = customPath;
+        MP.editingMacro.customIconId = nil;
+        MP.editorAutoIconKey = 'custom::' .. tostring(customPath);
+    end
+
+    -- Fallback PNGs in addons/XIUI/assets/icons/ (ma.png, ja.png, macro.png, refresh.png, …)
+    local function SetIconXiuiDefault(stem)
+        if not stem or stem == '' then
+            stem = 'refresh';
+        end
+        MP.editingMacro.customIconType = 'xiui_default';
+        MP.editingMacro.customIconPath = stem;
+        MP.editingMacro.customIconId = nil;
+        MP.editorAutoIconKey = 'xiui_default::' .. stem;
+    end
+
+    local function DefaultIconStemForActionType(at)
+        if at == 'ma' then return 'ma'; end
+        if at == 'ja' then return 'ja'; end
+        if at == 'ws' then return 'ws'; end
+        if at == 'item' then return 'item'; end
+        if at == 'equip' then return 'equip'; end
+        if at == 'pet' then return 'pet'; end
+        if at == 'macro' then return 'macro'; end
+        return 'refresh';
+    end
+
+    local function TryAutoPickCustomIcon(actionName)
+        local icon = MP.ResolveBestCustomIconMatchForActionName(actionName, MP.editorCustomIconCategory or 'all');
+        if icon and icon.path then
+            SetIconCustom(icon.path);
+            return true;
+        end
+        return false;
+    end
+
+    -- Game spell icon: player's cache first, then horizon DB (context-aware for /ma vs /pet duplicates).
+    local function TryAutoPickSpellIconByActionName(actionName, actionType)
+        if not actionName or actionName == '' then
+            return false;
+        end
+        if actionType ~= 'ma' and actionType ~= 'pet' then
+            return false;
+        end
+        local spells = MP.GetCachedSpells();
+        if spells then
+            for _, s in ipairs(spells) do
+                if s and s.name and s.id and string.lower(s.name) == string.lower(actionName) then
+                    SetIconSpell(s.id);
+                    return true;
+                end
+            end
+        end
+        local spellId = MP.actions.GetSpellIdByEnglishName(actionName, actionType);
+        if spellId then
+            SetIconSpell(spellId);
+            return true;
+        end
+        return false;
+    end
+
+    -- Game item texture by item/equip action + itemId / name lookup.
+    local function TryAutoPickItemIconByAction(actionName, actionType)
+        if actionType ~= 'item' and actionType ~= 'equip' then
+            return false;
+        end
+        local itemId = MP.editingMacro.itemId;
+        if (not itemId or itemId == 0) and actionName and actionName ~= '' then
+            itemId = MP.actiondb.GetItemId(actionName);
+        end
+        if itemId and itemId ~= 0 then
+            SetIconItem(itemId);
+            return true;
+        end
+        return false;
+    end
+
+    local function VirtualStemForParsedPrimary(pType)
+        if pType == 'ma' then return 'ma'; end
+        if pType == 'ja' then return 'ja'; end
+        if pType == 'ws' then return 'ws'; end
+        if pType == 'pet' then return 'pet'; end
+        if pType == 'item' then return 'item'; end
+        if pType == 'equip' then return 'equip'; end
+        return 'macro';
+    end
+
+    -- Resolve icon from parsed macro lines (primary /ws /ma /pet …) using the same source rules as other types.
+    local function PickIconForMacroParsedPrimary()
+        local mp = require('modules.hotbar.macroparse');
+        local pType, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+        if not pName or pName == '' then
+            SetIconXiuiDefault('macro');
+            return;
+        end
+        local src = MP.editorIconAutoSource;
+        if src == 'all' then
+            if pType == 'ma' and TryAutoPickSpellIconByActionName(pName, 'ma') then return; end
+            -- /pet and /ja: custom assets (SMN folders, Summoning, etc.) before horizon "spell" ids — school magic ≠ blood pact
+            if pType == 'pet' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                if TryAutoPickSpellIconByActionName(pName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if pType == 'ja' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            if (pType == 'item' or pType == 'equip') and TryAutoPickItemIconByAction(pName, pType) then return; end
+            if TryAutoPickCustomIcon(pName) then return; end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+            return;
+        end
+        if src == 'spells' then
+            if pType == 'ma' and TryAutoPickSpellIconByActionName(pName, 'ma') then return; end
+            if pType == 'pet' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                if TryAutoPickSpellIconByActionName(pName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if pType == 'ja' then
+                if TryAutoPickCustomIcon(pName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+            return;
+        end
+        if src == 'items' then
+            if (pType == 'item' or pType == 'equip') and TryAutoPickItemIconByAction(pName, pType) then return; end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+            return;
+        end
+        if src == 'custom' then
+            if TryAutoPickCustomIcon(pName) then return; end
+            SetIconXiuiDefault(VirtualStemForParsedPrimary(pType));
+        end
+    end
+
+    local function SyncMacroSlotLabelFromParsedCommands()
+        local mp = require('modules.hotbar.macroparse');
+        local _, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+        if pName and pName ~= '' then
+            MP.editingMacro.displayName = pName;
+            MP.editorFields.displayName[1] = pName;
+            MP.editorAutoLabel = pName;
+        end
+    end
+
+    -- Clear JA badge overrides so the badge uses default resolution for the current /ja line (GetBindIcon ja).
+    local function SyncJaBadgeIconFromMacro()
+        MP.editorJaBadgeManuallySet = false;
+        MP.editingMacro.jaBadgeCustomIconType = nil;
+        MP.editingMacro.jaBadgeCustomIconId = nil;
+        MP.editingMacro.jaBadgeCustomIconPath = nil;
+        if MP.ClearPaletteJaBadgeIconCache then
+            MP.ClearPaletteJaBadgeIconCache();
+        end
+    end
+
+    local function AutoPickIconForSelection(force)
+        if not MP.editingMacro then return; end
+        if not force and not ShouldAllowImplicitAutoIconPick() then return; end
+
+        local actionType = tostring(MP.editingMacro.actionType or '');
+        if actionType == 'macro' then
+            PickIconForMacroParsedPrimary();
+            return;
+        end
+
+        local actionName = GetCurrentActionNameForIcon();
+        if not actionName or actionName == '' then
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        local src = MP.editorIconAutoSource;
+        if src == 'all' then
+            if actionType == 'ma' and TryAutoPickSpellIconByActionName(actionName, 'ma') then return; end
+            if actionType == 'pet' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                if TryAutoPickSpellIconByActionName(actionName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if actionType == 'ja' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            if TryAutoPickItemIconByAction(actionName, actionType) then return; end
+            if TryAutoPickCustomIcon(actionName) then return; end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        if src == 'spells' then
+            if actionType == 'ma' and TryAutoPickSpellIconByActionName(actionName, 'ma') then return; end
+            if actionType == 'pet' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                if TryAutoPickSpellIconByActionName(actionName, 'pet') then return; end
+                SetIconXiuiDefault('pet');
+                return;
+            end
+            if actionType == 'ja' then
+                if TryAutoPickCustomIcon(actionName) then return; end
+                SetIconXiuiDefault('ja');
+                return;
+            end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        if src == 'items' then
+            if TryAutoPickItemIconByAction(actionName, actionType) then return; end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+            return;
+        end
+
+        if src == 'custom' then
+            if TryAutoPickCustomIcon(actionName) then return; end
+            SetIconXiuiDefault(DefaultIconStemForActionType(actionType));
+        end
+    end
+
+    local function RefreshEditorAutoIconKey()
+        local t = MP.editingMacro.customIconType;
+        local id = MP.editingMacro.customIconId;
+        local p = MP.editingMacro.customIconPath;
+        if t == nil and id == nil and (p == nil or p == '') then
+            MP.editorAutoIconKey = nil;
+        else
+            MP.editorAutoIconKey = tostring(t or '') .. ':' .. tostring(id or '') .. ':' .. tostring(p or '');
+        end
+    end
+
+    -- Dropdown picks = intentional action change: icon should follow; clear manual flag.
+    local function SyncEditorIconAfterListPick()
+        MP.editorIconManuallySet = false;
+        AutoPickIconForSelection(true);
+        RefreshEditorAutoIconKey();
+    end
+
+    -- One-time implicit auto-pick when typing (manual action / macro lines).
+    -- Skipped when the user has manually chosen an icon via the Change button.
+    local function TryFirstImplicitActionIconAuto()
+        if MP.editorImplicitActionIconDone then
+            return;
+        end
+        if MP.editorIconManuallySet then
+            return;
+        end
+        -- Use force=false so saved/manual icons are not overwritten when macro text changes
+        -- (AutoPickIconForSelection(true) bypasses ShouldAllowImplicitAutoIconPick).
+        AutoPickIconForSelection(false);
+        MP.editorImplicitActionIconDone = true;
+        RefreshEditorAutoIconKey();
+    end
+
+    -- First editor frame: align MP.editorAutoIconKey with the saved macro (no automatic icon refresh on open).
+    if not MP.editorDidInitialIconPick then
+        MP.editorDidInitialIconPick = true;
+        RefreshEditorAutoIconKey();
+    end
+
+    -- Manual resize: do NOT use AlwaysAutoResize — it fights the resize grip every frame.
+    MP.imgui.SetNextWindowSize({520, 680}, ImGuiCond_FirstUseEver);
+    MP.imgui.SetNextWindowSizeConstraints({480, 320}, {1000, 900});
+
+    -- Apply XIUI styling
+    MP.PushWindowStyle();
+
+    if MP.imgui.Begin(title, isOpen, ImGuiWindowFlags_NoCollapse) then
+        local avail = MP.imgui.GetContentRegionAvail();
+        local contentWidth = (type(avail) == 'table' and avail[1]) or avail or 400;
+        local miniToolBtn = 22;
+        local uiIconRefresh = MP.actions.LoadXiuiAssetIcon('refresh');
+        local uiIconSync = MP.actions.LoadXiuiAssetIcon('sync');
+        local uiIconFolder = MP.actions.LoadXiuiAssetIcon('folder');
+
+        -- ── Save-target toolbar (create mode) ──
+        MP.M.DrawMacroEditorSaveToSection(MP.isCreatingNew, contentWidth);
+
+        -- ── Layout metrics ──
+        local iconPreviewSize = 56;
+        local previewInset = 2;
+        local hasJaBadge = false;
+        do
+            local mp = require('modules.hotbar.macroparse');
+            hasJaBadge = MP.editingMacro.actionType == 'macro' and mp.MacroHasJaBadgePair(MP.editingMacro.macroText or '');
+        end
+        local iconPanelW = 198;
+        local iconPanelPad = 10;
+        -- Wider window → wider fields (icon column stays fixed width).
+        local fieldW = math.max(120, math.min(contentWidth - iconPanelW - 24, 640));
+        local changeBtnW = iconPreviewSize;
+        local showFolder = (MP.editorIconAutoSource == 'custom');
+
+        -- ── Action Type (left column, top) ──
+        local topY = MP.imgui.GetCursorPosY();
+
+        MP.imgui.TextColored(MP.COLORS.goldDim, 'Action Type');
+        MP.PushComboStyle();
+        MP.imgui.SetNextItemWidth(fieldW);
+        local typesForCombo = MP.ACTION_TYPES;
+        if MP.M.EditorMacroPaletteKeyIsItems(MP.editorPaletteKey) then
+            typesForCombo = MP.ACTION_TYPES_ITEMS_BUCKET;
+        end
+        local currentType = MP.ACTION_TYPES[MP.editorFields.actionType[1]];
+        if MP.imgui.BeginCombo('##actionType', MP.ACTION_TYPE_LABELS[currentType] or 'Select...') then
+            for _, actionType in ipairs(typesForCombo) do
+                local i = MP.FindIndex(MP.ACTION_TYPES, actionType);
+                local isSelected = MP.editorFields.actionType[1] == i;
+                if isSelected then
+                    MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold);
+                end
+                if MP.imgui.Selectable(MP.ACTION_TYPE_LABELS[actionType], isSelected) then
+                    MP.editorFields.actionType[1] = i;
+                    MP.editingMacro.actionType = actionType;
+                    MP.editingMacro.action = '';
+                    MP.editorFields.action[1] = '';
+                    MP.searchFilter[1] = '';
+                    if actionType ~= 'macro' then
+                        MP.editingMacro.recastSourceType = nil;
+                        MP.editingMacro.recastSourceAction = nil;
+                        MP.editingMacro.recastSourceItemId = nil;
+                        MP.editorFields.recastSourceType[1] = 1;
+                        MP.editorFields.recastSourceAction[1] = '';
+                        MP.editingMacro.showJaBadgeOnMacro = nil;
+                    end
+                    if actionType == 'pet' then
+                        MP.SyncSaveSubTypeFromPetAvatarFilter();
+                        MP.SyncSaveSubTypeFromBstJugFamily();
+                    end
+                    MP.editorImplicitActionIconDone = false;
+                end
+                if isSelected then
+                    MP.imgui.PopStyleColor();
+                end
+            end
+            MP.imgui.EndCombo();
+        end
+        MP.PopComboStyle();
+
+        -- Remember Y after action type so dynamic fields flow right below
+        local yAfterActionType = MP.imgui.GetCursorPosY();
+
+        -- Icon panel height: Custom + JA badge stacks the left column taller than the preview column;
+        -- JA block must start below BOTH or labels overlap ("Folder" vs "JA badge").
+        local function estimateIconPanelTotalH()
+            local frameH = (MP.imgui.GetFrameHeight and MP.imgui.GetFrameHeight()) or 28;
+            local tls = (MP.imgui.GetTextLineHeightWithSpacing and MP.imgui.GetTextLineHeightWithSpacing()) or 20;
+            local tl = (MP.imgui.GetTextLineHeight and MP.imgui.GetTextLineHeight()) or 14;
+            local iconRowH = math.max(miniToolBtn, tl + 2);
+            local hLeft = iconPanelPad + iconRowH + tls + frameH + tls + frameH;
+            if showFolder then
+                hLeft = hLeft + tls + frameH + tls + tl + 6 + miniToolBtn;
+            end
+            local previewTop = iconPanelPad + previewInset;
+            local hRight = previewTop + iconPreviewSize + 4 + 20;
+            local core = math.max(hLeft, hRight);
+            if hasJaBadge then
+                -- Label + spacing + checkbox row + SameLine Change (needs extra slack; some ImGui builds clip low)
+                core = core + 8 + tl + 8 + tls + frameH + 28;
+                if showFolder then
+                    core = core + 16;
+                end
+            end
+            return core + iconPanelPad + 8;
+        end
+
+        -- ── Icon sub-container (float to top-right) ──
+        local iconPanelX = contentWidth - iconPanelW;
+        local iconPanelTotalH = estimateIconPanelTotalH();
+
+        MP.imgui.SetCursorPos({iconPanelX, topY});
+        MP.imgui.PushStyleColor(ImGuiCol_ChildBg, {0.18, 0.16, 0.11, 0.95});
+
+        local iconPanelScreenPos = {MP.imgui.GetCursorScreenPos()};
+        -- Optional vertical scrollbar when Macro + Custom (tall stack); avoids clipped buttons if estimate is short
+        local iconChildFlags = 0;
+        if hasJaBadge and showFolder and ImGuiWindowFlags_AlwaysVerticalScrollbar ~= nil then
+            iconChildFlags = ImGuiWindowFlags_AlwaysVerticalScrollbar;
+        end
+        if MP.imgui.BeginChild('##iconPanel', {iconPanelW, iconPanelTotalH}, false, iconChildFlags) then
+            local innerAvail = MP.imgui.GetContentRegionAvail();
+            local innerW = (type(innerAvail) == 'table' and innerAvail[1]) or innerAvail or iconPanelW;
+
+            -- Manual insets since WindowPadding isn't reliable in this ImGui
+            MP.imgui.SetCursorPos({iconPanelPad, iconPanelPad});
+            local usableW = innerW - iconPanelPad * 2;
+            local previewGap = 22;
+
+            -- Left column: source combo + optional folder
+            local leftColW = usableW - iconPreviewSize - previewGap;
+
+            -- Icon label + tool buttons (first row)
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Icon');
+            MP.imgui.SameLine(0, 4);
+            if MP.DrawIconButton('##macroEditorIconReset', uiIconRefresh, miniToolBtn, false,
+                    'Reset icon to type default') then
+                SetIconXiuiDefault(DefaultIconStemForActionType(tostring(MP.editingMacro.actionType or '')));
+            end
+            MP.imgui.SameLine(0, 2);
+            if MP.DrawIconButton('##macroEditorIconSync', uiIconSync, miniToolBtn, false,
+                    'Sync main slot icon from current action or macro lines') then
+                MP.editorIconManuallySet = false;
+                AutoPickIconForSelection(true);
+                RefreshEditorAutoIconKey();
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Choosing from the list syncs the main icon. For Macro type, text edits do not change the main icon after you use Change — press Sync to refresh, or Sync after typing.');
+
+            -- Source combo
+            MP.imgui.SetCursorPosX(iconPanelPad);
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(leftColW);
+            local srcLabel = MP.ICON_AUTO_SOURCE_LABELS[MP.editorIconAutoSource] or 'All';
+            if MP.imgui.BeginCombo('##iconAutoSource', srcLabel, ImGuiComboFlags_None) then
+                for _, src in ipairs(MP.ICON_AUTO_SOURCES) do
+                    local isSel = (MP.editorIconAutoSource == src);
+                    if MP.imgui.Selectable(MP.ICON_AUTO_SOURCE_LABELS[src] or src, isSel) then
+                        MP.editorIconAutoSource = src;
+                        MP.PersistMacroEditorIconPrefs();
+                    end
+                    if isSel then MP.imgui.SetItemDefaultFocus(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+            -- Custom icon source: category combo then folder row (finish left column before preview / JA block)
+            if showFolder then
+                MP.LoadCustomIcons();
+
+                -- Category sub-menu
+                MP.imgui.SetCursorPosX(iconPanelPad);
+                local categories = MP.CUSTOM_ICON_CATEGORIES or { 'all' };
+                if not MP.editorCustomIconCategory then MP.editorCustomIconCategory = 'all'; end
+                local catLabel = MP.CUSTOM_ICON_LABELS[MP.editorCustomIconCategory] or MP.editorCustomIconCategory or 'All';
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(leftColW);
+                if MP.imgui.BeginCombo('##iconCustomFolder', catLabel, ImGuiComboFlags_None) then
+                    local isAll = (MP.editorCustomIconCategory == 'all');
+                    if MP.imgui.Selectable(MP.CUSTOM_ICON_LABELS['all'] or 'All', isAll) then
+                        MP.editorCustomIconCategory = 'all';
+                        MP.PersistMacroEditorIconPrefs();
+                    end
+                    MP.imgui.Separator();
+                    for _, cat in ipairs(categories) do
+                        if cat ~= 'all' then
+                            local isSel = (MP.editorCustomIconCategory == cat);
+                            local catLbl = MP.CUSTOM_ICON_LABELS[cat] or cat;
+                            if MP.imgui.Selectable(catLbl, isSel) then
+                                MP.editorCustomIconCategory = cat;
+                                MP.PersistMacroEditorIconPrefs();
+                            end
+                            if isSel then MP.imgui.SetItemDefaultFocus(); end
+                        end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                -- Folder open button
+                MP.imgui.SetCursorPosX(iconPanelPad);
+                MP.imgui.TextColored(MP.COLORS.textDim, 'Folder');
+                MP.imgui.SameLine(0, 4);
+                if MP.DrawIconButton('##openXiuiAssetsFolder', uiIconFolder, miniToolBtn, false,
+                        'Open assets folder in Explorer') then
+                    local assetsRoot = string.format('%saddons\\XIUI\\assets\\', AshitaCore:GetInstallPath());
+                    if ashita and ashita.fs and not ashita.fs.exists(assetsRoot) then
+                        ashita.fs.create_directory(assetsRoot);
+                    end
+                    os.execute('explorer "' .. assetsRoot .. '"');
+                end
+            end
+
+            local yLeftEnd = MP.imgui.GetCursorPosY();
+
+            -- Preview + main Change (right column), top-aligned with icon row
+            local previewX = innerW - iconPreviewSize - iconPanelPad - previewInset;
+            local previewTopY = iconPanelPad + previewInset;
+            MP.imgui.SetCursorPos({previewX, previewTopY});
+            local screenPos = {MP.imgui.GetCursorScreenPos()};
+            MP.DrawIconPreview(MP.editingMacro, screenPos[1], screenPos[2], iconPreviewSize);
+
+            MP.imgui.SetCursorPos({previewX, previewTopY + iconPreviewSize + 4});
+            MP.imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
+            MP.imgui.PushStyleColor(ImGuiCol_Border, MP.COLORS.gold);
+            if MP.imgui.Button('Change##macroEditorIconChange', {changeBtnW, 20}) then
+                MP.InvalidateCustomIconScanCaches();
+                MP.iconPickerTargetIsJaBadge = false;
+                MP.iconPickerOpen = true;
+                MP.editorIconManuallySet = true;
+                MP.M.ApplyIconPickerContextFromEditor(false);
+            end
+            MP.imgui.PopStyleColor();
+            MP.imgui.PopStyleVar();
+
+            local yRightEnd = previewTopY + iconPreviewSize + 4 + 20;
+
+            -- JA badge block starts below the taller of the left stack or the preview column (no overlap with Folder row)
+            if hasJaBadge then
+                if MP.editingMacro.showJaBadgeOnMacro == nil then
+                    MP.editingMacro.showJaBadgeOnMacro = true;
+                end
+                local jaY = math.max(yLeftEnd, yRightEnd) + 8;
+                MP.imgui.SetCursorPos({iconPanelPad, jaY});
+                MP.imgui.TextColored(MP.COLORS.textDim, 'JA badge');
+                MP.imgui.SameLine(0, 4);
+                if MP.DrawIconButton('##macroEditorJaBadgeSync', uiIconSync, miniToolBtn, false,
+                        'Sync JA badge icon from the current /ja line (clears a manual badge icon)') then
+                    SyncJaBadgeIconFromMacro();
+                end
+                MP.imgui.SameLine(0, 2);
+                MP.imgui.ShowHelp('After you pick a badge icon with Change, it stays until you Sync here. Macro text edits do not override a manual badge icon.');
+                MP.imgui.Spacing();
+                MP.imgui.SetCursorPosX(iconPanelPad);
+                local showJaBadgeBuf = { MP.editingMacro.showJaBadgeOnMacro ~= false };
+                if MP.imgui.Checkbox('Use JA Badge##showJaBadgeMacro', showJaBadgeBuf) then
+                    MP.editingMacro.showJaBadgeOnMacro = showJaBadgeBuf[1];
+                end
+                MP.imgui.SameLine(0, 8);
+                MP.imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
+                MP.imgui.PushStyleColor(ImGuiCol_Border, MP.COLORS.gold);
+                if MP.imgui.Button('Change##macroJaBadgeIconChange', {changeBtnW, 20}) then
+                    MP.InvalidateCustomIconScanCaches();
+                    MP.iconPickerOpen = true;
+                    MP.editorJaBadgeManuallySet = true;
+                    MP.M.ApplyIconPickerContextFromEditor(true);
+                end
+                MP.imgui.PopStyleColor();
+                MP.imgui.PopStyleVar();
+            end
+        end
+        MP.imgui.EndChild();
+        MP.imgui.PopStyleColor();
+
+        -- Draw gold border manually (child border style not reliable in this ImGui)
+        local drawList = MP.imgui.GetWindowDrawList();
+        if drawList then
+            local bx = iconPanelScreenPos[1] or iconPanelScreenPos.x or 0;
+            local by = iconPanelScreenPos[2] or iconPanelScreenPos.y or 0;
+            local borderCol = MP.imgui.GetColorU32(MP.COLORS.gold);
+            drawList:AddRect({bx, by}, {bx + iconPanelW, by + iconPanelTotalH}, borderCol, 4, 0, 1.5);
+        end
+
+        -- ── Continue left column below Action Type ──
+        MP.imgui.SetCursorPos({8, yAfterActionType});
+        MP.imgui.Spacing();
+
+        -- Dynamic fields based on action type
+        currentType = MP.ACTION_TYPES[MP.editorFields.actionType[1]];
+
+        if currentType == 'ma' then
+            -- Spell: Show searchable dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Spell');
+            MP.imgui.SameLine();
+            local showAllSpells = { MP.showAllMode };
+            if MP.imgui.Checkbox('Show All##showAllSpells', showAllSpells) then
+                MP.showAllMode = showAllSpells[1];
+                MP.playerdata.ClearExpandedCaches();
+                if MP.showAllMode and MP.spellTypeFilter == 'All' then
+                    local jobTypes = MP.playerdata.GetMagicTypesForJob();
+                    if #jobTypes > 0 then
+                        MP.spellTypeFilter = jobTypes[1].key;
+                        MP.playerdata.ClearExpandedCaches();
+                    end
+                end
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Green = known, Yellow = learnable (right job/level), Red = unavailable');
+            local spells;
+            local useStatusColors = false;
+            if MP.showAllMode then
+                -- Magic Type filter dropdown
+                local filterLabel = MP.playerdata.GetMagicTypeLabel(MP.spellTypeFilter);
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if MP.imgui.BeginCombo('##spellTypeFilter', filterLabel) then
+                    local allTypes = MP.playerdata.GetAllMagicTypes();
+                    local jobTypes = MP.playerdata.GetMagicTypesForJob();
+                    local jobSet = {};
+                    for _, jt in ipairs(jobTypes) do jobSet[jt.key] = true; end
+
+                    for _, mt in ipairs(allTypes) do
+                        local isSel = (MP.spellTypeFilter == mt.key);
+                        local label = mt.label;
+                        if jobSet[mt.key] then label = label .. '  [Current]'; end
+                        if isSel then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(label, isSel) then
+                            MP.spellTypeFilter = mt.key;
+                            MP.playerdata.ClearExpandedCaches();
+                        end
+                        if isSel then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                spells = MP.playerdata.GetAllSpellsForCurrentJob(MP.spellTypeFilter);
+                useStatusColors = true;
+            else
+                spells = MP.GetCachedSpells();
+            end
+            if spells and #spells > 0 then
+                MP.DrawSearchableCombo('##spellCombo', spells, MP.editingMacro.action or '', function(spell)
+                    MP.editingMacro.action = spell.name;
+                    MP.editorFields.action[1] = spell.name;
+                    AutoSetDisplayName(spell.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No spells available for this job');
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'ja' then
+            -- Ability: Show searchable dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Ability');
+            MP.imgui.SameLine();
+            local showAllJA = { MP.showAllMode };
+            if MP.imgui.Checkbox('Show All##showAllAbilities', showAllJA) then
+                MP.showAllMode = showAllJA[1];
+                MP.playerdata.ClearExpandedCaches();
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Green = known, Yellow = learnable (right job/level), Red = unavailable.\nUse the Job filter to browse abilities for any job.');
+            local abilities;
+            local useStatusColors = false;
+            if MP.showAllMode then
+                -- Job filter dropdown (only shown when Show All is on)
+                local player = AshitaCore:GetMemoryManager():GetPlayer();
+                local mainJobId = player and player:GetMainJob() or 0;
+                local subJobId = player and player:GetSubJob() or 0;
+                local mainJobAbbr = MP.jobs[mainJobId] or '???';
+                local subJobAbbr = (subJobId and subJobId > 0) and MP.jobs[subJobId] or nil;
+
+                local filterLabel;
+                if MP.abilityJobFilter == 0 then
+                    if subJobAbbr then
+                        filterLabel = mainJobAbbr .. ' + ' .. subJobAbbr .. ' (Current)';
+                    else
+                        filterLabel = mainJobAbbr .. ' (Current)';
+                    end
+                else
+                    filterLabel = MP.jobs[MP.abilityJobFilter] or '???';
+                end
+
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Job');
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if MP.imgui.BeginCombo('##abilityJobFilter', filterLabel) then
+                    -- "Current Jobs" option (main + sub)
+                    local isAutoSelected = MP.abilityJobFilter == 0;
+                    if isAutoSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    local autoLabel;
+                    if subJobAbbr then
+                        autoLabel = mainJobAbbr .. ' + ' .. subJobAbbr .. ' (Current)';
+                    else
+                        autoLabel = mainJobAbbr .. ' (Current)';
+                    end
+                    if MP.imgui.Selectable(autoLabel, isAutoSelected) then
+                        if MP.abilityJobFilter ~= 0 then
+                            MP.abilityJobFilter = 0;
+                            MP.playerdata.ClearExpandedCaches();
+                        end
+                    end
+                    if isAutoSelected then MP.imgui.PopStyleColor(); end
+
+                    MP.imgui.Separator();
+
+                    -- All 15 base jobs (HorizonXI cap)
+                    for jid = 1, 15 do
+                        local abbr = MP.jobs[jid] or '???';
+                        local label = abbr;
+                        if jid == mainJobId then
+                            label = label .. '  [Main]';
+                        elseif jid == subJobId then
+                            label = label .. '  [Sub]';
+                        end
+                        local isSelected = MP.abilityJobFilter == jid;
+                        if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(label, isSelected) then
+                            if MP.abilityJobFilter ~= jid then
+                                MP.abilityJobFilter = jid;
+                                MP.playerdata.ClearExpandedCaches();
+                            end
+                        end
+                        if isSelected then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                abilities = MP.playerdata.GetAllAbilitiesForCurrentJob(MP.abilityJobFilter);
+                useStatusColors = true;
+            else
+                abilities = MP.GetCachedAbilities();
+            end
+            if abilities and #abilities > 0 then
+                MP.DrawSearchableCombo('##abilityCombo', abilities, MP.editingMacro.action or '', function(ability)
+                    MP.editingMacro.action = ability.name;
+                    MP.editorFields.action[1] = ability.name;
+                    AutoSetDisplayName(ability.name);
+                    ApplyDefaultEditorTargetForJaAbility(ability.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No abilities available');
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'ws' then
+            -- Weaponskill: Show searchable dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Weaponskill');
+            MP.imgui.SameLine();
+            local showAllWS = { MP.showAllMode };
+            if MP.imgui.Checkbox('Show All##showAllWS', showAllWS) then
+                MP.showAllMode = showAllWS[1];
+                MP.playerdata.ClearExpandedCaches();
+                if MP.showAllMode then
+                    -- Default filter to the weapon type matching current known WS
+                    local currentWs = MP.GetCachedWeaponskills();
+                    if currentWs and #currentWs > 0 then
+                        local wsDb = require('modules.hotbar.database.ws_weapon_types');
+                        for _, ws in ipairs(currentWs) do
+                            local info = wsDb[ws.name];
+                            if info then
+                                MP.wsWeaponFilter = info.weapon;
+                                break;
+                            end
+                        end
+                    end
+                end
+            end
+            MP.imgui.SameLine(0, 2);
+            MP.imgui.ShowHelp('Green = known, Red = not yet learned. Filter by weapon type below.');
+            local weaponskills;
+            local useStatusColors = false;
+            if MP.showAllMode then
+                -- Weapon type filter dropdown
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if MP.imgui.BeginCombo('##wsWeaponFilter', MP.wsWeaponFilter) then
+                    if MP.imgui.Selectable('All', MP.wsWeaponFilter == 'All') then
+                        MP.wsWeaponFilter = 'All';
+                        MP.playerdata.ClearExpandedCaches();
+                    end
+                    local weaponTypes = MP.playerdata.GetWeaponTypes();
+                    for _, wt in ipairs(weaponTypes) do
+                        local isSel = (MP.wsWeaponFilter == wt);
+                        if isSel then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(wt, isSel) then
+                            MP.wsWeaponFilter = wt;
+                            MP.playerdata.ClearExpandedCaches();
+                        end
+                        if isSel then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                local allWs = MP.playerdata.GetAllWeaponskillsExpanded();
+                if MP.wsWeaponFilter ~= 'All' then
+                    local filtered = {};
+                    for _, ws in ipairs(allWs) do
+                        if ws.weapon == MP.wsWeaponFilter then
+                            table.insert(filtered, ws);
+                        end
+                    end
+                    weaponskills = filtered;
+                else
+                    weaponskills = allWs;
+                end
+                useStatusColors = true;
+            else
+                weaponskills = MP.GetCachedWeaponskills();
+            end
+            if weaponskills and #weaponskills > 0 then
+                MP.DrawSearchableCombo('##wsCombo', weaponskills, MP.editingMacro.action or '', function(ws)
+                    MP.editingMacro.action = ws.name;
+                    MP.editorFields.action[1] = ws.name;
+                    AutoSetDisplayName(ws.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No weaponskills available');
+            end
+
+            -- Target dropdown (default to <t>)
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'item' then
+            -- Item: Searchable dropdown or manual input
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Item');
+            local items = MP.GetCachedItems();
+            if items and #items > 0 then
+                MP.DrawSearchableCombo('##itemCombo', items, MP.editingMacro.action or '', function(item)
+                    MP.editingMacro.action = item.name;
+                    MP.editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
+                    MP.editorFields.action[1] = item.name;
+                    AutoSetDisplayName(item.name);
+                    SyncEditorIconAfterListPick();
+                end, true, nil, fieldW);  -- Show icons
+                MP.imgui.SameLine();
+                MP.imgui.TextColored(MP.COLORS.textMuted, '(' .. #items .. ')');
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No items found in storage');
+            end
+
+            -- Manual input fallback
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Or type item name:');
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.InputText('##itemName', MP.editorFields.action, MP.INPUT_BUFFER_SIZE) then
+                MP.editingMacro.action = MP.editorFields.action[1];
+                AutoSetDisplayName(MP.editingMacro.action);
+                if (MP.editingMacro.action or '') ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+        elseif currentType == 'equip' then
+            -- Equipment slot dropdown
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Equipment Slot');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##equipSlot', MP.EQUIP_SLOT_LABELS[MP.EQUIP_SLOTS[MP.editorFields.equipSlot[1]]] or 'Select...') then
+                for i, slot in ipairs(MP.EQUIP_SLOTS) do
+                    local isSelected = MP.editorFields.equipSlot[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.EQUIP_SLOT_LABELS[slot], isSelected) then
+                        MP.editorFields.equipSlot[1] = i;
+                        MP.editingMacro.equipSlot = slot;
+                        -- Clear item selection when slot changes (old item may not fit new slot)
+                        MP.editingMacro.action = '';
+                        MP.editingMacro.itemId = nil;
+                        MP.editingMacro.displayName = '';
+                        MP.editorFields.action[1] = '';
+                        MP.editorFields.displayName[1] = '';
+                        MP.editorImplicitActionIconDone = false;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+
+            -- Item: Searchable dropdown or manual input (filtered by selected equipment slot)
+            MP.imgui.Spacing();
+            local selectedSlot = MP.EQUIP_SLOTS[MP.editorFields.equipSlot[1]];
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Item (' .. MP.EQUIP_SLOT_LABELS[selectedSlot] .. ')');
+            local equipItems = MP.GetCachedItems();
+            if equipItems and #equipItems > 0 then
+                MP.DrawSearchableCombo('##equipItemCombo', equipItems, MP.editingMacro.action or '', function(item)
+                    MP.editingMacro.action = item.name;
+                    MP.editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
+                    MP.editorFields.action[1] = item.name;
+                    AutoSetDisplayName(item.name);
+                    SyncEditorIconAfterListPick();
+                end, true, selectedSlot, fieldW);  -- Show icons, filter by selected slot
+                MP.imgui.SameLine();
+                MP.imgui.TextColored(MP.COLORS.textMuted, '(' .. #equipItems .. ')');
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No items found in storage');
+            end
+
+            -- Manual input fallback
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Or type item name:');
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.InputText('##equipItemName', MP.editorFields.action, MP.INPUT_BUFFER_SIZE) then
+                MP.editingMacro.action = MP.editorFields.action[1];
+                AutoSetDisplayName(MP.editingMacro.action);
+                if (MP.editingMacro.action or '') ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+        elseif currentType == 'macro' then
+            -- Raw macro command (8 lines like native FFXI macro editor)
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Macro Commands (8 lines)');
+
+            -- Style the multiline input
+            MP.imgui.PushStyleColor(ImGuiCol_FrameBg, MP.COLORS.bgMedium);
+            MP.imgui.PushStyleColor(ImGuiCol_FrameBgHovered, MP.COLORS.bgLight);
+            MP.imgui.PushStyleColor(ImGuiCol_FrameBgActive, MP.COLORS.bgLight);
+
+            -- 8 rows * ~16px line height + padding
+            local lineHeight = MP.imgui.GetTextLineHeight();
+            local inputHeight = (lineHeight * 8) + 8;
+
+            if MP.imgui.InputTextMultiline('##macroText', MP.editorFields.macroText, MP.MACRO_BUFFER_SIZE, {math.max(120, fieldW), inputHeight}) then
+                MP.editingMacro.macroText = MP.editorFields.macroText[1];
+                local mp = require('modules.hotbar.macroparse');
+                local _, pName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+                MP.editingMacro.action = (pName and pName ~= '') and pName or '';
+                if pName and pName ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+            MP.imgui.PopStyleColor(3);
+            MP.imgui.ShowHelp('Enter commands, one per line (e.g., /ma "Cure" <stpc>)');
+
+            -- Recast Source section (optional)
+            MP.imgui.Spacing();
+            MP.imgui.Spacing();
+            if MP.imgui.TreeNode('Recast Source (Optional)##recastSource') then
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'Show cooldown from a different action');
+                MP.imgui.Spacing();
+
+                -- Recast source type dropdown
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Source Type');
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                local currentRecastType = MP.RECAST_SOURCE_TYPES[MP.editorFields.recastSourceType[1]] or 'none';
+                if MP.imgui.BeginCombo('##recastSourceType', MP.RECAST_SOURCE_LABELS[currentRecastType] or 'None') then
+                    for i, sourceType in ipairs(MP.RECAST_SOURCE_TYPES) do
+                        local isSelected = MP.editorFields.recastSourceType[1] == i;
+                        if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(MP.RECAST_SOURCE_LABELS[sourceType], isSelected) then
+                            MP.editorFields.recastSourceType[1] = i;
+                            if sourceType == 'none' then
+                                MP.editingMacro.recastSourceType = nil;
+                                MP.editingMacro.recastSourceAction = nil;
+                                MP.editingMacro.recastSourceItemId = nil;
+                            else
+                                MP.editingMacro.recastSourceType = sourceType;
+                            end
+                            -- Clear action when type changes
+                            MP.editingMacro.recastSourceAction = nil;
+                            MP.editingMacro.recastSourceItemId = nil;
+                            MP.editorFields.recastSourceAction[1] = '';
+                        end
+                        if isSelected then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+
+                -- Show action selector based on recast source type
+                currentRecastType = MP.RECAST_SOURCE_TYPES[MP.editorFields.recastSourceType[1]] or 'none';
+
+                if currentRecastType == 'ma' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Spell');
+                    local spells = MP.GetCachedSpells();
+                    if spells and #spells > 0 then
+                        MP.DrawSearchableCombo('##recastSpellCombo', spells, MP.editingMacro.recastSourceAction or '', function(spell)
+                            MP.editingMacro.recastSourceAction = spell.name;
+                            MP.editorFields.recastSourceAction[1] = spell.name;
+                        end, nil, nil, fieldW);
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No spells available');
+                    end
+
+                elseif currentRecastType == 'ja' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Ability');
+                    local abilities = MP.GetCachedAbilities();
+                    if abilities and #abilities > 0 then
+                        MP.DrawSearchableCombo('##recastAbilityCombo', abilities, MP.editingMacro.recastSourceAction or '', function(ability)
+                            MP.editingMacro.recastSourceAction = ability.name;
+                            MP.editorFields.recastSourceAction[1] = ability.name;
+                        end, nil, nil, fieldW);
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No abilities available');
+                    end
+
+                elseif currentRecastType == 'item' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Item');
+                    local items = MP.GetCachedItems();
+                    if items and #items > 0 then
+                        MP.DrawSearchableCombo('##recastItemCombo', items, MP.editingMacro.recastSourceAction or '', function(item)
+                            MP.editingMacro.recastSourceAction = item.name;
+                            MP.editingMacro.recastSourceItemId = item.id;
+                            MP.editorFields.recastSourceAction[1] = item.name;
+                        end, true, nil, fieldW);  -- Show icons
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No items available');
+                    end
+
+                elseif currentRecastType == 'pet' then
+                    MP.imgui.Spacing();
+                    MP.imgui.TextColored(MP.COLORS.goldDim, 'Pet Command');
+                    local viewedJobId = GetEditorPetJobId();
+                    local avatarName = nil;
+                    if viewedJobId == MP.petregistry.JOB_SMN then
+                        avatarName = SmnAvatarNameFromEditorFilter(MP.petregistry.GetAvatarList());
+                    end
+                    local petCommands = MP.GetPetCommandsForJob(viewedJobId, avatarName, nil);
+                    if petCommands and #petCommands > 0 then
+                        MP.DrawSearchableCombo('##recastPetCombo', petCommands, MP.editingMacro.recastSourceAction or '', function(cmd)
+                        MP.editingMacro.recastSourceAction = cmd.petMacroAction or cmd.name;
+                        MP.editorFields.recastSourceAction[1] = MP.editingMacro.recastSourceAction;
+                        end, nil, nil, fieldW);
+                    else
+                        MP.imgui.TextColored(MP.COLORS.textMuted, 'No pet commands available');
+                    end
+                end
+
+                MP.imgui.TreePop();
+            end
+
+        elseif currentType == 'pet' then
+            -- ── Pet Type selector ──────────────────────────────────
+            local PET_TYPE_OPTIONS = {
+                { id = MP.petregistry.JOB_SMN, label = 'Avatar (SMN)' },
+                { id = MP.petregistry.JOB_BST, label = 'Beast (BST)' },
+                { id = MP.petregistry.JOB_DRG, label = 'Wyvern (DRG)' },
+                { id = MP.petregistry.JOB_PUP, label = 'Automaton (PUP)' },
+            };
+
+            -- Resolve default pet type from player's current job
+            local defaultPetJobId = GetEditorPetJobId();
+            if not MP.petregistry.IsPetJob(defaultPetJobId) then
+                defaultPetJobId = MP.petregistry.JOB_SMN;
+            end
+
+            local viewedJobId;
+            if MP.petTypeOverride > 0 then
+                viewedJobId = MP.petTypeOverride;
+            else
+                viewedJobId = defaultPetJobId;
+            end
+
+            -- Find the label for the current selection
+            local petTypeLabel = '???';
+            for _, opt in ipairs(PET_TYPE_OPTIONS) do
+                if opt.id == viewedJobId then
+                    petTypeLabel = opt.label;
+                    break;
+                end
+            end
+
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Pet Type');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##petTypeSelector', petTypeLabel) then
+                for _, opt in ipairs(PET_TYPE_OPTIONS) do
+                    local isSelected = viewedJobId == opt.id;
+                    local label = opt.label;
+                    if opt.id == defaultPetJobId then
+                        label = label .. '  [Current]';
+                    end
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(label, isSelected) then
+                        if viewedJobId ~= opt.id then
+                            MP.petTypeOverride = opt.id;
+                            MP.cachedPetCommands = nil;
+                            MP.showAllPetMode = false;
+                            MP.petAvatarFilter = 1;
+                        end
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+            MP.imgui.Spacing();
+
+            -- ── Avatar Filter (SMN only) ───────────────────────────
+            local avatarList = MP.petregistry.GetAvatarList();
+            if viewedJobId == MP.petregistry.JOB_SMN then
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Avatar');
+                MP.PushComboStyle();
+                MP.imgui.SetNextItemWidth(fieldW);
+                local filterLabel = MP.petAvatarFilter == 1 and 'All Avatars' or avatarList[MP.petAvatarFilter - 1];
+                if MP.imgui.BeginCombo('##avatarFilter', filterLabel) then
+                    local isAllSelected = MP.petAvatarFilter == 1;
+                    if isAllSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable('All Avatars', isAllSelected) then
+                        MP.petAvatarFilter = 1;
+                        MP.cachedPetCommands = nil;
+                    end
+                    if isAllSelected then MP.imgui.PopStyleColor(); end
+
+                    MP.imgui.Separator();
+
+                    for i, avatar in ipairs(avatarList) do
+                        local isSelected = MP.petAvatarFilter == i + 1;
+                        if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                        if MP.imgui.Selectable(avatar, isSelected) then
+                            MP.petAvatarFilter = i + 1;
+                            MP.cachedPetCommands = nil;
+                        end
+                        if isSelected then MP.imgui.PopStyleColor(); end
+                    end
+                    MP.imgui.EndCombo();
+                end
+                MP.PopComboStyle();
+                MP.imgui.Spacing();
+            end
+
+            -- ── Show All toggle (SMN/BST only) ────────────────────
+            local supportShowAll = (viewedJobId == MP.petregistry.JOB_SMN or viewedJobId == MP.petregistry.JOB_BST);
+
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Pet Command');
+            if supportShowAll then
+                MP.imgui.SameLine();
+                local showAllPet = { MP.showAllPetMode };
+                if MP.imgui.Checkbox('Show All##showAllPet', showAllPet) then
+                    MP.showAllPetMode = showAllPet[1];
+                    MP.cachedPetCommands = nil;
+                end
+                MP.imgui.SameLine(0, 2);
+                if viewedJobId == MP.petregistry.JOB_BST then
+                    MP.imgui.ShowHelp('Green = available at your level, Red = too high level');
+                else
+                    MP.imgui.ShowHelp('Green = available at your level, Red = too high level.\nBlood pacts shown with level requirements.');
+                end
+            end
+
+            -- ── Resolve player level for the selected pet job ──────
+            local player = AshitaCore:GetMemoryManager():GetPlayer();
+            local mainJobId = player and player:GetMainJob() or 0;
+            local mainJobLevel = player and player:GetMainJobLevel() or 0;
+            local subJobId = player and player:GetSubJob() or 0;
+            local subJobLevel = player and player:GetSubJobLevel() or 0;
+
+            local petJobLevel = 0;
+            if viewedJobId == mainJobId then
+                petJobLevel = mainJobLevel;
+            elseif viewedJobId == subJobId then
+                petJobLevel = subJobLevel;
+            end
+
+            local bstActivePetForReady = nil;
+            if viewedJobId == MP.petregistry.JOB_BST then
+                bstActivePetForReady = MP.petpalette.GetCurrentPetEntityName();
+                local act0 = MP.editingMacro.action or '';
+                if act0 == 'Ready' and MP.editingMacro.bstReadyMode == nil then
+                    MP.editingMacro.bstReadyMode = 'recast';
+                end
+                if MP.petregistry.IsBstJugReadyMovesEnabled() and act0 ~= ''
+                    and MP.petregistry.IsBstJugReadyMoveName(act0) then
+                    if MP.editingMacro.bstJugReadyMovesKey == nil then
+                        MP.editingMacro.bstJugReadyMovesKey = MP.petregistry.ResolveBstJugMovesKeyFromMoveName(act0);
+                    end
+                    if MP.editingMacro.bstJugReadyMovesKey and MP.editingMacro.bstJugReadyFamilyLabel == nil then
+                        for _, row in ipairs(MP.petregistry.GetBstJugReadyFamilyPickerList()) do
+                            if row.movesKey == MP.editingMacro.bstJugReadyMovesKey then
+                                MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+                                break;
+                            end
+                        end
+                    end
+                end
+            end
+
+            -- ── Build the command list ─────────────────────────────
+            local petCommands;
+            local useStatusColors = false;
+
+            if supportShowAll then
+                -- SMN/BST: always use expanded data so level-gating is applied
+                local avatarName = nil;
+                local activePetName = nil;
+                if viewedJobId == MP.petregistry.JOB_SMN then
+                    avatarName = SmnAvatarNameFromEditorFilter(avatarList);
+                elseif viewedJobId == MP.petregistry.JOB_BST then
+                    activePetName = bstActivePetForReady;
+                end
+
+                local expandedList;
+                if viewedJobId == MP.petregistry.JOB_BST then
+                    expandedList = MP.petregistry.GetBstPetCommandsExpanded(petJobLevel, activePetName);
+                else
+                    expandedList = MP.petregistry.GetBloodPactsExpanded(avatarName, petJobLevel);
+                end
+
+                if MP.showAllPetMode then
+                    petCommands = expandedList;
+                    useStatusColors = true;
+                else
+                    petCommands = {};
+                    for _, cmd in ipairs(expandedList) do
+                        if cmd.status == MP.petregistry.STATUS_HAVE then
+                            table.insert(petCommands, cmd);
+                        end
+                    end
+                end
+            else
+                -- DRG/PUP: standard cached list
+                if not MP.cachedPetCommands then
+                    MP.cachedPetCommands = MP.GetPetCommandsForJob(viewedJobId, nil, nil);
+                end
+                petCommands = MP.cachedPetCommands;
+            end
+
+            -- ── Pet command selector dropdown ──────────────────────
+            MP.imgui.SetNextItemWidth(fieldW);
+            local petPrimaryComboValue = BstPetPrimaryComboCurrentLabel(MP.editingMacro, viewedJobId);
+            if petCommands and #petCommands > 0 then
+                MP.DrawSearchableCombo('##petCommandCombo', petCommands, petPrimaryComboValue, function(cmd)
+                    if cmd.bstReadySynthetic == 'recast' then
+                        MP.editingMacro.action = cmd.petMacroAction or 'Ready';
+                        MP.editingMacro.bstReadyMode = 'recast';
+                        MP.editingMacro.bstJugReadyMovesKey = nil;
+                        MP.editingMacro.bstJugReadyFamilyLabel = nil;
+                    elseif cmd.bstReadySynthetic == 'use' then
+                        MP.editingMacro.bstReadyMode = 'use';
+                        MP.editingMacro.action = '';
+                        MP.editingMacro.bstJugReadyMovesKey = nil;
+                        MP.editingMacro.bstJugReadyFamilyLabel = nil;
+                    else
+                        MP.editingMacro.bstReadyMode = nil;
+                        MP.editingMacro.action = cmd.name;
+                        MP.editingMacro.bstJugReadyMovesKey = nil;
+                        MP.editingMacro.bstJugReadyFamilyLabel = nil;
+                    end
+                    MP.editorFields.action[1] = MP.editingMacro.action or '';
+                    AutoSetDisplayName(cmd.name);
+                    ApplyDefaultEditorTargetForPetCommand(cmd.name);
+                    SyncEditorIconAfterListPick();
+                end, nil, nil, fieldW, useStatusColors);
+            else
+                MP.imgui.TextColored(MP.COLORS.textMuted, 'No pet commands available');
+            end
+
+            local showBstJugPicker = viewedJobId == MP.petregistry.JOB_BST
+                and MP.petregistry.IsBstJugReadyMovesEnabled()
+                and (MP.editingMacro.bstReadyMode == 'use'
+                    or MP.petregistry.IsBstJugReadyMoveName(MP.editingMacro.action or ''));
+
+            if showBstJugPicker then
+                MP.imgui.Spacing();
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Family');
+                MP.imgui.SameLine(0, 2);
+                MP.imgui.ShowHelp('Jug pet families (same Ready abilities per family as SMN avatars share blood pact pools). Pick family, then the Ready move.');
+                local famList = MP.petregistry.GetBstJugReadyFamilyPickerList();
+                MP.imgui.SetNextItemWidth(fieldW);
+                if famList and #famList > 0 then
+                    MP.DrawSearchableCombo('##bstJugFamilyCombo', famList, MP.editingMacro.bstJugReadyFamilyLabel or '', function(row)
+                        MP.editingMacro.bstJugReadyMovesKey = row.movesKey;
+                        MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+                        local movesFam = MP.petregistry.GetReadyMovesForFamilyMovesKey(row.movesKey);
+                        local curAct = MP.editingMacro.action or '';
+                        local moveStillOk = false;
+                        if movesFam and curAct ~= '' then
+                            for _, m in ipairs(movesFam) do
+                                if m.name == curAct then
+                                    moveStillOk = true;
+                                    break;
+                                end
+                            end
+                        end
+                        if not moveStillOk then
+                            MP.editingMacro.action = '';
+                            MP.editorFields.action[1] = '';
+                        end
+                        SyncEditorIconAfterListPick();
+                        MP.SyncSaveSubTypeFromBstJugFamily();
+                    end, nil, nil, fieldW, false);
+                end
+
+                MP.imgui.Spacing();
+                MP.imgui.TextColored(MP.COLORS.goldDim, 'Jug Ready ability');
+                MP.imgui.SameLine(0, 2);
+                MP.imgui.ShowHelp('/pet uses this ability name; charges match your jug. A * beside a Ready move appears only when some jugs in that picker row do not learn it — hover for detail.');
+                local jugMoves = {};
+                local mk = MP.editingMacro.bstJugReadyMovesKey;
+                if mk then
+                    local rm = MP.petregistry.GetReadyMovesForFamilyMovesKey(mk);
+                    if rm then
+                        for _, m in ipairs(rm) do
+                            table.insert(jugMoves, m);
+                        end
+                    end
+                end
+                MP.imgui.SetNextItemWidth(fieldW);
+                if #jugMoves > 0 then
+                    MP.DrawSearchableCombo('##bstJugReadyMoveCombo', jugMoves, MP.editingMacro.action or '', function(move)
+                        MP.editingMacro.action = move.name;
+                        MP.editingMacro.bstReadyMode = nil;
+                        MP.editorFields.action[1] = move.name;
+                        AutoSetDisplayName(move.name);
+                        SyncEditorIconAfterListPick();
+                    end, nil, nil, fieldW, false);
+                elseif MP.editingMacro.bstJugReadyMovesKey then
+                    MP.imgui.TextColored(MP.COLORS.textMuted, 'No Ready moves for this family in database');
+                else
+                    MP.imgui.TextColored(MP.COLORS.textMuted, 'Select a family first');
+                end
+            end
+
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Or type manually:');
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.InputText('##petCommandManual', MP.editorFields.action, MP.INPUT_BUFFER_SIZE) then
+                MP.editingMacro.action = MP.editorFields.action[1];
+                AutoSetDisplayName(MP.editingMacro.action);
+                if (MP.editingMacro.action or '') ~= '' then
+                    TryFirstImplicitActionIconAuto();
+                end
+            end
+
+            -- Target dropdown
+            MP.imgui.Spacing();
+            MP.imgui.TextColored(MP.COLORS.goldDim, 'Target');
+            MP.PushComboStyle();
+            MP.imgui.SetNextItemWidth(fieldW);
+            if MP.imgui.BeginCombo('##targetType', MP.TARGET_LABELS[MP.TARGET_OPTIONS[MP.editorFields.target[1]]] or 'Select...') then
+                for i, target in ipairs(MP.TARGET_OPTIONS) do
+                    local isSelected = MP.editorFields.target[1] == i;
+                    if isSelected then MP.imgui.PushStyleColor(ImGuiCol_Text, MP.COLORS.gold); end
+                    if MP.imgui.Selectable(MP.TARGET_LABELS[target], isSelected) then
+                        MP.editorFields.target[1] = i;
+                        MP.editingMacro.target = target;
+                    end
+                    if isSelected then MP.imgui.PopStyleColor(); end
+                end
+                MP.imgui.EndCombo();
+            end
+            MP.PopComboStyle();
+        end
+
+        -- Ensure we're past both left column and icon panel before continuing
+        local yAfterFields = MP.imgui.GetCursorPosY();
+        local yAfterIconPanel = topY + iconPanelTotalH + 4;
+        if yAfterIconPanel > yAfterFields then
+            MP.imgui.SetCursorPosY(yAfterIconPanel);
+        end
+
+        -- Slot Label input (for all types)
+        MP.imgui.Spacing();
+        MP.imgui.Separator();
+        MP.imgui.Spacing();
+        MP.imgui.TextColored(MP.COLORS.goldDim, 'Slot Label');
+        MP.imgui.SameLine(0, 6);
+        if MP.DrawIconButton('##macroEditorSlotLabelReset', uiIconRefresh, miniToolBtn, false,
+                'Clear slot label (on save, uses action name, or "Macro" for macro type)') then
+            MP.editingMacro.displayName = '';
+            MP.editorFields.displayName[1] = '';
+            MP.editorAutoLabel = nil;
+        end
+        if currentType == 'macro' then
+            MP.imgui.SameLine(0, 4);
+            if MP.DrawIconButton('##macroEditorSlotLabelSync', uiIconSync, miniToolBtn, false,
+                    'Sync label from parsed macro (prioritized /ws > /ma > /pet > /ja )') then
+                SyncMacroSlotLabelFromParsedCommands();
+            end
+        end
+        MP.imgui.SameLine(0, 6);
+        MP.imgui.SetNextItemWidth(math.max(80, contentWidth * 0.45));
+        if MP.imgui.InputText('##displayName', MP.editorFields.displayName, 32) then
+            MP.editingMacro.displayName = MP.editorFields.displayName[1];
+            MP.editorAutoLabel = nil; -- User manually edited the label; don't auto-overwrite on future selections.
+        end
+        if currentType ~= 'macro' then
+            MP.imgui.ShowHelp('Short label shown on the slot (e.g., "Cure3"). Leave empty to use action name.');
+        else
+            MP.imgui.ShowHelp('Label on the slot. Sync sets it from the prioritized command in macro text (same order as icon sync).');
+        end
+
+        MP.imgui.Spacing();
+        MP.imgui.Separator();
+        MP.imgui.Spacing();
+
+        local function SyncMacroEditorBuffersToEditingMacro()
+            local atIdx = MP.editorFields.actionType[1];
+            if type(atIdx) == 'number' and atIdx >= 1 and atIdx <= #MP.ACTION_TYPES then
+                MP.editingMacro.actionType = MP.ACTION_TYPES[atIdx];
+            end
+            local tgIdx = MP.editorFields.target[1];
+            if type(tgIdx) == 'number' and tgIdx >= 1 and tgIdx <= #MP.TARGET_OPTIONS then
+                MP.editingMacro.target = MP.TARGET_OPTIONS[tgIdx];
+            end
+            local eqIdx = MP.editorFields.equipSlot[1];
+            if type(eqIdx) == 'number' and eqIdx >= 1 and eqIdx <= #MP.EQUIP_SLOTS then
+                MP.editingMacro.equipSlot = MP.EQUIP_SLOTS[eqIdx];
+            end
+            local rsIdx = MP.editorFields.recastSourceType[1];
+            if type(rsIdx) == 'number' and rsIdx >= 1 and rsIdx <= #MP.RECAST_SOURCE_TYPES then
+                MP.editingMacro.recastSourceType = MP.RECAST_SOURCE_TYPES[rsIdx];
+            end
+            MP.editingMacro.recastSourceAction = MP.editorFields.recastSourceAction[1] or '';
+            MP.editingMacro.macroText = MP.editorFields.macroText[1] or '';
+            local actBuf = tostring(MP.editorFields.action[1] or ''):match('^%s*(.-)%s*$') or '';
+            if MP.editingMacro.actionType ~= 'macro' then
+                MP.editingMacro.action = actBuf;
+            end
+        end
+
+        local function SaveMacro(shouldCloseEditor)
+            SyncMacroEditorBuffersToEditingMacro();
+
+            -- Validate before saving
+            local canSave = false;
+
+            if currentType == 'macro' then
+                canSave = (MP.editingMacro.macroText or '') ~= '';
+                if canSave and (MP.editingMacro.displayName or '') == '' then
+                    MP.editingMacro.displayName = 'Macro';
+                end
+                -- Clear target for macro type (targets are embedded in macro text)
+                MP.editingMacro.target = nil;
+            else
+                canSave = (MP.editingMacro.action or '') ~= '';
+                if canSave and (MP.editingMacro.displayName or '') == '' then
+                    MP.editingMacro.displayName = MP.editingMacro.action;
+                end
+            end
+
+            if not canSave then
+                return;
+            end
+
+            local okMg, mgd = pcall(require, 'modules.hotbar.macro_global_defaults');
+            if okMg and mgd and mgd.IsUniversalTwoHourMacro(MP.editingMacro) and not MP.isCreatingNew then
+                return;
+            end
+
+            -- Look up itemId for item/equip macros if not already set
+            -- This handles cases where user typed item name manually instead of selecting from dropdown
+            if (currentType == 'item' or currentType == 'equip') and not MP.editingMacro.itemId and MP.editingMacro.action then
+                MP.editingMacro.itemId = MP.actiondb.GetItemId(MP.editingMacro.action);
+            end
+
+            if MP.isCreatingNew then
+                -- AddMacro mutates macroData.id; keep editor selections by inserting a copy.
+                local macroCopy = deep_copy_table(MP.editingMacro);
+                macroCopy.id = nil;
+                MP.M.AddMacro(macroCopy, MP.editorPaletteKey);
+                -- Navigate to last page to show the new macro
+                local db = MP.M.GetMacroDatabase();
+                MP.currentPalettePage = math.max(1, math.ceil(#db / MP.PALETTE_MACROS_PER_PAGE));
+
+                -- Ensure editor stays in "Create" mode (no id should be present)
+                MP.editingMacro.id = nil;
+
+                -- EFP double-click auto-bind: when the editor was opened from a double-click on
+                -- an empty Edit Full Palette slot, OpenEditorForSlotData stashed the target slot
+                -- coords. Now that AddMacro has minted an id on macroCopy, write the binding into
+                -- the EFP draft so the slot reflects the new macro on the next frame. One-shot
+                -- (cleared below) so "Save & Add Another" doesn't repeatedly stomp the same slot.
+                local target = MP.pendingNewMacroBindTarget;
+                if target and macroCopy.id then
+                    local okData, dataLib = pcall(require, 'modules.hotbar.data');
+                    if okData and dataLib and dataLib.SetDraftSlotData and dataLib.BuildMacroSlotAfterDrop then
+                        local arm = {};
+                        for k, v in pairs(macroCopy) do arm[k] = v; end
+                        arm.macroRef = macroCopy.id;
+                        arm.macroPaletteKey = arm.macroPaletteKey or MP.editorPaletteKey;
+                        local store = (MP.M.GetMacroSourceTagForDrops and MP.M.GetMacroSourceTagForDrops()) or 'profile';
+                        arm.macroSourceStore = arm.macroSourceStore or store;
+                        local existing;
+                        if dataLib.GetCrossbarSlotRawForSwapOverlay and dataLib.NormalizeCrossbarSlotRawForSwap then
+                            existing = dataLib.NormalizeCrossbarSlotRawForSwap(
+                                dataLib.GetCrossbarSlotRawForSwapOverlay(target.comboMode, target.slotIndex)
+                            );
+                        end
+                        local built = dataLib.BuildMacroSlotAfterDrop(arm, store, existing);
+                        dataLib.SetDraftSlotData(target.comboMode, target.slotIndex, built);
+                        -- Visual refresh so the EFP preview picks up the new binding next frame.
+                        -- 1.8.0 immediate-mode renderer has no persistent slot prim cache; the
+                        -- crossbar icon-cache clear is the only refresh needed to surface the new
+                        -- binding on the next frame.
+                        local okCb, crossbar = pcall(require, 'modules.hotbar.crossbar');
+                        if okCb and crossbar and crossbar.ClearIconCacheForSlot then
+                            crossbar.ClearIconCacheForSlot(target.comboMode, target.slotIndex);
+                        end
+                    end
+                    MP.pendingNewMacroBindTarget = nil;
+                end
+            else
+                MP.M.UpdateMacro(MP.editingMacro.id, MP.editingMacro, MP.editorPaletteKey);
+            end
+
+            MP.paletteMainIconCache = {};
+            if MP.ClearPaletteJaBadgeIconCache then
+                MP.ClearPaletteJaBadgeIconCache();
+            end
+
+            if shouldCloseEditor then
+                MP.editingMacro = nil;
+                MP.isCreatingNew = false;
+                MP.searchFilter[1] = '';
+                MP.iconPickerOpen = false;
+                MP.iconPickerFilter[1] = '';
+                MP.editorPaletteKey = nil;
+                MP.editorDidInitialIconPick = false;
+                MP.editorJaBadgeManuallySet = false;
+                MP.ClearEditorPreviewIconCache();
+            end
+        end
+
+        -- Save buttons
+        MP.imgui.PushStyleColor(ImGuiCol_Button, MP.COLORS.success);
+        MP.imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.5, 0.8, 0.5, 1.0});
+        MP.imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.6, 0.9, 0.6, 1.0});
+        MP.imgui.PushStyleColor(ImGuiCol_Text, {0.1, 0.1, 0.1, 1.0});
+
+        if MP.imgui.Button('Save & Close', {110, 28}) then
+            SaveMacro(true);
+        end
+
+        MP.imgui.SameLine(0, 8);
+
+        if MP.imgui.Button('Save & Add Another', {150, 28}) then
+            SaveMacro(false);
+        end
+
+        MP.imgui.PopStyleColor(4);
+
+        MP.imgui.SameLine(0, 12);
+
+        if MP.imgui.Button('Cancel', {80, 28}) then
+            MP.editingMacro = nil;
+            MP.isCreatingNew = false;
+            MP.searchFilter[1] = '';
+            MP.iconPickerOpen = false;
+            MP.iconPickerFilter[1] = '';
+            MP.editorPaletteKey = nil;
+            MP.editorDidInitialIconPick = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.pendingNewMacroBindTarget = nil;
+            MP.ClearEditorPreviewIconCache();
+        end
+    end
+
+    MP.imgui.End();
+    MP.PopWindowStyle();
+
+    if not isOpen[1] then
+        MP.editingMacro = nil;
+        MP.isCreatingNew = false;
+        MP.searchFilter[1] = '';
+        MP.iconPickerOpen = false;
+        MP.iconPickerFilter[1] = '';
+        MP.editorPaletteKey = nil;
+        MP.editorJaBadgeManuallySet = false;
+        MP.pendingNewMacroBindTarget = nil;
+        MP.ClearEditorPreviewIconCache();
+    end
+
+    -- Draw icon picker if open
+    MP.DrawIconPicker();
+    end
+end

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -16,10 +16,35 @@ local textures = require('modules.hotbar.textures');
 local skillchain = require('modules.hotbar.skillchain');
 local statusHandler = require('handlers.statushandler');
 local imtext = require('libs.imtext');
+-- TextureManager.DeferRelease holds Lua refs alive for one frame so wiping the
+-- texturePtrCache mid-frame (e.g. palette delete fires InvalidateAllVisualCachesAfter
+-- PaletteListMutation) doesn't race the current frame's queued AddImage calls.
+local TextureManager = require('libs.texturemanager');
+-- libs/color.lua has ARGB <-> ImGui U32 + HSV<->RGB helpers we use for UTH effects.
+-- Audit pass deduped a local ArgbToImguiU32 and a local UthHsvToRgb that had identical math.
+local colorlib = require('libs.color');
+-- universal_two_hour is a Ferris addition that tracks the universal-2hr armed-slot state
+-- so the rainbow ring glow knows which slot to decorate. Loaded with pcall so 1.7.5-era
+-- forks without the module still render normal slots without crashing.
+local universalTwoHour = nil;
+do
+    local ok, mod = pcall(require, 'modules.hotbar.universal_two_hour');
+    if ok then universalTwoHour = mod; end
+end
 
 -- Deferred tooltip: stored during render, drawn after all windows to ensure z-order
 local pendingTooltipBind = nil;
 local tooltipFontSettings = nil;
+
+-- Manual double-click tracking. Using `imgui.IsMouseDoubleClicked` here is unreliable
+-- because the drag/drop system swallows the first click on slots that participate in
+-- drag (the first MouseDown starts a deferred-drag candidate which suppresses the click).
+-- We instead track the last click target and its timestamp ourselves and decide on
+-- MouseReleased(0) — that's the same point WasDragAttempted resolves, so double-click
+-- semantics stay consistent with single-click semantics.
+local lastClickButtonId = nil;
+local lastClickTime = 0;
+local DOUBLE_CLICK_INTERVAL = 0.35;
 
 -- Tooltip constants (ARGB for text colors used with imtext, ABGR/U32 for rect colors)
 local TOOLTIP_FONT_SIZE = 12;
@@ -36,10 +61,80 @@ local ACTION_TYPE_LABELS = {
 
 -- Cache for MP cost lookups (keyed by action key string)
 local mpCostCache = {};
+local mpCostCacheSize = 0;
+local MP_COST_CACHE_MAX = 4096;
 
--- Cache for action availability checks (keyed by action key string)
+-- Cache for action availability checks (keyed by action key string).
 -- Structure: { isAvailable = bool, reason = string|nil }
+-- The cache key embeds (main job, sub job, main level, sub level, party-member main/sub level)
+-- so Level Sync transitions invalidate previously-cached availabilities (a spell that was
+-- available at L75 may stop being available at synced L40). Without this the cache returns
+-- stale results across sync changes. Size-bounded by AVAILABILITY_CACHE_MAX — when exceeded
+-- the cache is reset wholesale (cheaper than LRU eviction for a frequently-rebuilt cache).
 local availabilityCache = {};
+local availabilityCacheSize = 0;
+local AVAILABILITY_CACHE_MAX = 8192;
+
+local function PutMpCostCache(key, value)
+    if mpCostCache[key] == nil then
+        mpCostCacheSize = mpCostCacheSize + 1;
+        if mpCostCacheSize > MP_COST_CACHE_MAX then
+            mpCostCache = {};
+            mpCostCacheSize = 0;
+        end
+    end
+    mpCostCache[key] = value;
+end
+
+local function PutAvailabilityCache(key, value)
+    if availabilityCache[key] == nil then
+        availabilityCacheSize = availabilityCacheSize + 1;
+        if availabilityCacheSize > AVAILABILITY_CACHE_MAX then
+            availabilityCache = {};
+            availabilityCacheSize = 0;
+        end
+    end
+    availabilityCache[key] = value;
+end
+
+-- Per-frame snapshot of (player, party, job ids, effective levels). Reset at BeginFrame
+-- and read lazily from the availability path so we only walk the MemoryManager once per
+-- frame instead of once per (slot * frame). At ~16 main-bar slots + 16 preview slots + N
+-- keyboard bars this drops the per-frame FFI walk from N*7 getters to a constant ~7. The
+-- snapshot is intentionally lazy (first slot that needs it warms it) so frames without
+-- any availability checks pay zero cost.
+--
+-- IMPORTANT: keep this declared BEFORE M.DrawSlot — Lua local-function forward references
+-- only work if the symbol is visible at the call site. Putting it after caused a
+-- "attempt to call global 'GetFrameAvailability' (a nil value)" load error.
+local frameAvail = { ready = false };
+
+local function GetFrameAvailability()
+    if frameAvail.ready then return frameAvail; end
+    local memMgr = AshitaCore:GetMemoryManager();
+    local player = memMgr and memMgr:GetPlayer();
+    if not player then
+        frameAvail.ready = true;
+        frameAvail.jobId = 0; frameAvail.subjobId = 0;
+        frameAvail.mainLevel = 0; frameAvail.subLevel = 0;
+        frameAvail.partyMain = 0; frameAvail.partySub = 0;
+        return frameAvail;
+    end
+    frameAvail.jobId     = player:GetMainJob() or 0;
+    frameAvail.subjobId  = player:GetSubJob() or 0;
+    frameAvail.mainLevel = player:GetMainJobLevel() or 0;
+    frameAvail.subLevel  = player:GetSubJobLevel() or 0;
+    local partyMain, partySub = 0, 0;
+    local party = memMgr and memMgr:GetParty();
+    if party then
+        partyMain = party:GetMemberMainJobLevel(0) or 0;
+        partySub  = party:GetMemberSubJobLevel(0) or 0;
+    end
+    frameAvail.partyMain = partyMain;
+    frameAvail.partySub  = partySub;
+    frameAvail.ready     = true;
+    return frameAvail;
+end
 
 -- Cache for item quantity lookups (keyed by itemId or itemName)
 -- Structure: { quantity = number, timestamp = number }
@@ -366,7 +461,10 @@ local assetsPath = nil;
 
 -- Reusable result table for DrawSlot to avoid GC pressure
 -- (Creating tables per-slot per-frame causes ~7200 allocations/sec)
-local drawSlotResult = { isHovered = false };
+-- Reusable result table for M.DrawSlot. `command` is the resolved command string for the
+-- slot's bind (so callers can dispatch on click without re-calling actions.BuildCommandString
+-- per click); nil for empty / unbindable slots.
+local drawSlotResult = { isHovered = false, command = nil };
 
 -- Reusable position/UV tables for AddImage (avoids per-call table allocations)
 local imgP1 = {0, 0};
@@ -399,12 +497,22 @@ end
 -- Clear all cached state
 function M.ClearAllCache()
     availabilityCache = {};
+    availabilityCacheSize = 0;
     mpCostCache = {};
+    mpCostCacheSize = 0;
     equipmentCheckCache = {};
     ninjutsuCache = {};
     itemQuantityCache = {};
     stackSizeCache = {};
     ammoStatusCache = {};
+    -- texturePtrCache holds the SOLE Lua ref to D3D textures loaded via LoadTextureFromPath
+    -- (the underlying entries have a d3d8.gc_safe_release finalizer). Dropping the table
+    -- mid-frame would let Lua GC release the COM texture while AddImage calls for it are
+    -- still queued in this frame's draw list — that's the same EXCEPTION_ACCESS_VIOLATION
+    -- pattern that TextureManager.deferRelease guards against. Hand the table off to
+    -- TextureManager.DeferRelease so it stays alive until FlushPendingReleases runs at the
+    -- top of next d3d_present.
+    TextureManager.DeferRelease(texturePtrCache);
     texturePtrCache = {};
 end
 
@@ -412,12 +520,15 @@ end
 -- Does NOT clear availability, MP cost, or item quantity caches
 -- OPTIMIZED: Use this for palette changes to avoid unnecessary recalculation cascade
 function M.ClearSlotRenderingCache()
+    -- See M.ClearAllCache for rationale; same mid-frame texture-release race applies here.
+    TextureManager.DeferRelease(texturePtrCache);
     texturePtrCache = {};
 end
 
 -- Clear availability cache (call on job change, level sync, etc.)
 function M.ClearAvailabilityCache()
     availabilityCache = {};
+    availabilityCacheSize = 0;
 end
 
 -- Clear MP cost cache (call when a slot's action/spell may have changed, e.g. macro edits).
@@ -425,6 +536,7 @@ end
 -- until the addon reloads.
 function M.ClearMPCostCache()
     mpCostCache = {};
+    mpCostCacheSize = 0;
 end
 
 -- Clear item quantity cache (call on inventory changes)
@@ -533,6 +645,146 @@ local function DrawDashedLine(drawList, x1, y1, x2, y2, color, thickness, dashLe
     end
 end
 
+-- ============================================
+-- ARGB color helpers (XIUI palette uses 0xAARRGGBB; ImGui AddText/AddRect take GetColorU32{r,g,b,a}).
+-- ScaleArgbOpacity / DimArgbColor / LerpArgbTowardWhite are slotrenderer-specific tone-mapping
+-- ops and live here; the basic ARGB<->ImGui U32 conversion is delegated to libs/color.lua.
+-- ============================================
+
+local ArgbToImguiU32 = colorlib.ARGBToU32;
+
+local function ScaleArgbOpacity(argb, opacity)
+    if not opacity or opacity >= 0.999 then return argb; end
+    local a = bit.rshift(bit.band(argb, 0xFF000000), 24);
+    a = math.floor(a * opacity);
+    if a < 0 then a = 0; elseif a > 255 then a = 255; end
+    return bit.bor(bit.lshift(a, 24), bit.band(argb, 0x00FFFFFF));
+end
+
+local function DimArgbColor(argb, factor)
+    if not factor or factor >= 0.999 then return argb; end
+    local a = bit.band(bit.rshift(argb, 24), 0xFF);
+    local r = math.floor(bit.band(bit.rshift(argb, 16), 0xFF) * factor);
+    local g = math.floor(bit.band(bit.rshift(argb, 8), 0xFF) * factor);
+    local b = math.floor(bit.band(argb, 0xFF) * factor);
+    return bit.bor(bit.lshift(a, 24), bit.lshift(r, 16), bit.lshift(g, 8), b);
+end
+
+local function LerpArgbTowardWhite(argb, t)
+    if not argb or t <= 0 then return argb; end
+    if t > 1 then t = 1; end
+    local a = bit.rshift(bit.band(argb, 0xFF000000), 24);
+    local r = bit.rshift(bit.band(argb, 0x00FF0000), 16);
+    local g = bit.rshift(bit.band(argb, 0x0000FF00), 8);
+    local b = bit.band(argb, 0x000000FF);
+    r = math.floor(r + (255 - r) * t);
+    g = math.floor(g + (255 - g) * t);
+    b = math.floor(b + (255 - b) * t);
+    return bit.bor(bit.lshift(a, 24), bit.lshift(r, 16), bit.lshift(g, 8), b);
+end
+
+-- ============================================
+-- Universal Two-Hour (UTH) visual effects: rainbow marching border + subtarget ring glow.
+-- Triggered when an action is the "armed" universal 2hr ability awaiting <stpc>/<stnpc> confirmation.
+-- All pure ImGui drawList ops; no font or persistent-primitive dependencies.
+-- ============================================
+
+-- HSV (h in [0,1)) -> RGB used by the rainbow color cycling for UTH.
+-- Thin wrapper over libs/color.lua's shared hsvToRgb so the UTH animation always
+-- stays in sync with whatever color math the rest of the addon uses.
+local function UthHsvToRgb(h, s, v)
+    h = math.fmod(h, 1.0);
+    if h < 0 then h = h + 1.0; end
+    return colorlib.hsvToRgb(h, s, v);
+end
+
+-- Skillchain-style marching dashed rect; rainbow hue shifts with animation offset + time.
+local function DrawUniversalTwoHourRainbowMarchingBorder(drawList, x1, y1, x2, y2, opacityMul)
+    if not drawList or opacityMul <= 0.01 then return; end
+    local animOffset = skillchain.GetAnimationOffset();
+    local t = os.clock();
+    local dashLen = 4;
+    local gapLen = 4;
+    local thickness = 2.5;
+    local hueBase = math.fmod(animOffset * 0.0035 + t * 0.052, 1.0);
+    local function edgeColor(edgeIdx)
+        local h = math.fmod(hueBase + edgeIdx * 0.085, 1.0);
+        local r, g, b = UthHsvToRgb(h, 0.74, 1.0);
+        return imgui.GetColorU32({ r, g, b, 0.9 * opacityMul });
+    end
+    DrawDashedLine(drawList, x1, y1, x2, y1, edgeColor(0), thickness, dashLen, gapLen, animOffset);
+    DrawDashedLine(drawList, x2, y1, x2, y2, edgeColor(1), thickness, dashLen, gapLen, animOffset);
+    DrawDashedLine(drawList, x2, y2, x1, y2, edgeColor(2), thickness, dashLen, gapLen, animOffset);
+    DrawDashedLine(drawList, x1, y2, x1, y1, edgeColor(3), thickness, dashLen, gapLen, animOffset);
+end
+
+-- Rainbow rotating rings while Universal 2 Hour waits on <stpc>/<stnpc> confirmation.
+-- Ring radii breathe (collapse / expand); dashed border stays on the slot edge.
+-- Opacity uses animOpacity * dimFactor * armFadeScale.
+local function DrawUniversalTwoHourSubtargetGlow(drawList, x, y, size, animOpacity, dimFactor, armFadeScale)
+    if not drawList or animOpacity <= 0.01 then return; end
+    armFadeScale = armFadeScale or 1.0;
+    if armFadeScale <= 0.01 then return; end
+    local cx = x + size * 0.5;
+    local cy = y + size * 0.5;
+    local t = os.clock();
+    local op = math.min(1.0, animOpacity * dimFactor) * armFadeScale;
+
+    -- Collapse toward center then expand (cosine ease per cycle) — line rings only, no filled wash over the icon.
+    local breatheMin = 0.46;
+    local breathe = breatheMin + (1.0 - breatheMin) * (0.5 + 0.5 * math.cos(t * 3.05));
+
+    local function rainbowDashRing(spin, rad, thick, segs, hueSpin, lineAlpha, dashPred)
+        rad = rad * breathe;
+        for i = 0, segs - 1 do
+            if dashPred(i) then
+                local a0 = spin + (i / segs) * math.pi * 2;
+                local a1 = spin + ((i + 1) / segs) * math.pi * 2;
+                local mid = (a0 + a1) * 0.5;
+                local hue = math.fmod(mid / (math.pi * 2) + hueSpin, 1.0);
+                local r, g, b = UthHsvToRgb(hue, 0.82, 1.0);
+                drawList:AddLine(
+                    { cx + math.cos(a0) * rad, cy + math.sin(a0) * rad },
+                    { cx + math.cos(a1) * rad, cy + math.sin(a1) * rad },
+                    imgui.GetColorU32({ r, g, b, lineAlpha * op }),
+                    thick
+                );
+            end
+        end
+    end
+
+    local spinOuter = t * 4.2;
+    local spinInner = -t * 3.1;
+    local hueTravel = t * 0.14;
+
+    rainbowDashRing(-spinOuter, size * 0.485, 2.5, 28, hueTravel + 0.08, 0.78,
+        function(i) return i % 3 ~= 2; end);
+    rainbowDashRing(spinOuter, size * 0.52, 3.2, 28, hueTravel, 0.85,
+        function(i) return i % 3 ~= 0; end);
+    rainbowDashRing(spinInner, size * 0.46, 2.2, 28, hueTravel + 0.17, 0.80,
+        function(i) return i % 3 ~= 0; end);
+
+    local ringPulse = 0.55 + 0.45 * math.sin(t * 5.1);
+    local outerRad = (size * 0.58 + ringPulse * 1.5) * breathe;
+    local outerThick = 2.2 + ringPulse * 0.35;
+    local segsO = 48;
+    for i = 0, segsO - 1 do
+        local a0 = (i / segsO) * math.pi * 2;
+        local a1 = ((i + 1) / segsO) * math.pi * 2;
+        local mid = (a0 + a1) * 0.5;
+        local hue = math.fmod(mid / (math.pi * 2) + hueTravel + 0.05, 1.0);
+        local r, g, b = UthHsvToRgb(hue, 0.75, 1.0);
+        drawList:AddLine(
+            { cx + math.cos(a0) * outerRad, cy + math.sin(a0) * outerRad },
+            { cx + math.cos(a1) * outerRad, cy + math.sin(a1) * outerRad },
+            imgui.GetColorU32({ r, g, b, 0.88 * op }),
+            outerThick
+        );
+    end
+
+    DrawUniversalTwoHourRainbowMarchingBorder(drawList, x, y, x + size, y + size, op);
+end
+
 -- Draw skillchain highlight on a slot (animated dashed border + icon)
 -- @param drawList: ImGui draw list (foreground recommended)
 -- @param x, y: Top-left corner of slot
@@ -540,7 +792,10 @@ end
 -- @param scName: Skillchain name (e.g., 'Light', 'Darkness', 'Fusion')
 -- @param color: Highlight color (ARGB)
 -- @param opacity: Overall opacity (0-1)
-local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opacity)
+-- @param iconScaleOverride, iconOxOverride, iconOyOverride: optional per-call overrides
+--        (used by the macro palette editor to push the skillchain icon out of the corner
+--        when it would otherwise overlap an action-label or BST-Ready badge).
+local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opacity, iconScaleOverride, iconOxOverride, iconOyOverride)
     if not drawList or not scName or opacity <= 0.01 then return; end
 
     -- Animation offset for marching ants effect
@@ -568,11 +823,13 @@ local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opac
     -- Left edge
     DrawDashedLine(drawList, x, y + size, x, y, lineColor, thickness, dashLen, gapLen, animOffset);
 
-    -- Draw skillchain icon in top-right corner
-    local scale = gConfig.hotbarGlobal.skillchainIconScale or 1.0;
+    -- Draw skillchain icon in top-right corner. Per-call overrides take precedence over the
+    -- global config (used by the macro palette editor to relocate the icon out of corners
+    -- that the editor uses for action labels or BST-Ready badges).
+    local scale = iconScaleOverride or gConfig.hotbarGlobal.skillchainIconScale or 1.0;
     local iconSize = math.floor(size * 0.35 * scale);
-    local offsetX = gConfig.hotbarGlobal.skillchainIconOffsetX or 0;
-    local offsetY = gConfig.hotbarGlobal.skillchainIconOffsetY or 0;
+    local offsetX = iconOxOverride or gConfig.hotbarGlobal.skillchainIconOffsetX or 0;
+    local offsetY = iconOyOverride or gConfig.hotbarGlobal.skillchainIconOffsetY or 0;
     local iconX = x + size - iconSize - 2 + offsetX;
     local iconY = y + 2 + offsetY;
 
@@ -600,17 +857,205 @@ local function DrawSkillchainHighlight(drawList, x, y, size, scName, color, opac
     end
 end
 
+-- Draw a Magic Burst highlight on a spell slot. Mirrors DrawSkillchainHighlight (dashed
+-- border + SC-name icon corner badge) so the two highlights read as a visual family, with
+-- two intentional differences:
+--   * Color is sourced from `color` (cyan-blue default), distinct from the gold skillchain
+--     border, so a glance tells the player which window is open.
+--   * Icon is placed in the BOTTOM-LEFT corner instead of top-right. Spells almost never
+--     have a charges-quantity badge to collide with there, and it keeps the corner-budget
+--     separate from MP cost (top-left), skillchain icon (top-right), and stack quantity
+--     (bottom-right). On the rare slot where MB and skillchain are both eligible (a /ws
+--     macro that also matches a /ma element via macroparse picking the wrong primary,
+--     etc.), both icons remain visible.
+-- @param drawList   ImGui draw list (window or foreground)
+-- @param x, y       Top-left of slot
+-- @param size       Slot size in pixels
+-- @param scName     Skillchain name driving the icon (e.g. 'Fusion', 'Light') — same asset
+--                   pool as DrawSkillchainHighlight (assets/hotbar/skillchain/<name>.png).
+-- @param color      Border color in ARGB (0xAARRGGBB)
+-- @param opacity    Render opacity (0-1)
+-- @param iconScaleOverride, iconOxOverride, iconOyOverride: optional per-call overrides
+--                   (mirrors DrawSkillchainHighlight's editor-corner-pushing hooks).
+local function DrawMagicBurstHighlight(drawList, x, y, size, scName, color, opacity, iconScaleOverride, iconOxOverride, iconOyOverride)
+    if not drawList or not scName or opacity <= 0.01 then return; end
+
+    local animOffset = skillchain.GetAnimationOffset();
+
+    -- Decompose ARGB. Same shape as DrawSkillchainHighlight so any future migration to a
+    -- shared helper is a single refactor (not duplicated unpack logic).
+    local a = math.floor(bit.rshift(bit.band(color, 0xFF000000), 24) * opacity);
+    local r = bit.rshift(bit.band(color, 0x00FF0000), 16) / 255;
+    local g = bit.rshift(bit.band(color, 0x0000FF00), 8) / 255;
+    local b = bit.band(color, 0x000000FF) / 255;
+    local lineColor = imgui.GetColorU32({ r, g, b, a / 255 });
+
+    local dashLen = 4;
+    local gapLen = 4;
+    local thickness = 2;
+
+    -- Phase-shift the marching ants by half a dash so the MB pattern doesn't look identical
+    -- to the skillchain pattern when (in some future build) both fire on the same slot.
+    local mbAnimOffset = (animOffset + (dashLen + gapLen) * 0.5) % (dashLen + gapLen);
+
+    DrawDashedLine(drawList, x, y, x + size, y, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+    DrawDashedLine(drawList, x + size, y, x + size, y + size, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+    DrawDashedLine(drawList, x + size, y + size, x, y + size, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+    DrawDashedLine(drawList, x, y + size, x, y, lineColor, thickness, dashLen, gapLen, mbAnimOffset);
+
+    -- Bottom-left icon corner. Reuses the skillchainIcon{Scale|OffsetX|OffsetY} global settings
+    -- so users who already tuned their SC icon size don't have to redo it; the offsets are
+    -- applied relative to the BOTTOM-LEFT anchor (not top-right) so positive Y still means
+    -- "shift down" and positive X still means "shift right" intuitively from the corner.
+    local scale = iconScaleOverride or gConfig.hotbarGlobal.skillchainIconScale or 1.0;
+    local iconSize = math.floor(size * 0.35 * scale);
+    local offsetX = iconOxOverride or gConfig.hotbarGlobal.skillchainIconOffsetX or 0;
+    local offsetY = iconOyOverride or gConfig.hotbarGlobal.skillchainIconOffsetY or 0;
+    local iconX = x + 2 + offsetX;
+    local iconY = y + size - iconSize - 2 + offsetY;
+
+    local iconPath = GetSkillchainIconsPath() .. scName .. '.png';
+    if not skillchainIconCache[scName] then
+        local tex = textures:LoadTextureFromPath(iconPath);
+        skillchainIconCache[scName] = tex;
+    end
+
+    local iconTex = skillchainIconCache[scName];
+    if iconTex and iconTex.image then
+        local iconPtr = tonumber(ffi.cast("uint32_t", iconTex.image));
+        if iconPtr then
+            local iconAlpha = math.floor(255 * opacity);
+            local iconTint = bit.bor(bit.lshift(iconAlpha, 24), 0x00FFFFFF);
+            drawList:AddImage(
+                iconPtr,
+                { iconX, iconY },
+                { iconX + iconSize, iconY + iconSize },
+                { 0, 0 }, { 1, 1 },
+                iconTint
+            );
+        end
+    end
+end
+
 -- Helper: determine if movement/drag-drop is locked for this slot
--- Shift key overrides the lock to allow dragging while locked
+-- Shift key overrides the lock to allow dragging while locked.
+-- Hotbar slots use hotbarLockMovement; crossbar slots use crossbarLockMovement;
+-- palette editor slots ('paled*' drop zones) are never locked so users can edit them.
 local function IsMovementLockedForDropZone(dropZoneId)
     if not dropZoneId then return false; end
     if imgui.GetIO().KeyShift then
         return false;
     end
-    if gConfig and gConfig.hotbarLockMovement then
-        return true;
+    if not gConfig then return false; end
+    if type(dropZoneId) == 'string' and dropZoneId:sub(1, 5) == 'paled' then
+        return false;
     end
-    return false;
+    if type(dropZoneId) == 'string' and dropZoneId:sub(1, 9) == 'crossbar_' then
+        return gConfig.crossbarLockMovement == true;
+    end
+    return gConfig.hotbarLockMovement == true;
+end
+
+-- ============================================
+-- Editor label helpers (Ferris's "Edit Full Palette" view).
+-- Crossbar editor passes `labelForeground = true` + `editorMinimalView = true` so the action
+-- name renders on the slot via ImGui drawList (not via the GDI labelFont). When the editor
+-- view is OFF but `labelForeground` is on, labels render above/below the slot with a soft wrap.
+-- ============================================
+
+local function SplitNewlinesEditor(s)
+    if not s or s == '' then return {}; end
+    local t = {};
+    local startPos = 1;
+    local len = #s;
+    while startPos <= len do
+        local nl = s:find('\n', startPos, true);
+        if not nl then
+            t[#t + 1] = s:sub(startPos);
+            break;
+        end
+        t[#t + 1] = s:sub(startPos, nl - 1);
+        startPos = nl + 1;
+    end
+    return t;
+end
+
+-- Idle abbreviation for Edit Full Palette: first 4 non-whitespace chars of the trimmed name.
+-- Full text is shown when the user hovers the slot; the abbreviation lets even cramped 32px
+-- slots show *something* recognisable while editing the palette.
+local function EditorIdleAbbrev4(fullName)
+    if not fullName or fullName == '' then return ''; end
+    local t = fullName:gsub('^%s+', ''):gsub('%s+$', '');
+    if t == '' then return ''; end
+    if #t <= 4 then return t; end
+    return t:sub(1, 4);
+end
+
+-- Wrap rule for editor labels: at most one newline, with the line closest to the slot holding
+-- a single word so the slot stays visually attached to its label.
+-- labelAboveSlot=true  → "A B C D" -> "A B C\nD"  (last word lands beside the slot)
+-- labelAboveSlot=false → "A B C D" -> "A\nB C D"  (first word lands beside the slot)
+local function EditorLabelWrapNearSlot(text, labelAboveSlot)
+    if not text or text == '' then return text; end
+    local t = text:gsub('^%s+', ''):gsub('%s+$', '');
+    if not t:find('%s') then return t; end
+    local words = {};
+    for w in t:gmatch('%S+') do words[#words + 1] = w; end
+    if #words < 2 then return t; end
+    if labelAboveSlot then
+        local last = table.remove(words);
+        return table.concat(words, ' ') .. '\n' .. last;
+    end
+    local first = table.remove(words, 1);
+    return first .. '\n' .. table.concat(words, ' ');
+end
+
+-- Pixel-snap centre X so adjacent slots' labels line up vertically (fonts at fractional X
+-- jitter visibly when neighbours sit at integer positions).
+local function EditorLabelCenterX(cx, line, fontSize)
+    local w = imtext.Measure(line, fontSize);
+    return math.floor(cx - w * 0.5 + 0.5);
+end
+
+-- Multi-line outlined label centred on slot (editorMinimalView). One imtext.Draw call per line
+-- (which already includes the 4-cardinal outline) — matches Ferris's "thin outline only, no
+-- scrim or halo" style so wrapped lines don't stack thick shadows on each other.
+local function DrawEditorMultilineCenteredOnSlot(drawList, slotX, slotY, slotSize, argbColor, multilineText, fontSize)
+    if not drawList or not multilineText or multilineText == '' or not slotSize or slotSize <= 0 then return; end
+    local raw = SplitNewlinesEditor(multilineText);
+    local lines = {};
+    for i = 1, #raw do
+        if raw[i] ~= '' then lines[#lines + 1] = raw[i]; end
+    end
+    if #lines == 0 then return; end
+    local _, lineH = imtext.Measure('Mg', fontSize);
+    local lineStep = (lineH and lineH > 0) and (lineH + 1) or (fontSize + 2);
+    local cx = slotX + slotSize * 0.5;
+    local cy = slotY + slotSize * 0.5;
+    local totalH = #lines * lineStep;
+    local topY = math.floor(cy - totalH * 0.5 + 0.5);
+    for i = 1, #lines do
+        local px = EditorLabelCenterX(cx, lines[i], fontSize);
+        imtext.Draw(drawList, lines[i], px, topY, argbColor, fontSize);
+        topY = topY + lineStep;
+    end
+end
+
+-- Multi-line outlined label centred above/below the slot (non-minimal editor view).
+local function DrawEditorMultilineCenteredAtY(drawList, cx, topY, argbColor, multilineText, fontSize)
+    if not drawList or not multilineText or multilineText == '' then return; end
+    local lines = SplitNewlinesEditor(multilineText);
+    local _, lineH = imtext.Measure('Mg', fontSize);
+    local lineStep = (lineH and lineH > 0) and (lineH + 1) or (fontSize + 2);
+    local py = math.floor(topY + 0.5);
+    for i = 1, #lines do
+        local line = lines[i];
+        if line ~= '' then
+            local px = EditorLabelCenterX(cx, line, fontSize);
+            imtext.Draw(drawList, line, px, py, argbColor, fontSize);
+        end
+        py = py + lineStep;
+    end
 end
 
 --[[
@@ -619,7 +1064,13 @@ end
     MUST be called inside an ImGui window context for interactions to work.
 
     @param params: Rendering and interaction parameters (position, bind, icon, visual settings, callbacks)
-    @return table: { isHovered } (reused - read values immediately, do NOT cache)
+        Edit Full Palette extras (set by crossbar editor only):
+        - editorClipRect: { minX, minY, maxX, maxY } — slot is hidden when fully outside the rect.
+        - editorStrictContain: bool — when true, ALL of the slot (incl. label) must be inside the rect.
+        - labelForeground: bool — draw the action name via ImGui drawList instead of any GDI font path.
+        - editorMinimalView: bool — draw the label centred on the slot (idle abbreviation, full on hover).
+        - labelAboveSlot: bool — place label above the slot rather than below.
+    @return table: { isHovered, command } (reused - read values immediately, do NOT cache)
 ]]--
 function M.DrawSlot(params)
     local x = params.x;
@@ -632,14 +1083,69 @@ function M.DrawSlot(params)
     local animOpacity = params.animOpacity or 1.0;
     local isPressed = params.isPressed or false;
 
+    -- Crossbar: use the current window draw list so MP/timer/hover overlays stack with other
+    -- ImGui windows (GetForegroundDrawList always paints above every window, which can cover
+    -- modal dialogs). Hotbar and editors keep the shared UI draw list. The selector returns
+    -- the appropriate drawList for overlays drawn on top of the slot icon.
+    local function slotOverlayDrawList()
+        if params.windowName == 'Crossbar' then
+            local wdl = imgui.GetWindowDrawList();
+            if wdl then return wdl; end
+        end
+        return GetUIDrawList();
+    end
+
     -- Reuse result table to avoid GC pressure
     -- NOTE: Caller must read values immediately, do not cache the return value
     drawSlotResult.isHovered = false;
+    drawSlotResult.command = nil;
     local result = drawSlotResult;
 
     -- Skip rendering if fully transparent
     if animOpacity <= 0.01 then
         return result;
+    end
+
+    -- Editor clip rect culling: when the crossbar's Edit Full Palette window scrolls, slots
+    -- can land outside the visible region. With all rendering on ImGui draw lists the parent
+    -- window's clip rect already culls drawing, but the slot still pays for per-frame state
+    -- checks (recast, MP, availability, hover, drag) and emits ImGui draw commands that get
+    -- discarded later. Short-circuiting here turns ~120 slots * (full pipeline) into a single
+    -- 4-comparison reject for off-screen rows.
+    local minimalEditorView = params.editorMinimalView == true;
+    do
+        local clip = params.editorClipRect;
+        if clip and clip[1] and clip[2] and clip[3] and clip[4] then
+            local fs = params.labelFontSize or 10;
+            local padTop, padBot = 4, 4;
+            if params.showLabel and params.labelText and params.labelText ~= '' then
+                if not minimalEditorView then
+                    local extraLinePad = 0;
+                    if params.labelText:find('%s') then
+                        extraLinePad = math.floor(fs * 1.05 + 0.5);
+                    end
+                    if params.labelAboveSlot then
+                        padTop = fs + 14 + extraLinePad;
+                    else
+                        padBot = fs + 14 + extraLinePad;
+                    end
+                end
+                -- editorMinimalView labels render on the slot itself, no extra pad needed.
+            end
+            local sx1 = x;
+            local sy1 = y - padTop;
+            local sx2 = x + size;
+            local sy2 = y + size + padBot;
+            if params.editorStrictContain then
+                if sx1 < clip[1] or sy1 < clip[2] or sx2 > clip[3] or sy2 > clip[4] then
+                    return result;
+                end
+            else
+                if sx2 < clip[1] or sx1 > clip[3] or sy2 < clip[2] or sy1 > clip[4] then
+                    return result;
+                end
+            end
+        end
     end
 
     -- Check hover state
@@ -651,7 +1157,11 @@ function M.DrawSlot(params)
     -- ========================================
     -- 1. Slot Background (ImGui AddImage)
     -- ========================================
-    local drawList = GetUIDrawList();
+    -- For Crossbar windows we draw to the window draw list so all of the slot's
+    -- visual layers (background -> icon -> text -> hover) stack within the window's
+    -- z-order; the shared UI draw list lands ABOVE every ImGui window which can
+    -- cover modals and tooltips.
+    local drawList = slotOverlayDrawList();
     do
         local slotTexPtr = GetCachedTexturePtr(GetSlotTexPath());
         if slotTexPtr and drawList then
@@ -715,7 +1225,7 @@ function M.DrawSlot(params)
         local mpCost = mpCostCache[bindKey];
         if mpCost == nil then
             mpCost = actions.GetMPCost(bind) or false;
-            mpCostCache[bindKey] = mpCost;
+            PutMpCostCache(bindKey, mpCost);
         end
         if mpCost and mpCost ~= false then
             local party = AshitaCore:GetMemoryManager():GetParty();
@@ -724,30 +1234,53 @@ function M.DrawSlot(params)
         end
     end
 
-    -- Check if action is available (job/level requirements)
+    -- Check if action is available (job/level requirements). Allowlist covers magic ('ma'),
+    -- job abilities ('ja'), weapon skills ('ws'), pet pacts ('pet'), and macros — macros are
+    -- validated against their resolved primary line (and optional /ja badge) so a macro that
+    -- /pet's a not-yet-learned blood pact reads as unavailable too.
     local isUnavailable = false;
     local unavailableReason = nil;
-    if bind and (bind.actionType == 'ma' or bind.actionType == 'ja' or bind.actionType == 'ws') then
-        -- Include job/subjob in cache key so cache invalidates on job change
-        local player = AshitaCore:GetMemoryManager():GetPlayer();
-        local jobId = player and player:GetMainJob() or 0;
-        local subjobId = player and player:GetSubJob() or 0;
-        local availKey = bindKey .. ':' .. jobId .. ':' .. subjobId;
+    local unavailDisplayText = nil;  -- pre-parsed 'Lv65' / 'X' string (computed at insert time)
+    if bind and (
+            bind.actionType == 'ma'
+            or bind.actionType == 'ja'
+            or bind.actionType == 'ws'
+            or bind.actionType == 'pet'
+            or bind.actionType == 'macro') then
+        local fa = GetFrameAvailability();
+        local availKey = bindKey .. ':' .. fa.jobId .. ':' .. fa.subjobId .. ':'
+            .. fa.mainLevel .. ':' .. fa.subLevel .. ':' .. fa.partyMain .. ':' .. fa.partySub;
 
         local cached = availabilityCache[availKey];
         if cached == nil then
             local available, reason = actions.IsActionAvailable(bind);
             -- Don't cache if reason is "pending" (player state invalid, e.g., during zoning)
             if reason ~= "pending" then
-                availabilityCache[availKey] = { isAvailable = available, reason = reason };
-                cached = availabilityCache[availKey];
+                -- Pre-parse the display text once at insert time so the MP-cost render path
+                -- doesn't call string.match every frame for every unavailable slot.
+                local dispText = 'X';
+                if reason then
+                    local lv = reason:match('^Lv(%d+)$');
+                    if lv then
+                        dispText = 'Lv' .. lv;
+                    else
+                        local legacyLvl = reason:match('^Lvl%.(%d+)$');
+                        if legacyLvl then
+                            dispText = 'Lv' .. legacyLvl;
+                        end
+                    end
+                end
+                local entry = { isAvailable = available, reason = reason, displayText = dispText };
+                PutAvailabilityCache(availKey, entry);
+                cached = entry;
             else
                 -- Use temp result but don't cache
-                cached = { isAvailable = available, reason = nil };
+                cached = { isAvailable = available, reason = nil, displayText = 'X' };
             end
         end
         isUnavailable = not cached.isAvailable;
         unavailableReason = cached.reason;
+        unavailDisplayText = cached.displayText;
     end
 
     -- ========================================
@@ -900,7 +1433,13 @@ function M.DrawSlot(params)
     end
 
     -- ========================================
-    -- 9. Label Text (action name below slot)
+    -- 9. Label Text (action name)
+    -- Three modes:
+    --   (a) Standard hotbar/crossbar: single line below the slot (default).
+    --   (b) labelForeground + editorMinimalView: multi-line centred ON the slot
+    --       (Edit Full Palette idle view — 4-char abbrev, full text shown via hover tooltip).
+    --   (c) labelForeground (non-minimal): multi-line centred above/below the slot
+    --       with EditorLabelWrapNearSlot soft-wrap putting one word beside the slot.
     -- ========================================
     if params.showLabel and params.labelText and params.labelText ~= '' and animOpacity > 0.5 and drawList then
         local lblFontSize = params.labelFontSize or 10;
@@ -913,10 +1452,53 @@ function M.DrawSlot(params)
         elseif notEnoughMp then
             labelColor = params.labelNoMpColor or 0xFFFF4444;
         end
-        local lblW = imtext.Measure(params.labelText, lblFontSize);
-        local labelX = x + (size - lblW) / 2 + (params.labelOffsetX or 0);
-        local labelY = y + size + 2 + (params.labelOffsetY or 0);
-        imtext.Draw(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
+
+        -- Apply animation opacity into the label color (label paths below don't otherwise modulate alpha).
+        if animOpacity < 1.0 then
+            local a = math.floor(bit.rshift(bit.band(labelColor, 0xFF000000), 24) * animOpacity);
+            if a < 0 then a = 0; elseif a > 255 then a = 255; end
+            labelColor = bit.bor(bit.lshift(a, 24), bit.band(labelColor, 0x00FFFFFF));
+        end
+
+        if params.labelForeground then
+            if minimalEditorView then
+                -- (b) On-slot view: 4-char abbrev when idle, full name on hover. Multi-line if hover label wraps.
+                local textForDraw = isHovered and params.labelText or EditorIdleAbbrev4(params.labelText);
+                if textForDraw and textForDraw ~= '' then
+                    DrawEditorMultilineCenteredOnSlot(drawList, x, y, size, labelColor, textForDraw, lblFontSize);
+                end
+            else
+                -- (c) Above/below-slot view with soft wrap so one word lands beside the slot.
+                local wrapped = EditorLabelWrapNearSlot(params.labelText, params.labelAboveSlot);
+                local cx = x + size * 0.5 + (params.labelOffsetX or 0);
+                local lineCount = 1;
+                if wrapped and wrapped:find('\n') then lineCount = 2; end
+                local _, lineH = imtext.Measure('Mg', lblFontSize);
+                local lineStep = (lineH and lineH > 0) and (lineH + 1) or (lblFontSize + 2);
+                local topY;
+                if params.labelAboveSlot then
+                    topY = y - 2 - lineStep * lineCount + (params.labelOffsetY or 0);
+                else
+                    topY = y + size + 2 + (params.labelOffsetY or 0);
+                end
+                DrawEditorMultilineCenteredAtY(drawList, cx, topY, labelColor, wrapped, lblFontSize);
+            end
+        else
+            -- (a) Default single-line render. Honors params.labelAboveSlot so the crossbar's
+            -- top diamond slot can flip its label above (otherwise the bottom slot's MP/qty
+            -- text overlaps the top slot's label). Keyboard hotbars always pass false → below.
+            local lblW = imtext.Measure(params.labelText, lblFontSize);
+            local labelX = x + (size - lblW) / 2 + (params.labelOffsetX or 0);
+            local labelY;
+            if params.labelAboveSlot then
+                local _, lblH = imtext.Measure('Mg', lblFontSize);
+                local h = (lblH and lblH > 0) and lblH or lblFontSize;
+                labelY = y - 2 - h + (params.labelOffsetY or 0);
+            else
+                labelY = y + size + 2 + (params.labelOffsetY or 0);
+            end
+            imtext.Draw(drawList, params.labelText, labelX, labelY, labelColor, lblFontSize);
+        end
     end
 
     -- ========================================
@@ -930,20 +1512,24 @@ function M.DrawSlot(params)
             local mpFontSize = params.mpCostFontSize or 10;
             local mpX, mpY = GetAnchoredPosition(x, y, size, mpAnchor, params.mpCostOffsetX, params.mpCostOffsetY);
 
-            -- If action is unavailable, show "X" instead of MP cost
+            -- If action is unavailable, render either a level requirement ("Lv65") when
+            -- IsActionAvailable returned an Lv-style reason, or a plain "X" for non-level
+            -- failures (e.g. weaponskills not learned, wrong job, missing scroll). The
+            -- display text was pre-parsed by the availability cache insert above, so this
+            -- hot-path branch just reads the field — no per-frame string.match here.
             if isUnavailable then
-                local xText = "X";
+                local unavailText = unavailDisplayText or 'X';
                 local xColor = 0xFFFF4444;
                 if mpAnchor == 'topRight' or mpAnchor == 'bottomRight' then
-                    local w = imtext.Measure(xText, mpFontSize);
+                    local w = imtext.Measure(unavailText, mpFontSize);
                     mpX = mpX - w;
                 end
-                imtext.Draw(drawList, xText, mpX, mpY, xColor, mpFontSize);
+                imtext.Draw(drawList, unavailText, mpX, mpY, xColor, mpFontSize);
             else
                 local mpCost = mpCostCache[bindKey];
                 if mpCost == nil then
                     mpCost = actions.GetMPCost(bind) or false;
-                    mpCostCache[bindKey] = mpCost;
+                    PutMpCostCache(bindKey, mpCost);
                 end
                 if mpCost and mpCost ~= false then
                     local mpText = tostring(mpCost);
@@ -1069,7 +1655,33 @@ function M.DrawSlot(params)
         -- Skillchain highlight (animated dotted border + icon)
         if params.skillchainName then
             local scColor = params.skillchainColor or 0xFFD4AA44;
-            DrawSkillchainHighlight(drawList, x, y, size, params.skillchainName, scColor, animOpacity);
+            -- Per-call icon scale/offset overrides used by the macro palette editor
+            -- to push the skillchain icon out of corner badges. Falls back to
+            -- gConfig.hotbarGlobal.skillchainIcon* when not provided.
+            DrawSkillchainHighlight(drawList, x, y, size, params.skillchainName, scColor, animOpacity,
+                params.skillchainIconScale, params.skillchainIconOffsetX, params.skillchainIconOffsetY);
+        end
+
+        -- Magic Burst highlight (animated dotted border + SC-name icon in BOTTOM-LEFT corner).
+        -- Renders independently from the skillchain highlight: a slot can legitimately have
+        -- ONE of them active at a time (WS slots → skillchain prediction, spell slots → MB).
+        -- Drawing this AFTER the skillchain pass means if both ever fire on the same slot
+        -- (rare — primary-parse path would have to disagree), the MB border ends up on top.
+        if params.magicBurstName then
+            local mbColor = params.magicBurstColor or 0xFF44D4FF;
+            DrawMagicBurstHighlight(drawList, x, y, size, params.magicBurstName, mbColor, animOpacity,
+                params.skillchainIconScale, params.skillchainIconOffsetX, params.skillchainIconOffsetY);
+        end
+
+        -- Universal Two-Hour: rainbow rotating rings + marching border while the user is
+        -- confirming <stpc>/<stnpc> (or briefly after click during the arming-shimmer
+        -- fade window). universal_two_hour module decides whether this slot is the armed
+        -- ability; if the module isn't loaded (1.7.5 fork) the check is a silent no-op.
+        if bind and not isOnCooldown and universalTwoHour and universalTwoHour.ShouldGlowUniversalTwoHourSlot
+            and universalTwoHour.ShouldGlowUniversalTwoHourSlot(bind) then
+            local armScale = universalTwoHour.GetArmingShimmerOpacityScale
+                and universalTwoHour.GetArmingShimmerOpacityScale() or 1.0;
+            DrawUniversalTwoHourSubtargetGlow(drawList, x, y, size, animOpacity, dimFactor, armScale);
         end
     end
 
@@ -1080,6 +1692,10 @@ function M.DrawSlot(params)
         dragdrop.DropZone(params.dropZoneId, x, y, size, size, {
             accepts = params.dropAccepts or {'macro'},
             highlightColor = params.dropHighlightColor or 0xA8FFFFFF,
+            -- dropPriority is the tie-break for overlapping zones (e.g. Edit Full Palette preview
+            -- overlay on top of a live crossbar slot); the higher number wins via FlushDeferredDrops.
+            -- Default is nil so the existing first-registered-wins behavior is preserved.
+            dropPriority = params.dropPriority,
             onDrop = params.onDrop,
         });
     end
@@ -1111,10 +1727,30 @@ function M.DrawSlot(params)
             end
         end
 
-        -- Left click to execute (BuildCommand deferred to click time to avoid per-frame cost)
+        -- Left click / double-click. Edit Full Palette slots set `suppressActionOnClick`:
+        -- a single click on those is meaningless (no live action to fire — the slot is a
+        -- draft preview), but we still need to track the click to detect double-click and
+        -- open the macro editor. `params.suppressActionOnClick` also tells us to ignore a
+        -- cancelled-micro-drag attempt (without this, even a tiny mouse jitter between
+        -- press and release blocks the double-click pipeline).
         if isItemHovered and imgui.IsMouseReleased(0) then
-            if not dragdrop.IsDragging() and not dragdrop.WasDragAttempted() then
-                if params.onClick then
+            local ignoreCancelledMicroDrag = params.suppressActionOnClick;
+            if not dragdrop.IsDragging()
+                and (ignoreCancelledMicroDrag or not dragdrop.WasDragAttempted()) then
+                local now = os.clock();
+                local isDoubleClick = (params.buttonId == lastClickButtonId)
+                    and (now - lastClickTime) < DOUBLE_CLICK_INTERVAL;
+
+                if isDoubleClick and params.onDoubleClick then
+                    params.onDoubleClick();
+                    lastClickButtonId = nil;
+                    lastClickTime = 0;
+                elseif params.suppressActionOnClick then
+                    -- Treat as the first half of a potential double-click and do nothing
+                    -- else. Editor slots intentionally don't fire any action on single click.
+                    lastClickButtonId = params.buttonId;
+                    lastClickTime = now;
+                elseif params.onClick then
                     params.onClick();
                 elseif bind then
                     local cmd = actions.BuildCommand(bind);
@@ -1125,9 +1761,11 @@ function M.DrawSlot(params)
             end
         end
 
-        -- Right click (disabled when Lock Movement is enabled)
+        -- Right click (disabled when the slot's Lock Movement is enabled). Uses the same
+        -- per-zone lock policy as drop zones so the Hotbar lock doesn't accidentally disable
+        -- right-click-to-clear on crossbar slots (and vice versa).
         if isItemHovered and imgui.IsMouseClicked(1) and bind then
-            if params.onRightClick and not gConfig.hotbarLockMovement then
+            if params.onRightClick and not IsMovementLockedForDropZone(params.dropZoneId) then
                 params.onRightClick();
             end
         end
@@ -1159,14 +1797,20 @@ function M.DrawTooltip(bind)
         return '<' .. cleaned .. '>';
     end
 
-    -- Check if action is unavailable for current job/subjob (cached lookup)
+    -- Check if action is unavailable for current job/subjob (cached lookup). Cache key
+    -- shape MUST match the one DrawSlot uses or we'd get spurious cache misses every time
+    -- the tooltip checks: same (action key, jobs, levels, party-effective levels). Routes
+    -- through the same per-frame snapshot used by DrawSlot so we don't re-walk MM here.
     local isUnavailable = false;
-    if bind.actionType == 'ma' or bind.actionType == 'ja' or bind.actionType == 'ws' then
+    if bind.actionType == 'ma'
+        or bind.actionType == 'ja'
+        or bind.actionType == 'ws'
+        or bind.actionType == 'pet'
+        or bind.actionType == 'macro' then
         local bindKey = (bind.actionType or '') .. ':' .. (bind.action or '');
-        local player = AshitaCore:GetMemoryManager():GetPlayer();
-        local jobId = player and player:GetMainJob() or 0;
-        local subjobId = player and player:GetSubJob() or 0;
-        local availKey = bindKey .. ':' .. jobId .. ':' .. subjobId;
+        local fa = GetFrameAvailability();
+        local availKey = bindKey .. ':' .. fa.jobId .. ':' .. fa.subjobId .. ':'
+            .. fa.mainLevel .. ':' .. fa.subLevel .. ':' .. fa.partyMain .. ':' .. fa.partySub;
         local cached = availabilityCache[availKey];
         if cached then
             isUnavailable = not cached.isAvailable;
@@ -1235,6 +1879,7 @@ end
 function M.BeginFrame(fontSettings)
     pendingTooltipBind = nil;
     tooltipFontSettings = fontSettings;
+    frameAvail.ready = false;
 end
 
 -- Size of the abbreviation "pick-up" tile that follows the cursor on icon-less drags.


### PR DESCRIPTION
… and deferred drop UX

What changed
- data.lua: Draft layer (draftByKey + draftTouchedKeys). Empty-slot sentinel distinguishes cleared palette slots from sparse untouched ones so overlay swap reads do not resurrect live binds. GetCrossbarSlotRawForSwapOverlay for palette row reads. SwapActiveMacroArmsInPlace, FinalizeCrossbarRawSlotForStorage, NormalizeCrossbarSlotRawForSwap. SyncDraftSlotFromLive merges HUD edits into draft only when HUD palette storage key matches draft (liveKey == rk) so hops between active palettes do not overwrite unrelated drafts. 6 EFP public functions. BeginDraftUndoGroup / EndDraftUndoGroup / UndoDraft / CanUndoDraft stack. resolveSlotMacro returns nil for minimal macro binding tables (macroRef + macroPaletteKey only, no displayName/action) when the referenced macro no longer resolves - slot draws empty instead of showing abbreviation '?' (orphan cleanup after macro delete). RewriteMacroPaletteBindingsInConfig + RewriteMacroPaletteBindingsInDraft update all bindings on Move Macro.
- crossbar.lua: GetCbInteractionPaletteEditor: getDragData uses GetCrossbarSlotRawForSwapOverlay; onDrop handlers use SwapActiveMacroArmsInPlace + FinalizeCrossbarRawSlotForStorage + proper ClearDraftSlotData; all drop branches pair BeginDraftUndoGroup with EndDraftUndoGroup; all drop and onRightClick handlers call ClearCrossbarIconCacheForSlot (via DeferRelease). Stale slotrenderer.InvalidateSlotByKey calls removed (not applicable to 1.8.0 immediate-mode renderer; their crashes previously prevented EndDrag from firing and left isDragging stuck true). onDoubleClick closure: seeds fresh macro from active palette defaults and passes bindTargetSlot to macropalette.OpenEditorForSlotData. Editor slot params: editorClipRect for clipped preview, dropPriority=10 so palette editor wins over live crossbar zone.
- libs/dragdrop.lua: deferredDropCandidates, FlushDeferredDrops() with dropPriority + registration- order tiebreaker. Re-applied 1.8.0 simplification (centralized tooltip in slotrenderer.FlushTooltip).
- macropalette.lua: OpenEditorForSlotData accepts opts.bindTargetSlot; stashed as MP.pendingNewMacroBindTarget for SaveMacro auto-bind.
- macropalette_macroeditor.lua: SaveMacro auto-binds new macro to pendingNewMacroBindTarget slot via data.SetDraftSlotData when set by EFP double-click flow.
- init.lua: M.FinalizeFrame() calls FlushDeferredDrops before drag renderer so palette editor drop zones are resolved in correct priority order.
- XIUI.lua: hotbar.FinalizeFrame() called after palette manager draw.
- config/palettemanager.lua: Consumes data.pendingPaletteSlotEdit next frame for double-click new-macro flow. Editor clip rect culling. Label rendering (minimal vs full multiline). Scroll-safe layout. Job-shared copy. Override/Pet rows for segment editing.

Why
- Removes duplicate/wrong swap behavior when draft clears overlapped live-only slots. Drag-drop visual artifact (square stuck on cursor) fixed by removing stale InvalidateSlotByKey calls that crashed the drop handler mid-frame. Undo works correctly after slot swaps. Double-clicking an empty EFP slot creates a new macro and auto-binds it to that slot. Orphan '?' placeholder eliminated after macro delete. Move Macro avoids broken binds after relocating a library row.