### PR TITLE
Crossbar settings: separated config files, EFP pets tab, skillchain/M…

### DIFF
--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 * XIUI Config Menu - Main Window
 * Entry point for the config menu, handles window rendering and dispatches to module files
 ]]--
@@ -24,16 +24,27 @@ local petbarModule = require('config.petbar');
 local notificationsModule = require('config.notifications');
 local treasurepoolModule = require('config.treasurepool');
 local hotbarModule = require('config.hotbar');
+local crossbarModule = require('config.crossbar');
 local readycheckModule = require('config.readycheck');
 
 local treasurePool = require('modules.treasurepool.init');
 local macropalette = require('modules.hotbar.macropalette');
 local palette = require('modules.hotbar.palette');
+local paletteJson = require('modules.hotbar.palette_json');
 
 local config = {};
 
 -- Track previous config state to detect when config closes
 local wasConfigOpen = false;
+
+-- Lazy: defer closing XIUI Config when Edit Full Palette is open (see config.palettemanager).
+local paletteManagerForCloseDefer = nil;
+local function getPaletteManagerForCloseDefer()
+    if not paletteManagerForCloseDefer then
+        paletteManagerForCloseDefer = require('config.palettemanager');
+    end
+    return paletteManagerForCloseDefer;
+end
 
 -- Track last known config window geometry for smart reposition on open
 local lastConfigPosX, lastConfigPosY = 20, 20;
@@ -114,6 +125,23 @@ local showNewProfilePopup = false;
 local triggerNewProfilePopup = false;
 local triggerDeleteProfilePopup = false;
 local triggerRenameProfilePopup = false;
+local triggerCopyProfilePopup = false;
+-- [1] = include full macroDB when using Copy (DuplicateProfile)
+local copyProfileIncludeMacros = { true };
+
+-- Profile JSON export/import (whole-profile: all palettes + all macros)
+local profileJsonWinOpen = { false };
+local profileJsonMode = 'export'; -- 'export' | 'import'
+local profileJsonBuf = { '' };
+local profileJsonErr = nil;
+local profileJsonInfo = nil;
+local profileJsonExportPart = { 'all' }; -- paletteJson.EXPORT_PART_*
+local profileJsonImportPalettes = { true };
+local profileJsonImportMacros = { true };
+local profileJsonImportMode = { paletteJson.IMPORT_MODE_MERGE }; -- merge | replace (see palette_json)
+local profileJsonImportFiles = {};
+local profileJsonImportSelectedIdx = { -1 };
+local profileJsonImportSelectedName = nil;
 
 -- XIUI Theme Colors (dark + gold accent)
 local gold = {0.957, 0.855, 0.592, 1.0};           -- #F4DA97 - Primary gold accent
@@ -192,12 +220,275 @@ local function PopThemeStyles()
     imgui.PopStyleColor(34);
 end
 
+local function OpenProfileJsonExport()
+    profileJsonMode = 'export';
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+    profileJsonBuf[1] = '';
+    profileJsonExportPart[1] = paletteJson.EXPORT_PART_ALL;
+    profileJsonWinOpen[1] = true;
+end
+
+local function RefreshProfileJsonImportFiles()
+    local files = paletteJson.ListExportFiles();
+    profileJsonImportFiles = files or {};
+    if profileJsonImportSelectedName then
+        profileJsonImportSelectedIdx[1] = -1;
+        for i, n in ipairs(profileJsonImportFiles) do
+            if n == profileJsonImportSelectedName then
+                profileJsonImportSelectedIdx[1] = i - 1;
+                break;
+            end
+        end
+    else
+        profileJsonImportSelectedIdx[1] = -1;
+    end
+end
+
+local function LoadSelectedProfileJsonImportFile()
+    local idx = profileJsonImportSelectedIdx[1];
+    if not idx or idx < 0 then
+        profileJsonErr = 'Pick a file from the list first (or paste JSON below).';
+        return;
+    end
+    local name = profileJsonImportFiles[idx + 1];
+    if not name then
+        profileJsonErr = 'Selected file is no longer present.';
+        return;
+    end
+    local text, err = paletteJson.ReadExportFile(name);
+    if not text then
+        profileJsonErr = err or ('Could not read ' .. name);
+        return;
+    end
+    profileJsonBuf[1] = text;
+    profileJsonErr = nil;
+    profileJsonInfo = 'Loaded ' .. name;
+    profileJsonImportSelectedName = name;
+end
+
+local function OpenProfileJsonImport()
+    profileJsonMode = 'import';
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+    profileJsonBuf[1] = '';
+    profileJsonImportPalettes[1] = true;
+    profileJsonImportMacros[1] = true;
+    profileJsonImportMode[1] = paletteJson.IMPORT_MODE_MERGE;
+    profileJsonImportSelectedName = nil;
+    profileJsonWinOpen[1] = true;
+    RefreshProfileJsonImportFiles();
+end
+
+local function RunProfileJsonExport()
+    local text, err = paletteJson.ExportProfile(profileJsonExportPart[1] or paletteJson.EXPORT_PART_ALL);
+    if not text then
+        profileJsonErr = err or 'Export failed';
+        return;
+    end
+    profileJsonBuf[1] = text;
+    profileJsonErr = nil;
+    profileJsonInfo = nil;
+end
+
+local function RunProfileJsonSaveToFile()
+    local baseName = (GetCurrentProfileName and GetCurrentProfileName()) or 'profile';
+    local part = profileJsonExportPart[1] or paletteJson.EXPORT_PART_ALL;
+    baseName = tostring(baseName) .. '_' .. part;
+    local ok, path = paletteJson.SaveTextFile(baseName, profileJsonBuf[1] or '');
+    if ok then
+        profileJsonInfo = path;
+        profileJsonErr = nil;
+    else
+        profileJsonErr = tostring(path);
+    end
+end
+
+local function RunProfileJsonImport()
+    local okImp, errImp = paletteJson.ImportProfile(profileJsonBuf[1] or '', {
+        importPalettes = profileJsonImportPalettes[1],
+        importMacros = profileJsonImportMacros[1],
+        importMode = profileJsonImportMode[1] or paletteJson.IMPORT_MODE_MERGE,
+    });
+    if okImp then
+        profileJsonErr = nil;
+        profileJsonInfo = 'Import applied.';
+        profileJsonWinOpen[1] = false;
+    else
+        profileJsonErr = errImp or 'Import failed';
+    end
+end
+
+local function DrawProfileJsonWindow()
+    if not profileJsonWinOpen[1] then return; end
+
+    PushThemeStyles();
+    imgui.SetNextWindowSize({ 680, 560 }, ImGuiCond_FirstUseEver);
+    local title = (profileJsonMode == 'export') and 'Profile Export (JSON)##xiuiProfJson' or 'Profile Import (JSON)##xiuiProfJson';
+    if imgui.Begin(title, profileJsonWinOpen, ImGuiWindowFlags_NoCollapse) then
+        if profileJsonMode == 'export' then
+            imgui.TextWrapped(
+                'Export this profile\'s palettes and/or macros to a single JSON file. Use it to back up this profile or transfer it to a new character. Entries are pretty-printed with human-readable "_label" tags (job / subjob / palette name), so you can open the file in a text editor, delete the blocks you do not want, save, and then import only the rest.'
+            );
+        else
+            imgui.TextWrapped(
+                'Pick a file from the exports folder, or paste JSON below. Choose Add to existing to merge with this profile, or Replace with file to clear the matching data first so the result matches the export.'
+            );
+        end
+        imgui.Spacing();
+
+        if profileJsonErr then
+            imgui.TextColored({ 1.0, 0.3, 0.3, 1.0 }, profileJsonErr);
+        end
+        if profileJsonInfo then
+            imgui.TextColored({ 0.65, 0.8, 0.65, 1.0 }, profileJsonInfo);
+        end
+        imgui.Separator();
+
+        if profileJsonMode == 'export' then
+            imgui.Text('Include in file:');
+            if imgui.RadioButton('All palettes + macros##pjExAll', profileJsonExportPart[1] == paletteJson.EXPORT_PART_ALL) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_ALL;
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('All palettes only##pjExPal', profileJsonExportPart[1] == paletteJson.EXPORT_PART_PALETTES_ONLY) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_PALETTES_ONLY;
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('All macros only##pjExMac', profileJsonExportPart[1] == paletteJson.EXPORT_PART_MACROS_ONLY) then
+                profileJsonExportPart[1] = paletteJson.EXPORT_PART_MACROS_ONLY;
+            end
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'All palettes + macros: complete profile backup (every keyboard hotbar palette, every crossbar palette, and all macro text).\nAll palettes only: every palette for this profile without macro definitions. Import into a profile that already has the macros.\nAll macros only: the entire macro library without changing any palette layouts.'
+                );
+            end
+
+            imgui.Spacing();
+            if imgui.Button('Generate JSON##pjGen') then
+                RunProfileJsonExport();
+            end
+            imgui.SameLine();
+            if imgui.Button('Save to file##pjSave') then
+                if profileJsonBuf[1] == nil or profileJsonBuf[1] == '' then
+                    RunProfileJsonExport();
+                end
+                if profileJsonBuf[1] ~= nil and profileJsonBuf[1] ~= '' then
+                    RunProfileJsonSaveToFile();
+                end
+            end
+            imgui.SameLine();
+            if imgui.Button('Open exports folder##pjExOpenDir') then
+                paletteJson.OpenExportsDir();
+            end
+            imgui.SameLine();
+            imgui.TextColored({ 0.6, 0.6, 0.65, 1.0 }, 'Files save to config/addons/xiui/exports/.');
+
+            imgui.Spacing();
+            imgui.InputTextMultiline('##profJsonBuf', profileJsonBuf, 200000, { -1, -1 });
+        else
+            if imgui.Checkbox('Import palettes##pjImpPal', profileJsonImportPalettes) then end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Apply keyboard hotbar and crossbar layouts from the file. Add to existing: overlay slot data and merge palette name lists. Replace with file: clear those layouts first, then apply; palette order lists come only from the file.'
+                );
+            end
+            if imgui.Checkbox('Import macros##pjImpMac', profileJsonImportMacros) then end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Add to existing: append macro rows with new IDs and remap palette references. Replace with file: macro library becomes exactly what is in the file (same macro IDs as the export). If you import palettes only and uncheck macros, the file must reference macros that already exist here.'
+                );
+            end
+
+            imgui.Spacing();
+            imgui.Text('Apply mode:');
+            if imgui.RadioButton('Add to existing (merge)##pjModeMerge', profileJsonImportMode[1] == paletteJson.IMPORT_MODE_MERGE) then
+                profileJsonImportMode[1] = paletteJson.IMPORT_MODE_MERGE;
+            end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Overlay the file onto this profile: palette slot data and name lists merge with what you already have; new macro rows get new IDs.'
+                );
+            end
+            if imgui.RadioButton('Replace with file (overwrite)##pjModeReplace', profileJsonImportMode[1] == paletteJson.IMPORT_MODE_REPLACE) then
+                profileJsonImportMode[1] = paletteJson.IMPORT_MODE_REPLACE;
+            end
+            imgui.SameLine();
+            if imgui.ShowHelp then
+                imgui.ShowHelp(
+                    'Before applying: clears hotbar/crossbar layouts for sides present in the file, replaces palette order lists from the file, and replaces the macro library with the file when Import macros is checked. Use this when you want the profile to match the export instead of mixing with old data.'
+                );
+            end
+            if profileJsonImportMode[1] == paletteJson.IMPORT_MODE_REPLACE then
+                imgui.PushStyleColor(ImGuiCol_Text, { 1.0, 0.55, 0.35, 1.0 });
+                if imgui.TextWrapped then
+                    imgui.TextWrapped(
+                        'Replace mode can remove existing bars, combos, palette lists, and macros (for the options you checked) so only the file remains.'
+                    );
+                end
+                imgui.PopStyleColor();
+            end
+
+            imgui.Spacing();
+            imgui.Text('Pick a file from config/addons/xiui/exports/:');
+            imgui.SetNextItemWidth(-220);
+            local fileCount = #profileJsonImportFiles;
+            if fileCount == 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, { 0.7, 0.7, 0.75, 1.0 });
+                -- BeginListBox is not available on all Ashita ImGui builds; use a bordered child instead.
+                imgui.BeginChild('##profJsonFilesEmpty', { -220, 90 }, true);
+                imgui.Text('(No .json files found in the exports folder.)');
+                imgui.EndChild();
+                imgui.PopStyleColor();
+            else
+                if imgui.ListBox and imgui.ListBox('##profJsonFiles', profileJsonImportSelectedIdx, profileJsonImportFiles, fileCount, 5) then
+                    local idx = profileJsonImportSelectedIdx[1];
+                    if idx and idx >= 0 then
+                        profileJsonImportSelectedName = profileJsonImportFiles[idx + 1];
+                    end
+                end
+            end
+            imgui.SameLine();
+            imgui.BeginGroup();
+            if imgui.Button('Load selected##pjLoadFile', { 200, 0 }) then
+                LoadSelectedProfileJsonImportFile();
+            end
+            if imgui.Button('Refresh list##pjRefreshFiles', { 200, 0 }) then
+                RefreshProfileJsonImportFiles();
+                profileJsonInfo = 'Refreshed (' .. #profileJsonImportFiles .. ' file(s)).';
+            end
+            if imgui.Button('Open exports folder##pjOpenDir', { 200, 0 }) then
+                paletteJson.OpenExportsDir();
+            end
+            imgui.EndGroup();
+
+            imgui.Spacing();
+            if imgui.Button('Apply import##pjApply', { 140, 0 }) then
+                RunProfileJsonImport();
+            end
+            imgui.SameLine();
+            imgui.TextColored({ 0.6, 0.6, 0.65, 1.0 }, 'Or paste JSON directly below and Apply.');
+
+            imgui.Spacing();
+            imgui.InputTextMultiline('##profJsonBuf', profileJsonBuf, 200000, { -1, -1 });
+        end
+    end
+    imgui.End();
+    PopThemeStyles();
+end
+
 local function DrawProfilesWindow()
-    if (not showProfilesWindow[1]) then return; end
+    if (not showProfilesWindow[1]) then
+        DrawProfileJsonWindow();
+        return;
+    end
 
     PushThemeStyles();
 
-    imgui.SetNextWindowSize({ 350, 145 }, ImGuiCond_Always);
+    imgui.SetNextWindowSize({ 380, 300 }, ImGuiCond_Always);
     -- Using + for flags as they are typically integers
     if (imgui.Begin("Profiles", showProfilesWindow, ImGuiWindowFlags_NoCollapse + ImGuiWindowFlags_NoResize)) then
 
@@ -221,6 +512,17 @@ local function DrawProfilesWindow()
             imgui.EndCombo();
         end
 
+        if imgui.TextWrapped then
+            imgui.Spacing();
+            imgui.PushStyleColor(ImGuiCol_Text, { 0.55, 0.55, 0.62, 1.0 });
+            imgui.TextWrapped(
+                'Every character that uses this profile name shares the same XIUI data (palettes, macros, layout). '
+                .. 'Use Copy to duplicate the active profile: you can include the full macro library or only layout/appearance. '
+                .. 'To move specific macros, use Export/Import JSON. Empty palette buckets (e.g. Items) are not stored on disk until you add something there.'
+            );
+            imgui.PopStyleColor();
+        end
+
         imgui.Spacing();
         imgui.Spacing();
 
@@ -234,7 +536,8 @@ local function DrawProfilesWindow()
         imgui.SameLine();
 
         if (imgui.Button("Copy")) then
-            DuplicateProfile(currentProfile);
+            copyProfileIncludeMacros[1] = true;
+            triggerCopyProfilePopup = true;
         end
 
         imgui.SameLine();
@@ -282,12 +585,30 @@ local function DrawProfilesWindow()
             imgui.PopStyleColor(3);
         end
 
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
 
+        imgui.Text('Backup / Transfer:');
+        if imgui.ShowHelp then
+            imgui.SameLine();
+            imgui.ShowHelp(
+                'Export or import this entire profile as one JSON file: all keyboard hotbar palettes, all crossbar palettes, and the full macro library for this profile. Use it to back up this profile or move everything onto a new character. You can choose to include palettes, macros, or both on both sides.'
+            );
+        end
+        if imgui.Button('Export JSON##profJsonOpenEx') then
+            OpenProfileJsonExport();
+        end
+        imgui.SameLine();
+        if imgui.Button('Import JSON##profJsonOpenIm') then
+            OpenProfileJsonImport();
+        end
 
         imgui.End();
     end
 
     PopThemeStyles();
+    DrawProfileJsonWindow();
 end
 
 -- Navigation state
@@ -304,8 +625,7 @@ local selectedPetTypeTab = 1;  -- 1 = Avatar, 2 = Charm, 3 = Jug, 4 = Automaton,
 local selectedPetTypeColorTab = 1;  -- Pet type color sub-tab
 local selectedPetBarColorTab = 1;  -- 1 = Pet Bar, 2 = Pet Target (for color settings)
 local selectedHotbarTab = 1;  -- 1 = Bar 1, 2 = Bar 2, etc. (for hotbar settings)
-local selectedModeTab = 'hotbar';  -- 'hotbar' or 'crossbar' (for hotbar/crossbar toggle in 'both' mode)
-local selectedCrossbarTab = 1;  -- 1=L2, 2=R2, 3=L2R2, 4=R2L2, 5=L2x2, 6=R2x2
+local selectedCrossbarTab = 1;  -- 1=Global, 2=L2, â€¦ (for Crossbar category panel)
 
 -- Category definitions
 local categories = {
@@ -323,13 +643,26 @@ local categories = {
     { name = 'notifications', label = 'Notifications' },
     { name = 'treasurePool', label = 'Treasure Pool' },
     { name = 'hotbar', label = 'Hotbar' },
+    { name = 'crossbar', label = 'Crossbar' },
     { name = 'readyCheck', label = 'Ready Check' },
 };
 
 
+-- Index of the Crossbar sidebar category (for palette edit context sync)
+local function GetCrossbarCategoryIndex()
+    for i, c in ipairs(categories) do
+        if c.name == 'crossbar' then
+            return i;
+        end
+    end
+    return nil;
+end
+
 -- Build state object for modules that need tab state
 local function buildState()
     return {
+        selectedCategory = selectedCategory,
+        crossbarCategoryIndex = GetCrossbarCategoryIndex(),
         selectedPartyTab = selectedPartyTab,
         selectedPartyColorTab = selectedPartyColorTab,
         selectedInventoryTab = selectedInventoryTab,
@@ -341,7 +674,6 @@ local function buildState()
         selectedPetTypeTab = selectedPetTypeTab,
         selectedPetTypeColorTab = selectedPetTypeColorTab,
         selectedHotbarTab = selectedHotbarTab,
-        selectedModeTab = selectedModeTab,
         selectedCrossbarTab = selectedCrossbarTab,
         githubTexture = githubTexture,
     };
@@ -356,7 +688,6 @@ local function applySettingsState(newState)
         if newState.selectedPetBarTab then selectedPetBarTab = newState.selectedPetBarTab; end
         if newState.selectedPetTypeTab then selectedPetTypeTab = newState.selectedPetTypeTab; end
         if newState.selectedHotbarTab then selectedHotbarTab = newState.selectedHotbarTab; end
-        if newState.selectedModeTab then selectedModeTab = newState.selectedModeTab; end
         if newState.selectedCrossbarTab then selectedCrossbarTab = newState.selectedCrossbarTab; end
     end
 end
@@ -369,7 +700,6 @@ local function applyColorState(newState)
         if newState.selectedPetBarColorTab then selectedPetBarColorTab = newState.selectedPetBarColorTab; end
         if newState.selectedPetTypeColorTab then selectedPetTypeColorTab = newState.selectedPetTypeColorTab; end
         if newState.selectedHotbarTab then selectedHotbarTab = newState.selectedHotbarTab; end
-        if newState.selectedModeTab then selectedModeTab = newState.selectedModeTab; end
         if newState.selectedCrossbarTab then selectedCrossbarTab = newState.selectedCrossbarTab; end
     end
 end
@@ -433,6 +763,11 @@ end
 
 local function DrawHotbarSettings()
     local newState = hotbarModule.DrawSettings(buildState());
+    applySettingsState(newState);
+end
+
+local function DrawCrossbarSettingsPanel()
+    local newState = crossbarModule.DrawSettings(buildState());
     applySettingsState(newState);
 end
 
@@ -502,6 +837,11 @@ local function DrawHotbarColorSettings()
     applyColorState(newState);
 end
 
+local function DrawCrossbarColorSettingsPanel()
+    local newState = crossbarModule.DrawColorSettings(buildState());
+    applyColorState(newState);
+end
+
 local function DrawReadyCheckColorSettings()
     readycheckModule.DrawColorSettings();
 end
@@ -522,6 +862,7 @@ local settingsDrawFunctions = {
     DrawNotificationsSettings,
     DrawTreasurePoolSettings,
     DrawHotbarSettings,
+    DrawCrossbarSettingsPanel,
     DrawReadyCheckSettings,
 };
 
@@ -540,6 +881,7 @@ local colorSettingsDrawFunctions = {
     DrawNotificationsColorSettings,
     DrawTreasurePoolColorSettings,
     DrawHotbarColorSettings,
+    DrawCrossbarColorSettingsPanel,
     DrawReadyCheckColorSettings,
 };
 
@@ -559,9 +901,13 @@ local function DrawProfilePopups()
         imgui.OpenPopup("Delete Profile");
         triggerDeleteProfilePopup = false;
     end
+    if (triggerCopyProfilePopup) then
+        imgui.OpenPopup("Copy Profile");
+        triggerCopyProfilePopup = false;
+    end
 
     -- New Profile Popup
-    if (imgui.BeginPopupModal("New Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("New Profile")) then
         isModalOpen = true;
         imgui.Text("Create New Profile:");
         imgui.InputText("##NewProfileName", newProfileName, 32);
@@ -584,7 +930,7 @@ local function DrawProfilePopups()
     end
 
     -- Rename Popup
-    if (imgui.BeginPopupModal("Rename Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("Rename Profile")) then
         isModalOpen = true;
         imgui.Text("Rename '" .. GetCurrentProfileName() .. "' to:");
         imgui.InputText("##RenameInput", renameProfileName, 32);
@@ -606,7 +952,7 @@ local function DrawProfilePopups()
     end
 
     -- Delete Confirmation Popup
-    if (imgui.BeginPopupModal("Delete Profile", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+    if (imgui.BeginPopup("Delete Profile")) then
         isModalOpen = true;
         imgui.Text("Are you sure you want to delete profile:");
         imgui.TextColored({1.0, 0.3, 0.3, 1.0}, profileToDelete);
@@ -624,7 +970,41 @@ local function DrawProfilePopups()
         end
         imgui.EndPopup();
     end
-    
+
+    -- Copy Profile: optional macro library (full clone vs layout-only for another character)
+    if (imgui.BeginPopup("Copy Profile")) then
+        isModalOpen = true;
+        local src = (GetCurrentProfileName and GetCurrentProfileName()) or '';
+        imgui.Text("Create a new profile from:");
+        imgui.TextColored(gold, src);
+        imgui.Spacing();
+        imgui.TextWrapped(
+            'Copy is a full snapshot of the selected profile on disk, except you can start without a macro library. '
+            .. 'Buckets that were never used (e.g. Items / Equipment) are not in the file â€” that is why a clone can show Global/job rows but no separate items bucket until you add some.'
+        );
+        imgui.Spacing();
+        imgui.Checkbox("Include full macro library##copyInclMacros", copyProfileIncludeMacros);
+        if (imgui.ShowHelp) then
+            imgui.SameLine();
+            imgui.ShowHelp(
+                "When checked: all macro palette buckets in this profile (same as a full file copy). When unchecked: empty macro list and custom categories reset; keyboard/crossbar slots that used palette macros are cleared. Spells, abilities, and items on bars are kept. Use Profile â†’ Export/Import JSON to move chosen macros between profiles."
+            );
+        end
+        imgui.Spacing();
+        if (imgui.Button("Create copy##CopyProfileGo", { 120, 0 })) then
+            if (DuplicateProfile and GetCurrentProfileName) then
+                if (DuplicateProfile(GetCurrentProfileName(), { includeMacroLibrary = (copyProfileIncludeMacros[1] == true) })) then
+                    imgui.CloseCurrentPopup();
+                end
+            end
+        end
+        imgui.SameLine();
+        if (imgui.Button("Cancel##CopyProfile", { 120, 0 })) then
+            imgui.CloseCurrentPopup();
+        end
+        imgui.EndPopup();
+    end
+
     return isModalOpen;
 end
 
@@ -634,23 +1014,32 @@ config.DrawWindow = function(us)
     -- Detect when config closes and clear treasure pool preview
     local isConfigOpen = showConfig[1];
     if wasConfigOpen and not isConfigOpen then
-        -- Config just closed - always save profile to persist window positions
-        SaveSettingsToDisk();
-        
-        -- Clear dirty flags if they were set
-        if macropalette.IsHotbarDirty() then
-            macropalette.ClearHotbarDirty();
+        local deferClose = getPaletteManagerForCloseDefer().DeferConfigCloseIfEditFullPaletteOpen();
+        if deferClose then
+            -- Keep XIUI Config open; palette manager shows a confirm popup on the next draw.
+            showConfig[1] = true;
+        else
+            -- Config just closed - always save profile to persist window positions
+            SaveSettingsToDisk();
+
+            -- Clear dirty flags if they were set
+            if macropalette.IsHotbarDirty() then
+                macropalette.ClearHotbarDirty();
+            end
+            if palette.IsPaletteStateDirty() then
+                palette.ClearPaletteStateDirty();
+            end
+            -- Clear preview state and reset settings
+            treasurePool.ClearPreview();
+            gConfig.treasurePoolMiniPreview = false;
+            gConfig.treasurePoolFullPreview = false;
         end
-        if palette.IsPaletteStateDirty() then
-            palette.ClearPaletteStateDirty();
-        end
-        -- Clear preview state and reset settings
-        treasurePool.ClearPreview();
-        gConfig.treasurePoolMiniPreview = false;
-        gConfig.treasurePoolFullPreview = false;
     end
     local configJustOpened = isConfigOpen and not wasConfigOpen;
     wasConfigOpen = isConfigOpen;
+    if configJustOpened then
+        crossbarModule.OnConfigWindowOpened();
+    end
 
     -- Early exit if config window isn't shown (atom0s recommendation)
     -- This prevents unnecessary style pushes and imgui.End() calls when window is hidden
@@ -658,9 +1047,9 @@ config.DrawWindow = function(us)
 
     -- Constrain config window to never exceed the game's render resolution.
     -- Prevents the window from being larger than the screen or lost off-screen on small resolutions.
-    local ioData = imgui.GetIO();
-    local sw = ioData.DisplaySize.x;
-    local sh = ioData.DisplaySize.y;
+    local io = imgui.GetIO();
+    local sw = io.DisplaySize.x;
+    local sh = io.DisplaySize.y;
     if not sw or sw < 1 then return; end
     if not sh or sh < 1 then return; end
 
@@ -690,8 +1079,7 @@ config.DrawWindow = function(us)
             imgui.SetNextWindowPos({ 20, 20 }, ImGuiCond_Always);
         end
     end
-    local configVisible = imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking));
-    if configVisible then
+    if(imgui.Begin("XIUI Config - v" .. addon.version, showConfig, bit.bor(ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoDocking))) then
         local windowWidth = imgui.GetContentRegionAvail();
         local sidebarWidth = 180;
         local contentWidth = windowWidth - sidebarWidth - 20;
@@ -819,7 +1207,7 @@ config.DrawWindow = function(us)
             showRestoreDefaultsConfirm = false;
         end
 
-        if (imgui.BeginPopupModal("Confirm Reset Settings", true, ImGuiWindowFlags_AlwaysAutoResize)) then
+        if (imgui.BeginPopup("Confirm Reset Settings")) then
             anyModalOpen = true;
             imgui.Text("Are you sure you want to reset all settings to defaults?");
             imgui.Text("This will reset all your customizations including:");
@@ -985,10 +1373,12 @@ config.DrawWindow = function(us)
     end
 
     -- Capture config window geometry while open for smart reposition on next open.
-    -- Two local assignments per frame — negligible cost, but ensures we always have
+    -- Two local assignments per frame â€” negligible cost, but ensures we always have
     -- current values even on addon unload or profile change without an extra frame.
     lastConfigPosX, lastConfigPosY = imgui.GetWindowPos();
     lastConfigSizeW, lastConfigSizeH = imgui.GetWindowSize();
+    -- For other UI (e.g. Crossbar full palette window) to stagger offset from this window without a require() cycle
+    _G._XIUI_CONFIG_LAST_GEOM = { lastConfigPosX, lastConfigPosY, lastConfigSizeW, lastConfigSizeH };
 
     imgui.End();
 
@@ -1023,4 +1413,42 @@ function config.OpenResetSettingsPopup()
     showRestoreDefaultsConfirm = true;
 end
 
+-- Open XIUI config on Crossbar category, Manage Palettes & Crossbar tab (/xiui cpalette)
+-- Used by palette manager modal to close XIUI Config after forcing Edit Full Palette shut.
+function config.SetWindowOpen(isOpen)
+    showConfig[1] = isOpen and true or false;
+end
+
+function config.OpenCrossbarManagePalettes()
+    local idx = GetCrossbarCategoryIndex();
+    if not idx then
+        return false;
+    end
+    selectedCategory = idx;
+    selectedTab = 1;
+    showConfig[1] = true;
+    crossbarModule.OpenCrossbarManagePalettesTab();
+    return true;
+end
+
+-- Toggle: close config if already on Crossbar â†’ Manage Palettes; otherwise open there (/xiui cpalette with no subcommand)
+function config.ToggleCrossbarManagePalettes()
+    local idx = GetCrossbarCategoryIndex();
+    if not idx then
+        return nil;
+    end
+    if showConfig[1] and selectedCategory == idx and selectedTab == 1 then
+        local cross = gConfig and gConfig.hotbarCrossbar;
+        if cross and cross.configUiTab == 2 then
+            showConfig[1] = false;
+            return 'closed';
+        end
+    end
+    if not config.OpenCrossbarManagePalettes() then
+        return nil;
+    end
+    return 'opened';
+end
+
 return config;
+

--- a/XIUI/config/crossbar.lua
+++ b/XIUI/config/crossbar.lua
@@ -1,0 +1,80 @@
+--[[
+* XIUI Config Menu - Crossbar (sidebar entry)
+* Delegates to config/crossbar_settings.lua for controller layout, palettes, and visuals.
+* Keyboard hotbars are config/hotbar.lua only.
+]]--
+
+require('handlers.helpers');
+local imgui = require('imgui');
+local drawing = require('libs.drawing');
+local components = require('config.components');
+local hotbarConfig = require('config.hotbar');
+local crossbarSettings = require('config.crossbar_settings');
+
+local M = {};
+
+function M.DrawSettings(state)
+    local cross = gConfig.hotbarCrossbar;
+    if not cross then
+        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+        return { selectedCrossbarTab = (state and state.selectedCrossbarTab) or 1 };
+    end
+
+    local en = { gConfig.crossbarEnabled ~= false };
+    if imgui.Checkbox('Enable Crossbar##xbEnable', en) then
+        gConfig.crossbarEnabled = en[1];
+        cross.showCrossbar = en[1];
+        SaveSettingsOnly();
+        DeferredUpdateVisuals();
+    end
+    imgui.ShowHelp('When enabled, the L2/R2 controller crossbar loads and can be used in-game. When disabled, crossbar UI and controller handling for it stay off to save overhead. Independent from keyboard hotbars (Hotbar category).');
+
+    local lock = { gConfig.crossbarLockMovement == true };
+    if imgui.Checkbox('Lock Crossbar##xbLockMove', lock) then
+        gConfig.crossbarLockMovement = lock[1];
+        if gConfig.crossbarLockMovement then
+            drawing.ResetAnchorState('Crossbar');
+        end
+        SaveSettingsOnly();
+        DeferredUpdateVisuals();
+    end
+    imgui.ShowHelp('When enabled, prevents dragging the crossbar window and drag/drop or slot swaps on crossbar slots. Separate from Lock Movement on the Hotbar category.');
+
+    imgui.Spacing();
+    components.DrawPartyCheckbox(cross, 'Hide When Menu Open', 'crossbarHideOnMenuFocus', DeferredUpdateVisuals);
+    imgui.ShowHelp('Hide the crossbar when a game menu is open (equipment, map, etc.). Separate from Hotbar → Hide When Menu Open (keyboard strips).');
+
+    components.DrawPartyCheckbox(cross, 'Disable Crossbar While In Menu##xbDisableInMenu', 'crossbarDisableInMenu', DeferredUpdateVisuals);
+    imgui.ShowHelp('This options temporarily disables the crossbars while keeping them visible while the main menu is open. This setting allows users to continue to use the games "Quick Jump" option in inventories when holding down either trigger and using Left/Right on the DPad');
+
+    hotbarConfig.DrawSharedDisableXiMacrosControls('xb');
+    hotbarConfig.DrawSharedSkillchainHighlightControls('xb');
+
+    if gConfig.crossbarEnabled ~= false then
+        imgui.Spacing();
+        crossbarSettings.DrawControllerPaletteCycleGlobalOptions();
+        imgui.Spacing();
+        crossbarSettings.DrawLogPaletteNameCheckboxCrossbar('##xbLogPal');
+    end
+
+    imgui.Spacing();
+    imgui.Separator();
+    imgui.Spacing();
+
+    return crossbarSettings.DrawStandaloneCrossbarSettings(state);
+end
+
+function M.DrawColorSettings(state)
+    return crossbarSettings.DrawStandaloneCrossbarColorSettings(state);
+end
+
+-- Used by config.lua (window open, /xiui cpalette) — single entry; no separate require of crossbar_settings
+function M.OnConfigWindowOpened()
+    return crossbarSettings.OnConfigWindowOpened();
+end
+
+function M.OpenCrossbarManagePalettesTab()
+    return crossbarSettings.OpenCrossbarManagePalettesTab();
+end
+
+return M;

--- a/XIUI/config/crossbar_settings.lua
+++ b/XIUI/config/crossbar_settings.lua
@@ -1,0 +1,1479 @@
+--[[
+* XIUI Config - Crossbar settings (sidebar Crossbar category only)
+* Sibling to keyboard hotbar settings in config/hotbar.lua - not mixed at edit time.
+]]--
+
+require('common');
+require('handlers.helpers');
+local ffi = require('ffi');
+local TextureManager = require('libs.texturemanager');
+local components = require('config.components');
+local imgui = require('imgui');
+local data = require('modules.hotbar.data');
+local jobs = require('libs.jobs');
+local macropalette = require('modules.hotbar.macropalette');
+local palette = require('modules.hotbar.palette');
+local paletteManager = require('config.palettemanager');
+local controller = require('modules.hotbar.controller');
+
+local hotbarConfig = require('config.hotbar');
+
+local M = {};
+
+local lastConfigCategorySeenForCrossbar = nil;
+
+-- Crossbar config UI: default to Controller Settings (tab 1) each addon load until user picks another sub-tab this session
+local crossbarConfigSubTabUserChosen = false;
+
+-- Global Visual Settings (tab 3): collapse sections when switching to this tab unless the user expanded them this session
+local CROSSBAR_GLOBAL_VIS_KEYS = { 'palCtrl', 'slot', 'bg', 'text', 'vfb' };
+local crossbarGlobalVis_prevUit = nil;
+local crossbarGlobalVis_openedSections = {};
+local crossbarGlobalVis_sectionNonce = {};
+
+local function CrossbarGlobalVisualCollapsingSection(sectionKey, label, defaultOpen)
+    local nonce = crossbarGlobalVis_sectionNonce[sectionKey] or 0;
+    local fullLabel = string.format('%s##xbGlobalVis_%s_%d', label, sectionKey, nonce);
+    if defaultOpen == nil then defaultOpen = false; end
+    imgui.Spacing();
+    local flags = defaultOpen and ImGuiTreeNodeFlags_DefaultOpen or 0;
+    local isOpen = imgui.CollapsingHeader(fullLabel, flags);
+    if imgui.IsItemClicked() then
+        crossbarGlobalVis_openedSections[sectionKey] = true;
+    end
+    if isOpen then
+        imgui.Spacing();
+    end
+    return isOpen;
+end
+
+local function ResolveCrossbarPaletteJobIconTheme(cs)
+    local t = cs and cs.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+local buttonDetectionState = {
+    active = false,
+    progress = 0,
+};
+-- ============================================
+-- Crossbar Global Palettes UI Section
+-- ============================================
+
+-- Global crossbar palette error state
+local crossbarGlobalPaletteErrorMessage = nil;
+
+-- Enable Global crossbar sets + optional scope + default palette type (only when Global sets enabled)
+local function DrawCrossbarUniversalTierOptions(crossbarSettings, opts)
+    opts = opts or {};
+    if opts.showEnableCheckbox ~= false then
+        local uEn = { crossbarSettings.enableUniversalCrossbarPalettes == true };
+        if imgui.Checkbox('Enable "Global" Crossbar Sets##xcuEn', uEn) then
+            crossbarSettings.enableUniversalCrossbarPalettes = uEn[1];
+            if uEn[1] then
+                palette.EnsureUniversalCrossbarDefaultExists();
+            end
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Crossbar palettes shared by every job, labeled [G] in lists. Hold L1 and tap R1 in-game to switch between Global [G] storage and Job/Subjob [J] storage for the crossbar.\nWhen Global sets are off, only [J] job/subjob palettes are used.');
+    end
+
+    if not crossbarSettings.enableUniversalCrossbarPalettes then
+        return;
+    end
+
+    if opts.includeScopeLine ~= false then
+        local scope = palette.GetCrossbarPaletteScope();
+        imgui.TextColored({0.7, 0.75, 1.0, 1.0}, 'Scope: ' .. (scope == 'universal' and 'Global [G]' or 'Job / Subjob [J]'));
+        imgui.Spacing();
+    end
+
+    if not crossbarSettings.defaultCrossbarPaletteScope then
+        crossbarSettings.defaultCrossbarPaletteScope = 'job';
+    end
+    imgui.AlignTextToFramePadding();
+    imgui.Text('Default Palette Type on Profile Load:');
+    imgui.SameLine();
+    imgui.SetNextItemWidth(160);
+    local defLabel = crossbarSettings.defaultCrossbarPaletteScope == 'universal' and 'Global [G]' or 'Job / Subjob [J]';
+    if imgui.BeginCombo('##xcuDefScope', defLabel) then
+        if imgui.Selectable('Job / Subjob [J]', crossbarSettings.defaultCrossbarPaletteScope ~= 'universal') then
+            crossbarSettings.defaultCrossbarPaletteScope = 'job';
+            SaveSettingsOnly();
+        end
+        if imgui.Selectable('Global [G]', crossbarSettings.defaultCrossbarPaletteScope == 'universal') then
+            crossbarSettings.defaultCrossbarPaletteScope = 'universal';
+            SaveSettingsOnly();
+        end
+        imgui.EndCombo();
+    end
+    imgui.ShowHelp('Which Job vs Global [G] palette tier is applied when a profile is loaded or reloaded from disk. While playing, use L1+R1 to switch tier without changing this setting.');
+end
+
+-- Draw the global crossbar palettes management section
+-- opts.showEnableCheckbox (default true): show Enable "Global" Crossbar Sets (also on Controller tab)
+-- opts.skipUniversalTierOptions: when true, toggles were drawn elsewhere (e.g. Manage strip)
+-- opts.jobId / opts.subjobId: which job/subjob to edit for [J] palettes (config preview)
+local function DrawCrossbarGlobalPalettesSection(opts)
+    opts = opts or {};
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return;
+    end
+
+    if opts.skipUniversalTierOptions ~= true then
+        DrawCrossbarUniversalTierOptions(crossbarSettings, {
+            showEnableCheckbox = opts.showEnableCheckbox,
+            includeScopeLine = opts.includeScopeLine ~= false,
+        });
+    end
+
+    if crossbarSettings.enableUniversalCrossbarPalettes then
+        if opts.includeUniversalLists ~= false then
+        imgui.Spacing();
+        if opts.embedCrossbarUniversalPaletteManager then
+            palette.EnsureUniversalCrossbarDefaultExists();
+            paletteManager.DrawEmbeddedCrossbarManageUniversal();
+            imgui.Dummy({ 0, 4 });
+            imgui.AlignTextToFramePadding();
+            imgui.TextColored(components.TAB_STYLE.gold, 'Active palette');
+            imgui.SameLine();
+            imgui.ShowHelp('Active Global [G] palette when in-game scope is Global (toggle with L1+R1).');
+            local uList = palette.GetUniversalCrossbarPaletteNamesOrdered();
+            local uActive = palette.GetActiveUniversalCrossbarPalette();
+            local availU = imgui.GetContentRegionAvail();
+            local comboWU = math.max(220, ((type(availU) == 'table' and availU[1]) or availU or 400) * 0.5);
+            imgui.SetNextItemWidth(comboWU);
+            local comboLabelU = uActive or (#uList > 0 and uList[1]) or '(none)';
+            if imgui.BeginCombo('##xbManageActivePalUniversal', comboLabelU) then
+                for _, un in ipairs(uList) do
+                    local labelU = un .. ' (G)';
+                    local isSelU = (uActive == un);
+                    if imgui.Selectable(labelU .. '##xbActUni', isSelU) then
+                        palette.SetActiveUniversalCrossbarPalette(un);
+                    end
+                    if isSelU then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+        else
+            imgui.TextColored(components.TAB_STYLE.gold, 'Global [G] palette list');
+            local uList = palette.GetUniversalCrossbarPaletteNamesOrdered();
+            local lineH = imgui.GetTextLineHeightWithSpacing();
+            local globalScrollH = opts.compactGlobalPaletteScroll and (lineH * 4) or nil;
+            if globalScrollH then
+                imgui.BeginChild('##xcuGlobalPalScroll', { 0, globalScrollH }, true);
+            end
+            for _, un in ipairs(uList) do
+                imgui.PushID('xcuRow' .. un);
+                local inc = palette.GetUniversalPaletteIncludeInCycle(un);
+                local incBuf = { inc };
+                if imgui.Checkbox('Cycle##xcuCyc', incBuf) then
+                    palette.SetUniversalPaletteIncludeInCycle(un, incBuf[1]);
+                end
+                imgui.SameLine();
+                imgui.TextColored({0.85, 0.85, 0.5, 1.0}, '[G]');
+                imgui.SameLine();
+                imgui.Text(un);
+                imgui.PopID();
+            end
+            if globalScrollH then
+                imgui.EndChild();
+            end
+
+            imgui.Spacing();
+            imgui.PushStyleColor(ImGuiCol_Button, {0.15, 0.35, 0.2, 1.0});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.25, 0.45, 0.3, 1.0});
+            if imgui.Button('New Global palette##xcuNew', {140, 0}) then
+                hotbarConfig.OpenPaletteCreateModal('crossbar_universal');
+            end
+            imgui.PopStyleColor(2);
+
+            local uActive = palette.GetActiveUniversalCrossbarPalette();
+            if #uList > 0 then
+                imgui.SameLine();
+                imgui.SetNextItemWidth(180);
+                local comboLabel = uActive or uList[1];
+                if imgui.BeginCombo('##xcuActive', comboLabel) then
+                    for _, un in ipairs(uList) do
+                        if imgui.Selectable(un .. '##xcuSel' .. un, un == uActive) then
+                            palette.SetActiveUniversalCrossbarPalette(un);
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                imgui.ShowHelp('Active Global [G] palette when in-game scope is Global (toggle with L1+R1).');
+            end
+        end
+
+        imgui.Separator();
+        imgui.Spacing();
+        end
+    end
+
+    if opts.includeJobPalettes == false then
+        if crossbarGlobalPaletteErrorMessage then
+            imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
+        end
+        imgui.Spacing();
+        return;
+    end
+
+    local jobId = opts.jobId or data.jobId or 1;
+    local subjobId = opts.subjobId ~= nil and opts.subjobId or (data.subjobId or 0);
+
+    -- Embedded full Palette Manager (Manage tab): Job (J) + Subjob (SJ) tiers
+    if opts.embedCrossbarJobPaletteManager then
+        palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
+        paletteManager.DrawEmbeddedCrossbarManage(jobId, subjobId);
+        imgui.Dummy({ 0, 4 });
+        imgui.AlignTextToFramePadding();
+        imgui.TextColored(components.TAB_STYLE.gold, 'Active palette');
+        imgui.SameLine();
+        imgui.ShowHelp('Matches in-game crossbar scope: Global [G] shows universal palettes; Job [J]/[SJ] shows palettes for this job/subjob. (J) = job-wide; (SJ) = this job+subjob tier.');
+        local mergedRows = palette.GetCrossbarManagePaletteRows(jobId, subjobId);
+        local activeName = palette.GetActivePaletteForCombo('L2');
+        local activeSt = palette.GetCrossbarActiveStorageSubjob();
+        local scopeUniversal = palette.GetCrossbarPaletteScope() == 'universal';
+        local comboLabel = '(none)';
+        if scopeUniversal then
+            local uName = palette.GetActiveUniversalCrossbarPalette() or activeName;
+            if uName and uName ~= '' then
+                comboLabel = uName .. ' (G)';
+            end
+        else
+            for _, r in ipairs(mergedRows) do
+                if r.name == activeName and (activeSt == nil or activeSt == r.storageSubjob) then
+                    comboLabel = r.name .. palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+                    break;
+                end
+            end
+            if activeName and comboLabel == '(none)' then
+                comboLabel = activeName;
+            end
+        end
+        local avail = imgui.GetContentRegionAvail();
+        local comboW = math.max(220, ((type(avail) == 'table' and avail[1]) or avail or 400) * 0.5);
+        imgui.SetNextItemWidth(comboW);
+        if imgui.BeginCombo('##xbManageActivePal', comboLabel) then
+            if scopeUniversal then
+                local uList = palette.GetUniversalCrossbarPaletteNamesOrdered();
+                local uActive = palette.GetActiveUniversalCrossbarPalette();
+                for _, un in ipairs(uList) do
+                    local label = un .. ' (G)';
+                    local isSel = (uActive == un);
+                    if imgui.Selectable(label .. '##xbActU', isSel) then
+                        palette.SetActiveUniversalCrossbarPalette(un);
+                    end
+                    if isSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+            else
+                for _, r in ipairs(mergedRows) do
+                    local label = r.name .. palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+                    local isSel = (r.name == activeName and (activeSt == nil or activeSt == r.storageSubjob));
+                    if imgui.Selectable(label .. '##xbActPal', isSel) then
+                        palette.SetActivePaletteForCombo('L2', r.name, r.storageSubjob);
+                    end
+                    if isSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        if crossbarGlobalPaletteErrorMessage then
+            imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
+        end
+        imgui.Spacing();
+        return;
+    end
+
+    -- Ensure at least one palette exists for this job
+    palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
+    local mergedRows = palette.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local cycleRows = palette.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+    local currentPalette = palette.GetActivePaletteForCombo('L2');
+    local currentStorage = palette.GetCrossbarActiveStorageSubjob();
+
+    local paletteCount = #cycleRows;
+    local currentPaletteIndex = nil;
+    for i, r in ipairs(cycleRows) do
+        if r.name == currentPalette and (currentStorage == nil or currentStorage == r.storageSubjob) then
+            currentPaletteIndex = i;
+            break;
+        end
+    end
+    local totalMergedCount = #mergedRows;
+
+    if #mergedRows > 0 and not currentPalette then
+        local pick = cycleRows[1] or mergedRows[1];
+        palette.SetActivePaletteForCombo('L2', pick.name, pick.storageSubjob);
+        currentPalette = pick.name;
+        currentStorage = pick.storageSubjob;
+        currentPaletteIndex = 1;
+    end
+
+    imgui.TextColored(components.TAB_STYLE.gold, 'Job / subjob crossbar palettes  [J]');
+    components.PushPaletteManagerButtonStyle();
+    if imgui.SmallButton('Manage Palettes##crossbar') then
+        local xiuiConfig = require('config');
+        xiuiConfig.OpenCrossbarManagePalettes();
+    end
+    components.PopPaletteManagerButtonStyle();
+    imgui.Spacing();
+
+    -- Header with count
+    imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Palettes:');
+    imgui.SameLine();
+    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' in cycle');
+    imgui.ShowHelp('Create named palettes to quickly switch between crossbar configurations.\nPalettes are GLOBAL - switching changes all combo modes (L2, R2, L2+R2, etc.) at once.\n"Inactive" in Palette Manager is excluded from RB+D-pad cycling and from this count.');
+
+    local currentDisplayName = currentPalette or 'Select palette';
+    if currentPalette and currentPaletteIndex then
+        local r = nil;
+        for _, row in ipairs(cycleRows) do
+            if row.name == currentPalette and (currentStorage == nil or currentStorage == row.storageSubjob) then
+                r = row;
+                break;
+            end
+        end
+        local suf = r and palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId) or '';
+        currentDisplayName = currentPaletteIndex .. '. ' .. currentPalette .. suf;
+    elseif currentPalette then
+        local suf = '';
+        for _, r in ipairs(mergedRows) do
+            if r.name == currentPalette and (currentStorage == nil or currentStorage == r.storageSubjob) then
+                suf = palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+                break;
+            end
+        end
+        currentDisplayName = currentPalette .. suf .. ' (inactive)';
+    end
+
+    imgui.SetNextItemWidth(150);
+    if imgui.BeginCombo('##crossbarGlobalPalette', currentDisplayName) then
+        local cycleIdxByKey = {};
+        for i, r in ipairs(cycleRows) do
+            cycleIdxByKey[r.name .. '\0' .. tostring(r.storageSubjob)] = i;
+        end
+        for i, r in ipairs(mergedRows) do
+            local suf = palette.FormatCrossbarTierSuffixLabel(r.storageSubjob, subjobId);
+            local isSelected = (r.name == currentPalette and (currentStorage == nil or currentStorage == r.storageSubjob));
+            local cycIdx = cycleIdxByKey[r.name .. '\0' .. tostring(r.storageSubjob)];
+            local displayName = (cycIdx and (cycIdx .. '. ') or '– ') .. r.name .. suf;
+            if imgui.Selectable(displayName .. '##cbGlobalPal' .. i, isSelected) then
+                palette.SetActivePaletteForCombo('L2', r.name, r.storageSubjob);
+            end
+            if isSelected then
+                imgui.SetItemDefaultFocus();
+            end
+        end
+        imgui.EndCombo();
+    end
+
+    -- Rename button (for any palette)
+    if currentPalette then
+        imgui.SameLine();
+        if imgui.Button('Rename##cbGlobalPalette', {55, 0}) then
+            hotbarConfig.OpenPaletteRenameModal('crossbar', currentPalette);
+        end
+    end
+
+    -- New button (always visible, green)
+    imgui.SameLine();
+    imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.5, 0.2, 1.0});
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.3, 0.6, 0.3, 1.0});
+    if imgui.Button('New##cbGlobalPalette', {40, 0}) then
+        hotbarConfig.OpenPaletteCreateModal('crossbar');
+    end
+    imgui.PopStyleColor(2);
+
+    -- Delete button (only if more than 1 palette exists - can't delete the last one)
+    if currentPalette and totalMergedCount > 1 then
+        imgui.SameLine();
+        imgui.PushStyleColor(ImGuiCol_Button, {0.6, 0.2, 0.2, 1.0});
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.8, 0.3, 0.3, 1.0});
+        if imgui.Button('Delete##cbGlobalPalette', {50, 0}) then
+            local delTier = currentStorage or 0;
+            local success, err = palette.DeleteCrossbarPalette(currentPalette, jobId, delTier);
+            if not success then
+                crossbarGlobalPaletteErrorMessage = err or 'Failed to delete palette';
+            else
+                crossbarGlobalPaletteErrorMessage = nil;
+            end
+        end
+        imgui.PopStyleColor(2);
+    end
+
+    -- Reorder within the same storage tier (Job [J] vs Subjob [SJ])
+    if currentPalette and totalMergedCount > 1 then
+        imgui.SameLine();
+        imgui.TextColored({0.5, 0.5, 0.5, 1.0}, '|');
+        imgui.SameLine();
+
+        local moveTier = currentStorage or 0;
+        local tierNames = {};
+        for _, r in ipairs(mergedRows) do
+            if r.storageSubjob == moveTier then
+                table.insert(tierNames, r.name);
+            end
+        end
+        local idxInTier = nil;
+        for ti, n in ipairs(tierNames) do
+            if n == currentPalette then
+                idxInTier = ti;
+                break;
+            end
+        end
+        local canMoveUp = idxInTier and idxInTier > 1;
+        local canMoveDown = idxInTier and idxInTier < #tierNames;
+
+        if not canMoveUp then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
+        end
+        if imgui.Button('^##cbGlobalPaletteUp', {20, 0}) and canMoveUp then
+            palette.MoveCrossbarPalette(currentPalette, -1, jobId, moveTier);
+        end
+        if not canMoveUp then
+            imgui.PopStyleColor(3);
+        end
+
+        imgui.SameLine();
+
+        if not canMoveDown then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
+            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
+        end
+        if imgui.Button('v##cbGlobalPaletteDown', {20, 0}) and canMoveDown then
+            palette.MoveCrossbarPalette(currentPalette, 1, jobId, moveTier);
+        end
+        if not canMoveDown then
+            imgui.PopStyleColor(3);
+        end
+    end
+
+    -- Show error message (for delete failures)
+    if crossbarGlobalPaletteErrorMessage then
+        imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
+    end
+
+    imgui.Spacing();
+end
+
+local function SyncCrossbarPaletteEditContextFromLiveJob(crossbarSettings)
+    if not crossbarSettings or crossbarSettings.configFocus ~= 'job' then
+        return;
+    end
+    data.SetPlayerJob();
+    local j = data.jobId;
+    if not j or j < 1 then
+        return;
+    end
+    crossbarSettings.configEditJobId = j;
+    crossbarSettings.configEditSubjobId = data.subjobId or 0;
+    SaveSettingsOnly();
+end
+
+-- When entering the Crossbar sidebar category, align palette edit job/subjob with the live character
+local function MaybeSyncCrossbarEditContextOnCategoryEnter(crossbarSettings, menuState)
+    local crossIdx = menuState and menuState.crossbarCategoryIndex;
+    if not crossIdx then
+        return;
+    end
+    local cat = menuState.selectedCategory;
+    if cat == crossIdx then
+        if lastConfigCategorySeenForCrossbar ~= crossIdx then
+            SyncCrossbarPaletteEditContextFromLiveJob(crossbarSettings);
+        end
+        lastConfigCategorySeenForCrossbar = crossIdx;
+    else
+        lastConfigCategorySeenForCrossbar = cat;
+    end
+end
+
+local function GetSubjobMenuLabel(subjobId)
+    if subjobId == nil or subjobId == 0 then
+        return 'Shared';
+    end
+    return jobs[subjobId] or ('Job ' .. tostring(subjobId));
+end
+
+local function DrawCrossbarJobIconStrip(crossbarSettings, stripOpts)
+    stripOpts = stripOpts or {};
+    if not crossbarSettings.configFocus then
+        crossbarSettings.configFocus = 'job';
+    end
+    data.SetPlayerJob();
+    if crossbarSettings.configFocus == 'job' then
+        if crossbarSettings.configEditJobId == nil then
+            local j = data.jobId;
+            if j and j > 0 then
+                crossbarSettings.configEditJobId = j;
+            else
+                crossbarSettings.configEditJobId = 1;
+            end
+        end
+        if crossbarSettings.configEditSubjobId == nil then
+            crossbarSettings.configEditSubjobId = data.subjobId or 0;
+        end
+    end
+
+    -- Global [G] requires "Enable Global Crossbar Sets"; otherwise fall back to job context
+    if crossbarSettings.enableUniversalCrossbarPalettes ~= true and crossbarSettings.configFocus == 'universal' then
+        crossbarSettings.configFocus = 'job';
+        if crossbarSettings.configEditJobId == nil then
+            local j = data.jobId;
+            if j and j > 0 then
+                crossbarSettings.configEditJobId = j;
+            else
+                crossbarSettings.configEditJobId = 1;
+            end
+        end
+        if crossbarSettings.configEditSubjobId == nil then
+            crossbarSettings.configEditSubjobId = data.subjobId or 0;
+        end
+        SaveSettingsOnly();
+    end
+
+    imgui.TextColored(components.TAB_STYLE.gold, 'Palette edit context');
+    imgui.ShowHelp('Global [G] edits crossbar palettes shared by every job. A job icon selects that job’s [J] palettes here (separate from your live character; bindings follow your current job in-game).');
+    imgui.Spacing();
+
+    local iconSize = 34;
+    local pad = 3;
+
+    local function drawIconButton(id, tex, tip, selected, disabled, disabledTip)
+        disabled = disabled == true;
+        local showSel = selected and not disabled;
+        local pos = { imgui.GetCursorScreenPos() };
+        local clicked = false;
+        imgui.PushStyleVar(ImGuiStyleVar_FramePadding, { 0, 0 });
+        if showSel then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.12, 0.11, 0.1, 1.0});
+            imgui.PushStyleColor(ImGuiCol_Border, {1.0, 1.0, 1.0, 1.0});
+            imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
+        elseif disabled then
+            imgui.PushStyleColor(ImGuiCol_Button, {0.10, 0.09, 0.08, 0.72});
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.11, 0.10, 0.09, 0.82});
+            imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.11, 0.10, 0.09, 0.82});
+        else
+            imgui.PushStyleColor(ImGuiCol_Button, {0.18, 0.16, 0.14, 1.0});
+        end
+        if imgui.Button(id, { iconSize, iconSize }) then
+            if not disabled then
+                clicked = true;
+            end
+        end
+        if showSel then
+            imgui.PopStyleVar(1);
+            imgui.PopStyleColor(2);
+        elseif disabled then
+            imgui.PopStyleColor(3);
+        else
+            imgui.PopStyleColor(1);
+        end
+        imgui.PopStyleVar(1);
+        local dl = imgui.GetWindowDrawList();
+        if tex and tex.image and dl then
+            local p = tonumber(ffi.cast('uint32_t', tex.image));
+            if p then
+                local imgTint = disabled
+                    and imgui.GetColorU32({ 0.38, 0.10, 0.10, 0.88 })
+                    or imgui.GetColorU32({ 1, 1, 1, 1 });
+                dl:AddImage(
+                    p,
+                    { pos[1] + pad, pos[2] + pad },
+                    { pos[1] + iconSize - pad, pos[2] + iconSize - pad },
+                    { 0, 0 },
+                    { 1, 1 },
+                    imgTint
+                );
+            end
+        end
+        if showSel and dl then
+            local rMin = { imgui.GetItemRectMin() };
+            local rMax = { imgui.GetItemRectMax() };
+            dl:AddRect(rMin, rMax, 0xFFFFFFFF, 0, 0, 2.0);
+        end
+        local hoverTip = disabled and disabledTip or tip;
+        if hoverTip and imgui.IsItemHovered() then
+            imgui.BeginTooltip();
+            imgui.Text(hoverTip);
+            imgui.EndTooltip();
+        end
+        return clicked;
+    end
+
+    local infTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not infTex or not infTex.image then
+        infTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    local globalSetsEnabled = crossbarSettings.enableUniversalCrossbarPalettes == true;
+    local selG = crossbarSettings.configFocus == 'universal';
+    imgui.BeginGroup();
+    if drawIconButton(
+        '##xbJobInf',
+        infTex,
+        'Global [G] crossbar sets',
+        selG,
+        not globalSetsEnabled,
+        'Global Crossbar Sets must be enabled under Controller Settings.'
+    ) then
+        crossbarSettings.configFocus = 'universal';
+        crossbarSettings.configEditJobId = nil;
+        SaveSettingsOnly();
+    end
+    imgui.SameLine();
+    local col = 0;
+    local palJobIconTheme = ResolveCrossbarPaletteJobIconTheme(crossbarSettings);
+    for ji = 1, 22 do
+        local abbr = jobs[ji];
+        if abbr then
+            local jtex = TextureManager.getJobIcon(ji, palJobIconTheme);
+            local sel = crossbarSettings.configFocus == 'job' and (crossbarSettings.configEditJobId == ji);
+            if drawIconButton('##xbJobIcon' .. ji, jtex, abbr, sel) then
+                crossbarSettings.configFocus = 'job';
+                crossbarSettings.configEditJobId = ji;
+                -- Subjob (SJ) tier cannot match main job; fall back to Shared
+                if crossbarSettings.configEditSubjobId == ji then
+                    crossbarSettings.configEditSubjobId = 0;
+                end
+                SaveSettingsOnly();
+            end
+            col = col + 1;
+            if col < 11 then
+                imgui.SameLine();
+            else
+                col = 0;
+            end
+        end
+    end
+    imgui.EndGroup();
+    imgui.Spacing();
+
+    if stripOpts.showGlobalOptionsRow then
+        if crossbarSettings.configFocus == 'job' then
+            imgui.AlignTextToFramePadding();
+            imgui.Text('Subjob');
+            imgui.SameLine();
+            imgui.SetNextItemWidth(120);
+            local sjCur = crossbarSettings.configEditSubjobId;
+            if sjCur == nil then
+                sjCur = data.subjobId or 0;
+            end
+            local mainJobForTier = crossbarSettings.configEditJobId or data.jobId or 1;
+            if sjCur ~= 0 and sjCur == mainJobForTier then
+                crossbarSettings.configEditSubjobId = 0;
+                sjCur = 0;
+                SaveSettingsOnly();
+            end
+            local sjLabel = GetSubjobMenuLabel(sjCur);
+            if imgui.BeginCombo('##xbCfgSubjob', sjLabel) then
+                if imgui.Selectable('Shared##xbsj0', sjCur == 0) then
+                    crossbarSettings.configEditSubjobId = 0;
+                    SaveSettingsOnly();
+                end
+                for sj = 1, 22 do
+                    if sj ~= mainJobForTier then
+                        local nm = jobs[sj];
+                        if nm and imgui.Selectable(nm .. '##xbsj' .. sj, sjCur == sj) then
+                            crossbarSettings.configEditSubjobId = sj;
+                            SaveSettingsOnly();
+                        end
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.SameLine();
+            components.PushMacroManagerButtonStyle();
+            if imgui.Button('Macro Manager##xbMacro', {120, 0}) then
+                macropalette.TogglePalette();
+            end
+            components.PopMacroManagerButtonStyle();
+            imgui.ShowHelp('Palette storage tier for this job (Shared = job-wide library). Use Macro Manager for macro bar palettes.');
+        else
+            imgui.AlignTextToFramePadding();
+            imgui.TextColored({0.65, 0.65, 0.7, 1.0}, 'Editing Global [G] crossbar sets');
+            imgui.SameLine();
+            components.PushMacroManagerButtonStyle();
+            if imgui.Button('Macro Manager##xbMacroG', { 120, 0 }) then
+                macropalette.TogglePalette();
+            end
+            components.PopMacroManagerButtonStyle();
+            imgui.ShowHelp('Global [G] palettes are shared across all jobs. Use Macro Manager for macro bar palettes.');
+        end
+        imgui.Spacing();
+    end
+end
+
+local function DrawCrossbarSettings(selectedCrossbarTab, menuState)
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+        return selectedCrossbarTab;
+    end
+
+    data.SetPlayerJob();
+    MaybeSyncCrossbarEditContextOnCategoryEnter(crossbarSettings, menuState);
+
+    selectedCrossbarTab = selectedCrossbarTab or 1;
+
+    if not crossbarConfigSubTabUserChosen then
+        crossbarSettings.configUiTab = 1;
+    elseif not crossbarSettings.configUiTab or crossbarSettings.configUiTab < 1 or crossbarSettings.configUiTab > 3 then
+        crossbarSettings.configUiTab = 1;
+    end
+    local uit = crossbarSettings.configUiTab;
+    local function saveCrossbarConfigTab(i)
+        crossbarSettings.configUiTab = i;
+        if i ~= 1 then
+            crossbarConfigSubTabUserChosen = true;
+        end
+        SaveSettingsOnly();
+    end
+
+    do
+        local clicked1 = components.DrawStyledTab('Controller Settings', 'xbCfgTab1', uit == 1, nil, components.TAB_STYLE.height, components.TAB_STYLE.padding);
+        if clicked1 then
+            saveCrossbarConfigTab(1);
+        end
+        imgui.SameLine();
+        local clicked2 = components.DrawStyledTab('Manage Palettes & Crossbar', 'xbCfgTab2', uit == 2, nil, components.TAB_STYLE.height, components.TAB_STYLE.padding, 'green');
+        if clicked2 then
+            saveCrossbarConfigTab(2);
+        end
+        imgui.SameLine();
+        local clicked3 = components.DrawStyledTab('Global Visual Settings', 'xbCfgTab3', uit == 3, nil, components.TAB_STYLE.height, components.TAB_STYLE.padding);
+        if clicked3 then
+            saveCrossbarConfigTab(3);
+        end
+    end
+    imgui.Spacing();
+    imgui.Separator();
+    imgui.Spacing();
+
+    if uit == 1 then
+    -- Controller Settings section
+    imgui.TextColored(components.TAB_STYLE.gold, 'Controller Settings');
+    imgui.Spacing();
+
+    -- Controller Profile selection
+    local devices = require('modules.hotbar.devices');
+    local currentScheme = controller.GetControllerScheme();
+    local deviceSchemes = devices.GetSchemeNames();
+    local deviceDisplayNames = devices.GetSchemeDisplayNames();
+
+    -- Find current selection index
+    local currentIndex = 1;
+    for i, scheme in ipairs(deviceSchemes) do
+        if scheme == currentScheme then
+            currentIndex = i;
+            break;
+        end
+    end
+
+    -- Map profile to matching theme
+    local profileToTheme = {
+        xbox = 'Xbox',
+        dualsense = 'PlayStation',
+        switchpro = 'Nintendo',
+        dinput = 'Xbox',
+    };
+
+    imgui.AlignTextToFramePadding();
+    imgui.Text('Controller Profile:');
+    imgui.SameLine();
+    imgui.SetNextItemWidth(150);
+    if imgui.BeginCombo('##controllerSelect', deviceDisplayNames[currentScheme] or currentScheme, ImGuiComboFlags_None) then
+        for i, scheme in ipairs(deviceSchemes) do
+            local isSelected = (scheme == currentScheme);
+            if imgui.Selectable(deviceDisplayNames[scheme], isSelected) then
+                crossbarSettings.controllerScheme = scheme;
+                -- If switching to dinput, apply custom mapping if it exists
+                local customMapping = nil;
+                if scheme == 'dinput' and crossbarSettings.customControllerMappings and crossbarSettings.customControllerMappings.dinput then
+                    customMapping = crossbarSettings.customControllerMappings.dinput;
+                end
+                controller.SetControllerScheme(scheme, customMapping);
+                -- Auto-adjust theme to match profile
+                local matchingTheme = profileToTheme[scheme];
+                if matchingTheme then
+                    crossbarSettings.controllerTheme = matchingTheme;
+                end
+                SaveSettingsOnly();
+            end
+            if isSelected then
+                imgui.SetItemDefaultFocus();
+            end
+        end
+        imgui.EndCombo();
+    end
+    imgui.ShowHelp('Select which button mapping profile to use.\n\n- Xbox: For XInput controllers (Xbox, 8BitDo in X-mode)\n- PlayStation: For DualSense/DualShock via DirectInput\n- Switch Pro: For Nintendo Switch Pro controller\n- Generic DirectInput: For other DirectInput controllers\n\nChanging this will also update the button icon theme.');
+
+    local hasAnalogTriggers = (currentScheme == 'xbox' or currentScheme == 'dualsense');
+
+    -- Display Mode (directly under Controller Profile)
+    do
+        local displayModes = { 'normal', 'activeOnly' };
+        local displayModeLabels = { 'Normal', 'Active Only' };
+        local currentDisplayMode = crossbarSettings.displayMode or 'normal';
+        local currentDisplayIndex = 1;
+        for i, mode in ipairs(displayModes) do
+            if mode == currentDisplayMode then
+                currentDisplayIndex = i;
+                break;
+            end
+        end
+
+        imgui.Spacing();
+        imgui.AlignTextToFramePadding();
+        imgui.Text('Display Mode:');
+        imgui.SameLine();
+        imgui.SetNextItemWidth(150);
+        if imgui.BeginCombo('##displayModeCrossbar', displayModeLabels[currentDisplayIndex]) then
+            for i, label in ipairs(displayModeLabels) do
+                local isSelected = (i == currentDisplayIndex);
+                if imgui.Selectable(label, isSelected) then
+                    crossbarSettings.displayMode = displayModes[i];
+                    SaveSettingsOnly();
+                end
+                if isSelected then
+                    imgui.SetItemDefaultFocus();
+                end
+            end
+            imgui.EndCombo();
+        end
+        imgui.ShowHelp('Normal: Always show both sides (inactive side dimmed).\nActive Only: Show only when trigger is held, displaying only the active side.');
+    end
+
+    -- Analog Trigger Threshold Settings (Xbox and PlayStation only)
+    if hasAnalogTriggers then
+        imgui.Spacing();
+        imgui.Text('Analog Trigger Settings');
+        imgui.Separator();
+
+        components.DrawPartySliderInt(crossbarSettings, 'Press Threshold##crossbar', 'triggerPressThreshold', 5, 250, '%d', function()
+            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
+        end, 30);
+        imgui.ShowHelp('Analog trigger value (0-255) required to register as pressed. Higher values require a deeper press. Default: 30');
+
+        components.DrawPartySliderInt(crossbarSettings, 'Release Threshold##crossbar', 'triggerReleaseThreshold', 5, 250, '%d', function()
+            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
+        end, 15);
+        imgui.ShowHelp('Analog trigger value (0-255) below which the trigger is considered released. Provides hysteresis to prevent jitter. Default: 15');
+    end
+
+    imgui.Spacing();
+
+    -- Custom DirectInput button mapping section (only for dinput scheme)
+    if currentScheme == 'dinput' then
+        imgui.Indent(20);
+
+        local hasCustomMapping = crossbarSettings.customControllerMappings and 
+                                  crossbarSettings.customControllerMappings.dinput;
+
+        -- Configure button
+        if imgui.Button('Configure Button Mapping##dinput', {0, 0}) then
+            local buttondetect = require('modules.hotbar.buttondetect');
+            buttonDetectionState.active = true;
+            buttonDetectionState.progress = 0;
+            buttondetect.StartDetection(function(results)
+                if not crossbarSettings.customControllerMappings then
+                    crossbarSettings.customControllerMappings = {};
+                end
+                crossbarSettings.customControllerMappings.dinput = results;
+                buttonDetectionState.active = false;
+                SaveSettingsOnly();
+                -- Re-initialize controller with new mapping
+                controller.SetControllerScheme('dinput', results);
+            end);
+        end
+        imgui.SameLine();
+        imgui.ShowHelp('Launch wizard to configure button layout for your controller. Custom mappings allow you to define your own button layout for DirectInput controllers.');
+
+        -- Status indicator
+        imgui.SameLine();
+        if hasCustomMapping then
+            imgui.TextColored({0, 1, 0, 1}, '(Using custom mapping)');
+        else
+            imgui.TextColored({0.7, 0.7, 0.7, 1}, '(Using default mapping)');
+        end
+
+        -- Clear custom mapping button (only show if custom mapping exists)
+        if hasCustomMapping then
+            imgui.SameLine();
+            if imgui.Button('Clear Custom Mapping##dinput', {150, 0}) then
+                crossbarSettings.customControllerMappings.dinput = nil;
+                SaveSettingsOnly();
+                -- Re-initialize controller without custom mapping
+                controller.SetControllerScheme('dinput');
+            end
+            imgui.SameLine();
+            imgui.ShowHelp('Remove custom mapping and revert to defaults.');
+        end
+
+        -- Show progress bar during detection
+        if buttonDetectionState.active then
+            local buttondetect = require('modules.hotbar.buttondetect');
+            local progress, maxProgress = buttondetect.GetProgress();
+            imgui.ProgressBar(progress / maxProgress, {-1, 20}, string.format('Button %d of %d', progress, maxProgress));
+            imgui.TextWrapped('Detecting buttons... ' .. (buttondetect.GetCurrentPrompt() or ''));
+            if imgui.Button('Cancel##buttondetect', {0, 0}) then
+                buttondetect.Cancel();
+                buttonDetectionState.active = false;
+            end
+        end
+
+        imgui.Unindent(20);
+    end
+
+    imgui.Spacing();
+
+    -- Enable "Global" Crossbar Sets (+ default palette tier when enabled); omit live Scope preview line here
+    DrawCrossbarUniversalTierOptions(crossbarSettings, { includeScopeLine = false });
+
+    imgui.Spacing();
+
+    -- Double-Tap (window + minimum trigger hold under it when enabled)
+    components.DrawPartyCheckbox(crossbarSettings, 'Enable Double-Tap##crossbar', 'enableDoubleTap', DeferredUpdateVisuals);
+    imgui.ShowHelp('Enable L2x2 and R2x2 double-tap modes. Tap a trigger twice quickly (hold on second tap) to access double-tap bars.\nPer-trigger [G] attach and pet overrides are set in Edit Full Palette (Manage Palettes & Crossbar tab).');
+
+    if crossbarSettings.enableDoubleTap then
+        components.DrawPartySlider(crossbarSettings, 'Double-Tap Window##crossbar', 'doubleTapWindow', 0.1, 0.6, '%.2f sec', function()
+            controller.SetDoubleTapWindow(crossbarSettings.doubleTapWindow);
+        end, 0.3);
+        imgui.ShowHelp('Time window to register a double-tap (in seconds).');
+
+        if hasAnalogTriggers then
+            components.DrawPartySlider(crossbarSettings, 'Minimum Trigger Hold##crossbar', 'minTriggerHold', 0.01, 0.15, '%.3f sec', function()
+                controller.SetMinTriggerHold(crossbarSettings.minTriggerHold);
+            end, 0.05);
+            imgui.ShowHelp('Minimum time the trigger must be held before releasing for the release to count toward double-tap detection. Prevents false double-taps from analog jitter or accidental taps. Default: 0.050 sec (50ms)');
+        end
+
+        imgui.Spacing();
+        components.DrawPartyCheckbox(crossbarSettings, 'Show Double-Tap Crossbars Preview##crossbar', 'showDoubleTapPreview', DeferredUpdateVisuals);
+        imgui.ShowHelp('Show two small floating crossbar windows that always display your L2x2 and R2x2 double-tap bars,\nincluding cooldowns. While a double-tap is active, the preview swaps to show your base bar so you\ncan reference both at once. Drag anchors (visible when config is open) to reposition each preview.');
+
+        if crossbarSettings.showDoubleTapPreview then
+            imgui.Indent(20);
+            components.DrawPartySlider(crossbarSettings, 'Preview Scale##crossbar', 'doubleTapPreviewScale', 0.30, 1.0, '%.2f', DeferredUpdateVisuals, 0.60);
+            imgui.ShowHelp('Size of the preview windows relative to the main crossbar. 0.60 = 60% of full size.');
+            components.DrawPartySlider(crossbarSettings, 'Preview Opacity##crossbar', 'doubleTapPreviewOpacity', 0.20, 1.0, '%.2f', DeferredUpdateVisuals, 1.0);
+            imgui.ShowHelp('Base opacity of the preview windows. Follows trigger-dim behaviour: the inactive preview dims when\nthe opposite trigger is held, matching how the main crossbar dims its inactive side.');
+            components.DrawPartyCheckbox(crossbarSettings, 'Lock Preview Positions##crossbar', 'doubleTapPreviewLocked', DeferredUpdateVisuals);
+            imgui.ShowHelp('Lock the L2x2 and R2x2 preview windows in place so they cannot be dragged.\nIndependent of the main crossbar position lock.');
+            imgui.Unindent(20);
+        end
+    end
+
+    imgui.Spacing();
+
+    -- Chords: L2+R2 / R2+L2 expanded bars (+ shared expanded bar when enabled)
+    components.DrawPartyCheckbox(crossbarSettings, 'Enable Chords (L2+R2 / R2+L2)', 'enableExpandedCrossbar');
+    imgui.ShowHelp('Enable L2+R2 and R2+L2 combo modes. Hold one trigger, then press the other to access expanded bars.\nOptional Global [G] palette attach per trigger group is set in Edit Full Palette when editing a Job palette; [G] sets are labeled in palette lists.');
+
+    if crossbarSettings.enableExpandedCrossbar then
+        imgui.Indent(20);
+        components.DrawPartyCheckbox(crossbarSettings, 'Use Shared Expanded Bar##crossbar', 'useSharedExpandedBar', DeferredUpdateVisuals);
+        imgui.ShowHelp('When enabled, L2+R2 and R2+L2 will access the same shared expanded bar instead of separate bars.\nThis shared bar is completely independent from the separate L2+R2 and R2+L2 bars.');
+        imgui.Unindent(20);
+    end
+
+    imgui.Spacing();
+
+    DrawCrossbarGlobalPalettesSection({
+        skipUniversalTierOptions = true,
+        includeUniversalLists = false,
+        includeJobPalettes = false,
+    });
+
+    elseif uit == 2 then
+        DrawCrossbarJobIconStrip(crossbarSettings, { showGlobalOptionsRow = true });
+        if crossbarSettings.configFocus == 'universal' then
+            DrawCrossbarGlobalPalettesSection({
+                showEnableCheckbox = false,
+                skipUniversalTierOptions = true,
+                includeUniversalLists = true,
+                includeJobPalettes = false,
+                compactGlobalPaletteScroll = true,
+                embedCrossbarUniversalPaletteManager = true,
+            });
+        else
+            local effJob = crossbarSettings.configEditJobId or data.jobId or 1;
+            local effSub = crossbarSettings.configEditSubjobId;
+            if effSub == nil then
+                effSub = data.subjobId or 0;
+            end
+            DrawCrossbarGlobalPalettesSection({
+                showEnableCheckbox = false,
+                skipUniversalTierOptions = true,
+                includeUniversalLists = false,
+                includeJobPalettes = true,
+                jobId = effJob,
+                subjobId = effSub,
+                embedCrossbarJobPaletteManager = true,
+            });
+        end
+
+        if crossbarSettings.configFocus == 'job' then
+            imgui.Spacing();
+            imgui.TextWrapped(
+                'Per-trigger layout, Pet palette, and Global [G] overrides are edited in Edit Full Palette (button in the palette list above). ' ..
+                'Visual slot styling remains under Global Visual Settings.'
+            );
+        end
+
+    elseif uit == 3 then
+        imgui.TextColored(components.TAB_STYLE.gold, 'Global Visual Settings');
+        imgui.Spacing();
+
+        if crossbarGlobalVis_prevUit ~= 3 then
+            for _, sk in ipairs(CROSSBAR_GLOBAL_VIS_KEYS) do
+                if not crossbarGlobalVis_openedSections[sk] then
+                    crossbarGlobalVis_sectionNonce[sk] = (crossbarGlobalVis_sectionNonce[sk] or 0) + 1;
+                end
+            end
+        end
+
+        if crossbarSettings.paletteJobIconTheme == nil
+            or crossbarSettings.paletteJobIconTheme == 'ClassicFFXIV' then
+            crossbarSettings.paletteJobIconTheme = 'Classic';
+        end
+
+        if CrossbarGlobalVisualCollapsingSection('palCtrl', 'Palette & Controller Icons##crossbar', false) then
+            imgui.TextColored({ 0.85, 0.82, 0.7, 1.0 }, 'Palette Icons');
+            imgui.Spacing();
+            local paletteIconThemes = { 'Classic', 'FFXI', 'FFXIV-1' };
+            components.DrawPartyComboBox(crossbarSettings, 'Icon set##paletteJobIconTheme', 'paletteJobIconTheme', paletteIconThemes, DeferredUpdateVisuals);
+            imgui.ShowHelp('Job icons for Manage Palettes (crossbar) and the in-game palette scope icon when using Job [J] storage. Folders: addons/XIUI/assets/jobs/Classic, FFXI, FFXIV-1.');
+
+            components.DrawPartySlider(crossbarSettings, 'Icon Height##crossbarScopeLift', 'paletteScopeIconOffsetY', 0, 48, '%.0f', DeferredUpdateVisuals, 12);
+            imgui.ShowHelp('Vertical lift for the job / Global palette icon above the center line (pixels). Increase if it overlaps the L2/R2 combo text.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Icon Size (px)##crossbarScopeIconSize', 'paletteScopeIconSize', 8, 64, '%d', DeferredUpdateVisuals, 22);
+            imgui.ShowHelp('Width and height of the job or Global palette scope icon drawn above the center divider (when the scope icon is enabled).');
+
+            do
+                local effScope = crossbarSettings.showPaletteScopeIcon;
+                if effScope == nil then
+                    effScope = crossbarSettings.showPaletteName;
+                end
+                if imgui.Checkbox('Show Palette Scope Icon##crossbarPaletteScopeIcon', { effScope }) then
+                    crossbarSettings.showPaletteScopeIcon = not effScope;
+                    SaveSettingsOnly();
+                    UpdateUserSettings();
+                    DeferredUpdateVisuals();
+                end
+            end
+            imgui.ShowHelp('Infinity for Global [G] storage or main job icon for Job [J] storage, above the center line. Uncheck to hide only the icon; palette name is separate below.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Palette Name##crossbarPaletteName', 'showPaletteName');
+            if crossbarSettings.showPaletteName then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarpalette', 'paletteNameOffsetX', 'paletteNameOffsetY', 35);
+            end
+            imgui.ShowHelp('Current palette name and index below the crossbar (e.g. "Stuns (2/5)"). X/Y adjust position.');
+
+            imgui.Spacing();
+            imgui.Separator();
+            imgui.Spacing();
+
+            local controllerThemes = { 'PlayStation', 'Xbox', 'Nintendo' };
+            components.DrawPartyComboBox(crossbarSettings, 'Controller Theme##crossbar', 'controllerTheme', controllerThemes);
+            imgui.ShowHelp('Select controller button icon style. Nintendo layout: X top, A right, B bottom, Y left.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Button Icons##crossbar', 'showButtonIcons');
+            imgui.ShowHelp('Show d-pad and face button icons on slots.');
+
+            if crossbarSettings.showButtonIcons then
+                components.DrawPartySliderInt(crossbarSettings, 'Button Icon Size##crossbar', 'buttonIconSize', 8, 32, '%d', nil, 16);
+                imgui.ShowHelp('Size of controller button icons.');
+
+                components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (H)##crossbar', 'buttonIconGapH', 0, 24, '%d', nil, 2);
+                imgui.ShowHelp('Horizontal spacing between center controller icons.');
+
+                components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (V)##crossbar', 'buttonIconGapV', 0, 24, '%d', nil, 2);
+                imgui.ShowHelp('Vertical spacing between center controller icons.');
+            end
+
+            imgui.Separator();
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Trigger Icons##crossbar', 'showTriggerLabels');
+            imgui.ShowHelp('Show L2/R2 trigger icons above the crossbar groups.');
+
+            if crossbarSettings.showTriggerLabels then
+                components.DrawPartySlider(crossbarSettings, 'Trigger Icon Scale##crossbar', 'triggerIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
+                imgui.ShowHelp('Scale for L2/R2 trigger icons above groups (base size 49x28).');
+            end
+        end
+
+        if CrossbarGlobalVisualCollapsingSection('slot', 'Slot Settings##crossbar', false) then
+            components.DrawPartySliderInt(crossbarSettings, 'Slot Size (px)##crossbar', 'slotSize', 32, 64, '%d', nil, 48);
+            imgui.ShowHelp('Size of each slot in pixels.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Vertical)##crossbar', 'slotGapV', 0, 128, '%d', nil, 4);
+            imgui.ShowHelp('Vertical gap between top and bottom slots in each diamond.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Horizontal)##crossbar', 'slotGapH', 0, 128, '%d', nil, 4);
+            imgui.ShowHelp('Horizontal gap between left and right slots in each diamond.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Diamond Spacing##crossbar', 'diamondSpacing', 0, 128, '%d', nil, 20);
+            imgui.ShowHelp('Horizontal space between D-pad and face button diamonds.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Group Spacing##crossbar', 'groupSpacing', 0, 128, '%d', nil, 40);
+            imgui.ShowHelp('Space between L2 and R2 groups.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Divider##crossbar', 'showDivider');
+            imgui.ShowHelp('Show a divider line between L2 and R2 groups.');
+
+            -- Show MP Cost with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show MP Cost##crossbar', 'showMpCost');
+            if crossbarSettings.showMpCost then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarmp', 'mpCostOffsetX', 'mpCostOffsetY', 35);
+            end
+            imgui.ShowHelp('Display MP cost on spell slots. X/Y offsets adjust position.');
+
+            -- Show Item Quantity with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Item Quantity##crossbar', 'showQuantity');
+            if crossbarSettings.showQuantity then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarqty', 'quantityOffsetX', 'quantityOffsetY', 35);
+            end
+            imgui.ShowHelp('Display item quantity on item slots. X/Y offsets adjust position.');
+
+            -- 1.8.0 addition: full-stack count above the item quantity (only counts complete stacks)
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Stack Quantity##crossbar', 'showStackQuantity');
+            imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
+
+            -- Show Combo Text with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Combo Text##crossbar', 'showComboText');
+            if crossbarSettings.showComboText then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarcombo', 'comboTextOffsetX', 'comboTextOffsetY', 35);
+            end
+            imgui.ShowHelp('Show current combo mode text in center (L2+R2, R2+L2, L2x2, R2x2). X/Y offsets adjust position.');
+
+            -- Show Action Labels with X/Y offsets
+            components.DrawPartyCheckbox(crossbarSettings, 'Show Action Labels##crossbar', 'showActionLabels');
+            if crossbarSettings.showActionLabels then
+                imgui.SameLine();
+                components.DrawInlineOffsets(crossbarSettings, 'crossbarlbl', 'actionLabelOffsetX', 'actionLabelOffsetY', 35);
+            end
+            imgui.ShowHelp('Show spell/ability names below slots. X/Y offsets adjust position.');
+        end
+
+        if CrossbarGlobalVisualCollapsingSection('bg', 'Background##crossbar', false) then
+            local bgThemes = {'-None-', 'Plain', 'Window1', 'Window2', 'Window3', 'Window4', 'Window5', 'Window6', 'Window7', 'Window8'};
+            components.DrawPartyComboBox(crossbarSettings, 'Theme##bgcrossbar', 'backgroundTheme', bgThemes, DeferredUpdateVisuals);
+            imgui.ShowHelp('Select the background window theme.');
+
+            components.DrawPartySlider(crossbarSettings, 'Background Scale##crossbar', 'bgScale', 0.1, 3.0, '%.2f', nil, 1.0);
+            imgui.ShowHelp('Scale of the background texture.');
+
+            components.DrawPartySlider(crossbarSettings, 'Border Scale##crossbar', 'borderScale', 0.1, 3.0, '%.2f', nil, 1.0);
+            imgui.ShowHelp('Scale of the window borders.');
+
+            components.DrawPartySlider(crossbarSettings, 'Background Opacity##crossbar', 'backgroundOpacity', 0.0, 1.0, '%.2f');
+            imgui.ShowHelp('Opacity of the background.');
+
+            components.DrawPartySlider(crossbarSettings, 'Border Opacity##crossbar', 'borderOpacity', 0.0, 1.0, '%.2f');
+            imgui.ShowHelp('Opacity of the window borders.');
+        end
+
+        -- Text section
+        if CrossbarGlobalVisualCollapsingSection('text', 'Text Settings##crossbar', false) then
+            components.DrawPartySliderInt(crossbarSettings, 'Keybind Text Size##crossbar', 'keybindFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for keybind labels.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Label Text Size##crossbar', 'labelFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for action labels.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Cooldown Text Size##crossbar', 'recastTimerFontSize', 6, 24, '%d', DeferredUpdateVisuals, 11);
+            imgui.ShowHelp('Text size for cooldown timer display.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Flash Under 5 Seconds##crossbar', 'flashCooldownUnder5');
+            imgui.ShowHelp('Flash the cooldown timer text when remaining time is under 5 seconds.');
+
+            components.DrawPartyCheckbox(crossbarSettings, 'Use Hh:MM Cooldown Format##crossbar', 'useHHMMCooldownFormat');
+            imgui.ShowHelp('Display cooldown timers as Hh:MM (e.g., "1h:49") instead of "1h 49m" for shorter text.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Trigger Label Text Size##crossbar', 'triggerLabelFontSize', 6, 24, '%d', nil, 14);
+            imgui.ShowHelp('Text size for combo mode labels (L2, R2, etc.).');
+
+            components.DrawPartySliderInt(crossbarSettings, 'MP Cost Text Size##crossbar', 'mpCostFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for MP cost display.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Quantity Text Size##crossbar', 'quantityFontSize', 6, 24, '%d', nil, 10);
+            imgui.ShowHelp('Text size for item quantity display.');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Combo Text Size##crossbar', 'comboTextFontSize', 8, 24, '%d', nil, 12);
+            imgui.ShowHelp('Font size for combo mode text (L2+R2, R2+L2, etc.).');
+
+            components.DrawPartySliderInt(crossbarSettings, 'Palette Name Text Size##crossbar', 'paletteNameFontSize', 8, 24, '%d', nil, 10);
+            imgui.ShowHelp('Font size for palette name display.');
+        end
+
+        -- Visual Feedback section
+        if CrossbarGlobalVisualCollapsingSection('vfb', 'Visual Feedback##crossbar', false) then
+            components.DrawPartySlider(crossbarSettings, 'Inactive Dim##crossbar', 'inactiveSlotDim', 0.0, 1.0, '%.2f', nil, 0.5);
+            imgui.ShowHelp('Dim factor for inactive trigger side (0 = black, 1 = full brightness).');
+
+            components.DrawPartySlider(crossbarSettings, 'Inactive Dim (trigger held)##crossbar', 'inactiveSideWhileTriggerDim', 0.0, 1.0, '%.2f', nil, 0.15);
+            imgui.ShowHelp('Brightness for the half of the bar you are not using while L2 or R2 is held. Lower hides those slots so the active set stands out.');
+
+            -- Default to true if not set
+            if crossbarSettings.enableTransitionAnimations == nil then
+                crossbarSettings.enableTransitionAnimations = true;
+            end
+            local transAnimEnabled = { crossbarSettings.enableTransitionAnimations };
+            if imgui.Checkbox('Enable Transition Animations##crossbar', transAnimEnabled) then
+                crossbarSettings.enableTransitionAnimations = transAnimEnabled[1];
+                SaveSettingsOnly();
+            end
+            imgui.ShowHelp('Enable smooth animations when switching between crossbar modes (L2, R2, combos). Disable for instant transitions.');
+
+            -- Default to true if not set
+            if crossbarSettings.enablePressScale == nil then
+                crossbarSettings.enablePressScale = true;
+            end
+            local pressScaleEnabled = { crossbarSettings.enablePressScale };
+            if imgui.Checkbox('Enable Press Scale##crossbar', pressScaleEnabled) then
+                crossbarSettings.enablePressScale = pressScaleEnabled[1];
+                SaveSettingsOnly();
+            end
+            imgui.ShowHelp('Enable icon scaling animation when pressing an action slot. Disable for no visual feedback on press.');
+        end
+    end
+
+    crossbarGlobalVis_prevUit = uit;
+
+    -- Draw confirmation popup for job-specific toggle
+    hotbarConfig.DrawJobSpecificConfirmPopup();
+
+    -- Draw palette modal (unified for both hotbar and crossbar; implementation in config/hotbar.lua)
+    hotbarConfig.DrawPaletteModal();
+
+    return selectedCrossbarTab;
+end
+
+local function DrawCrossbarColorSettings()
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+        return;
+    end
+
+    local colorFlags = bit.bor(ImGuiColorEditFlags_NoInputs, ImGuiColorEditFlags_AlphaPreviewHalf, ImGuiColorEditFlags_AlphaBar);
+
+    imgui.TextColored(components.TAB_STYLE.gold, 'Crossbar Color Settings');
+    imgui.Spacing();
+
+    if components.CollapsingSection('Window Colors##crossbarcolor', true) then
+        local bgColor = crossbarSettings.bgColor or 0xFFFFFFFF;
+        local bgColorTable = ARGBToImGui(bgColor);
+        if imgui.ColorEdit4('Background Color##crossbar', bgColorTable, colorFlags) then
+            crossbarSettings.bgColor = ImGuiToARGB(bgColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color tint for the window background.');
+
+        local borderColor = crossbarSettings.borderColor or 0xFFFFFFFF;
+        local borderColorTable = ARGBToImGui(borderColor);
+        if imgui.ColorEdit4('Border Color##crossbar', borderColorTable, colorFlags) then
+            crossbarSettings.borderColor = ImGuiToARGB(borderColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color tint for the window borders.');
+    end
+
+    if components.CollapsingSection('Slot Colors##crossbarcolor', true) then
+        local slotBgColor = crossbarSettings.slotBackgroundColor or 0x55000000;
+        local slotBgColorTable = ARGBToImGui(slotBgColor);
+        if imgui.ColorEdit4('Slot Background##crossbar', slotBgColorTable, colorFlags) then
+            crossbarSettings.slotBackgroundColor = ImGuiToARGB(slotBgColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color and transparency of slot backgrounds.');
+
+        components.DrawPartySlider(crossbarSettings, 'Slot Opacity##crossbar', 'slotOpacity', 0.0, 1.0, '%.2f', nil, 1.0);
+        imgui.ShowHelp('Opacity of the slot background texture.');
+
+        local highlightColor = crossbarSettings.activeSlotHighlight or 0x44FFFFFF;
+        local highlightColorTable = ARGBToImGui(highlightColor);
+        if imgui.ColorEdit4('Active Highlight##crossbar', highlightColorTable, colorFlags) then
+            crossbarSettings.activeSlotHighlight = ImGuiToARGB(highlightColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Highlight color for slots when trigger is held.');
+    end
+
+    if components.CollapsingSection('Text Colors##crossbarcolor', true) then
+        local keybindColor = crossbarSettings.keybindFontColor or 0xFFFFFFFF;
+        local keybindColorTable = ARGBToImGui(keybindColor);
+        if imgui.ColorEdit4('Keybind Color##crossbar', keybindColorTable, colorFlags) then
+            crossbarSettings.keybindFontColor = ImGuiToARGB(keybindColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for keybind labels.');
+
+        local triggerLabelColor = crossbarSettings.triggerLabelColor or 0xFFFFCC00;
+        local triggerLabelColorTable = ARGBToImGui(triggerLabelColor);
+        if imgui.ColorEdit4('Trigger Label Color##crossbar', triggerLabelColorTable, colorFlags) then
+            crossbarSettings.triggerLabelColor = ImGuiToARGB(triggerLabelColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for combo mode labels (L2, R2, etc.).');
+
+        local mpCostColor = crossbarSettings.mpCostFontColor or 0xFFD4FF97;
+        local mpCostColorTable = ARGBToImGui(mpCostColor);
+        if imgui.ColorEdit4('MP Cost Color##crossbar', mpCostColorTable, colorFlags) then
+            crossbarSettings.mpCostFontColor = ImGuiToARGB(mpCostColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for MP cost display on spell slots.');
+
+        local quantityColor = crossbarSettings.quantityFontColor or 0xFFFFFFFF;
+        local quantityColorTable = ARGBToImGui(quantityColor);
+        if imgui.ColorEdit4('Quantity Color##crossbar', quantityColorTable, colorFlags) then
+            crossbarSettings.quantityFontColor = ImGuiToARGB(quantityColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for item quantity display. Note: Shows red when quantity is 0.');
+
+        local labelColor = crossbarSettings.labelFontColor or 0xFFFFFFFF;
+        local labelColorTable = ARGBToImGui(labelColor);
+        if imgui.ColorEdit4('Label Color##crossbar', labelColorTable, colorFlags) then
+            crossbarSettings.labelFontColor = ImGuiToARGB(labelColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for action labels below slots.');
+
+        local timerColor = crossbarSettings.recastTimerFontColor or 0xFFFFFFFF;
+        local timerColorTable = ARGBToImGui(timerColor);
+        if imgui.ColorEdit4('Cooldown Timer Color##crossbar', timerColorTable, colorFlags) then
+            crossbarSettings.recastTimerFontColor = ImGuiToARGB(timerColorTable);
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Color for cooldown timer text displayed on slots.');
+    end
+end
+
+-- Controller palette cycle (hotbarGlobal); top strip in config/crossbar.lua when crossbar is enabled
+function M.DrawControllerPaletteCycleGlobalOptions()
+    local ctrlOptions = { 'Disabled', 'Enabled' };
+    local currentCtrlIndex = (gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false) and 2 or 1;
+
+    imgui.AlignTextToFramePadding();
+    imgui.Text('Palette Cycle:');
+    imgui.SameLine();
+    imgui.SetNextItemWidth(90);
+    if imgui.BeginCombo('##ctrlPaletteCycle', ctrlOptions[currentCtrlIndex]) then
+        for i, label in ipairs(ctrlOptions) do
+            local isSelected = currentCtrlIndex == i;
+            if imgui.Selectable(label, isSelected) then
+                gConfig.hotbarGlobal.paletteCycleControllerEnabled = (i == 2);
+                SaveSettingsOnly();
+            end
+            if isSelected then imgui.SetItemDefaultFocus(); end
+        end
+        imgui.EndCombo();
+    end
+
+    if gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false then
+        imgui.SameLine();
+        imgui.Text('Button:');
+        imgui.SameLine();
+
+        local buttonOptions = { 'R1', 'L1' };
+        local currentButton = gConfig.hotbarGlobal.hotbarPaletteCycleButton or 'R1';
+        local currentButtonIndex = 1;
+        for i, btn in ipairs(buttonOptions) do
+            if btn == currentButton then
+                currentButtonIndex = i;
+                break;
+            end
+        end
+
+        imgui.SetNextItemWidth(60);
+        if imgui.BeginCombo('##hotbarCycleBtn', currentButton) then
+            for i, btn in ipairs(buttonOptions) do
+                local isSelected = (i == currentButtonIndex);
+                if imgui.Selectable(btn .. '##hbCycleBtn' .. i, isSelected) then
+                    gConfig.hotbarGlobal.hotbarPaletteCycleButton = btn;
+                    SaveSettingsOnly();
+                end
+                if isSelected then imgui.SetItemDefaultFocus(); end
+            end
+            imgui.EndCombo();
+        end
+    end
+    imgui.ShowHelp('Controller shortcut to cycle palettes.\nHold the selected shoulder button + D-pad Up/Down to cycle keyboard hotbar palettes and the active crossbar palette.');
+end
+
+function M.DrawLogPaletteNameCheckboxCrossbar(idSuffix)
+    idSuffix = idSuffix or '##logPalNameXb';
+    local hg = gConfig.hotbarGlobal;
+    if not hg then
+        return;
+    end
+    local logPaletteName = hg.logPaletteNameCrossbar;
+    if logPaletteName == nil then logPaletteName = true; end
+    local logVal = { logPaletteName };
+    if imgui.Checkbox('Log Palette Name (crossbar)' .. idSuffix, logVal) then
+        hg.logPaletteNameCrossbar = logVal[1];
+        SaveSettingsOnly();
+    end
+    imgui.ShowHelp('Log crossbar palette lines in chat for /xiui cpal and controller palette cycling.');
+    if logVal[1] then
+        imgui.Indent(18);
+        local hintOn = hg.logPaletteNameCrossbarCycleHint;
+        if hintOn == nil then hintOn = true; end
+        local hintVal = { hintOn };
+        if imgui.Checkbox('Include RB(R1)+Up/Down return hint (CLI preview)' .. idSuffix .. '_rbHint', hintVal) then
+            hg.logPaletteNameCrossbarCycleHint = hintVal[1];
+            SaveSettingsOnly();
+        end
+        imgui.ShowHelp('Extra line after /xiui cpal when previewing another job palette.');
+        imgui.Unindent(18);
+    end
+end
+
+-- Invoked from config/crossbar.lua only (Hotbar category uses config/hotbar.lua M.DrawSettings).
+function M.DrawStandaloneCrossbarSettings(state)
+    local selectedCrossbarTab = state and state.selectedCrossbarTab or 1;
+    selectedCrossbarTab = DrawCrossbarSettings(selectedCrossbarTab, state);
+    return { selectedCrossbarTab = selectedCrossbarTab };
+end
+
+function M.DrawStandaloneCrossbarColorSettings(_state)
+    DrawCrossbarColorSettings();
+end
+
+-- Via config/crossbar.lua when the XIUI config window opens (resync Crossbar palette edit job from player)
+function M.OnConfigWindowOpened()
+    lastConfigCategorySeenForCrossbar = nil;
+end
+
+-- Select Crossbar → Manage Palettes & Crossbar (middle tab); used by /xiui cpalette
+function M.OpenCrossbarManagePalettesTab()
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false;
+    end
+    crossbarSettings.configUiTab = 2;
+    crossbarConfigSubTabUserChosen = true;
+    return true;
+end
+
+return M;

--- a/XIUI/config/efp_pets_tab.lua
+++ b/XIUI/config/efp_pets_tab.lua
@@ -1,0 +1,222 @@
+--[[
+* Edit Full Palette: Pets tab - pick a pet family, then a concrete pet key, for editing petpalette:* crossbar data.
+* Lists are profile-wide (not tied to current main job): each family uses the class-appropriate key set.
+* ASCII labels only (game font).
+]]--
+
+local imgui = require('imgui');
+local components = require('config.components');
+local petreg = require('modules.hotbar.petregistry');
+
+local M = {};
+
+local T_AVATARS = 1;
+local T_ELEMENTALS = 2;
+local T_BEASTS = 3;
+local T_WYVERN = 4;
+local T_PUPPET = 5;
+
+M.state = {
+    typeTab = T_AVATARS,
+    subIdx = 1,
+};
+
+M._curList = {};
+
+function M.resetState()
+    M.state.typeTab = T_AVATARS;
+    M.state.subIdx = 1;
+    M._curList = {};
+end
+
+local excl = petreg.PETBAR_EXCLUDED_STORAGE_KEYS;
+
+local function jobIdForFamilyTab(typeTab)
+    if typeTab == T_AVATARS or typeTab == T_ELEMENTALS then
+        return petreg.JOB_SMN;
+    end
+    if typeTab == T_BEASTS then
+        return petreg.JOB_BST;
+    end
+    if typeTab == T_WYVERN then
+        return petreg.JOB_DRG;
+    end
+    if typeTab == T_PUPPET then
+        return petreg.JOB_PUP;
+    end
+    return petreg.JOB_SMN;
+end
+
+local function buildListForType(typeTab)
+    local j = jobIdForFamilyTab(typeTab);
+    local all = petreg.GetAvailablePetKeys(j) or {};
+    local out = {};
+    local function addKey(k, label)
+        if not k then
+            return;
+        end
+        if excl and excl[k] then
+            return;
+        end
+        table.insert(out, { key = k, label = label or petreg.GetDisplayNameForKey(k) });
+    end
+    for _, k in ipairs(all) do
+        if typeTab == T_AVATARS then
+            if k:find('^avatar:') then
+                addKey(k);
+            end
+        elseif typeTab == T_ELEMENTALS then
+            if k:find('^spirit:') then
+                addKey(k);
+            end
+        elseif typeTab == T_BEASTS then
+            if k == 'jug' or k == 'charm' or k:find('^jug:') then
+                addKey(k);
+            end
+        elseif typeTab == T_WYVERN then
+            if k == 'wyvern' then
+                addKey(k, 'Wyvern');
+            end
+        elseif typeTab == T_PUPPET then
+            if k == 'automaton' then
+                addKey(k, 'Automaton');
+            end
+        end
+    end
+    if typeTab == T_AVATARS or typeTab == T_ELEMENTALS then
+        table.sort(out, function(a, b)
+            return petreg.GetSmnPetKeyOrderWeight(a.key) < petreg.GetSmnPetKeyOrderWeight(b.key);
+        end);
+    else
+        table.sort(out, function(a, b)
+            return (a.label or '') < (b.label or '');
+        end);
+    end
+    return out;
+end
+
+function M.rebuildListAndClamp()
+    M._curList = buildListForType(M.state.typeTab);
+    if #M._curList == 0 then
+        M.state.subIdx = 1;
+        return;
+    end
+    if M.state.subIdx > #M._curList then
+        M.state.subIdx = #M._curList;
+    end
+    if M.state.subIdx < 1 then
+        M.state.subIdx = 1;
+    end
+end
+
+-- Full pet key suffix, e.g. "avatar:carbuncle" or "wyvern" (no "petpalette:" prefix).
+function M.getPetKeyString()
+    M.rebuildListAndClamp();
+    if #M._curList == 0 then
+        return 'wyvern';
+    end
+    return M._curList[M.state.subIdx].key;
+end
+
+local function efpTextWrapped(s, col)
+    if not s then
+        return;
+    end
+    if col and imgui.PushStyleColor and ImGuiCol_Text then
+        imgui.PushStyleColor(ImGuiCol_Text, col);
+    end
+    if imgui.TextWrapped then
+        imgui.TextWrapped(s);
+    else
+        imgui.Text(s);
+    end
+    if col and imgui.PopStyleColor then
+        imgui.PopStyleColor(1);
+    end
+end
+
+function M.draw(cross, disablePetTargetChange)
+    M.rebuildListAndClamp();
+    local jn = 'p';
+
+    efpTextWrapped(
+        'These layouts are stored per pet on this profile. When you have that pet out and a trigger row uses Pet Palette, your job crossbar uses these slots.',
+        { 0.55, 0.53, 0.5, 1.0 }
+    );
+    imgui.Spacing();
+
+    if disablePetTargetChange and imgui.BeginDisabled then
+        imgui.BeginDisabled();
+    end
+    local tnames = { 'Avatars', 'Elementals', 'Beasts', 'Wyvern', 'Puppet' };
+    imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Pet family:');
+    imgui.SameLine(0, 8);
+    for ti = 1, 5 do
+        if ti > 1 then
+            imgui.SameLine(0, 4);
+        end
+        local sel = (M.state.typeTab == ti);
+        if components.DrawStyledTab(tnames[ti], 'efppty_' .. ti .. '_' .. jn, sel, nil, components.TAB_STYLE.smallHeight, components.TAB_STYLE.smallPadding, 'palette') then
+            local prev = M.state.typeTab;
+            M.state.typeTab = ti;
+            if prev ~= ti then
+                M.state.subIdx = 1;
+            end
+        end
+    end
+    M.rebuildListAndClamp();
+
+    if #M._curList == 0 then
+        efpTextWrapped('No pets in this family to edit (unexpected). Try another family tab.', { 0.85, 0.5, 0.45, 1.0 });
+    else
+        if M.state.subIdx < 1 or M.state.subIdx > #M._curList then
+            M.state.subIdx = 1;
+        end
+        local cur = M._curList[M.state.subIdx];
+        local preview = cur.label;
+        do
+            local aw, _ah = imgui.GetContentRegionAvail and imgui.GetContentRegionAvail() or 400, 0;
+            local w = 280;
+            if type(aw) == 'table' then
+                w = math.max(200, (aw[1] or aw.x or w));
+            elseif type(aw) == 'number' then
+                w = math.max(200, aw);
+            end
+            imgui.SetNextItemWidth(math.min(w, 520));
+        end
+        if imgui.BeginCombo('Pet##efppcombo' .. jn, preview) then
+            for i, row in ipairs(M._curList) do
+                if imgui.Selectable(row.label, i == M.state.subIdx) then
+                    M.state.subIdx = i;
+                end
+            end
+            imgui.EndCombo();
+        end
+        efpTextWrapped(
+            'Choose pet, then edit slots below. A few avatars are omitted where there is no pet bar to bind. Elementals (spirits) are separate from avatars in Pet Palette settings.',
+            { 0.5, 0.5, 0.48, 1.0 }
+        );
+    end
+
+    if cross then
+        local n = 0;
+        for _, m in ipairs({ 'L2', 'R2', 'L2x2', 'R2x2', 'L2R2', 'R2L2' }) do
+            local s = cross.comboModeSettings and cross.comboModeSettings[m];
+            if s and s.petAware == true then
+                n = n + 1;
+            end
+        end
+        efpTextWrapped(
+            string.format('Pet Palette segments on in Slots: %d (turn on more there to see more rows in this list).', n),
+            { 0.55, 0.53, 0.48, 1.0 }
+        );
+    end
+    if disablePetTargetChange and imgui.EndDisabled then
+        imgui.EndDisabled();
+    end
+    if disablePetTargetChange then
+        efpTextWrapped('Apply or Undo to change which pet you are editing.', { 0.7, 0.55, 0.3, 1.0 });
+    end
+end
+
+return M;

--- a/XIUI/config/hotbar.lua
+++ b/XIUI/config/hotbar.lua
@@ -1,10 +1,13 @@
---[[
-* XIUI Config Menu - Hotbar Settings
-* Contains settings and color settings for Hotbar with per-bar customization
+﻿--[[
+* XIUI Config Menu - Hotbar (keyboard bars) settings
+* Controller crossbar UI lives in config/crossbar_settings.lua (sibling module).
+* Contains settings and color settings for Hotbar with per-bar customization.
 ]]--
 
 require('common');
 require('handlers.helpers');
+local ffi = require('ffi');
+local TextureManager = require('libs.texturemanager');
 local components = require('config.components');
 local statusHandler = require('handlers.statushandler');
 local imgui = require('imgui');
@@ -14,13 +17,14 @@ local actions = require('modules.hotbar.actions');
 local jobs = require('libs.jobs');
 local macropalette = require('modules.hotbar.macropalette');
 local playerdata = require('modules.hotbar.playerdata');
-local controller = require('modules.hotbar.controller');
 local macrosLib = require('libs.ffxi.macros');
 local palette = require('modules.hotbar.palette');
 local migrationWizard = require('config.migration');
 local paletteManager = require('config.palettemanager');
+local petAllowlist = require('modules.hotbar.pet_palette_allowlist');
 
 local M = {};
+
 
 -- Expose migration wizard for external access (used by config.lua to draw the popup)
 M.migrationWizard = migrationWizard;
@@ -38,16 +42,37 @@ local jobSpecificConfirmState = {
     isCrossbar = false,
 };
 
--- Button detection wizard state
-local buttonDetectionState = {
-    active = false,
-    progress = 0,
-};
 
 -- ============================================
 -- Unified Palette Modal System
 -- Shared between hotbar and crossbar palettes
 -- ============================================
+
+-- Persists the last-selected crossbar create job/storageSubjob across popup opens.
+-- Resets to live job/sj only when the character's job or subjob changes.
+local xbCreatePersisted = {
+    jobId = nil,
+    storageSubjob = nil,
+    lastSeenJobId = nil,
+    lastSeenSubjobId = nil,
+};
+
+local function GetOrResetXbCreateDefaults()
+    local liveJob = data.jobId or 1;
+    local liveSj  = data.subjobId or 0;
+    if xbCreatePersisted.lastSeenJobId ~= liveJob or xbCreatePersisted.lastSeenSubjobId ~= liveSj then
+        xbCreatePersisted.jobId          = liveJob;
+        xbCreatePersisted.storageSubjob  = liveSj;
+        xbCreatePersisted.lastSeenJobId  = liveJob;
+        xbCreatePersisted.lastSeenSubjobId = liveSj;
+    end
+    return xbCreatePersisted.jobId, xbCreatePersisted.storageSubjob;
+end
+
+-- One-shot open flags (see palettemanager.lua for rationale)
+local xbHotbarCreatePopupPending = false;
+local palettePopupPendingId      = nil;
+local jobSpecificPopupPending    = false;
 
 -- Single modal state for all palette operations
 local paletteModal = {
@@ -57,6 +82,9 @@ local paletteModal = {
     paletteName = nil,    -- For rename: current name
     inputBuffer = { '' },
     errorMessage = nil,
+    -- Job crossbar create (non-modal popup): storage tier 0 = Shared [J], else Subjob [SJ] id
+    crossbarCreateJobId = nil,
+    crossbarCreateStorageSubjob = nil,
 };
 
 -- Helper: Open palette create modal
@@ -67,6 +95,14 @@ local function OpenPaletteCreateModal(paletteType)
     paletteModal.paletteName = nil;
     paletteModal.inputBuffer[1] = '';
     paletteModal.errorMessage = nil;
+    if paletteType == 'crossbar' then
+        local j, s = GetOrResetXbCreateDefaults();
+        paletteModal.crossbarCreateJobId = j;
+        paletteModal.crossbarCreateStorageSubjob = s;
+    else
+        paletteModal.crossbarCreateJobId = nil;
+        paletteModal.crossbarCreateStorageSubjob = nil;
+    end
 end
 
 -- Helper: Open palette rename modal
@@ -87,15 +123,21 @@ local function ClosePaletteModal()
     paletteModal.paletteName = nil;
     paletteModal.inputBuffer[1] = '';
     paletteModal.errorMessage = nil;
+    paletteModal.crossbarCreateJobId = nil;
+    paletteModal.crossbarCreateStorageSubjob = nil;
+    xbHotbarCreatePopupPending = false;
+    palettePopupPendingId      = nil;
 end
 
 -- Helper function to draw the job-specific confirmation popup
 local function DrawJobSpecificConfirmPopup()
-    if jobSpecificConfirmState.showPopup then
+    if jobSpecificConfirmState.showPopup and not jobSpecificPopupPending then
         imgui.OpenPopup('Confirm Action Storage Change##jobSpecificConfirm');
+        jobSpecificConfirmState.showPopup = false;
+        jobSpecificPopupPending = true;
     end
 
-    if imgui.BeginPopupModal('Confirm Action Storage Change##jobSpecificConfirm', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if imgui.BeginPopup('Confirm Action Storage Change##jobSpecificConfirm', ImGuiWindowFlags_AlwaysAutoResize) then
         local targetName;
         if jobSpecificConfirmState.isCrossbar then
             targetName = jobSpecificConfirmState.targetBarIndex and ('Crossbar ' .. jobSpecificConfirmState.targetBarIndex) or 'Crossbar';
@@ -159,28 +201,172 @@ local function DrawJobSpecificConfirmPopup()
         end
 
         imgui.EndPopup();
+    else
+        -- Dismissed by clicking outside
+        jobSpecificPopupPending = false;
+        jobSpecificConfirmState.showPopup = false;
     end
 end
 
 -- Unified palette modal - handles create/rename for both hotbar and crossbar
 local function DrawPaletteModal()
     if not paletteModal.isOpen then
+        xbHotbarCreatePopupPending = false;
+        palettePopupPendingId      = nil;
+        return;
+    end
+
+    -- Job crossbar create: non-modal popup (same idea as Palette Manager Copy To â€” no fullscreen dim).
+    if paletteModal.mode == 'create' and paletteModal.paletteType == 'crossbar' then
+        if paletteModal.crossbarCreateJobId == nil then
+            paletteModal.crossbarCreateJobId = data.jobId or 1;
+        end
+        if paletteModal.crossbarCreateStorageSubjob == nil then
+            paletteModal.crossbarCreateStorageSubjob = data.subjobId or 0;
+        end
+        local cj = paletteModal.crossbarCreateJobId;
+        if cj < 1 then cj = 1; end
+        if cj > 22 then cj = 22; end
+        paletteModal.crossbarCreateJobId = cj;
+
+        if not xbHotbarCreatePopupPending then
+            imgui.SetNextWindowSize({ 560, 0 }, ImGuiCond_Always);
+            imgui.OpenPopup('Crossbar Create Palette##paletteModalXbJobNm');
+            xbHotbarCreatePopupPending = true;
+        end
+        if imgui.BeginPopup('Crossbar Create Palette##paletteModalXbJobNm', ImGuiWindowFlags_AlwaysAutoResize) then
+            imgui.TextWrapped('Create a new palette for Job [J] / Subjob [SJ] crossbar storage.');
+            imgui.Spacing();
+
+            local storSj = paletteModal.crossbarCreateStorageSubjob or 0;
+            if storSj ~= 0 then
+                local usingFallback = palette.IsUsingFallback(cj, storSj, 'crossbar');
+                if usingFallback then
+                    local jobName = jobs[cj] or ('Job ' .. cj);
+                    local subjobName = jobs[storSj] or ('Job ' .. storSj);
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'Warning: Creating this palette will stop');
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'using shared palettes for ' .. jobName .. '/' .. subjobName .. '.');
+                    imgui.Spacing();
+                end
+            end
+
+            imgui.Text('Job:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            if imgui.BeginCombo('##xbCreateJobCfg', jobs[cj] or ('Job ' .. cj)) then
+                for jobId = 1, 22 do
+                    local isSelected = (jobId == cj);
+                    if imgui.Selectable((jobs[jobId] or ('Job ' .. jobId)) .. '##xbCj' .. jobId, isSelected) then
+                        paletteModal.crossbarCreateJobId = jobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.SameLine();
+            imgui.Text('Subjob storage:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            local subLabel = storSj == 0 and 'Shared' or (jobs[storSj] or ('Job ' .. storSj));
+            if imgui.BeginCombo('##xbCreateSubCfg', subLabel) then
+                local sharedSel = (storSj == 0);
+                if imgui.Selectable('Shared##xbCs0', sharedSel) then
+                    paletteModal.crossbarCreateStorageSubjob = 0;
+                end
+                if sharedSel then
+                    imgui.SetItemDefaultFocus();
+                end
+                for subjobId = 1, 22 do
+                    local isSelected = (subjobId == storSj);
+                    if imgui.Selectable((jobs[subjobId] or ('Job ' .. subjobId)) .. '##xbCs' .. subjobId, isSelected) then
+                        paletteModal.crossbarCreateStorageSubjob = subjobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.Spacing();
+            imgui.Text('Palette name:');
+            imgui.PushItemWidth(220);
+            local enterPressed = imgui.InputText('##paletteModalXbCreateInput', paletteModal.inputBuffer, 32, ImGuiInputTextFlags_EnterReturnsTrue);
+            imgui.PopItemWidth();
+
+            if paletteModal.errorMessage then
+                imgui.Spacing();
+                imgui.TextColored({ 1.0, 0.4, 0.4, 1.0 }, paletteModal.errorMessage);
+            end
+
+            imgui.Spacing();
+            local newName = paletteModal.inputBuffer[1];
+            local canCreate = newName and newName ~= '';
+            if not canCreate then
+                imgui.BeginDisabled();
+            end
+            if imgui.Button('Create##paletteModalXbCreateOk', { 88, 0 }) or (enterPressed and canCreate) then
+                if canCreate then
+                    storSj = paletteModal.crossbarCreateStorageSubjob or 0;
+                    local createJob = paletteModal.crossbarCreateJobId;
+                    local success, err = palette.CreateCrossbarPalette(newName, createJob, storSj);
+                    if success then
+                        xbCreatePersisted.jobId         = createJob;
+                        xbCreatePersisted.storageSubjob = storSj;
+                        ClosePaletteModal();
+                        imgui.CloseCurrentPopup();
+                    else
+                        paletteModal.errorMessage = err or 'Failed to create palette';
+                    end
+                else
+                    paletteModal.errorMessage = 'Name cannot be empty';
+                end
+            end
+            if not canCreate then
+                imgui.EndDisabled();
+            end
+
+            imgui.SameLine();
+            if imgui.Button('Cancel##paletteModalXbCreateCancel', { 88, 0 }) then
+                ClosePaletteModal();
+                imgui.CloseCurrentPopup();
+            end
+
+            imgui.EndPopup();
+        else
+            xbHotbarCreatePopupPending = false;
+            ClosePaletteModal();
+        end
         return;
     end
 
     -- Determine popup title based on mode and type
-    local typeLabel = paletteModal.paletteType == 'crossbar' and 'Crossbar ' or '';
+    local typeLabel = '';
+    if paletteModal.paletteType == 'crossbar_universal' then
+        typeLabel = 'Global Crossbar ';
+    elseif paletteModal.paletteType == 'crossbar' then
+        typeLabel = 'Crossbar ';
+    end
     local popupId = paletteModal.mode == 'create'
         and (typeLabel .. 'Create Palette##paletteModal')
         or (typeLabel .. 'Rename Palette##paletteModal');
 
-    imgui.OpenPopup(popupId);
+    if palettePopupPendingId ~= popupId then
+        imgui.SetNextWindowSize({ 320, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup(popupId);
+        palettePopupPendingId = popupId;
+    end
 
-    if imgui.BeginPopupModal(popupId, nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
         -- Warning when creating will break away from shared palettes
         local jobId = data.jobId or 1;
         local subjobId = data.subjobId or 0;
-        if paletteModal.mode == 'create' and subjobId ~= 0 then
+        if paletteModal.mode == 'create' and subjobId ~= 0 and paletteModal.paletteType == 'hotbar' then
             local usingFallback = palette.IsUsingFallback(jobId, subjobId, paletteModal.paletteType);
             if usingFallback then
                 local jobName = jobs[jobId] or ('Job ' .. jobId);
@@ -234,19 +420,19 @@ local function DrawPaletteModal()
 
                 if isCreateMode then
                     -- Create palette
-                    if paletteModal.paletteType == 'crossbar' then
-                        success, err = palette.CreateCrossbarPalette(newName, jobId, subjobId);
-                    else
+                    if paletteModal.paletteType == 'crossbar_universal' then
+                        success, err = palette.CreateUniversalCrossbarPalette(newName);
+                    elseif paletteModal.paletteType == 'hotbar' then
                         success, err = palette.CreatePalette(1, newName, jobId, subjobId);
-                        if success then
-                            palette.SetActivePalette(1, newName);
-                        end
                     end
                 else
                     -- Rename palette
                     local oldName = paletteModal.paletteName;
-                    if paletteModal.paletteType == 'crossbar' then
-                        success, err = palette.RenameCrossbarPalette(oldName, newName, jobId, subjobId);
+                    if paletteModal.paletteType == 'crossbar_universal' then
+                        success, err = palette.RenameUniversalCrossbarPalette(oldName, newName);
+                    elseif paletteModal.paletteType == 'crossbar' then
+                        local renameTier = palette.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, subjobId);
+                        success, err = palette.RenameCrossbarPalette(oldName, newName, jobId, renameTier);
                     else
                         success, err = palette.RenamePalette(1, oldName, newName, jobId, subjobId);
                     end
@@ -275,6 +461,9 @@ local function DrawPaletteModal()
         end
 
         imgui.EndPopup();
+    else
+        -- Dismissed by clicking outside
+        ClosePaletteModal();
     end
 end
 
@@ -382,34 +571,42 @@ local function DrawGlobalPalettesSection()
     -- Ensure at least one palette exists for this job
     palette.EnsureDefaultPaletteExists(jobId, subjobId);
     local availablePalettes = palette.GetAvailablePalettes(1, jobId, subjobId);
+    local cyclePalettes = palette.GetHotbarPaletteNamesInRbCycle(1, jobId, subjobId);
     local currentPalette = palette.GetActivePalette(1);  -- Same for all bars
 
-    -- OPTIMIZED: Cache palette count and index for reuse within this frame
-    local paletteCount = #availablePalettes;
-    local currentPaletteIndex = nil;
-    if currentPalette then
-        for i, name in ipairs(availablePalettes) do
-            if name == currentPalette then
-                currentPaletteIndex = i;
-                break;
-            end
+    -- Index/total for "Active" (RB-cycle) palettes only â€” inactive palettes are omitted from numbering
+    local paletteCount = #cyclePalettes;
+    local cycleIndexByName = {};
+    for i, name in ipairs(cyclePalettes) do
+        cycleIndexByName[name] = i;
+    end
+    local currentPaletteIndex = currentPalette and cycleIndexByName[currentPalette] or nil;
+    local fullPaletteIndex = nil;
+    for i, name in ipairs(availablePalettes) do
+        if name == currentPalette then
+            fullPaletteIndex = i;
+            break;
         end
     end
+    local totalPaletteCount = #availablePalettes;
 
     -- Check if using fallback (shared library) palettes
     local usingFallback = palette.IsUsingFallback(jobId, subjobId, 'hotbar');
 
     -- Ensure active palette is set if we have palettes but none active
-    if paletteCount > 0 and not currentPalette then
-        currentPalette = availablePalettes[1];
-        currentPaletteIndex = 1;
+    if #availablePalettes > 0 and not currentPalette then
+        local pick = cyclePalettes[1] or availablePalettes[1];
+        currentPalette = pick;
+        currentPaletteIndex = cycleIndexByName[pick];
         palette.SetActivePalette(1, currentPalette);
     end
 
     imgui.TextColored(components.TAB_STYLE.gold, 'Palettes');
+    components.PushPaletteManagerButtonStyle();
     if imgui.SmallButton('Palette Manager##hotbar') then
         paletteManager.Open();
     end
+    components.PopPaletteManagerButtonStyle();
     if usingFallback then
         imgui.SameLine();
         imgui.TextColored({0.4, 0.8, 1.0, 1.0}, '(Shared Library)');
@@ -420,22 +617,24 @@ local function DrawGlobalPalettesSection()
     -- Header with count
     imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Palettes:');
     imgui.SameLine();
-    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' palette(s)');
-    imgui.ShowHelp('Create named palettes to quickly switch between different hotbar configurations.\nPalettes are GLOBAL - switching changes all 6 hotbars at once.\nUse keybind cycling or /xiui palette <name> to switch.');
+    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' in cycle');
+    imgui.ShowHelp('Create named palettes to quickly switch between different hotbar configurations.\nPalettes are GLOBAL - switching changes all 6 hotbars at once.\n"Inactive" in Palette Manager is excluded from RB/key cycling and from this count.\nUse keybind cycling or /xiui palette <name> to switch.');
 
     -- Current palette selector with inline buttons
     -- Get display name with number prefix for the closed dropdown
     local currentDisplayName = currentPalette or 'Select palette';
     if currentPalette and currentPaletteIndex then
         currentDisplayName = currentPaletteIndex .. '. ' .. currentPalette;
+    elseif currentPalette then
+        currentDisplayName = currentPalette .. ' (inactive)';
     end
 
     imgui.SetNextItemWidth(150);
     if imgui.BeginCombo('##globalPalette', currentDisplayName) then
         for i, paletteName in ipairs(availablePalettes) do
             local isSelected = (paletteName == currentPalette);
-            -- Show number prefix for all palettes
-            local displayName = i .. '. ' .. paletteName;
+            local cycIdx = cycleIndexByName[paletteName];
+            local displayName = (cycIdx and (cycIdx .. '. ') or 'â€“ ') .. paletteName;
             if imgui.Selectable(displayName .. '##globalPal', isSelected) then
                 palette.SetActivePalette(1, paletteName);  -- Sets global palette
             end
@@ -464,8 +663,7 @@ local function DrawGlobalPalettesSection()
     imgui.PopStyleColor(2);
 
     -- Delete button (only if more than 1 palette exists - can't delete the last one)
-    -- OPTIMIZED: Using cached paletteCount instead of calling GetPaletteCount again
-    if currentPalette and paletteCount > 1 then
+    if currentPalette and totalPaletteCount > 1 then
         imgui.SameLine();
         imgui.PushStyleColor(ImGuiCol_Button, {0.6, 0.2, 0.2, 1.0});
         imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.8, 0.3, 0.3, 1.0});
@@ -480,16 +678,15 @@ local function DrawGlobalPalettesSection()
         imgui.PopStyleColor(2);
     end
 
-    -- Arrow key reordering (for palettes with multiple items)
-    if currentPalette and paletteCount > 1 then
+    -- Arrow key reordering (full palette list order â€” not cycle-only)
+    if currentPalette and totalPaletteCount > 1 then
         imgui.SameLine();
         imgui.TextColored({0.5, 0.5, 0.5, 1.0}, '|');
         imgui.SameLine();
 
         -- Up arrow button
-        -- OPTIMIZED: Using cached currentPaletteIndex instead of calling GetPaletteIndex again
-        local canMoveUp = currentPaletteIndex and currentPaletteIndex > 1;
-        local canMoveDown = currentPaletteIndex and currentPaletteIndex < paletteCount;
+        local canMoveUp = fullPaletteIndex and fullPaletteIndex > 1;
+        local canMoveDown = fullPaletteIndex and fullPaletteIndex < totalPaletteCount;
 
         if not canMoveUp then
             imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
@@ -540,169 +737,6 @@ local function DrawGeneralPalettesSection(configKey, barSettings, barIndex)
     imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'Manage palettes in Global tab.');
 end
 
--- ============================================
--- Crossbar Global Palettes UI Section
--- ============================================
-
--- Global crossbar palette error state
-local crossbarGlobalPaletteErrorMessage = nil;
-
--- Draw the global crossbar palettes management section
--- Crossbar palettes are GLOBAL - one palette switch changes all combo modes
-local function DrawCrossbarGlobalPalettesSection()
-    local crossbarSettings = gConfig.hotbarCrossbar;
-    if not crossbarSettings then
-        return;
-    end
-
-    local jobId = data.jobId or 1;
-    local subjobId = data.subjobId or 0;
-
-    -- Ensure at least one palette exists for this job
-    palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
-    local availablePalettes = palette.GetCrossbarAvailablePalettes(jobId, subjobId);
-    local currentPalette = palette.GetActivePaletteForCombo('L2');  -- Global for all combos
-
-    -- OPTIMIZED: Cache palette count and index for reuse within this frame
-    local paletteCount = #availablePalettes;
-    local currentPaletteIndex = nil;
-    if currentPalette then
-        for i, name in ipairs(availablePalettes) do
-            if name == currentPalette then
-                currentPaletteIndex = i;
-                break;
-            end
-        end
-    end
-
-    -- Check if using fallback (shared library) palettes
-    local usingFallback = palette.IsUsingFallback(jobId, subjobId, 'crossbar');
-
-    -- Ensure active palette is set if we have palettes but none active
-    if paletteCount > 0 and not currentPalette then
-        currentPalette = availablePalettes[1];
-        currentPaletteIndex = 1;
-        palette.SetActivePaletteForCombo('L2', currentPalette);
-    end
-
-    imgui.TextColored(components.TAB_STYLE.gold, 'Crossbar Palettes');
-    if imgui.SmallButton('Palette Manager##crossbar') then
-        paletteManager.Open();
-    end
-    if usingFallback then
-        imgui.SameLine();
-        imgui.TextColored({0.4, 0.8, 1.0, 1.0}, '(Shared Library)');
-        imgui.ShowHelp('These palettes are from your Shared Library.\nOpen Palette Manager to create subjob-specific palettes.');
-    end
-    imgui.Spacing();
-
-    -- Header with count
-    imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Palettes:');
-    imgui.SameLine();
-    imgui.TextColored({0.5, 1.0, 0.5, 1.0}, tostring(paletteCount) .. ' palette(s)');
-    imgui.ShowHelp('Create named palettes to quickly switch between crossbar configurations.\nPalettes are GLOBAL - switching changes all combo modes (L2, R2, L2+R2, etc.) at once.');
-
-    -- Current palette selector with inline buttons
-    -- Get display name with number prefix for the closed dropdown
-    local currentDisplayName = currentPalette or 'Select palette';
-    if currentPalette and currentPaletteIndex then
-        currentDisplayName = currentPaletteIndex .. '. ' .. currentPalette;
-    end
-
-    imgui.SetNextItemWidth(150);
-    if imgui.BeginCombo('##crossbarGlobalPalette', currentDisplayName) then
-        for i, paletteName in ipairs(availablePalettes) do
-            local isSelected = (paletteName == currentPalette);
-            -- Show number prefix for all palettes
-            local displayName = i .. '. ' .. paletteName;
-            if imgui.Selectable(displayName .. '##cbGlobalPal' .. i, isSelected) then
-                palette.SetActivePaletteForCombo('L2', paletteName);
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-
-    -- Rename button (for any palette)
-    if currentPalette then
-        imgui.SameLine();
-        if imgui.Button('Rename##cbGlobalPalette', {55, 0}) then
-            OpenPaletteRenameModal('crossbar', currentPalette);
-        end
-    end
-
-    -- New button (always visible, green)
-    imgui.SameLine();
-    imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.5, 0.2, 1.0});
-    imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.3, 0.6, 0.3, 1.0});
-    if imgui.Button('New##cbGlobalPalette', {40, 0}) then
-        OpenPaletteCreateModal('crossbar');
-    end
-    imgui.PopStyleColor(2);
-
-    -- Delete button (only if more than 1 palette exists - can't delete the last one)
-    -- OPTIMIZED: Using cached paletteCount instead of calling GetCrossbarPaletteCount again
-    if currentPalette and paletteCount > 1 then
-        imgui.SameLine();
-        imgui.PushStyleColor(ImGuiCol_Button, {0.6, 0.2, 0.2, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.8, 0.3, 0.3, 1.0});
-        if imgui.Button('Delete##cbGlobalPalette', {50, 0}) then
-            local success, err = palette.DeleteCrossbarPalette(currentPalette, jobId, subjobId);
-            if not success then
-                crossbarGlobalPaletteErrorMessage = err or 'Failed to delete palette';
-            else
-                crossbarGlobalPaletteErrorMessage = nil;
-            end
-        end
-        imgui.PopStyleColor(2);
-    end
-
-    -- Arrow key reordering (for palettes with multiple items)
-    if currentPalette and paletteCount > 1 then
-        imgui.SameLine();
-        imgui.TextColored({0.5, 0.5, 0.5, 1.0}, '|');
-        imgui.SameLine();
-
-        -- OPTIMIZED: Using cached currentPaletteIndex instead of recalculating
-        local canMoveUp = currentPaletteIndex and currentPaletteIndex > 1;
-        local canMoveDown = currentPaletteIndex and currentPaletteIndex < paletteCount;
-
-        if not canMoveUp then
-            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
-        end
-        if imgui.Button('^##cbGlobalPaletteUp', {20, 0}) and canMoveUp then
-            palette.MoveCrossbarPalette(currentPalette, -1, jobId, subjobId);
-        end
-        if not canMoveUp then
-            imgui.PopStyleColor(3);
-        end
-
-        imgui.SameLine();
-
-        if not canMoveDown then
-            imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.2, 0.2, 0.2, 0.5});
-            imgui.PushStyleColor(ImGuiCol_Text, {0.4, 0.4, 0.4, 1.0});
-        end
-        if imgui.Button('v##cbGlobalPaletteDown', {20, 0}) and canMoveDown then
-            palette.MoveCrossbarPalette(currentPalette, 1, jobId, subjobId);
-        end
-        if not canMoveDown then
-            imgui.PopStyleColor(3);
-        end
-    end
-
-    -- Show error message (for delete failures)
-    if crossbarGlobalPaletteErrorMessage then
-        imgui.TextColored({1.0, 0.4, 0.4, 1.0}, crossbarGlobalPaletteErrorMessage);
-    end
-
-    imgui.Spacing();
-end
 
 -- Keybind editor modal state
 local keybindModal = {
@@ -1528,11 +1562,8 @@ local function DrawVisualSettingsContent(settings, configKey)
         components.DrawPartySliderInt(settings, 'Slot X Padding##' .. configKey, 'slotXPadding', 0, 32, '%d', nil, 8);
         imgui.ShowHelp('Horizontal gap between slots.');
 
-        -- Slot Y Padding slider removed: each hotbar is now positioned
-        -- independently, so bar-to-bar spacing is handled by drag-positioning.
-        -- The setting still exists on the data side and controls the row gap
-        -- inside multi-row bars; we keep the saved value but hide the slider
-        -- to avoid misleading users.
+        components.DrawPartySliderInt(settings, 'Slot Y Padding##' .. configKey, 'slotYPadding', 0, 32, '%d', nil, 6);
+        imgui.ShowHelp('Vertical gap between rows.');
 
         -- Show Hotbar Number with inline offsets
         components.DrawPartyCheckbox(settings, 'Show Hotbar Number##' .. configKey, 'showHotbarNumber');
@@ -1572,7 +1603,7 @@ local function DrawVisualSettingsContent(settings, configKey)
         end
         imgui.ShowHelp('Display item quantity on item slots. Choose anchor position and fine-tune with X/Y offsets.');
 
-        -- Show full-stack count above the item quantity (only counts complete stacks)
+        -- 1.8.0 addition: full-stack count above the item quantity (only counts complete stacks)
         components.DrawPartyCheckbox(settings, 'Show Stack Quantity##' .. configKey, 'showStackQuantity');
         imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
 
@@ -1758,21 +1789,34 @@ local function DrawBarVisualSettings(configKey, barLabel)
         end
         if imgui.Button(petAware and 'Enabled##pet' .. configKey or 'Disabled##pet' .. configKey, {100, 0}) then
             barSettings.petAware = not petAware;
+            if not barSettings.petAware then
+                barSettings.petPalettePetKeys = nil;
+            end
             SaveSettingsOnly();
         end
         imgui.PopStyleColor(3);
-        imgui.ShowHelp('Pet Palettes: Each summoned pet can have its own hotbar configuration.\nSMN: Per-avatar palettes (Ifrit, Shiva, etc.)\nDRG: Wyvern palette\nBST: Jug pet / Charm palettes\nPUP: Automaton palette\n\nClick to toggle.');
+        imgui.ShowHelp('Pet Palettes: Each pet can have its own hotbar configuration.\nSMN: Per-avatar and per-elemental (spirit) palettes (Ifrit, Fire Spirit, etc.)\nDRG: Wyvern palette\nBST: Jug pet / Charm palettes\nPUP: Automaton palette\n\nClick to toggle.');
 
-        -- Show indicator checkbox (only visible when petAware is enabled)
+        -- Show indicator + pet allowlist (only when petAware is enabled)
         if petAware then
-            imgui.SameLine();
-            imgui.SetCursorPosX(imgui.GetCursorPosX() + 10);
+            imgui.Dummy({ 0, 4 });
             local showIndicator = { barSettings.showPetIndicator ~= false };
             if imgui.Checkbox('Show Indicator##' .. configKey, showIndicator) then
                 barSettings.showPetIndicator = showIndicator[1];
                 SaveSettingsOnly();
             end
             imgui.ShowHelp('Show a small dot indicator next to the bar number when pet palettes are active.');
+            local popupId = 'petallow_hb_' .. configKey;
+            if imgui.SmallButton('Petsâ€¦##' .. popupId) then
+                imgui.OpenPopup(popupId);
+            end
+            imgui.ShowHelp('Optional: limit which pet types use a separate layout (Avatars, Elementals, Beasts, Wyvern, Puppet). Others use your normal job bar.');
+            if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
+                petAllowlist.DrawEditorInPopup(barSettings, data.jobId or 1, SaveSettingsOnly, function()
+                    data.InvalidateStorageKeyCache();
+                end);
+                imgui.EndPopup();
+            end
         end
     end
 
@@ -1824,736 +1868,29 @@ local function DrawBarVisualSettings(configKey, barLabel)
     end
 end
 
--- ============================================
--- Crossbar Settings Functions
--- ============================================
 
--- Helper: Get or initialize per-crossbar settings
--- Helper: Get per-combo-mode settings (from comboModeSettings)
--- NOTE: Only petAware is per-combo-mode; palettes are GLOBAL (see palette.lua)
-local function GetCrossbarComboModeSettings(crossbarSettings, comboMode)
-    if not crossbarSettings.comboModeSettings then
-        crossbarSettings.comboModeSettings = {};
-    end
-    if not crossbarSettings.comboModeSettings[comboMode] then
-        crossbarSettings.comboModeSettings[comboMode] = {
-            petAware = false,
-        };
-    end
-    return crossbarSettings.comboModeSettings[comboMode];
-end
-
--- Helper: Draw per-crossbar bar settings (simplified for global palette model)
-local function DrawCrossbarBarSettings(crossbarSettings, barType, comboMode)
-    local modeSettings = GetCrossbarComboModeSettings(crossbarSettings, comboMode);
-
-    imgui.TextColored(components.TAB_STYLE.gold, 'Settings for ' .. (barType.label or comboMode));
-    imgui.Spacing();
-
-    -- Pet-Aware Palettes toggle (per-combo-mode)
-    local petAware = modeSettings.petAware == true;
-    imgui.AlignTextToFramePadding();
-    imgui.TextColored({0.8, 0.8, 0.8, 1.0}, 'Pet Palettes:');
-    imgui.SameLine();
-    -- Color button based on state: cyan for enabled, grey for disabled
-    if petAware then
-        imgui.PushStyleColor(ImGuiCol_Button, {0.2, 0.5, 0.5, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.3, 0.6, 0.6, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.4, 0.7, 0.7, 1.0});
-    else
-        imgui.PushStyleColor(ImGuiCol_Button, {0.35, 0.35, 0.35, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.45, 0.45, 0.45, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.55, 0.55, 0.55, 1.0});
-    end
-    if imgui.Button(petAware and 'Enabled##petcb' .. comboMode or 'Disabled##petcb' .. comboMode, {100, 0}) then
-        modeSettings.petAware = not petAware;
-        SaveSettingsOnly();
-    end
-    imgui.PopStyleColor(3);
-    imgui.ShowHelp('Pet Palettes: Each summoned pet can have its own crossbar configuration.\nSMN: Per-avatar palettes\nDRG: Wyvern palette\nBST: Jug pet / Charm palettes\nPUP: Automaton palette\n\nClick to toggle.');
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Crossbar Palettes - redirect to Global tab (mirrors hotbar pattern)
-    local currentPalette = palette.GetActivePaletteForCombo(comboMode);
-    if currentPalette then
-        imgui.TextColored({0.4, 0.8, 1.0, 1.0}, 'Palette: ' .. currentPalette);
-    else
-        imgui.TextColored({0.6, 0.6, 0.6, 1.0}, 'Palette: (none)');
-    end
-    imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'Manage palettes in Global tab.');
-end
-
-local function DrawCrossbarSettings(selectedCrossbarTab)
-    local crossbarSettings = gConfig.hotbarCrossbar;
-    if not crossbarSettings then
-        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
-        return selectedCrossbarTab;
-    end
-
-    selectedCrossbarTab = selectedCrossbarTab or 1;
-
-    -- Controller Settings section
-    imgui.TextColored(components.TAB_STYLE.gold, 'Controller Settings');
-    imgui.Spacing();
-
-    -- Controller Profile selection
-    local devices = require('modules.hotbar.devices');
-    local currentScheme = controller.GetControllerScheme();
-    local deviceSchemes = devices.GetSchemeNames();
-    local deviceDisplayNames = devices.GetSchemeDisplayNames();
-
-    -- Find current selection index
-    local currentIndex = 1;
-    for i, scheme in ipairs(deviceSchemes) do
-        if scheme == currentScheme then
-            currentIndex = i;
-            break;
-        end
-    end
-
-    -- Map profile to matching theme
-    local profileToTheme = {
-        xbox = 'Xbox',
-        dualsense = 'PlayStation',
-        switchpro = 'Nintendo',
-        dinput = 'Xbox',
-    };
-
-    imgui.AlignTextToFramePadding();
-    imgui.Text('Controller Profile:');
-    imgui.SameLine();
-    imgui.SetNextItemWidth(150);
-    if imgui.BeginCombo('##controllerSelect', deviceDisplayNames[currentScheme] or currentScheme, ImGuiComboFlags_None) then
-        for i, scheme in ipairs(deviceSchemes) do
-            local isSelected = (scheme == currentScheme);
-            if imgui.Selectable(deviceDisplayNames[scheme], isSelected) then
-                crossbarSettings.controllerScheme = scheme;
-                -- If switching to dinput, apply custom mapping if it exists
-                local customMapping = nil;
-                if scheme == 'dinput' and crossbarSettings.customControllerMappings and crossbarSettings.customControllerMappings.dinput then
-                    customMapping = crossbarSettings.customControllerMappings.dinput;
-                end
-                controller.SetControllerScheme(scheme, customMapping);
-                -- Auto-adjust theme to match profile
-                local matchingTheme = profileToTheme[scheme];
-                if matchingTheme then
-                    crossbarSettings.controllerTheme = matchingTheme;
-                end
-                SaveSettingsOnly();
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-    imgui.ShowHelp('Select which button mapping profile to use.\n\n- Xbox: For XInput controllers (Xbox, 8BitDo in X-mode)\n- PlayStation: For DualSense/DualShock via DirectInput\n- Switch Pro: For Nintendo Switch Pro controller\n- Generic DirectInput: For other DirectInput controllers\n\nChanging this will also update the button icon theme.');
-
-    -- Analog Trigger Threshold Settings (Xbox and PlayStation only)
-    local hasAnalogTriggers = (currentScheme == 'xbox' or currentScheme == 'dualsense');
-    if hasAnalogTriggers then
-        imgui.Spacing();
-        imgui.Text('Analog Trigger Settings');
-        imgui.Separator();
-
-        components.DrawPartySliderInt(crossbarSettings, 'Press Threshold##crossbar', 'triggerPressThreshold', 5, 250, '%d', function()
-            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
-        end, 30);
-        imgui.ShowHelp('Analog trigger value (0-255) required to register as pressed. Higher values require a deeper press. Default: 30');
-
-        components.DrawPartySliderInt(crossbarSettings, 'Release Threshold##crossbar', 'triggerReleaseThreshold', 5, 250, '%d', function()
-            controller.SetTriggerThresholds(crossbarSettings.triggerPressThreshold, crossbarSettings.triggerReleaseThreshold);
-        end, 15);
-        imgui.ShowHelp('Analog trigger value (0-255) below which the trigger is considered released. Provides hysteresis to prevent jitter. Default: 15');
-    end
-
-    imgui.Spacing();
-
-    -- Custom DirectInput button mapping section (only for dinput scheme)
-    if currentScheme == 'dinput' then
-        imgui.Indent(20);
-
-        local hasCustomMapping = crossbarSettings.customControllerMappings and 
-                                  crossbarSettings.customControllerMappings.dinput;
-
-        -- Configure button
-        if imgui.Button('Configure Button Mapping##dinput', {0, 0}) then
-            local buttondetect = require('modules.hotbar.buttondetect');
-            buttonDetectionState.active = true;
-            buttonDetectionState.progress = 0;
-            buttondetect.StartDetection(function(results)
-                if not crossbarSettings.customControllerMappings then
-                    crossbarSettings.customControllerMappings = {};
-                end
-                crossbarSettings.customControllerMappings.dinput = results;
-                buttonDetectionState.active = false;
-                SaveSettingsOnly();
-                -- Re-initialize controller with new mapping
-                controller.SetControllerScheme('dinput', results);
-            end);
-        end
-        imgui.SameLine();
-        imgui.ShowHelp('Launch wizard to configure button layout for your controller. Custom mappings allow you to define your own button layout for DirectInput controllers.');
-
-        -- Status indicator
-        imgui.SameLine();
-        if hasCustomMapping then
-            imgui.TextColored({0, 1, 0, 1}, '(Using custom mapping)');
-        else
-            imgui.TextColored({0.7, 0.7, 0.7, 1}, '(Using default mapping)');
-        end
-
-        -- Clear custom mapping button (only show if custom mapping exists)
-        if hasCustomMapping then
-            imgui.SameLine();
-            if imgui.Button('Clear Custom Mapping##dinput', {150, 0}) then
-                crossbarSettings.customControllerMappings.dinput = nil;
-                SaveSettingsOnly();
-                -- Re-initialize controller without custom mapping
-                controller.SetControllerScheme('dinput');
-            end
-            imgui.SameLine();
-            imgui.ShowHelp('Remove custom mapping and revert to defaults.');
-        end
-
-        -- Show progress bar during detection
-        if buttonDetectionState.active then
-            local buttondetect = require('modules.hotbar.buttondetect');
-            local progress, maxProgress = buttondetect.GetProgress();
-            imgui.ProgressBar(progress / maxProgress, {-1, 20}, string.format('Button %d of %d', progress, maxProgress));
-            imgui.TextWrapped('Detecting buttons... ' .. (buttondetect.GetCurrentPrompt() or ''));
-            if imgui.Button('Cancel##buttondetect', {0, 0}) then
-                buttondetect.Cancel();
-                buttonDetectionState.active = false;
-            end
-        end
-
-        imgui.Unindent(20);
-    end
-
-    imgui.Spacing();
-    imgui.Spacing();
-
-    -- Controller Input settings (combo modes, double-tap) - directly under controller
-    components.DrawPartyCheckbox(crossbarSettings, 'Enable L2+R2 / R2+L2##crossbar', 'enableExpandedCrossbar');
-    imgui.ShowHelp('Enable L2+R2 and R2+L2 combo modes. Hold one trigger, then press the other to access expanded bars.');
-
-    -- Nested option: Use shared expanded bar (only visible when L2+R2/R2+L2 is enabled)
-    if crossbarSettings.enableExpandedCrossbar then
-        imgui.Indent(20);
-        components.DrawPartyCheckbox(crossbarSettings, 'Use Shared Expanded Bar##crossbar', 'useSharedExpandedBar', DeferredUpdateVisuals);
-        imgui.ShowHelp('When enabled, L2+R2 and R2+L2 will access the same shared expanded bar instead of separate bars.\nThis shared bar is completely independent from the separate L2+R2 and R2+L2 bars.');
-        imgui.Unindent(20);
-    end
-
-    components.DrawPartyCheckbox(crossbarSettings, 'Enable Double-Tap##crossbar', 'enableDoubleTap', DeferredUpdateVisuals);
-    imgui.ShowHelp('Enable L2x2 and R2x2 double-tap modes. Tap a trigger twice quickly (hold on second tap) to access double-tap bars.');
-
-    if crossbarSettings.enableDoubleTap then
-        components.DrawPartySlider(crossbarSettings, 'Double-Tap Window##crossbar', 'doubleTapWindow', 0.1, 0.6, '%.2f sec', function()
-            controller.SetDoubleTapWindow(crossbarSettings.doubleTapWindow);
-        end, 0.3);
-        imgui.ShowHelp('Time window to register a double-tap (in seconds).');
-
-        -- Minimum Trigger Hold (only for analog controllers with double-tap enabled)
-        if hasAnalogTriggers then
-            components.DrawPartySlider(crossbarSettings, 'Minimum Trigger Hold##crossbar', 'minTriggerHold', 0.01, 0.15, '%.3f sec', function()
-                controller.SetMinTriggerHold(crossbarSettings.minTriggerHold);
-            end, 0.05);
-            imgui.ShowHelp('Minimum time the trigger must be held before releasing for the release to count toward double-tap detection. Prevents false double-taps from analog jitter or accidental taps. Default: 0.050 sec (50ms)');
-        end
-    end
-
-    imgui.Spacing();
-
-    -- Display Mode dropdown
-    local displayModes = { 'normal', 'activeOnly' };
-    local displayModeLabels = { 'Normal', 'Active Only' };
-    local currentDisplayMode = crossbarSettings.displayMode or 'normal';
-    local currentDisplayIndex = 1;
-    for i, mode in ipairs(displayModes) do
-        if mode == currentDisplayMode then
-            currentDisplayIndex = i;
-            break;
-        end
-    end
-
-    imgui.AlignTextToFramePadding();
-    imgui.Text('Display Mode:');
-    imgui.SameLine();
-    imgui.SetNextItemWidth(150);
-    if imgui.BeginCombo('##displayModeCrossbar', displayModeLabels[currentDisplayIndex]) then
-        for i, label in ipairs(displayModeLabels) do
-            local isSelected = (i == currentDisplayIndex);
-            if imgui.Selectable(label, isSelected) then
-                crossbarSettings.displayMode = displayModes[i];
-                SaveSettingsOnly();
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-    imgui.ShowHelp('Normal: Always show both sides (inactive side dimmed).\nActive Only: Show only when trigger is held, displaying only the active side.');
-
-    imgui.Spacing();
-
-    -- Edit Mode for setting up crossbars without holding triggers
-    local editModeEnabled = { crossbarSettings.editMode == true };
-    if imgui.Checkbox('Edit Mode##crossbar', editModeEnabled) then
-        crossbarSettings.editMode = editModeEnabled[1];
-        SaveSettingsOnly();
-    end
-    imgui.ShowHelp('Enable Edit Mode to preview and set up crossbars without holding triggers.');
-
-    if crossbarSettings.editMode then
-        -- Preview bar dropdown on same line as checkbox
-        imgui.SameLine();
-
-        -- Build preview bar options dynamically based on settings
-        local previewBarOptions = { 'L2', 'R2' };
-        local previewBarKeys = { 'L2', 'R2' };
-
-        -- Add expanded bar options
-        if crossbarSettings.enableExpandedCrossbar then
-            if crossbarSettings.useSharedExpandedBar then
-                -- Shared mode: show single "L2+R2 (Shared)" option
-                table.insert(previewBarOptions, 'L2+R2 (Shared)');
-                table.insert(previewBarKeys, 'Shared');
-            else
-                -- Separate mode: show both L2+R2 and R2+L2
-                table.insert(previewBarOptions, 'L2+R2');
-                table.insert(previewBarKeys, 'L2R2');
-                table.insert(previewBarOptions, 'R2+L2');
-                table.insert(previewBarKeys, 'R2L2');
-            end
-        end
-
-        -- Add double-tap options if enabled
-        if crossbarSettings.enableDoubleTap then
-            table.insert(previewBarOptions, 'L2x2');
-            table.insert(previewBarKeys, 'L2x2');
-            table.insert(previewBarOptions, 'R2x2');
-            table.insert(previewBarKeys, 'R2x2');
-        end
-
-        local currentPreviewBar = crossbarSettings.editModeBar or 'L2';
-        -- Handle migration: if current bar is L2R2 or R2L2 but shared mode is now enabled, switch to Shared
-        if crossbarSettings.useSharedExpandedBar and (currentPreviewBar == 'L2R2' or currentPreviewBar == 'R2L2') then
-            currentPreviewBar = 'Shared';
-            crossbarSettings.editModeBar = 'Shared';
-        end
-        -- Handle migration: if current bar is Shared but shared mode is now disabled, switch to L2R2
-        if not crossbarSettings.useSharedExpandedBar and currentPreviewBar == 'Shared' then
-            currentPreviewBar = 'L2R2';
-            crossbarSettings.editModeBar = 'L2R2';
-        end
-
-        local currentPreviewLabel = currentPreviewBar;
-        -- Convert key to label
-        for i, key in ipairs(previewBarKeys) do
-            if key == currentPreviewBar then
-                currentPreviewLabel = previewBarOptions[i];
-                break;
-            end
-        end
-
-        imgui.SetNextItemWidth(110);
-        if imgui.BeginCombo('##editModeBar', currentPreviewLabel) then
-            for i, label in ipairs(previewBarOptions) do
-                local isSelected = (previewBarKeys[i] == currentPreviewBar);
-                if imgui.Selectable(label, isSelected) then
-                    crossbarSettings.editModeBar = previewBarKeys[i];
-                    SaveSettingsOnly();
-                end
-                if isSelected then
-                    imgui.SetItemDefaultFocus();
-                end
-            end
-            imgui.EndCombo();
-        end
-        imgui.ShowHelp('Select which crossbar to preview in Edit Mode.');
-
-        -- Warning text on next line
-        imgui.TextColored({1.0, 1.0, 0.0, 1.0}, '(!) Disable before playing');
-    end
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Per-Crossbar tabs
-    imgui.TextColored(components.TAB_STYLE.gold, 'Per-Crossbar Settings');
-    imgui.Spacing();
-
-    for i, crossbarType in ipairs(CROSSBAR_TYPES) do
-        local clicked, _ = components.DrawStyledTab(
-            crossbarType.label,
-            'crossbarTab' .. crossbarType.key,
-            selectedCrossbarTab == i,
-            nil,
-            components.TAB_STYLE.smallHeight,
-            components.TAB_STYLE.smallPadding
-        );
-        if clicked then
-            selectedCrossbarTab = i;
-        end
-        if i < #CROSSBAR_TYPES then
-            imgui.SameLine();
-        end
-    end
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Draw settings based on selected tab
-    local currentCrossbar = CROSSBAR_TYPES[selectedCrossbarTab];
-    if currentCrossbar then
-        if currentCrossbar.isGlobal then
-            -- Global Crossbar Palettes section first (most commonly used)
-            DrawCrossbarGlobalPalettesSection();
-            imgui.Separator();
-
-            -- Global Visual Settings
-            imgui.TextColored(components.TAB_STYLE.gold, 'Global Visual Settings');
-            imgui.Spacing();
-
-            if components.CollapsingSection('Slot Settings##crossbar', false) then
-                components.DrawPartySliderInt(crossbarSettings, 'Slot Size (px)##crossbar', 'slotSize', 32, 64, '%d', nil, 48);
-                imgui.ShowHelp('Size of each slot in pixels.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Vertical)##crossbar', 'slotGapV', 0, 128, '%d', nil, 4);
-                imgui.ShowHelp('Vertical gap between top and bottom slots in each diamond.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Slot Gap (Horizontal)##crossbar', 'slotGapH', 0, 128, '%d', nil, 4);
-                imgui.ShowHelp('Horizontal gap between left and right slots in each diamond.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Diamond Spacing##crossbar', 'diamondSpacing', 0, 128, '%d', nil, 20);
-                imgui.ShowHelp('Horizontal space between D-pad and face button diamonds.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Group Spacing##crossbar', 'groupSpacing', 0, 128, '%d', nil, 40);
-                imgui.ShowHelp('Space between L2 and R2 groups.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Divider##crossbar', 'showDivider');
-                imgui.ShowHelp('Show a divider line between L2 and R2 groups.');
-
-                -- Show MP Cost with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show MP Cost##crossbar', 'showMpCost');
-                if crossbarSettings.showMpCost then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarmp', 'mpCostOffsetX', 'mpCostOffsetY', 35);
-                end
-                imgui.ShowHelp('Display MP cost on spell slots. X/Y offsets adjust position.');
-
-                -- Show Item Quantity with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Item Quantity##crossbar', 'showQuantity');
-                if crossbarSettings.showQuantity then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarqty', 'quantityOffsetX', 'quantityOffsetY', 35);
-                end
-                imgui.ShowHelp('Display item quantity on item slots. X/Y offsets adjust position.');
-
-                -- Show full-stack count above the item quantity (only counts complete stacks)
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Stack Quantity##crossbar', 'showStackQuantity');
-                imgui.ShowHelp('Show full-stack count next to the item quantity. Only complete stacks are counted (e.g. 25 of stack-12 items shows "(2)"). Shares position/font with Show Item Quantity.');
-
-                -- Show Combo Text with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Combo Text##crossbar', 'showComboText');
-                if crossbarSettings.showComboText then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarcombo', 'comboTextOffsetX', 'comboTextOffsetY', 35);
-                end
-                imgui.ShowHelp('Show current combo mode text in center (L2+R2, R2+L2, L2x2, R2x2). X/Y offsets adjust position.');
-
-                -- Show Palette Name with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Palette Name##crossbar', 'showPaletteName');
-                if crossbarSettings.showPaletteName then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarpalette', 'paletteNameOffsetX', 'paletteNameOffsetY', 35);
-                end
-                imgui.ShowHelp('Display current palette name and index (e.g., "Stuns (2/5)"). X/Y offsets adjust position.');
-
-                -- Show Action Labels with X/Y offsets
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Action Labels##crossbar', 'showActionLabels');
-                if crossbarSettings.showActionLabels then
-                    imgui.SameLine();
-                    components.DrawInlineOffsets(crossbarSettings, 'crossbarlbl', 'actionLabelOffsetX', 'actionLabelOffsetY', 35);
-                end
-                imgui.ShowHelp('Show spell/ability names below slots. X/Y offsets adjust position.');
-            end
-
-            -- Background section
-            if components.CollapsingSection('Background##crossbar', false) then
-                local bgThemes = {'-None-', 'Plain', 'Window1', 'Window2', 'Window3', 'Window4', 'Window5', 'Window6', 'Window7', 'Window8'};
-                components.DrawPartyComboBox(crossbarSettings, 'Theme##bgcrossbar', 'backgroundTheme', bgThemes, DeferredUpdateVisuals);
-                imgui.ShowHelp('Select the background window theme.');
-
-                components.DrawPartySlider(crossbarSettings, 'Background Scale##crossbar', 'bgScale', 0.1, 3.0, '%.2f', nil, 1.0);
-                imgui.ShowHelp('Scale of the background texture.');
-
-                components.DrawPartySlider(crossbarSettings, 'Border Scale##crossbar', 'borderScale', 0.1, 3.0, '%.2f', nil, 1.0);
-                imgui.ShowHelp('Scale of the window borders.');
-
-                components.DrawPartySlider(crossbarSettings, 'Background Opacity##crossbar', 'backgroundOpacity', 0.0, 1.0, '%.2f');
-                imgui.ShowHelp('Opacity of the background.');
-
-                components.DrawPartySlider(crossbarSettings, 'Border Opacity##crossbar', 'borderOpacity', 0.0, 1.0, '%.2f');
-                imgui.ShowHelp('Opacity of the window borders.');
-            end
-
-            -- Controller Icons section
-            if components.CollapsingSection('Controller Icons##crossbar', false) then
-                local controllerThemes = { 'PlayStation', 'Xbox', 'Nintendo' };
-                components.DrawPartyComboBox(crossbarSettings, 'Controller Theme##crossbar', 'controllerTheme', controllerThemes);
-                imgui.ShowHelp('Select controller button icon style. Nintendo layout: X top, A right, B bottom, Y left.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Button Icons##crossbar', 'showButtonIcons');
-                imgui.ShowHelp('Show d-pad and face button icons on slots.');
-
-                if crossbarSettings.showButtonIcons then
-                    components.DrawPartySliderInt(crossbarSettings, 'Button Icon Size##crossbar', 'buttonIconSize', 8, 32, '%d', nil, 16);
-                    imgui.ShowHelp('Size of controller button icons.');
-
-                    components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (H)##crossbar', 'buttonIconGapH', 0, 24, '%d', nil, 2);
-                    imgui.ShowHelp('Horizontal spacing between center controller icons.');
-
-                    components.DrawPartySliderInt(crossbarSettings, 'Button Icon Gap (V)##crossbar', 'buttonIconGapV', 0, 24, '%d', nil, 2);
-                    imgui.ShowHelp('Vertical spacing between center controller icons.');
-                end
-
-                imgui.Separator();
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Show Trigger Icons##crossbar', 'showTriggerLabels');
-                imgui.ShowHelp('Show L2/R2 trigger icons above the crossbar groups.');
-
-                if crossbarSettings.showTriggerLabels then
-                    components.DrawPartySlider(crossbarSettings, 'Trigger Icon Scale##crossbar', 'triggerIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
-                    imgui.ShowHelp('Scale for L2/R2 trigger icons above groups (base size 49x28).');
-                end
-            end
-
-            -- Text section
-            if components.CollapsingSection('Text Settings##crossbar', false) then
-                components.DrawPartySliderInt(crossbarSettings, 'Keybind Text Size##crossbar', 'keybindFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for keybind labels.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Label Text Size##crossbar', 'labelFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for action labels.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Cooldown Text Size##crossbar', 'recastTimerFontSize', 6, 24, '%d', DeferredUpdateVisuals, 11);
-                imgui.ShowHelp('Text size for cooldown timer display.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Flash Under 5 Seconds##crossbar', 'flashCooldownUnder5');
-                imgui.ShowHelp('Flash the cooldown timer text when remaining time is under 5 seconds.');
-
-                components.DrawPartyCheckbox(crossbarSettings, 'Use Hh:MM Cooldown Format##crossbar', 'useHHMMCooldownFormat');
-                imgui.ShowHelp('Display cooldown timers as Hh:MM (e.g., "1h:49") instead of "1h 49m" for shorter text.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Trigger Label Text Size##crossbar', 'triggerLabelFontSize', 6, 24, '%d', nil, 14);
-                imgui.ShowHelp('Text size for combo mode labels (L2, R2, etc.).');
-
-                components.DrawPartySliderInt(crossbarSettings, 'MP Cost Text Size##crossbar', 'mpCostFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for MP cost display.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Quantity Text Size##crossbar', 'quantityFontSize', 6, 24, '%d', nil, 10);
-                imgui.ShowHelp('Text size for item quantity display.');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Combo Text Size##crossbar', 'comboTextFontSize', 8, 24, '%d', nil, 12);
-                imgui.ShowHelp('Font size for combo mode text (L2+R2, R2+L2, etc.).');
-
-                components.DrawPartySliderInt(crossbarSettings, 'Palette Name Text Size##crossbar', 'paletteNameFontSize', 8, 24, '%d', nil, 10);
-                imgui.ShowHelp('Font size for palette name display.');
-            end
-
-            -- Visual Feedback section
-            if components.CollapsingSection('Visual Feedback##crossbar', false) then
-                components.DrawPartySlider(crossbarSettings, 'Inactive Dim##crossbar', 'inactiveSlotDim', 0.0, 1.0, '%.2f', nil, 0.5);
-                imgui.ShowHelp('Dim factor for inactive trigger side (0 = black, 1 = full brightness).');
-
-                -- Default to true if not set
-                if crossbarSettings.enableTransitionAnimations == nil then
-                    crossbarSettings.enableTransitionAnimations = true;
-                end
-                local transAnimEnabled = { crossbarSettings.enableTransitionAnimations };
-                if imgui.Checkbox('Enable Transition Animations##crossbar', transAnimEnabled) then
-                    crossbarSettings.enableTransitionAnimations = transAnimEnabled[1];
-                    SaveSettingsOnly();
-                end
-                imgui.ShowHelp('Enable smooth animations when switching between crossbar modes (L2, R2, combos). Disable for instant transitions.');
-
-                -- Default to true if not set
-                if crossbarSettings.enablePressScale == nil then
-                    crossbarSettings.enablePressScale = true;
-                end
-                local pressScaleEnabled = { crossbarSettings.enablePressScale };
-                if imgui.Checkbox('Enable Press Scale##crossbar', pressScaleEnabled) then
-                    crossbarSettings.enablePressScale = pressScaleEnabled[1];
-                    SaveSettingsOnly();
-                end
-                imgui.ShowHelp('Enable icon scaling animation when pressing an action slot. Disable for no visual feedback on press.');
-            end
-        else
-            -- Per-crossbar settings (L2, R2, etc.)
-            DrawCrossbarBarSettings(crossbarSettings, currentCrossbar, currentCrossbar.settingsKey);
-        end
-    end
-
-    -- Draw confirmation popup for job-specific toggle
-    DrawJobSpecificConfirmPopup();
-
-    -- Draw palette modal (unified for both hotbar and crossbar)
-    DrawPaletteModal();
-
-    -- Draw palette manager window (separate window for advanced management)
-    paletteManager.Draw();
-
-    return selectedCrossbarTab;
-end
-
-local function DrawCrossbarColorSettings()
-    local crossbarSettings = gConfig.hotbarCrossbar;
-    if not crossbarSettings then
-        imgui.TextColored({1.0, 0.5, 0.5, 1.0}, 'Crossbar settings not initialized.');
+-- Disable XI Macros row + diagnostics + Controller Hold-to-Show (hotbarGlobal.disableMacroBars).
+-- Shared between Hotbar and Crossbar; idSuffix keeps ImGui IDs distinct when both UIs exist.
+function M.DrawSharedDisableXiMacrosControls(idSuffix)
+    idSuffix = idSuffix or 'hb';
+    local hg = gConfig.hotbarGlobal;
+    if not hg then
         return;
     end
 
-    local colorFlags = bit.bor(ImGuiColorEditFlags_NoInputs, ImGuiColorEditFlags_AlphaPreviewHalf, ImGuiColorEditFlags_AlphaBar);
-
-    imgui.TextColored(components.TAB_STYLE.gold, 'Crossbar Color Settings');
-    imgui.Spacing();
-
-    if components.CollapsingSection('Window Colors##crossbarcolor', true) then
-        local bgColor = crossbarSettings.bgColor or 0xFFFFFFFF;
-        local bgColorTable = ARGBToImGui(bgColor);
-        if imgui.ColorEdit4('Background Color##crossbar', bgColorTable, colorFlags) then
-            crossbarSettings.bgColor = ImGuiToARGB(bgColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color tint for the window background.');
-
-        local borderColor = crossbarSettings.borderColor or 0xFFFFFFFF;
-        local borderColorTable = ARGBToImGui(borderColor);
-        if imgui.ColorEdit4('Border Color##crossbar', borderColorTable, colorFlags) then
-            crossbarSettings.borderColor = ImGuiToARGB(borderColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color tint for the window borders.');
-    end
-
-    if components.CollapsingSection('Slot Colors##crossbarcolor', true) then
-        local slotBgColor = crossbarSettings.slotBackgroundColor or 0x55000000;
-        local slotBgColorTable = ARGBToImGui(slotBgColor);
-        if imgui.ColorEdit4('Slot Background##crossbar', slotBgColorTable, colorFlags) then
-            crossbarSettings.slotBackgroundColor = ImGuiToARGB(slotBgColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color and transparency of slot backgrounds.');
-
-        components.DrawPartySlider(crossbarSettings, 'Slot Opacity##crossbar', 'slotOpacity', 0.0, 1.0, '%.2f', nil, 1.0);
-        imgui.ShowHelp('Opacity of the slot background texture.');
-
-        local highlightColor = crossbarSettings.activeSlotHighlight or 0x44FFFFFF;
-        local highlightColorTable = ARGBToImGui(highlightColor);
-        if imgui.ColorEdit4('Active Highlight##crossbar', highlightColorTable, colorFlags) then
-            crossbarSettings.activeSlotHighlight = ImGuiToARGB(highlightColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Highlight color for slots when trigger is held.');
-    end
-
-    if components.CollapsingSection('Text Colors##crossbarcolor', true) then
-        local keybindColor = crossbarSettings.keybindFontColor or 0xFFFFFFFF;
-        local keybindColorTable = ARGBToImGui(keybindColor);
-        if imgui.ColorEdit4('Keybind Color##crossbar', keybindColorTable, colorFlags) then
-            crossbarSettings.keybindFontColor = ImGuiToARGB(keybindColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for keybind labels.');
-
-        local triggerLabelColor = crossbarSettings.triggerLabelColor or 0xFFFFCC00;
-        local triggerLabelColorTable = ARGBToImGui(triggerLabelColor);
-        if imgui.ColorEdit4('Trigger Label Color##crossbar', triggerLabelColorTable, colorFlags) then
-            crossbarSettings.triggerLabelColor = ImGuiToARGB(triggerLabelColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for combo mode labels (L2, R2, etc.).');
-
-        local mpCostColor = crossbarSettings.mpCostFontColor or 0xFFD4FF97;
-        local mpCostColorTable = ARGBToImGui(mpCostColor);
-        if imgui.ColorEdit4('MP Cost Color##crossbar', mpCostColorTable, colorFlags) then
-            crossbarSettings.mpCostFontColor = ImGuiToARGB(mpCostColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for MP cost display on spell slots.');
-
-        local quantityColor = crossbarSettings.quantityFontColor or 0xFFFFFFFF;
-        local quantityColorTable = ARGBToImGui(quantityColor);
-        if imgui.ColorEdit4('Quantity Color##crossbar', quantityColorTable, colorFlags) then
-            crossbarSettings.quantityFontColor = ImGuiToARGB(quantityColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for item quantity display. Note: Shows red when quantity is 0.');
-
-        local labelColor = crossbarSettings.labelFontColor or 0xFFFFFFFF;
-        local labelColorTable = ARGBToImGui(labelColor);
-        if imgui.ColorEdit4('Label Color##crossbar', labelColorTable, colorFlags) then
-            crossbarSettings.labelFontColor = ImGuiToARGB(labelColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for action labels below slots.');
-
-        local timerColor = crossbarSettings.recastTimerFontColor or 0xFFFFFFFF;
-        local timerColorTable = ARGBToImGui(timerColor);
-        if imgui.ColorEdit4('Cooldown Timer Color##crossbar', timerColorTable, colorFlags) then
-            crossbarSettings.recastTimerFontColor = ImGuiToARGB(timerColorTable);
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Color for cooldown timer text displayed on slots.');
-    end
-end
-
--- Section: Hotbar Settings
-function M.DrawSettings(state)
-    local selectedBarTab = state and state.selectedHotbarTab or 1;
-    local selectedModeTab = state and state.selectedModeTab or 'hotbar';  -- 'hotbar' or 'crossbar' when mode is 'both'
-    local selectedCrossbarTab = state and state.selectedCrossbarTab or 1;  -- 1=L2, 2=R2, 3=L2R2, etc.
-
-    -- Basic toggles at top
-    components.DrawCheckbox('Enabled', 'hotbarEnabled');
-    -- Lock Movement disables drag/drop and slot swapping for hotbar bars
-    components.DrawCheckbox('Lock Movement', 'hotbarLockMovement', function()
-        -- Only reset anchors when lock is being ENABLED
-        if gConfig.hotbarLockMovement then
-            for i = 1, 6 do
-                drawing.ResetAnchorState('Hotbar' .. tostring(i));
-            end
-            drawing.ResetAnchorState('Crossbar');
-        end
-        DeferredUpdateVisuals();
-    end);
-    imgui.ShowHelp('When enabled, prevents dragging/dropping and swapping of hotbar and crossbar slots.');
-    components.DrawCheckbox('Hide When Menu Open', 'hotbarHideOnMenuFocus');
-    imgui.ShowHelp('Hide hotbars when a game menu is open (equipment, map, etc.).');
-
-    -- Disable XI macros checkbox (stored in hotbarGlobal)
-    local disableMacroBars = { gConfig.hotbarGlobal.disableMacroBars or false };
-    if imgui.Checkbox('Disable XI Macros', disableMacroBars) then
-        gConfig.hotbarGlobal.disableMacroBars = disableMacroBars[1];
+    local disableMacroBars = { hg.disableMacroBars or false };
+    if imgui.Checkbox('Disable XI Macros##disableXi_' .. idSuffix, disableMacroBars) then
+        hg.disableMacroBars = disableMacroBars[1];
         SaveSettingsOnly();
         DeferredUpdateVisuals();
     end
+    imgui.ShowHelp('Toggle macro bar behavior:\n- OFF: Built-in macros work with speed fix (macrofix)\n- ON: Macro bar hidden, XIUI hotbar/crossbar only\n\nNote: When ON, also blocks native macro commands.');
 
-    -- Controller Hold-to-Show checkbox (only shown when Disable XI Macros is OFF)
-    if not gConfig.hotbarGlobal.disableMacroBars then
+    if not hg.disableMacroBars then
         imgui.Indent(20);
-        local holdToShow = { gConfig.hotbarGlobal.controllerHoldToShow ~= false };  -- default true
-        if imgui.Checkbox('Controller Hold-to-Show', holdToShow) then
-            gConfig.hotbarGlobal.controllerHoldToShow = holdToShow[1];
+        local holdToShow = { hg.controllerHoldToShow ~= false };
+        if imgui.Checkbox('Controller Hold-to-Show##holdXi_' .. idSuffix, holdToShow) then
+            hg.controllerHoldToShow = holdToShow[1];
             SaveSettingsOnly();
             DeferredUpdateVisuals();
         end
@@ -2562,10 +1899,9 @@ function M.DrawSettings(state)
     end
 
     imgui.SameLine();
-    -- Get diagnostic info for tooltip
+    imgui.PushID('diagXi_' .. idSuffix);
     local diag = macrosLib.get_diagnostics();
 
-    -- Show warning icon if macrofix addon conflict detected
     if diag.macrofixConflict then
         imgui.TextColored({1.0, 0.4, 0.0, 1.0}, '(!)');
         if imgui.IsItemHovered() then
@@ -2584,15 +1920,13 @@ function M.DrawSettings(state)
         end
         imgui.SameLine();
     end
-    -- Show status indicator with color based on mode
     if diag.mode == 'hide' then
-        imgui.TextColored({0.5, 1.0, 0.5, 1.0}, '(hidden)');  -- Green when hidden
+        imgui.TextColored({0.5, 1.0, 0.5, 1.0}, '(hidden)');
     elseif diag.mode == 'macrofix' then
-        -- Show hold-to-show status when in macrofix mode
         local statusText = diag.controllerHoldToShow and '(macrofix, hold-to-show)' or '(macrofix)';
-        imgui.TextColored({0.5, 0.8, 1.0, 1.0}, statusText);  -- Cyan for macrofix mode
+        imgui.TextColored({0.5, 0.8, 1.0, 1.0}, statusText);
     else
-        imgui.TextColored({1.0, 0.7, 0.3, 1.0}, '(init...)');  -- Orange if still initializing
+        imgui.TextColored({1.0, 0.7, 0.3, 1.0}, '(init...)');
     end
     if imgui.IsItemHovered() then
         imgui.BeginTooltip();
@@ -2606,13 +1940,11 @@ function M.DrawSettings(state)
         end
         imgui.Text('Mode: ' .. modeStr);
 
-        -- Show controller hold-to-show status when in macrofix mode
         if diag.mode == 'macrofix' then
             local holdStatus = diag.controllerHoldToShow and 'enabled' or 'disabled';
             imgui.Text('Controller Hold-to-Show: ' .. holdStatus);
         end
 
-        -- Check if macrofix addon is loaded (safely - GetAddonManager may not exist)
         local macrofixLoaded = false;
         local ok, addonManager = pcall(function() return AshitaCore:GetAddonManager(); end);
         if ok and addonManager then
@@ -2659,42 +1991,116 @@ function M.DrawSettings(state)
         imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'active = applied, ready = available');
         imgui.EndTooltip();
     end
-    imgui.ShowHelp('Toggle macro bar behavior:\n- OFF: Built-in macros work with speed fix (macrofix)\n- ON: Macro bar hidden, XIUI hotbar/crossbar only\n\nNote: When ON, also blocks native macro commands.');
+    imgui.PopID();
+end
 
-    -- Skillchain highlight checkbox (stored in hotbarGlobal)
-    local skillchainHighlight = { gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false };
-    if imgui.Checkbox('Skillchain Highlight', skillchainHighlight) then
-        gConfig.hotbarGlobal.skillchainHighlightEnabled = skillchainHighlight[1];
+-- Helper: draw a compact inline ARGB color swatch (no label, no input fields — just the
+-- swatch + click-to-open picker). Used inline with checkboxes so each toggle gets its color
+-- chip on the same row, e.g. `[x] Skillchain Highlight  [██]  (?)`. Saves on edit-finish
+-- the same way DrawTextColorPicker does, so behavior matches the rest of the config UI.
+local function DrawInlineArgbColorSwatch(parentTable, key, defaultArgb, imguiId)
+    local rgba = ARGBToImGui(parentTable[key] or defaultArgb);
+    local flags = bit.bor(ImGuiColorEditFlags_NoInputs, ImGuiColorEditFlags_NoLabel, ImGuiColorEditFlags_AlphaBar);
+    if imgui.ColorEdit4('##' .. imguiId, rgba, flags) then
+        parentTable[key] = ImGuiToARGB(rgba);
+    end
+    if imgui.IsItemDeactivatedAfterEdit() then
         SaveSettingsOnly();
     end
-    imgui.ShowHelp('Show animated border and skillchain icon on weapon skill slots when a skillchain window is open.');
+end
 
-    if gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false then
-        components.DrawPartySlider(gConfig.hotbarGlobal, 'Icon Scale##skillchain', 'skillchainIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
-        imgui.ShowHelp('Scale of the skillchain icon (default 1.0).');
-        components.DrawPartySliderInt(gConfig.hotbarGlobal, 'Icon Offset X##skillchain', 'skillchainIconOffsetX', -50, 50, '%d', nil, 0);
-        imgui.ShowHelp('Horizontal offset for skillchain icon position.');
-        components.DrawPartySliderInt(gConfig.hotbarGlobal, 'Icon Offset Y##skillchain', 'skillchainIconOffsetY', -50, 50, '%d', nil, 0);
-        imgui.ShowHelp('Vertical offset for skillchain icon position.');
+-- Skillchain & Magic Burst highlight options (hotbarGlobal); shared between Hotbar and Crossbar.
+-- Layout: each toggle gets its color swatch inline on the same row (only when enabled), with
+-- the (?) help marker trailing. Shared icon Scale/OffsetX/OffsetY sliders sit below and only
+-- render when at least one of the two highlights is enabled (they have no effect otherwise).
+function M.DrawSharedSkillchainHighlightControls(idSuffix)
+    idSuffix = idSuffix or 'hb';
+    local hg = gConfig.hotbarGlobal;
+    if not hg then
+        return;
     end
+
+    -- Skillchain highlight: checkbox + inline color swatch (when enabled) + help marker.
+    local skillchainHighlight = { hg.skillchainHighlightEnabled ~= false };
+    if imgui.Checkbox('Skillchain Highlight##skillchainHl_' .. idSuffix, skillchainHighlight) then
+        hg.skillchainHighlightEnabled = skillchainHighlight[1];
+        SaveSettingsOnly();
+    end
+    if hg.skillchainHighlightEnabled ~= false then
+        imgui.SameLine();
+        DrawInlineArgbColorSwatch(hg, 'skillchainHighlightColor', 0xFFD4AA44, 'skillchainColor_' .. idSuffix);
+    end
+    imgui.ShowHelp('Show animated border and skillchain icon (top-right corner) on weapon skill / Blood Pact / /ws|/pet-macro slots when a skillchain window is open on your target. Applies to keyboard hotbars and controller crossbar.');
+
+    -- Magic Burst highlight: checkbox + inline color swatch (when enabled) + help marker.
+    -- Sits directly under the skillchain row since the two are sibling features sharing the
+    -- icon scale/offset sliders below.
+    local magicBurst = { hg.magicBurstHighlightEnabled ~= false };
+    if imgui.Checkbox('Magic Burst Highlight##magicBurstHl_' .. idSuffix, magicBurst) then
+        hg.magicBurstHighlightEnabled = magicBurst[1];
+        SaveSettingsOnly();
+    end
+    if hg.magicBurstHighlightEnabled ~= false then
+        imgui.SameLine();
+        DrawInlineArgbColorSwatch(hg, 'magicBurstHighlightColor', 0xFF44D4FF, 'magicBurstColor_' .. idSuffix);
+    end
+    imgui.ShowHelp('When a skillchain closes on your target, highlight for 7 seconds any spell slots whose element matches the burstable elements (Fire/Ice/Wind/Earth/Lightning/Water/Light/Dark). Covers White / Black / Blue Magic, Ninjutsu, and the spell-named SMN Magic Blood Pact Rages (Fire II/IV, Blizzard II/IV, etc.). Border draws cyan-blue by default with the SC name in the bottom-left corner so it stays distinct from the skillchain highlight.');
+
+    -- Shared icon scale + offsets. Render only when at least one highlight is enabled — they
+    -- govern both, so showing the sliders with both highlights off would be confusing dead UI.
+    if hg.skillchainHighlightEnabled ~= false or hg.magicBurstHighlightEnabled ~= false then
+        components.DrawPartySlider(hg, 'Icon Scale##skillchainScale_' .. idSuffix, 'skillchainIconScale', 0.5, 2.0, '%.1f', nil, 1.0);
+        imgui.ShowHelp('Scale of the highlight icon (default 1.0). Shared between skillchain (top-right) and Magic Burst (bottom-left).');
+        components.DrawPartySliderInt(hg, 'Icon Offset X##skillchainOx_' .. idSuffix, 'skillchainIconOffsetX', -50, 50, '%d', nil, 0);
+        imgui.ShowHelp('Horizontal offset for the highlight icon (shared by both highlights).');
+        components.DrawPartySliderInt(hg, 'Icon Offset Y##skillchainOy_' .. idSuffix, 'skillchainIconOffsetY', -50, 50, '%d', nil, 0);
+        imgui.ShowHelp('Vertical offset for the highlight icon (shared by both highlights).');
+    end
+end
+
+
+-- Section: Hotbar Settings
+function M.DrawSettings(state)
+    local selectedBarTab = state and state.selectedHotbarTab or 1;
+
+    -- Basic toggles at top
+    components.DrawCheckbox('Enabled', 'hotbarEnabled');
+    -- Lock Movement disables drag/drop and slot swapping for keyboard hotbars only
+    components.DrawCheckbox('Lock Movement', 'hotbarLockMovement', function()
+        if gConfig.hotbarLockMovement then
+            for i = 1, 6 do
+                drawing.ResetAnchorState('Hotbar' .. tostring(i));
+            end
+        end
+        DeferredUpdateVisuals();
+    end);
+    imgui.ShowHelp('When enabled, prevents dragging, dropping, and swapping slots on keyboard hotbars (bars 1â€“6). Crossbar uses Lock Crossbar under the Crossbar category.');
+    components.DrawCheckbox('Hide When Menu Open', 'hotbarHideOnMenuFocus');
+    imgui.ShowHelp('Hide keyboard hotbars (bars 1â€“6) when a game menu is open (equipment, map, etc.). Crossbar has its own Hide When Menu Open next to Lock Crossbar.');
+
+    M.DrawSharedDisableXiMacrosControls('hb');
+    M.DrawSharedSkillchainHighlightControls('hb');
 
     imgui.Spacing();
     imgui.Separator();
     imgui.Spacing();
 
-    -- Action buttons
-    imgui.PushStyleColor(ImGuiCol_Button, components.TAB_STYLE.bgLight);
-    imgui.PushStyleColor(ImGuiCol_ButtonHovered, components.TAB_STYLE.bgLighter);
-    imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.22, 0.20, 0.17, 1.0});
-
+    -- Action buttons (Macro Manager = gold, Palette Manager = gold-accent, rest = default strip)
+    components.PushMacroManagerButtonStyle();
     if imgui.Button('Macro Manager', {120, 0}) then
-        macropalette.OpenPalette();
+        macropalette.TogglePalette();
     end
+    components.PopMacroManagerButtonStyle();
     imgui.SameLine();
+    components.PushPaletteManagerButtonStyle();
     if imgui.Button('Palette Manager', {120, 0}) then
         paletteManager.Open();
     end
+    components.PopPaletteManagerButtonStyle();
     imgui.SameLine();
+    imgui.PushStyleColor(ImGuiCol_Button, components.TAB_STYLE.bgLight);
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, components.TAB_STYLE.bgLighter);
+    imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.22, 0.20, 0.17, 1.0});
     -- selectedBarTab is index into BAR_TYPES where 1=Global, 2=Bar1, 3=Bar2, etc.
     -- So actual bar index is selectedBarTab - 1 (default to 1 if Global is selected)
     local editBarIndex = math.max(1, (selectedBarTab or 1) - 1);
@@ -2714,47 +2120,10 @@ function M.DrawSettings(state)
     imgui.Separator();
     imgui.Spacing();
 
-    -- Layout Mode dropdown
-    local modeOptions = { 'Hotbar', 'Crossbar', 'Both' };
-    local modeValues = { 'hotbar', 'crossbar', 'both' };
-    local currentMode = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-
-    -- Find current mode index
-    local currentModeIndex = 1;
-    for i, v in ipairs(modeValues) do
-        if v == currentMode then
-            currentModeIndex = i;
-            break;
-        end
-    end
-
-    imgui.AlignTextToFramePadding();
-    imgui.Text('Layout Mode:');
-    imgui.SameLine();
-    imgui.SetNextItemWidth(120);
-    if imgui.BeginCombo('##layoutMode', modeOptions[currentModeIndex]) then
-        for i, label in ipairs(modeOptions) do
-            local isSelected = currentModeIndex == i;
-            if imgui.Selectable(label, isSelected) then
-                if gConfig.hotbarCrossbar then
-                    gConfig.hotbarCrossbar.mode = modeValues[i];
-                    SaveSettingsOnly();
-                    DeferredUpdateVisuals();
-                end
-            end
-            if isSelected then
-                imgui.SetItemDefaultFocus();
-            end
-        end
-        imgui.EndCombo();
-    end
-    imgui.ShowHelp('Hotbar: Standard keyboard hotbars (Bars 1-6)\nCrossbar: Controller layout with L2/R2 triggers\nBoth: Show both hotbar and crossbar');
-
-    -- Conditional: KB Palette Cycle (show if mode is hotbar or both)
-    if currentMode == 'hotbar' or currentMode == 'both' then
+    if gConfig.hotbarEnabled ~= false then
         local kbOptions = { 'Disabled', 'Ctrl + Up/Down', 'Alt + Up/Down', 'Shift + Up/Down', 'Up/Down' };
         local kbModifierValues = { nil, 'ctrl', 'alt', 'shift', 'none' };
-        local currentKbIndex = 1;  -- Default to Disabled
+        local currentKbIndex = 1;
         if gConfig.hotbarGlobal.paletteCycleEnabled ~= false then
             local currentMod = gConfig.hotbarGlobal.paletteCycleModifier or 'ctrl';
             for i = 1, #kbModifierValues do
@@ -2786,72 +2155,53 @@ function M.DrawSettings(state)
             end
             imgui.EndCombo();
         end
-        imgui.ShowHelp('Keyboard shortcut to cycle through palettes.');
-    end
+        imgui.ShowHelp('Keyboard shortcut to cycle through hotbar palettes.');
 
-    -- Conditional: Controller Palette Cycle (show if mode is crossbar or both)
-    if currentMode == 'crossbar' or currentMode == 'both' then
-        local ctrlOptions = { 'Disabled', 'Enabled' };
-        local currentCtrlIndex = (gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false) and 2 or 1;
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
 
-        imgui.AlignTextToFramePadding();
-        imgui.Text('Palette Cycle:');
-        imgui.SameLine();
-        imgui.SetNextItemWidth(90);
-        if imgui.BeginCombo('##ctrlPaletteCycle', ctrlOptions[currentCtrlIndex]) then
-            for i, label in ipairs(ctrlOptions) do
-                local isSelected = currentCtrlIndex == i;
-                if imgui.Selectable(label, isSelected) then
-                    gConfig.hotbarGlobal.paletteCycleControllerEnabled = (i == 2);
-                    SaveSettingsOnly();
-                end
-                if isSelected then imgui.SetItemDefaultFocus(); end
+        -- Per-Bar Visual Settings header
+        imgui.TextColored(components.TAB_STYLE.gold, 'Per-Bar Visual Settings');
+        imgui.ShowHelp('Configure each hotbar independently. Each bar can have its own layout, theme, and button settings.');
+        imgui.Spacing();
+
+        -- Draw Bar 1-6 tabs
+        for i, barType in ipairs(BAR_TYPES) do
+            local clicked, tabWidth = components.DrawStyledTab(
+                barType.label,
+                'hotbarBarTab' .. i,
+                selectedBarTab == i,
+                nil,
+                components.TAB_STYLE.smallHeight,
+                components.TAB_STYLE.smallPadding
+            );
+            if clicked then
+                selectedBarTab = i;
             end
-            imgui.EndCombo();
-        end
-
-        -- Hotbar cycle button selection (only if enabled)
-        if gConfig.hotbarGlobal.paletteCycleControllerEnabled ~= false then
-            imgui.SameLine();
-            imgui.Text('Button:');
-            imgui.SameLine();
-
-            local buttonOptions = { 'R1', 'L1' };
-            local currentButton = gConfig.hotbarGlobal.hotbarPaletteCycleButton or 'R1';
-            local currentButtonIndex = 1;
-            for i, btn in ipairs(buttonOptions) do
-                if btn == currentButton then
-                    currentButtonIndex = i;
-                    break;
-                end
-            end
-
-            imgui.SetNextItemWidth(60);
-            if imgui.BeginCombo('##hotbarCycleBtn', currentButton) then
-                for i, btn in ipairs(buttonOptions) do
-                    local isSelected = (i == currentButtonIndex);
-                    if imgui.Selectable(btn .. '##hbCycleBtn' .. i, isSelected) then
-                        gConfig.hotbarGlobal.hotbarPaletteCycleButton = btn;
-                        SaveSettingsOnly();
-                    end
-                    if isSelected then imgui.SetItemDefaultFocus(); end
-                end
-                imgui.EndCombo();
+            if i < #BAR_TYPES then
+                imgui.SameLine();
             end
         end
-        imgui.ShowHelp('Controller shortcut to cycle palettes.\nPress the selected button + DPad Up/Down to cycle palettes for all hotbars and the active crossbar.');
+
+        imgui.Spacing();
+        imgui.Separator();
+        imgui.Spacing();
+
+        -- Draw settings for selected bar (Global tab vs per-bar tabs)
+        local currentBar = BAR_TYPES[selectedBarTab];
+        if currentBar then
+            if currentBar.isGlobal then
+                DrawGlobalVisualSettings();
+            else
+                DrawBarVisualSettings(currentBar.configKey, currentBar.label);
+            end
+        end
+    else
+        imgui.TextColored({0.55, 0.52, 0.48, 1.0}, 'Keyboard hotbars are turned off (Hotbar â†’ Enabled). Turn Hotbar on to configure bars 1â€“6, or use the Crossbar category for controller layout.');
     end
 
-    -- Log Palette Name checkbox (show if any palette cycling is potentially enabled)
-    if currentMode == 'hotbar' or currentMode == 'crossbar' or currentMode == 'both' then
-        local logPaletteName = gConfig.hotbarGlobal.logPaletteName;
-        if logPaletteName == nil then logPaletteName = true; end  -- Default to true
-        if imgui.Checkbox('Log Palette Name', {logPaletteName}) then
-            gConfig.hotbarGlobal.logPaletteName = not logPaletteName;
-            SaveSettingsOnly();
-        end
-        imgui.ShowHelp('Show palette name in chat log when cycling palettes.');
-    end
+    M.DrawLogPaletteNameCheckbox('##hbLogPal');
 
     -- Conflicting Game Keys section
     local blockedKeys = gConfig.hotbarGlobal.blockedGameKeys or {};
@@ -2928,105 +2278,13 @@ function M.DrawSettings(state)
         imgui.EndPopup();
     end
 
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- When mode is 'both', show tabs to switch between hotbar and crossbar settings
-    if currentMode == 'both' then
-        -- Draw Hotbar/Crossbar tabs
-        local hotbarClicked = components.DrawStyledTab(
-            'Hotbar',
-            'modeTabHotbar',
-            selectedModeTab == 'hotbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if hotbarClicked then
-            selectedModeTab = 'hotbar';
-        end
-
-        imgui.SameLine();
-
-        local crossbarClicked = components.DrawStyledTab(
-            'Crossbar',
-            'modeTabCrossbar',
-            selectedModeTab == 'crossbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if crossbarClicked then
-            selectedModeTab = 'crossbar';
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Show content based on selected tab
-        if selectedModeTab == 'crossbar' then
-            selectedCrossbarTab = DrawCrossbarSettings(selectedCrossbarTab);
-            return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
-        end
-        -- Fall through to hotbar settings below
-    elseif currentMode == 'crossbar' then
-        -- Show crossbar settings only
-        selectedCrossbarTab = DrawCrossbarSettings(selectedCrossbarTab);
-        return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
-    end
-
-    -- Show hotbar settings (mode is 'hotbar' or 'both' with hotbar tab selected)
-    imgui.Spacing();
-
-    -- Per-Bar Visual Settings header
-    imgui.TextColored(components.TAB_STYLE.gold, 'Per-Bar Visual Settings');
-    imgui.ShowHelp('Configure each hotbar independently. Each bar can have its own layout, theme, and button settings.');
-    imgui.Spacing();
-
-    -- Draw Bar 1-6 tabs
-    for i, barType in ipairs(BAR_TYPES) do
-        local clicked, tabWidth = components.DrawStyledTab(
-            barType.label,
-            'hotbarBarTab' .. i,
-            selectedBarTab == i,
-            nil,
-            components.TAB_STYLE.smallHeight,
-            components.TAB_STYLE.smallPadding
-        );
-        if clicked then
-            selectedBarTab = i;
-        end
-        if i < #BAR_TYPES then
-            imgui.SameLine();
-        end
-    end
-
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
-
-    -- Draw settings for selected bar (Global tab vs per-bar tabs)
-    local currentBar = BAR_TYPES[selectedBarTab];
-    if currentBar then
-        if currentBar.isGlobal then
-            DrawGlobalVisualSettings();
-        else
-            DrawBarVisualSettings(currentBar.configKey, currentBar.label);
-        end
-    end
-
     -- Draw confirmation popup for job-specific toggle
     DrawJobSpecificConfirmPopup();
 
     -- Draw palette modal (unified for both hotbar and crossbar)
     DrawPaletteModal();
 
-    -- Draw palette manager window (separate window for advanced management)
-    paletteManager.Draw();
-
-    return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
+    return { selectedHotbarTab = selectedBarTab };
 end
 
 -- Helper: Draw color settings content (shared between global and per-bar)
@@ -3169,63 +2427,15 @@ end
 -- Section: Hotbar Color Settings
 function M.DrawColorSettings(state)
     local selectedBarTab = state and state.selectedHotbarTab or 1;
-    local selectedModeTab = state and state.selectedModeTab or 'hotbar';  -- 'hotbar' or 'crossbar' when mode is 'both'
-    local selectedCrossbarTab = state and state.selectedCrossbarTab or 1;  -- 1=L2, 2=R2, 3=L2R2, etc.
 
-    -- Determine what to show based on mode
-    local currentMode = gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.mode or 'hotbar';
-
-    -- When mode is 'both', show tabs to switch between hotbar and crossbar color settings
-    if currentMode == 'both' then
-        -- Draw Hotbar/Crossbar tabs
-        local hotbarClicked = components.DrawStyledTab(
-            'Hotbar',
-            'colorModeTabHotbar',
-            selectedModeTab == 'hotbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if hotbarClicked then
-            selectedModeTab = 'hotbar';
-        end
-
-        imgui.SameLine();
-
-        local crossbarClicked = components.DrawStyledTab(
-            'Crossbar',
-            'colorModeTabCrossbar',
-            selectedModeTab == 'crossbar',
-            nil,
-            components.TAB_STYLE.height,
-            components.TAB_STYLE.padding
-        );
-        if crossbarClicked then
-            selectedModeTab = 'crossbar';
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Show content based on selected tab
-        if selectedModeTab == 'crossbar' then
-            DrawCrossbarColorSettings();
-            return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
-        end
-        -- Fall through to hotbar color settings below
-    elseif currentMode == 'crossbar' then
-        -- Show crossbar color settings only
-        DrawCrossbarColorSettings();
-        return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
+    if gConfig.hotbarEnabled == false then
+        imgui.TextColored({0.55, 0.52, 0.48, 1.0}, 'Keyboard hotbars are turned off. Crossbar colors are under the Crossbar category â†’ Color settings.');
+        return { selectedHotbarTab = selectedBarTab };
     end
 
-    -- Show hotbar color settings (mode is 'hotbar' or 'both' with hotbar tab selected)
-    -- Per-Bar Color Settings header
     imgui.TextColored(components.TAB_STYLE.gold, 'Per-Bar Color Settings');
     imgui.Spacing();
 
-    -- Draw Bar 1-6 tabs (same as visual settings)
     for i, barType in ipairs(BAR_TYPES) do
         local clicked, tabWidth = components.DrawStyledTab(
             barType.label,
@@ -3247,7 +2457,6 @@ function M.DrawColorSettings(state)
     imgui.Separator();
     imgui.Spacing();
 
-    -- Draw color settings for selected bar (Global tab vs per-bar tabs)
     local currentBar = BAR_TYPES[selectedBarTab];
     if currentBar then
         if currentBar.isGlobal then
@@ -3257,7 +2466,26 @@ function M.DrawColorSettings(state)
         end
     end
 
-    return { selectedHotbarTab = selectedBarTab, selectedModeTab = selectedModeTab, selectedCrossbarTab = selectedCrossbarTab };
+    return { selectedHotbarTab = selectedBarTab };
 end
 
+function M.DrawLogPaletteNameCheckbox(idSuffix)
+    idSuffix = idSuffix or '##logPalName';
+    local logPaletteName = gConfig.hotbarGlobal.logPaletteName;
+    if logPaletteName == nil then logPaletteName = true; end
+    local logVal = { logPaletteName };
+    if imgui.Checkbox('Log Palette Name' .. idSuffix, logVal) then
+        gConfig.hotbarGlobal.logPaletteName = logVal[1];
+        SaveSettingsOnly();
+    end
+    imgui.ShowHelp('Show palette name in chat log when cycling palettes.');
+end
+
+-- Shared palette modal API (used by config/crossbar_settings.lua for crossbar category)
+M.OpenPaletteCreateModal = OpenPaletteCreateModal;
+M.OpenPaletteRenameModal = OpenPaletteRenameModal;
+M.DrawJobSpecificConfirmPopup = DrawJobSpecificConfirmPopup;
+M.DrawPaletteModal = DrawPaletteModal;
+
 return M;
+


### PR DESCRIPTION
…B UI, AlwaysClamp sliders

What changed
- config/crossbar.lua: New file. Crossbar sidebar entry shell routing to crossbar_settings.lua. Lock Crossbar toggle (independent from hotbar lock). Disable Crossbar While In Menu checkbox.
- config/crossbar_settings.lua: New 70 KB file. Full crossbar settings UI extracted from hotbar.lua: controller layout, palette management (Job vs Global scope, palette lists), visuals (inactive dim, trigger icon scale, label above slot), double-tap preview sliders, disable-in-menu, palette scope icon theme (ClassicFFXIV removed; one-shot migration falls back to Classic). Show Double-Tap Crossbars Preview section. Shared skillchain + MB controls via DrawSharedSkillchainHighlightControls.
- config/hotbar.lua: Crossbar UI sections removed (~815 lines moved to crossbar.lua + crossbar_settings.lua). Ferris additions retained: DrawSharedDisableXiMacrosControls, DrawSharedSkillchainHighlightControls (SC color picker + MB checkbox + MB color picker), DrawLogPaletteNameCheckbox. AlwaysClamp on Rows/Columns sliders per 1.8.0 slider policy. Layout Mode dropdown removed from Hotbar tab. Edit Full Palette entry moved to Crossbar tab. AlwaysClamp also applied to castbar Fast Cast sliders and notification group sliders. Show Stack Quantity checkbox re-applied from 1.8.0. Slot Y Padding slider retained.
- config/efp_pets_tab.lua: New file. EFP pet family tabs (Avatars, Elementals, Beasts, Wyvern, Puppet). Avatar vs spirit elemental distinction. SMN sort and pet-bar omit rules.
- config.lua: Crossbar tab registration. Crossbar tab dispatches to config/crossbar.lua.

Why
- User explicitly separated hotbar and crossbar configuration concerns; Lock Crossbar and Edit Full Palette entry belong in the Crossbar tab. ClassicFFXIV removal prevents user-custom theme from appearing in a public dropdown. AlwaysClamp compliance brings all Ferris-touched config files into line with 1.8.0 slider policy.