### PR TITLE
Crossbar segment overrides: per-job storage, resolution, palette rena…

### DIFF
--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -274,7 +274,7 @@ end
 function M.createHotbarGlobalDefaults()
     return T{
         -- Game UI patches
-        disableMacroBars = false,  -- Disable native XI macros (macro bar display + controller macro blocking)
+        disableMacroBars = false,  -- Keyboard: hide native macro bar UI + block Ctrl/Alt+number macro keys (controller blocking is Crossbar → Disable XI Macros)
         controllerHoldToShow = true,  -- Controller triggers use hold-to-show (like macrofix addon) instead of tap-to-toggle
 
         -- Blocked game keys - array of key definitions that should be blocked from reaching the game
@@ -292,6 +292,10 @@ function M.createHotbarGlobalDefaults()
         -- Palette cycling controller (RB + Dpad)
         paletteCycleControllerEnabled = true,  -- Enable controller palette cycling
         hotbarPaletteCycleButton = 'R1',       -- 'R1' or 'L1' for hotbar cycling
+
+        logPaletteName = true,                 -- Log palette name when cycling keyboard hotbars
+        logPaletteNameCrossbar = true,         -- Log palette name when cycling via controller (crossbar)
+        logPaletteNameCrossbarCycleHint = true, -- Second CLI line: RB+D-pad return hint after job preview
 
         -- Visual settings
         slotSize = 48,          -- Slot size in pixels
@@ -333,7 +337,7 @@ function M.createHotbarGlobalDefaults()
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -350,7 +354,16 @@ function M.createHotbarGlobalDefaults()
         skillchainIconScale = 1.0,              -- Scale multiplier for icon (0.5-2.0)
         skillchainIconOffsetX = 0,              -- X offset in pixels
         skillchainIconOffsetY = 0,              -- Y offset in pixels
-    
+
+        -- Magic Burst highlight settings. Window opens IMMEDIATELY when a SC closes and runs
+        -- for 7.0s (matches retail's MB cutoff at the back end while front-loading the visual
+        -- cue). Highlights spell / magical pact rage / /ma-or-/pet macro slots whose element
+        -- matches one of the SC's burstable elements. Uses the same corner icon as the
+        -- skillchain highlight (the SC's name asset) but in the bottom-left corner with a
+        -- cyan-blue border to keep the two highlights visually distinct.
+        magicBurstHighlightEnabled = true,      -- Show MB highlight on element-matching spell slots
+        magicBurstHighlightColor = 0xFF44D4FF,  -- Cyan-blue (ARGB) — distinct from gold SC border
+
         -- Cooldown timer settings
         recastTimerFontSize = 11,               -- Font size for cooldown timer display
         recastTimerFontColor = 0xFFFFFFFF,      -- Color for cooldown timer text
@@ -372,6 +385,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Pet-aware toggle (when true, hotbar can have different palettes per pet for SMN/BST/DRG/PUP)
         petAware = false,
         showPetIndicator = true,  -- Show indicator dot when petAware is enabled
+        -- When set: array of type tokens 'avatars'|'elementals'|'beasts'|'wyvern'|'puppet' (legacy 'summons' = avatars+elementals). nil = all.
+        petPalettePetKeys = nil,
 
         -- Layout settings (always per-bar)
         enabled = true,
@@ -420,7 +435,7 @@ function M.createHotbarBarDefaults(overrides)
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -443,6 +458,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Structure: paletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Palettes are displayed in this order; missing palettes are appended alphabetically
         paletteOrder = {},
+        -- paletteExcludeFromCycle[orderKey][paletteName] = true skips palette for RB / keyboard cycling only
+        paletteExcludeFromCycle = {},
     };
     if overrides then
         for k, v in pairs(overrides) do
@@ -460,22 +477,51 @@ end
 -- The crossbar provides 4 combo modes: L2, R2, L2+R2, R2+L2 (32 total slots)
 function M.createCrossbarDefaults()
     return T{
-        -- Layout mode: 'hotbar', 'crossbar', or 'both'
-        mode = 'hotbar',
+        -- Show controller crossbar UI (mirrors gConfig.crossbarEnabled; kept for migration)
+        showCrossbar = true,
+
+        -- Hide crossbar when game menu open (independent from Hotbar → Hide When Menu Open)
+        crossbarHideOnMenuFocus = false,
+
+        -- Disable crossbar input while a game menu is open (keeps it visible but blocks trigger macros)
+        crossbarDisableInMenu = true,
+
+        -- Config UI: which main section is active (1=Controller, 2=Manage palettes, 3=Global visuals)
+        configUiTab = 1,
+        -- 'universal' = editing [G] all-jobs sets; 'job' = editing palettes for configEditJobId
+        configFocus = 'job',
+        configEditJobId = nil,   -- nil = use live main job from data when in job focus
+        configEditSubjobId = nil,
 
         -- Job-specific toggle (when true, actions are stored per-job; when false, actions are shared across all jobs)
         jobSpecific = true,
 
-        -- Per-combo-mode settings (pet-aware is per-combo, palettes are GLOBAL)
-        -- NOTE: activePalette was removed - crossbar palettes are now global (see palette.lua state.crossbarActivePalette)
+        -- All-jobs universal crossbar palettes (storage: global:palette:{name} in slotActions)
+        enableUniversalCrossbarPalettes = false,
+        -- 'job' = job/subjob named palettes; 'universal' = all-jobs sets (toggle L1+R1 when enabled)
+        defaultCrossbarPaletteScope = 'job',
+        -- Per-palette: includeInCycle = false hides palette from RB+D-pad when scope is universal
+        crossbarUniversalPaletteMeta = {},
+        universalCrossbarPaletteOrder = {},
+
+        -- Per-segment: petAware, optional per-segment petPalettePetKeys, universalOverridePalette = all-jobs palette name. Default pet types: petPalettePetKeys on parent.
         comboModeSettings = {
-            L2 = { petAware = false },
-            R2 = { petAware = false },
-            L2R2 = { petAware = false },
-            R2L2 = { petAware = false },
-            L2x2 = { petAware = false },
-            R2x2 = { petAware = false },
+            L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
         },
+        -- Optional per named [J] palette: comboMode -> { petAware?, universalOverridePalette? } (nil field = inherit Crossbar defaults)
+        namedPaletteComboModeSettings = {},
+
+        -- Crossbar [J] only: which pet families (avatars/elementals/beasts/wyvern/puppet) use pet hotbar storage; nil = all. Not per named palette.
+        petPalettePetKeys = nil,
+
+        -- Per main job id (string key): effective combo mode -> { scope = 'jobShared' | 'global', globalPalette = name? }
+        -- Primary L2/R2 are not used. Resolves slot data to jobsegment:{jobId}:{mode} or global:palette:{name}.
+        segmentOverrides = {},
 
         -- Layout
         slotSize = 40,              -- Slot size in pixels
@@ -495,7 +541,8 @@ function M.createCrossbarDefaults()
         slotBackgroundColor = 0x55000000,
         slotOpacity = 1.0,                  -- Opacity multiplier for slot.png (0.0-1.0)
         activeSlotHighlight = 0x44FFFFFF,   -- Highlight color when trigger held
-        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side
+        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side (expanded / non-trigger dim)
+        inactiveSideWhileTriggerDim = 0.15, -- Dim for the non-active half while L2 or R2 is held
 
         -- Display mode
         displayMode = 'normal',             -- 'normal' or 'activeOnly'
@@ -511,6 +558,8 @@ function M.createCrossbarDefaults()
         buttonIconGapH = 8,                 -- Horizontal spacing between center icons
         buttonIconGapV = 2,                 -- Vertical spacing between center icons
         buttonIconPosition = 'corner',      -- 'corner' or 'replace_keybind'
+        -- Job icon set for palette UI (Manage Palettes strip + in-game palette scope icon when Job [J])
+        paletteJobIconTheme = 'Classic',     -- 'Classic', 'FFXI', 'FFXIV-1' (under assets/jobs/)
         controllerTheme = 'Xbox',           -- 'PlayStation', 'Xbox', or 'Nintendo' button icons
         controllerScheme = 'xbox',          -- Controller profile: 'xbox', 'dualsense', 'switchpro', 'dinput'
         triggerIconScale = 0.8,             -- Scale for L2/R2 trigger icons (base 49x28)
@@ -545,10 +594,14 @@ function M.createCrossbarDefaults()
         comboTextOffsetY = 0,               -- Y offset for combo text position
 
         -- Palette name display (shows current palette and index, e.g., "Stuns (2/5)")
-        showPaletteName = false,            -- Toggle to show palette name
+        showPaletteName = false,            -- Toggle to show palette name text below crossbar
+        showPaletteScopeIcon = true,        -- Job / Global scope icon above divider; nil in saved config = legacy (follow showPaletteName)
         paletteNameFontSize = 10,           -- Font size for palette name
         paletteNameOffsetX = 0,             -- X offset for position
         paletteNameOffsetY = 0,             -- Y offset for position
+        -- Job / Global palette scope icon above center divider
+        paletteScopeIconOffsetY = 12,       -- Vertical lift (px); higher = icon moves up
+        paletteScopeIconSize = 22,          -- Icon width/height (px); legacy profiles fall back to font-based size if unset
 
         -- Expanded crossbar (L2+R2 combos)
         enableExpandedCrossbar = true,      -- Enable L2+R2 and R2+L2 combos
@@ -557,6 +610,12 @@ function M.createCrossbarDefaults()
         -- Double-tap crossbar (tap trigger twice quickly)
         enableDoubleTap = false,            -- Enable L2x2 and R2x2 double-tap modes
         doubleTapWindow = 0.3,              -- Time window for double-tap detection (seconds)
+
+        -- Double-tap preview windows (always-visible overlays showing L2x2 / R2x2 bars)
+        showDoubleTapPreview    = false,     -- Show floating preview windows for double-tap bars
+        doubleTapPreviewScale   = 0.60,     -- Preview scale relative to main crossbar (0.3–1.0)
+        doubleTapPreviewOpacity = 1.0,      -- Preview opacity multiplier (0.2–1.0; dims with trigger)
+        doubleTapPreviewLocked  = false,    -- Lock preview positions independently of the main crossbar
 
         -- Analog trigger thresholds (0-255 normalized range)
         -- Used by Xbox (XInput) and PlayStation (DirectInput with signed->unsigned conversion)
@@ -587,6 +646,8 @@ function M.createCrossbarDefaults()
         -- Structure: crossbarPaletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Note: Crossbar palettes are independent from hotbar palettes
         crossbarPaletteOrder = {},
+        -- Same shape as paletteExcludeFromCycle on hotbar; per job:storage-tier key
+        crossbarPaletteExcludeFromCycle = {},
     };
 end
 

--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -5,6 +5,8 @@
 
 local M = {};
 local profileManager = require('core.profile_manager');
+local macroXiuiDefaults = require('modules.hotbar.macro_xiui_defaults');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
 
 -- Migrate settings from HXUI to XIUI (one-time migration for users upgrading from HXUI)
 -- IMPORTANT: This must be called BEFORE settings.load() so that copied files are picked up
@@ -607,6 +609,20 @@ function M.MigrateIndividualSettings(gConfig, defaults)
             if petType.tpFontSize == nil then petType.tpFontSize = oldVitalsFontSize; end
         end
     end
+
+    if gConfig.petBarResizeAnchor == nil then
+        local wantsBottom = false;
+        for _, pt in ipairs(petTypeTables) do
+            if pt and pt.alignBottom then
+                wantsBottom = true;
+                break;
+            end
+        end
+        gConfig.petBarResizeAnchor = wantsBottom and 'bottom' or 'top';
+    end
+    if gConfig.petTargetSnapAnchor == 'top' and type(gConfig.petTargetSnapOffsetX) == 'number' and gConfig.petTargetSnapOffsetX >= 100 then
+        gConfig.petTargetSnapOffsetX = 0;
+    end
 end
 
 -- Migrate flat castCost* settings to nested castCost table
@@ -1053,7 +1069,116 @@ end
 
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
+-- Split legacy hotbarCrossbar.mode ('hotbar'|'crossbar'|'both') into separate visibility flags
+function M.MigrateCrossbarModuleFlags(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.crossbarEnabled == nil then
+        if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.showCrossbar ~= nil then
+            gConfig.crossbarEnabled = gConfig.hotbarCrossbar.showCrossbar;
+        else
+            gConfig.crossbarEnabled = true;
+        end
+    end
+    local hg = gConfig.hotbarGlobal;
+    if hg and hg.logPaletteNameCrossbar == nil then
+        hg.logPaletteNameCrossbar = hg.logPaletteName;
+    end
+    if hg and hg.logPaletteNameCrossbarCycleHint == nil then
+        hg.logPaletteNameCrossbarCycleHint = true;
+    end
+end
+
+function M.MigrateHotbarCrossbarLayoutFlags(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local m = gConfig.hotbarCrossbar.mode;
+    if m ~= nil then
+        if m == 'hotbar' then
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = false;
+        elseif m == 'crossbar' then
+            gConfig.hotbarShowKeyboardBars = false;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        else
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        end
+        gConfig.hotbarCrossbar.mode = nil;
+    end
+    if gConfig.hotbarShowKeyboardBars == nil then
+        gConfig.hotbarShowKeyboardBars = true;
+    end
+    if gConfig.hotbarCrossbar.showCrossbar == nil then
+        gConfig.hotbarCrossbar.showCrossbar = true;
+    end
+end
+
+-- Fold legacy hotbarShowKeyboardBars into hotbarEnabled (same intent as Hotbar → Enabled today).
+function M.MigrateHotbarShowKeyboardBarsRemoval(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.hotbarShowKeyboardBars == false and gConfig.hotbarEnabled ~= false then
+        gConfig.hotbarEnabled = false;
+    end
+    gConfig.hotbarShowKeyboardBars = nil;
+end
+
+-- Drop deprecated keys from profiles saved during older builds (macros/skillchain are hotbarGlobal only now).
+function M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local xb = gConfig.hotbarCrossbar;
+    xb.crossbarDisableXiMacros = nil;
+    xb.skillchainHighlightEnabled = nil;
+    xb.skillchainHighlightColor = nil;
+    xb.skillchainIconScale = nil;
+    xb.skillchainIconOffsetX = nil;
+    xb.skillchainIconOffsetY = nil;
+end
+
+function M.MigrateMacroGlobalUniversalTwoHour(gConfig)
+    if not gConfig then
+        return;
+    end
+    macroGlobalDefaults.SeedUniversalTwoHourIfNeeded(gConfig);
+end
+
+function M.MigrateMacroXiuiDefaults(gConfig)
+    if not gConfig then
+        return;
+    end
+    local inserted = macroXiuiDefaults.SeedIfNeeded(gConfig);
+    if inserted then
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if ok and hotbarData and hotbarData.MarkMacroLookupDirty then
+            hotbarData.MarkMacroLookupDirty();
+        end
+    end
+end
+
 function M.RunStructureMigrations(gConfig, defaults)
+    -- Run before anything touches macroDB: coalesce "4" vs 4 and dedupe macro ids (fixes wrong macro on hotbar / drag)
+    if gConfig then
+        local ok, data = pcall(require, 'modules.hotbar.data');
+        if ok and data and data.EnsureMacroDatabaseCoherence then
+            data.EnsureMacroDatabaseCoherence(gConfig);
+        end
+    end
+    M.MigrateCrossbarModuleFlags(gConfig);
+    M.MigrateHotbarCrossbarLayoutFlags(gConfig);
+    M.MigrateHotbarShowKeyboardBarsRemoval(gConfig);
+    M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig);
+    if gConfig then
+        local ok, hbData = pcall(require, 'modules.hotbar.data');
+        if ok and hbData and hbData.MigrateSlotDualMacroBindings then
+            hbData.MigrateSlotDualMacroBindings(gConfig);
+        end
+    end
     M.MigratePartyListLayoutSettings(gConfig, defaults);
     M.MigratePerPartySettings(gConfig, defaults);
     M.MigratePerPetTypeSettings(gConfig, defaults);
@@ -1067,6 +1192,8 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
     M.MigrateSlotMacroRefs(gConfig);
+    M.MigrateMacroXiuiDefaults(gConfig);
+    M.MigrateMacroGlobalUniversalTwoHour(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/modules/hotbar/data.lua
+++ b/XIUI/modules/hotbar/data.lua
@@ -6,8 +6,42 @@
 require('common');
 
 local gameState = require('core.gamestate');
+local petregistry = require('modules.hotbar.petregistry');
+local petAllowlist = require('modules.hotbar.pet_palette_allowlist');
 
 local M = {};
+
+-- While the Crossbar "Edit Full Palette" window is open, crossbar.lua uses this key with
+-- draft functions so edits don't go live until the user confirms.
+local crossbarPaletteEditStorageKey = nil;
+local draftForStorageKey = nil;   -- persists across Begin/End cycles to guard draft re-init
+-- Multi-key draft: segment overrides read/write alternate storage keys (jobsegment:…, global:palette:…)
+local draftByKey = nil;            -- [storageKey] = { L2 = { [slot]=... }, ... }
+local draftEditJobId = nil;       -- job context for Edit Full Palette (nil = universal editor)
+local draftTouchedKeys = nil;     -- { [storageKey] = true } keys modified this session
+local draftDirty = false;
+local draftUndoStack = {};
+local draftUndoGroupActive = false;
+local DRAFT_MAX_UNDO = 30;
+-- Draft slot cell == this string means "explicitly cleared in draft". String survives deepCopyTable (undo); a table
+-- sentinel would clone to a fresh {} and break equality. Missing slot index still means "inherit live" for overlay reads.
+local DRAFT_CROSSBAR_SLOT_EMPTY = '__XIUI_DRAFT_SLOT_EMPTY__';
+
+-- Draft CRUD functions are defined after helpers (deepCopyTable, buildSlotRecord, etc.)
+-- to satisfy Lua local scoping. See "Draft Layer" section below line 1112.
+
+function M.GetCrossbarPaletteEditSessionKey()
+    return crossbarPaletteEditStorageKey;
+end
+
+--- True while crossbar draft buffers exist (Edit Full Palette session). Palette rows use draft when drawing with
+--- palSk; the gameplay HUD keeps live binds until Apply. Swap reads use GetCrossbarSlotRawForSwapOverlay when draft is open.
+function M.IsCrossbarDraftLayerOpen()
+    return draftForStorageKey ~= nil and draftByKey ~= nil;
+end
+
+-- Pet-aware slot layouts are shared across job:subjob pairs; keyed only by pet subtype
+local PETPALETTE_STORAGE_PREFIX = 'petpalette:';
 
 -- Callback for slot data changes (used by macropalette for debounced saves)
 local onSlotDataChanged = nil;
@@ -40,31 +74,111 @@ local function getPalette()
 end
 
 -- ============================================
+-- Macro palette DB: many buckets, one profile (gConfig.macroDB)
+-- ============================================
+-- Each key is a separate palette: global, items, equipment, xiui, custom:*, job id
+-- (4 = BLM), SMN composite "15:avatar:ifrit", etc. Rows in different buckets are
+-- independent: same displayName, same numeric id, or same macro text in two jobs
+-- are all valid. Hotbar/crossbar slots disambiguate with macroRef + macroPaletteKey.
+--
+-- Coherence (EnsureMacroDatabaseCoherence) only: (1) merge accidental duplicate
+-- *job* storage keys "4" and 4 for the *same* job, never other key shapes; (2) fix
+-- duplicate macro.id *within* one bucket. It does not merge distinct palettes.
+
+-- ============================================
 -- Performance: Macro ID Lookup Cache
 -- ============================================
 -- O(1) lookup instead of O(n) linear search per GetMacroById call
 -- With 197 macros and 72 slots, this reduces from ~14,184 iterations/frame to 72 lookups
+-- macroIdLookup[paletteKey] is a separate id map per bucket (see design note above)
 
 local macroIdLookup = {};  -- macroIdLookup[paletteKey][macroId] = macro
 local macroIdLookupDirty = true;
--- Identity reference of the macroDB the lookup was built against. If gConfig
--- gets reassigned (profile switch / character swap), this will no longer
--- match gConfig.macroDB and we'll rebuild automatically. This prevents the
--- "globals from old profile" bug where switching characters left stale
--- macros (e.g. Ramrock's macroDB[3]="Heel") in the lookup while the new
--- profile (Mazungu) had macroDB[3]="SendPep".
-local macroIdLookupSource = nil;
+
+-- Per gConfig in-memory: avoid re-running and avoid persisting a sentinel in profile files
+local macroDbCoherenceIdentity = nil;
+
+-- One-time (per gConfig object) repair for macroDB (see "Macro palette DB" note above):
+-- - Coalesce string job keys (JSON "4") with numeric (4) so buckets are not split.
+-- - Deduplicate macro.id within each bucket (first row keeps id) so GetMacroById matches palette grid order.
+function M.EnsureMacroDatabaseCoherence(cfg)
+    local c = cfg or gConfig;
+    if not c or macroDbCoherenceIdentity == c then
+        return;
+    end
+    macroDbCoherenceIdentity = c;
+    if not c.macroDB or type(c.macroDB) ~= 'table' then
+        return;
+    end
+    local mdb = c.macroDB;
+    -- Collect first: do not modify mdb while iterating with pairs().
+
+    -- 1) Merge "4" and 4 (pure numeric string keys only; not composite "15:avatar:ifrit")
+    local stringNumberKeys = {};
+    for k, v in pairs(mdb) do
+        if type(k) == 'string' and k:match('^%d+$') and not k:find(':') and type(v) == 'table' then
+            stringNumberKeys[k] = v;
+        end
+    end
+    for k, v in pairs(stringNumberKeys) do
+        local n = tonumber(k);
+        if n and n > 0 then
+            if mdb[n] and type(mdb[n]) == 'table' then
+                for _, m in ipairs(v) do
+                    table.insert(mdb[n], m);
+                end
+            else
+                mdb[n] = v;
+            end
+            mdb[k] = nil;
+        end
+    end
+    -- 2) Deduplicate ids per bucket (stable: first row wins, later duplicates renumbered)
+    for _, macros in pairs(mdb) do
+        if type(macros) == 'table' then
+            local seen = {};
+            local maxId = 0;
+            for _, m in ipairs(macros) do
+                if m and m.id and type(m.id) == 'number' and m.id > maxId then
+                    maxId = m.id;
+                end
+            end
+            for _, m in ipairs(macros) do
+                if m then
+                    if not m.id or type(m.id) ~= 'number' then
+                        maxId = maxId + 1;
+                        m.id = maxId;
+                        seen[m.id] = true;
+                    elseif seen[m.id] then
+                        repeat
+                            maxId = maxId + 1;
+                        until not seen[maxId];
+                        m.id = maxId;
+                        seen[m.id] = true;
+                    else
+                        seen[m.id] = true;
+                    end
+                end
+            end
+        end
+    end
+end
 
 local function RebuildMacroLookup()
+    if gConfig then
+        M.EnsureMacroDatabaseCoherence(gConfig);
+    end
     macroIdLookup = {};
-    macroIdLookupSource = (gConfig and gConfig.macroDB) or nil;
     if gConfig and gConfig.macroDB then
         for paletteKey, macros in pairs(gConfig.macroDB) do
             macroIdLookup[paletteKey] = {};
             if type(macros) == 'table' then
                 for _, macro in ipairs(macros) do
-                    if macro.id then
-                        macroIdLookup[paletteKey][macro.id] = macro;
+                    if macro and macro.id then
+                        -- First wins: matches ipairs order in macropalette M.GetMacroById
+                        if not macroIdLookup[paletteKey][macro.id] then
+                            macroIdLookup[paletteKey][macro.id] = macro;
+                        end
                     end
                 end
             end
@@ -74,14 +188,34 @@ local function RebuildMacroLookup()
 end
 
 local function GetMacroFromLookup(macroId, paletteKey)
-    -- Rebuild if explicitly dirty OR if gConfig.macroDB has been reassigned
-    -- (i.e. profile switched out from under us).
-    if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
+    if macroIdLookupDirty then
         RebuildMacroLookup();
     end
-    local paletteLookup = macroIdLookup[paletteKey];
-    if paletteLookup then
-        return paletteLookup[macroId];
+    local function try(pk)
+        local t = macroIdLookup[pk];
+        if t then
+            return t[macroId];
+        end
+        return nil;
+    end
+    local m = try(paletteKey);
+    if m then
+        return m;
+    end
+    if type(paletteKey) == 'number' and paletteKey > 0 then
+        m = try(tostring(paletteKey));
+        if m then
+            return m;
+        end
+    end
+    if type(paletteKey) == 'string' and paletteKey:match('^%d+$') then
+        local n = tonumber(paletteKey);
+        if n and n > 0 then
+            m = try(n);
+            if m then
+                return m;
+            end
+        end
     end
     return nil;
 end
@@ -93,11 +227,6 @@ end
 
 local storageKeyCache = {};  -- storageKeyCache[barIndex] = storageKey
 local storageKeyCacheDirty = true;
--- Identity reference of the gConfig the storage key cache was built against.
--- If gConfig is reassigned (profile switch) the cached keys could be stale
--- (jobSpecific / petAware / palette names are profile-specific), so we
--- detect the swap and invalidate.
-local storageKeyCacheSource = nil;
 
 -- ============================================
 -- Constants
@@ -112,6 +241,32 @@ M.PADDING = 4;
 M.BUTTON_GAP = 8;
 M.LABEL_GAP = -8;  -- Default label position offset (was 4, moved up by 12px)
 M.ROW_GAP = 6;
+
+-- ============================================
+-- Per-Bar State
+-- ============================================
+
+-- Background primitive handles (one per bar)
+M.bgHandles = {};
+
+-- Legacy GDI font/primitive tables (kept as empty placeholders for migration safety only).
+-- 1.8.0 moved all per-slot rendering to libs/imtext.lua (stateless per-frame ImGui drawing)
+-- and libs/windowbackground.lua (immediate-mode background). None of these tables are
+-- populated anymore; any leftover writes from older crossbar/macropalette code are inert.
+-- Once the Tier 3 crossbar.lua / macropalette.lua passes are complete and all GDI writes
+-- are gone, this whole block can be deleted. Reads still work (table lookups just return nil).
+M.slotPrims = {};
+M.keybindFonts = {};
+M.labelFonts = {};
+M.iconPrims = {};
+M.cooldownPrims = {};
+M.framePrims = {};
+M.timerFonts = {};
+M.mpCostFonts = {};
+M.quantityFonts = {};
+M.abbreviationFonts = {};
+M.hotbarNumberFonts = {};
+M.allFonts = nil;
 
 -- ============================================
 -- Job State
@@ -135,42 +290,34 @@ local function normalizeJobId(jobId)
     return jobId or 1;
 end
 
--- Helper to get the storage key based on jobSpecific setting
--- Returns 'global' for global mode, or '{jobId}:{subjobId}' for job-specific mode
-local function getStorageKey(barSettings, jobId, subjobId)
-    if barSettings.jobSpecific == false then
+-- Shared helper: resolve a storage key from settings that have a jobSpecific flag.
+-- Used by both hotbar bars and crossbar.
+local function resolveStorageKey(settings, jobId, subjobId)
+    if settings.jobSpecific == false then
         return GLOBAL_SLOT_KEY;
     end
-    -- Always return composite key with job:subjob
     local normalizedJobId = normalizeJobId(jobId);
     local normalizedSubjobId = normalizeJobId(subjobId or 0);
     return string.format('%d:%d', normalizedJobId, normalizedSubjobId);
 end
 
-
--- Helper to get slotActions with storage key
--- Handles: 'global' and composite keys ('15:10', '15:10:avatar:ifrit', '15:10:palette:name')
--- Falls back to base job key (jobId:0) or base palette key (jobId:0:palette:name) if exact key doesn't exist
-local function getSlotActionsForJob(slotActions, storageKey)
+-- Shared helper: look up a slotActions bucket by storage key with subjob-0 fallback.
+-- Works for both hotbar (flat per-slot) and crossbar (per-combo-mode nesting) since
+-- this only resolves the top-level key; callers index into the result as needed.
+local function getSlotActionsForKey(slotActions, storageKey)
     if not slotActions then return nil; end
-    -- Handle 'global' key specially
     if storageKey == GLOBAL_SLOT_KEY then
         return slotActions[GLOBAL_SLOT_KEY];
     end
-    -- Try exact storage key first (e.g., '3:5' for WHM/RDM, '3:5:palette:Esuna')
     local result = slotActions[storageKey];
     if result then
         return result;
     end
-    -- Fallback: try base job key (jobId:0) for imported data without subjob
-    -- This handles tHotBar imports which don't track subjobs
     local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
     if jobId and subjobId ~= '0' then
-        -- Build fallback key with subjob=0, preserving any suffix (palette, avatar, etc.)
         local fallbackKey = jobId .. ':0' .. (suffix or '');
-        result = slotActions[fallbackKey];
-        if result then
-            return result;
+        if fallbackKey ~= storageKey then
+            return slotActions[fallbackKey];
         end
     end
     return nil;
@@ -186,40 +333,898 @@ local function deepCopyTable(tbl)
     return copy;
 end
 
--- Helper to ensure slotActions structure exists for a storage key
--- Handles: 'global' and composite keys ('15:10', '15:10:avatar:ifrit')
--- IMPORTANT: When creating a new key, copies data from fallback keys to preserve slot data
-local function ensureSlotActionsStructure(barSettings, storageKey)
-    if not barSettings.slotActions then
-        barSettings.slotActions = {};
+M.CopyTable = deepCopyTable;
+
+-- Shared helper: copy the canonical set of fields from one slot data table to another.
+-- Avoids repeating the field list in every Get/Set path.
+local SLOT_DATA_FIELDS = {
+    'actionType', 'action', 'target', 'displayName', 'equipSlot',
+    'macroText', 'itemId', 'customIconType', 'customIconId', 'customIconPath',
+    'recastSourceType', 'recastSourceAction', 'recastSourceItemId',
+    'showJaBadgeOnMacro',
+    'macroRef', 'macroPaletteKey', 'macroSourceStore',
+};
+-- Dual library placement: per-slot profile vs shared binding (independent of which macro file is "live").
+M.MACRO_BIND_PROFILE_KEY = 'macroBindProfile';
+M.MACRO_BIND_SHARED_KEY = 'macroBindShared';
+local K_BIND_P = M.MACRO_BIND_PROFILE_KEY;
+local K_BIND_S = M.MACRO_BIND_SHARED_KEY;
+local function copySlotFields(src)
+    local out = {};
+    for _, k in ipairs(SLOT_DATA_FIELDS) do
+        out[k] = src[k];
     end
-    -- Handle 'global' key specially
-    if storageKey == GLOBAL_SLOT_KEY then
-        if not barSettings.slotActions[GLOBAL_SLOT_KEY] then
-            barSettings.slotActions[GLOBAL_SLOT_KEY] = {};
+    return out;
+end
+
+
+--- true when slot uses per-library macroBindProfile / macroBindShared (post-migration).
+local function isDualMacroSlotTable(slotAction)
+    return slotAction and type(slotAction) == 'table'
+        and (slotAction[K_BIND_P] ~= nil or slotAction[K_BIND_S] ~= nil);
+end
+
+--- The active library's subtable for a macro row (or legacy flat macro slot). Returns: arm, isMacro.
+local function getActiveMacroBindingFromSlot(slotAction)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local sh = gConfig and (gConfig.macroStorageScope or 'profile') == 'shared';
+        if sh then
+            return slotAction[K_BIND_S], true;
         end
-        return barSettings.slotActions[GLOBAL_SLOT_KEY];
+        return slotAction[K_BIND_P], true;
     end
-    -- All job-specific keys are composite strings (job:subjob format)
-    if not barSettings.slotActions[storageKey] then
-        -- Before creating empty table, check for fallback data to migrate
-        -- This preserves slot data when subjob changes (e.g., '1:0' -> '1:5')
+    if slotAction.macroRef and slotAction.actionType == 'macro' then
+        return slotAction, true;
+    end
+    if slotAction.macroRef then
+        return slotAction, true;
+    end
+    return nil, false;
+end
+
+M._GetActiveMacroBindingFromSlot = getActiveMacroBindingFromSlot;
+M.IsMacroSlotDualLayout = isDualMacroSlotTable;
+
+-- Shared helper: build a write-ready slot table from incoming slotData (Set operations).
+-- Adds macroRef, macroPaletteKey, macroSourceStore on top of the canonical fields.
+local function buildSlotRecord(slotData)
+    local rec = copySlotFields(slotData);
+    rec.macroRef = slotData.macroRef or slotData.id;
+    rec.macroPaletteKey = slotData.macroPaletteKey;
+    rec.macroSourceStore = slotData.macroSourceStore;
+    return rec;
+end
+
+--- Public write-ready slot builder. Two output shapes:
+---   * macro binding → { macroRef, macroPaletteKey } (the live macro is resolved at read time
+---     via the macro DB so we never persist a stale copy of the macro action/text).
+---   * everything else → full slot record with the standard action / target / customIcon / etc.
+---     fields plus the Ferris extras (macroSourceStore for dual-arm bindings).
+--- This is the 1.8.0 public API that callers like `macropalette.HandleDropOnSlot` rely on.
+--- It coexists with the local `buildSlotRecord` (which always includes the macro extras —
+--- different shape because it's used by Ferris's macro-arm builders that already know they
+--- want the full record).
+---@param slotData table|nil
+---@return table|nil
+function M.BuildSlotDataForWrite(slotData)
+    if not slotData then return nil; end
+
+    local macroRef = slotData.macroRef or slotData.id;
+    if macroRef then
+        -- Preserve dual-arm metadata (macroSourceStore: 'profile'|'shared') and the JA badge flag
+        -- when the caller supplied them. The 1.8.0 minimal {macroRef, macroPaletteKey} shape is
+        -- still the default; the extras are only added when present so untouched slot data round-
+        -- trips losslessly through this builder (i.e. swap operations keep arm identity).
+        return {
+            macroRef = macroRef,
+            macroPaletteKey = slotData.macroPaletteKey,
+            macroSourceStore = slotData.macroSourceStore,
+            showJaBadgeOnMacro = slotData.showJaBadgeOnMacro,
+        };
+    end
+
+    return {
+        actionType = slotData.actionType,
+        action = slotData.action,
+        target = slotData.target,
+        displayName = slotData.displayName,
+        equipSlot = slotData.equipSlot,
+        macroText = slotData.macroText,
+        itemId = slotData.itemId,
+        customIconType = slotData.customIconType,
+        customIconId = slotData.customIconId,
+        customIconPath = slotData.customIconPath,
+        recastSourceType = slotData.recastSourceType,
+        recastSourceAction = slotData.recastSourceAction,
+        recastSourceItemId = slotData.recastSourceItemId,
+        -- showJaBadgeOnMacro applies to macro slots too; forward when present so swap/move
+        -- operations from macropalette.lua preserve the user's per-slot badge preference.
+        showJaBadgeOnMacro = slotData.showJaBadgeOnMacro,
+    };
+end
+
+--- Build a parent macro slot with one arm set from a palette drop, preserving the other arm from existing.
+function M.BuildMacroSlotAfterDrop(armData, sourceStore, existingParentSlot)
+    -- sourceStore: 'profile' | 'shared' (GetMacroSourceTagForDrops)
+    local sh = (sourceStore or 'profile') == 'shared';
+    local arm = buildSlotRecord(armData);
+    if not sh and arm.macroSourceStore == nil then
+        arm.macroSourceStore = 'profile';
+    end
+    if sh and arm.macroSourceStore == nil then
+        arm.macroSourceStore = 'shared';
+    end
+    local out = { actionType = 'macro' };
+    if existingParentSlot and isDualMacroSlotTable(existingParentSlot) then
+        out[K_BIND_P] = existingParentSlot[K_BIND_P] and deepCopyTable(existingParentSlot[K_BIND_P]);
+        out[K_BIND_S] = existingParentSlot[K_BIND_S] and deepCopyTable(existingParentSlot[K_BIND_S]);
+    elseif existingParentSlot and existingParentSlot.macroRef and not isDualMacroSlotTable(existingParentSlot) then
+        -- migrate-on-write: one legacy binding → the appropriate arm
+        local leg = buildSlotRecord(existingParentSlot);
+        if (existingParentSlot.macroSourceStore or 'profile') == 'shared' then
+            out[K_BIND_S] = leg;
+        else
+            out[K_BIND_P] = leg;
+        end
+    else
+        out[K_BIND_P] = nil;
+        out[K_BIND_S] = nil;
+    end
+    if sh then
+        out[K_BIND_S] = arm;
+    else
+        out[K_BIND_P] = arm;
+    end
+    if out[K_BIND_P] and out[K_BIND_S] and out[K_BIND_P] == out[K_BIND_S] then
+        out[K_BIND_S] = deepCopyTable(out[K_BIND_S]);
+    end
+    return out;
+end
+
+-- Shared helper: resolve a slot's macroRef to live macro data if available.
+-- Returns a fresh table with canonical fields, the original non-macro slotAction, or nil if the
+-- slot should not display (e.g. Shared scope with no match in the shared library).
+-- macroSourceStore disambiguates profile vs global shared; in Shared scope, profile-tagged keys do not show.
+local function resolveSlotMacro(slotAction)
+    if not slotAction then
+        return nil;
+    end
+    if slotAction.cleared then
+        return nil;
+    end
+
+    local arm, isMacro = getActiveMacroBindingFromSlot(slotAction);
+    if not isMacro then
+        return slotAction;
+    end
+    if not arm or not arm.macroRef then
+        if isDualMacroSlotTable(slotAction) then
+            return nil;
+        end
+        return slotAction;
+    end
+
+    local paletteKey = arm.macroPaletteKey or (M.jobId or 1);
+    local gcfg = gConfig;
+    local scopeShared = gcfg and (gcfg.macroStorageScope or 'profile') == 'shared';
+    local mss = arm.macroSourceStore;
+    if not mss and isDualMacroSlotTable(slotAction) then
+        if scopeShared and arm == slotAction[K_BIND_S] then
+            mss = 'shared';
+        elseif not scopeShared and arm == slotAction[K_BIND_P] then
+            mss = 'profile';
+        end
+    end
+    if not mss and arm == slotAction then
+        -- Unscoped legacy hotbar/crossbar macro slots behave as profile library binds; hidden in shared scope.
+        mss = slotAction.macroSourceStore or 'profile';
+    end
+    local liveMacro;
+    if mss == 'shared' and not scopeShared then
+        local ok, sms = pcall(require, 'core.shared_macro_store');
+        if ok and sms and sms.LookupInDiskSharedFile then
+            liveMacro = sms.LookupInDiskSharedFile(arm.macroRef, paletteKey);
+        end
+    elseif mss == 'profile' and scopeShared then
+        -- Shared mode: do not show profile library binding — empty until re-drag from shared.
+        liveMacro = nil;
+    else
+        liveMacro = M.GetMacroById and M.GetMacroById(arm.macroRef, paletteKey);
+    end
+    if not liveMacro then
+        if scopeShared then
+            return nil;
+        end
+        -- Orphan macro binding: the macroRef no longer resolves to a live macro (deleted from
+        -- Macro Manager, or the draft layer still holds a stale ref the live gConfig sweep
+        -- didn't reach). Modern slots are minimal {macroRef, macroPaletteKey} records with no
+        -- fallback displayName/action — returning slotAction would render the slot with no
+        -- name and the abbreviation pass produces "?" placeholder garbage. Return nil so the
+        -- slot draws empty. Legacy slots that still carry cached displayName/action keep their
+        -- old behaviour (slotAction fallback) so partially-migrated profiles aren't wiped.
+        if isDualMacroSlotTable(slotAction) then
+            return nil;
+        end
+        if not slotAction.displayName and not slotAction.action then
+            return nil;
+        end
+        return slotAction;
+    end
+    local out = copySlotFields(liveMacro);
+    out.macroRef = arm.macroRef;
+    out.macroPaletteKey = arm.macroPaletteKey;
+    out.macroSourceStore = mss;
+    return out;
+end
+
+--- Raw crossbar blobs still hold inactive macro arms (profile vs shared) while the HUD shows empty for the other library.
+--- Swap/drag reads use raw tables — align them with what resolveSlotMacro would display so "blank" slots behave empty.
+function M.NormalizeCrossbarSlotRawForSwap(raw)
+    if raw == nil then return nil; end
+    if type(raw) ~= 'table' or raw.cleared then return nil; end
+    if resolveSlotMacro(raw) == nil then
+        return nil;
+    end
+    return raw;
+end
+
+--- In-place: legacy single macro binding -> macroBindProfile or macroBindShared.
+local function migrateOneSlotToDualMacroBindings(slot)
+    if not slot or type(slot) ~= 'table' or slot.cleared then
+        return false;
+    end
+    if isDualMacroSlotTable(slot) then
+        return false;
+    end
+    if not slot.macroRef then
+        return false;
+    end
+    if slot.actionType and slot.actionType ~= 'macro' then
+        return false;
+    end
+    local arm = copySlotFields(slot);
+    arm.macroRef = slot.macroRef or slot.id;
+    arm.macroPaletteKey = slot.macroPaletteKey;
+    arm.macroSourceStore = slot.macroSourceStore;
+    for _, k in ipairs(SLOT_DATA_FIELDS) do
+        slot[k] = nil;
+    end
+    slot.actionType = 'macro';
+    if (arm.macroSourceStore or 'profile') == 'shared' then
+        slot[K_BIND_S] = arm;
+        slot[K_BIND_P] = nil;
+    else
+        slot[K_BIND_P] = arm;
+        slot[K_BIND_S] = nil;
+    end
+    return true;
+end
+
+local function migrateHotbarSlotActionsTable(slotActions)
+    if not slotActions or type(slotActions) ~= 'table' then
+        return;
+    end
+    for _, jobSlotActions in pairs(slotActions) do
+        if type(jobSlotActions) == 'table' then
+            for _, slot in pairs(jobSlotActions) do
+                if type(slot) == 'table' then
+                    migrateOneSlotToDualMacroBindings(slot);
+                end
+            end
+        end
+    end
+end
+
+local function migrateCrossbarSlotActionsTable(slotActions)
+    if not slotActions or type(slotActions) ~= 'table' then
+        return;
+    end
+    local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+    for _, jobSlotActions in pairs(slotActions) do
+        if type(jobSlotActions) == 'table' then
+            for _, comboMode in ipairs(comboModes) do
+                local comboSlots = jobSlotActions[comboMode];
+                if type(comboSlots) == 'table' then
+                    for _, slot in pairs(comboSlots) do
+                        if type(slot) == 'table' then
+                            migrateOneSlotToDualMacroBindings(slot);
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+--- One-time per-load migration: split macro hotbar/crossbar refs into profile vs shared arms.
+function M.MigrateSlotDualMacroBindings(gConfig)
+    if not gConfig then
+        return;
+    end
+    for bar = 1, 6 do
+        local configKey = 'hotbarBar' .. bar;
+        local barSettings = gConfig[configKey];
+        if barSettings and barSettings.slotActions then
+            migrateHotbarSlotActionsTable(barSettings.slotActions);
+        end
+    end
+    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        migrateCrossbarSlotActionsTable(gConfig.hotbarCrossbar.slotActions);
+    end
+end
+
+--- Unresolved slot as stored in config (for dual-arm swap / drop merge).
+function M.GetRawHotbarSlotAction(barIndex, slotIndex)
+    if not gConfig then
+        return nil;
+    end
+    local configKey = 'hotbarBar' .. barIndex;
+    local barSettings = gConfig[configKey];
+    if not barSettings or not barSettings.slotActions then
+        return nil;
+    end
+    local storageKey = M.GetStorageKeyForBar(barIndex);
+    local jobSlotActions = getSlotActionsForKey(barSettings.slotActions, storageKey);
+    if not jobSlotActions then
+        return nil;
+    end
+    local n = tonumber(slotIndex) or slotIndex;
+    return jobSlotActions[n] or jobSlotActions[tostring(n)];
+end
+
+function M.GetRawCrossbarSlotAction(comboMode, slotIndex)
+    if not gConfig or not gConfig.hotbarCrossbar or not gConfig.hotbarCrossbar.slotActions then
+        return nil;
+    end
+    -- M.*: local GetEffectiveComboModeForStorage is defined later; bare name would read as a nil global here.
+    local effectiveComboMode = M.GetEffectiveComboModeForStorage(comboMode);
+    local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then
+        return nil;
+    end
+    return jobSlotActions[effectiveComboMode][slotIndex];
+end
+
+--- Raw slot blob for `storageKey` (palette editor segment / named palette), ignoring the HUD active palette.
+--- Same shape as GetRawCrossbarSlotAction — used when Edit Full Palette draft inherits an untouched sparse cell.
+function M.GetRawCrossbarSlotActionForStorageKey(storageKey, comboMode, slotIndex)
+    if not storageKey or not gConfig or not gConfig.hotbarCrossbar or not gConfig.hotbarCrossbar.slotActions then
+        return nil;
+    end
+    local effectiveComboMode = M.GetEffectiveComboModeForStorage(comboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then
+        return nil;
+    end
+    return jobSlotActions[effectiveComboMode][slotIndex];
+end
+
+--- Convert legacy layout to dual for swap / merge logic. nil or cleared => empty macro slot (no arms yet).
+function M.DualizeRawMacroSlotForMerge(raw)
+    if not raw or type(raw) ~= 'table' or raw.cleared then
+        return { actionType = 'macro' };
+    end
+    if isDualMacroSlotTable(raw) then
+        return deepCopyTable(raw);
+    end
+    if not raw.macroRef then
+        return deepCopyTable(raw);
+    end
+    if raw.actionType and raw.actionType ~= 'macro' then
+        return deepCopyTable(raw);
+    end
+    local arm = copySlotFields(raw);
+    arm.macroRef = raw.macroRef or raw.id;
+    arm.macroPaletteKey = raw.macroPaletteKey;
+    arm.macroSourceStore = raw.macroSourceStore;
+    local out = { actionType = 'macro' };
+    if (raw.macroSourceStore or 'profile') == 'shared' then
+        out[K_BIND_S] = arm;
+    else
+        out[K_BIND_P] = arm;
+    end
+    return out;
+end
+
+function M.FinalizeHotbarRawSlotForStorage(s)
+    if s == nil then
+        return { cleared = true };
+    end
+    if type(s) ~= 'table' then
+        return s;
+    end
+    if s.cleared then
+        return s;
+    end
+    if s.actionType == 'macro' and not s[K_BIND_P] and not s[K_BIND_S] and not s.macroRef then
+        return { cleared = true };
+    end
+    return s;
+end
+
+-- Crossbar empty slots are nil (not { cleared = true }).
+function M.FinalizeCrossbarRawSlotForStorage(s)
+    if not s or type(s) ~= 'table' then
+        return s;
+    end
+    if s.cleared then
+        return nil;
+    end
+    if s.actionType == 'macro' and not s[K_BIND_P] and not s[K_BIND_S] and not s.macroRef then
+        return nil;
+    end
+    return s;
+end
+
+local function macroPaletteKeysEqualData(a, b)
+    if a == b then
+        return true;
+    end
+    if a == nil or b == nil then
+        return false;
+    end
+    local na, nb = tonumber(a), tonumber(b);
+    if na ~= nil and nb ~= nil then
+        return na == nb;
+    end
+    return false;
+end
+
+local function macroArmMatchesDelete(arm, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    if not arm or type(arm) ~= 'table' or arm.macroRef ~= macroId then
+        return false;
+    end
+    deleteKind = deleteKind or 'profile';
+    local mss = arm.macroSourceStore;
+    if deleteKind == 'shared' then
+        if mss == 'profile' then
+            return false;
+        end
+    else
+        if mss == 'shared' then
+            return false;
+        end
+    end
+    local spk = arm.macroPaletteKey;
+    if spk ~= nil then
+        return macroPaletteKeysEqualData(spk, deletedTypeKey);
+    end
+    return onlyBucketForThisId;
+end
+
+-- Clear macro arms that refer to a deleted macro row. emptyWhenGone: hotbar { cleared = true } or crossbar nil.
+function M.ApplyMacroDeleteToSlotAction(slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, emptyWhenGone)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local out = deepCopyTable(slotAction);
+        local chg = false;
+        if macroArmMatchesDelete(out[K_BIND_P], macroId, deletedTypeKey, onlyBucketForThisId, deleteKind) then
+            out[K_BIND_P] = nil;
+            chg = true;
+        end
+        if macroArmMatchesDelete(out[K_BIND_S], macroId, deletedTypeKey, onlyBucketForThisId, deleteKind) then
+            out[K_BIND_S] = nil;
+            chg = true;
+        end
+        if not chg then
+            return nil, false;
+        end
+        if not out[K_BIND_P] and not out[K_BIND_S] then
+            return emptyWhenGone, true;
+        end
+        out.actionType = 'macro';
+        return out, true;
+    end
+    if not slotAction.macroRef or slotAction.macroRef ~= macroId then
+        return nil, false;
+    end
+    if not macroArmMatchesDelete(slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind) then
+        return nil, false;
+    end
+    return emptyWhenGone, true;
+end
+
+--- True when a macro arm should be cleared because its entire palette bucket was removed.
+local function macroArmMatchesBucketRemove(arm, removedBucketKey, deleteKind)
+    if not arm or type(arm) ~= 'table' or not arm.macroRef then
+        return false;
+    end
+    deleteKind = deleteKind or 'profile';
+    local mss = arm.macroSourceStore;
+    if deleteKind == 'shared' then
+        if mss == 'profile' then
+            return false;
+        end
+    else
+        if mss == 'shared' then
+            return false;
+        end
+    end
+    if arm.macroPaletteKey == nil then
+        return false;
+    end
+    return macroPaletteKeysEqualData(arm.macroPaletteKey, removedBucketKey);
+end
+
+-- After removing an entire custom:* (or any) macro palette bucket: clear all bindings to that key.
+-- deleteKind: 'profile' = profile-library arms, 'shared' = shared-library arms. emptyWhenGone: hotbar {cleared} / cross nil.
+function M.ApplyMacroPaletteBucketRemovedToSlotAction(slotAction, removedBucketKey, deleteKind, emptyWhenGone)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local out = deepCopyTable(slotAction);
+        local chg = false;
+        if macroArmMatchesBucketRemove(out[K_BIND_P], removedBucketKey, deleteKind) then
+            out[K_BIND_P] = nil;
+            chg = true;
+        end
+        if macroArmMatchesBucketRemove(out[K_BIND_S], removedBucketKey, deleteKind) then
+            out[K_BIND_S] = nil;
+            chg = true;
+        end
+        if not chg then
+            return nil, false;
+        end
+        if not out[K_BIND_P] and not out[K_BIND_S] then
+            return emptyWhenGone, true;
+        end
+        out.actionType = 'macro';
+        return out, true;
+    end
+    if not slotAction.macroRef then
+        return nil, false;
+    end
+    if not macroArmMatchesBucketRemove(slotAction, removedBucketKey, deleteKind) then
+        return nil, false;
+    end
+    return emptyWhenGone, true;
+end
+
+--- Compare macro palette bucket keys (job id number vs string forms, reserved string buckets).
+function M.MacroPaletteKeysEqual(a, b)
+    return macroPaletteKeysEqualData(a, b);
+end
+
+-- Arms pointing at `macroId` in `sourceKey`: explicit palette key match, or nil key only when
+-- `onlyBucketForThisId` (macro id appears in a single macroDB bucket worldwide).
+local function macroArmMatchesMoveSource(arm, macroId, sourceKey, onlyBucketForThisId)
+    if not arm or type(arm) ~= 'table' or arm.macroRef ~= macroId then
+        return false;
+    end
+    local spk = arm.macroPaletteKey;
+    if spk ~= nil then
+        return macroPaletteKeysEqualData(spk, sourceKey);
+    end
+    return onlyBucketForThisId;
+end
+
+--- Rewrite palette macro bindings after MoveMacro: same slots keep working under new macroRef + macroPaletteKey.
+function M.ApplyMacroMoveToSlotAction(slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId)
+    if not slotAction or type(slotAction) ~= 'table' or slotAction.cleared then
+        return nil, false;
+    end
+    if isDualMacroSlotTable(slotAction) then
+        local out = deepCopyTable(slotAction);
+        local chg = false;
+        if macroArmMatchesMoveSource(out[K_BIND_P], oldId, oldKey, onlyBucketForThisId) then
+            out[K_BIND_P].macroRef = newId;
+            out[K_BIND_P].macroPaletteKey = newKey;
+            chg = true;
+        end
+        if macroArmMatchesMoveSource(out[K_BIND_S], oldId, oldKey, onlyBucketForThisId) then
+            out[K_BIND_S].macroRef = newId;
+            out[K_BIND_S].macroPaletteKey = newKey;
+            chg = true;
+        end
+        if not chg then
+            return nil, false;
+        end
+        out.actionType = 'macro';
+        return out, true;
+    end
+    if not slotAction.macroRef or slotAction.macroRef ~= oldId then
+        return nil, false;
+    end
+    if not macroArmMatchesMoveSource(slotAction, oldId, oldKey, onlyBucketForThisId) then
+        return nil, false;
+    end
+    local out = deepCopyTable(slotAction);
+    out.macroRef = newId;
+    out.macroPaletteKey = newKey;
+    return out, true;
+end
+
+local CROSSBAR_COMBO_MODES_FOR_MACRO_SWEEP = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+
+--- Hotbars + crossbar live slot maps in cfg (typically gConfig).
+function M.RewriteMacroPaletteBindingsInConfig(cfg, oldId, oldKey, newId, newKey, onlyBucketForThisId, notifyLayouts)
+    if not cfg or not oldId or oldKey == nil or not newId or newKey == nil then
+        return false;
+    end
+    local changed = false;
+    for barIndex = 1, 6 do
+        local configKey = 'hotbarBar' .. barIndex;
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
+            for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
+                if jobSlotActions then
+                    for slotIndex, slotAction in pairs(jobSlotActions) do
+                        local newSlot, chg = M.ApplyMacroMoveToSlotAction(
+                            slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId);
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
+        for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
+            if jobSlotActions then
+                for _, comboMode in ipairs(CROSSBAR_COMBO_MODES_FOR_MACRO_SWEEP) do
+                    local comboSlots = jobSlotActions[comboMode];
+                    if comboSlots then
+                        for slotIndex, slotAction in pairs(comboSlots) do
+                            local newSlot, chg = M.ApplyMacroMoveToSlotAction(
+                                slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if changed and notifyLayouts then
+        NotifySlotDataChanged();
+    end
+    return changed;
+end
+
+--- Edit Full Palette draft crossbar blobs (if open).
+function M.RewriteMacroPaletteBindingsInDraft(oldId, oldKey, newId, newKey, onlyBucketForThisId)
+    if not draftForStorageKey or not draftByKey then
+        return false;
+    end
+    local changed = false;
+    for _, blob in pairs(draftByKey) do
+        if type(blob) == 'table' then
+            for _, comboMode in ipairs(CROSSBAR_COMBO_MODES_FOR_MACRO_SWEEP) do
+                local comboSlots = blob[comboMode];
+                if comboSlots then
+                    for slotIndex, slotAction in pairs(comboSlots) do
+                        local newSlot, chg = M.ApplyMacroMoveToSlotAction(
+                            slotAction, oldId, oldKey, newId, newKey, onlyBucketForThisId);
+                        if chg then
+                            comboSlots[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if changed then
+        draftDirty = true;
+        NotifySlotDataChanged();
+    end
+    return changed;
+end
+
+local function isLibraryMacroSlotForSwap(s)
+    if not s or type(s) ~= 'table' or s.cleared then
+        return false;
+    end
+    if s[K_BIND_P] ~= nil or s[K_BIND_S] ~= nil then
+        return true;
+    end
+    if s.macroRef and (not s.actionType or s.actionType == 'macro') then
+        return true;
+    end
+    return false;
+end
+
+-- If profile and shared arm tables are the same reference (data corruption or legacy bug), the active-arm
+-- swap can move a profile binding into the wrong key or "clone" the same row — split into two tables.
+local function disambiguateDualMacroArms(t)
+    if not t or type(t) ~= 'table' then
+        return;
+    end
+    if t[K_BIND_P] ~= nil and t[K_BIND_S] ~= nil and t[K_BIND_P] == t[K_BIND_S] then
+        t[K_BIND_S] = deepCopyTable(t[K_BIND_S]);
+    end
+end
+
+--- Exchange only the active library's arm when both slots are palette macro bindings; else swap whole slot tables.
+-- rawA = source slot (dragged from), rawB = target slot (dropped onto).
+-- Returns (value for target index, value for source index) for callers that assign:
+--   job[target] = first; job[source] = second
+function M.SwapActiveMacroArmsInPlace(rawA, rawB)
+    if isLibraryMacroSlotForSwap(rawA) and isLibraryMacroSlotForSwap(rawB) then
+        local a = M.DualizeRawMacroSlotForMerge(rawA);
+        local b = M.DualizeRawMacroSlotForMerge(rawB);
+        disambiguateDualMacroArms(a);
+        disambiguateDualMacroArms(b);
+        local sh = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared');
+        local k = sh and K_BIND_S or K_BIND_P;
+        local t = a[k];
+        a[k] = b[k];
+        b[k] = t;
+        -- Deep copy so we never return tables that still alias nested refs from the other cell or from gConfig.
+        return deepCopyTable(b), deepCopyTable(a);
+    end
+    return deepCopyTable(rawA), deepCopyTable(rawB);
+end
+
+-- Merge slot maps when migrating legacy job:subjob:petKey -> petpalette:petKey (fill empty slots only)
+local function mergeHotbarSlotActions(dst, src)
+    if type(dst) ~= 'table' or type(src) ~= 'table' then
+        return;
+    end
+    for si, action in pairs(src) do
+        if dst[si] == nil then
+            dst[si] = deepCopyTable(action);
+        elseif type(dst[si]) == 'table' and dst[si].cleared
+            and type(action) == 'table' and not action.cleared then
+            dst[si] = deepCopyTable(action);
+        end
+    end
+end
+
+local function mergeCrossbarComboSlotActions(dst, src)
+    if type(dst) ~= 'table' or type(src) ~= 'table' then
+        return;
+    end
+    for comboMode, slots in pairs(src) do
+        if type(slots) == 'table' then
+            if not dst[comboMode] then
+                dst[comboMode] = {};
+            end
+            mergeHotbarSlotActions(dst[comboMode], slots);
+        end
+    end
+end
+
+-- One-time migration: legacy '{job}:{sub}:{petKey}' -> 'petpalette:{petKey}' for pet-aware storage
+function M.MigratePetAwareSlotStorageKeys()
+    if not gConfig then
+        return false;
+    end
+    local changed = false;
+    local palPrefix = 'palette:';
+
+    local function shouldMigrateKey(remainder)
+        if not remainder or remainder == '' then
+            return false;
+        end
+        if remainder:sub(1, #palPrefix) == palPrefix then
+            return false;
+        end
+        if remainder:sub(1, #PETPALETTE_STORAGE_PREFIX) == PETPALETTE_STORAGE_PREFIX then
+            return false;
+        end
+        return petregistry.IsValidPetKey(remainder);
+    end
+
+    local function migrateFlatSlotActions(slotActions)
+        if not slotActions or type(slotActions) ~= 'table' then
+            return;
+        end
+        local moves = {};
+        for key, payload in pairs(slotActions) do
+            if type(key) == 'string' and type(payload) == 'table' then
+                local jid, sjid, remainder = key:match('^(%d+):(%d+):(.+)$');
+                if jid and sjid and shouldMigrateKey(remainder) then
+                    local newKey = PETPALETTE_STORAGE_PREFIX .. remainder;
+                    moves[key] = newKey;
+                end
+            end
+        end
+        for oldKey, newKey in pairs(moves) do
+            local oldData = slotActions[oldKey];
+            slotActions[oldKey] = nil;
+            changed = true;
+            if not slotActions[newKey] then
+                slotActions[newKey] = deepCopyTable(oldData);
+            else
+                mergeHotbarSlotActions(slotActions[newKey], oldData);
+            end
+        end
+    end
+
+    local function migrateCrossbarSlotActions(slotActions)
+        if not slotActions or type(slotActions) ~= 'table' then
+            return;
+        end
+        local moves = {};
+        for key, payload in pairs(slotActions) do
+            if type(key) == 'string' and type(payload) == 'table' then
+                local jid, sjid, remainder = key:match('^(%d+):(%d+):(.+)$');
+                if jid and sjid and shouldMigrateKey(remainder) then
+                    local newKey = PETPALETTE_STORAGE_PREFIX .. remainder;
+                    moves[key] = newKey;
+                end
+            end
+        end
+        for oldKey, newKey in pairs(moves) do
+            local oldData = slotActions[oldKey];
+            slotActions[oldKey] = nil;
+            changed = true;
+            if not slotActions[newKey] then
+                slotActions[newKey] = deepCopyTable(oldData);
+            else
+                mergeCrossbarComboSlotActions(slotActions[newKey], oldData);
+            end
+        end
+    end
+
+    for barIndex = 1, M.NUM_BARS do
+        local configKey = 'hotbarBar' .. barIndex;
+        local barSettings = gConfig[configKey];
+        if barSettings and barSettings.slotActions then
+            migrateFlatSlotActions(barSettings.slotActions);
+        end
+    end
+    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        migrateCrossbarSlotActions(gConfig.hotbarCrossbar.slotActions);
+    end
+    if changed then
+        NotifySlotDataChanged();
+    end
+    return changed;
+end
+
+-- Shared helper: ensure slotActions structure exists for a storage key.
+-- When comboMode is provided (crossbar), also ensures the combo-mode sub-table and returns it.
+-- When comboMode is nil (hotbar), returns the top-level bucket for the key.
+-- Copies from subjob-0 fallback when creating a new key to preserve data across subjob changes.
+local function ensureSlotActionsStructure(settings, storageKey, comboMode)
+    if not settings.slotActions then
+        settings.slotActions = {};
+    end
+    if storageKey == GLOBAL_SLOT_KEY then
+        if not settings.slotActions[GLOBAL_SLOT_KEY] then
+            settings.slotActions[GLOBAL_SLOT_KEY] = {};
+        end
+        local bucket = settings.slotActions[GLOBAL_SLOT_KEY];
+        if comboMode then
+            if not bucket[comboMode] then bucket[comboMode] = {}; end
+            return bucket[comboMode];
+        end
+        return bucket;
+    end
+    if not settings.slotActions[storageKey] then
         local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
         if jobId and subjobId ~= '0' then
-            -- Build fallback key with subjob=0, preserving any suffix (palette, avatar, etc.)
             local fallbackKey = jobId .. ':0' .. (suffix or '');
-            local fallbackData = barSettings.slotActions[fallbackKey];
+            local fallbackData = settings.slotActions[fallbackKey];
             if fallbackData then
-                -- Deep copy fallback data to the new key to preserve all slots
-                barSettings.slotActions[storageKey] = deepCopyTable(fallbackData);
+                settings.slotActions[storageKey] = deepCopyTable(fallbackData);
             else
-                barSettings.slotActions[storageKey] = {};
+                settings.slotActions[storageKey] = {};
             end
         else
-            barSettings.slotActions[storageKey] = {};
+            settings.slotActions[storageKey] = {};
         end
     end
-    return barSettings.slotActions[storageKey];
+    local bucket = settings.slotActions[storageKey];
+    if comboMode then
+        if not bucket[comboMode] then bucket[comboMode] = {}; end
+        return bucket[comboMode];
+    end
+    return bucket;
 end
 
 -- Keys that are always per-bar (never pulled from global)
@@ -229,11 +1234,12 @@ local PER_BAR_ONLY_KEYS = {
     columns = true,
     slots = true,
     useGlobalSettings = true,
-    keybinds = true,
+    keyBindings = true,
     slotActions = true,
     jobSpecific = true,
     petAware = true,
     showPetIndicator = true,
+    petPalettePetKeys = true,
 };
 
 -- ============================================
@@ -241,18 +1247,11 @@ local PER_BAR_ONLY_KEYS = {
 -- ============================================
 
 -- Build full storage key for a bar, considering job, subjob, pet awareness, and general palettes
--- Returns: 'global', '{jobId}:{subjobId}' (base), '{jobId}:{subjobId}:{petKey}' (pet), or '{jobId}:{subjobId}:palette:{name}' (palette)
+-- Returns: 'global', '{jobId}:{subjobId}' (base), 'petpalette:{petKey}' (pet), or '{jobId}:{subjobId}:palette:{name}' (palette)
 -- Priority: global > pet-aware > general palette > base
 -- NOTE: Palettes can be subjob-specific or shared (subjob 0), with fallback to shared if no subjob-specific exist
 -- OPTIMIZED: Results are cached to avoid 72+ string allocations per frame
 function M.GetStorageKeyForBar(barIndex)
-    -- If gConfig was swapped out (profile change), invalidate.
-    if storageKeyCacheSource ~= gConfig then
-        storageKeyCache = {};
-        storageKeyCacheDirty = true;
-        storageKeyCacheSource = gConfig;
-    end
-
     -- Check cache first (major optimization for runtime rendering)
     if not storageKeyCacheDirty and storageKeyCache[barIndex] then
         return storageKeyCache[barIndex];
@@ -287,11 +1286,14 @@ function M.GetStorageKeyForBar(barIndex)
             if pp then
                 -- Check for manual override or auto-detected pet
                 petKey = pp.GetEffectivePetKey(barIndex);
+                if petKey and not petAllowlist.Allows(barSettings, petKey) then
+                    petKey = nil;
+                end
             end
         end
 
         if petKey then
-            result = string.format('%s:%s', baseKey, petKey);
+            result = PETPALETTE_STORAGE_PREFIX .. petKey;
         else
             -- Check for general palette (user-defined named palettes)
             -- Palettes use subjob-aware keys with fallback to shared (subjob 0) if no subjob-specific exist
@@ -347,7 +1349,9 @@ function M.GetAvailablePalettes(barIndex)
         if pp then
             local petPalettes = pp.GetAvailablePalettes(barIndex, jobId, subjobId);
             for _, p in ipairs(petPalettes) do
-                table.insert(palettes, p);
+                if p.key == nil or petAllowlist.Allows(barSettings, p.key) then
+                    table.insert(palettes, p);
+                end
             end
         end
     end
@@ -380,9 +1384,12 @@ function M.GetCurrentPaletteDisplayName(barIndex)
     if barSettings and barSettings.petAware then
         local pp = getPetPalette();
         if pp then
-            local petDisplayName = pp.GetPaletteDisplayName(barIndex, jobId);
-            if petDisplayName and petDisplayName ~= 'Base' then
-                return petDisplayName;
+            local ek = pp.GetEffectivePetKey(barIndex);
+            if ek and petAllowlist.Allows(barSettings, ek) then
+                local petDisplayName = pp.GetPaletteDisplayName(barIndex, jobId);
+                if petDisplayName and petDisplayName ~= 'Base' then
+                    return petDisplayName;
+                end
             end
         end
     end
@@ -426,13 +1433,147 @@ end
 -- Expose for external use (e.g., crossbar icon caching)
 M.GetEffectiveComboModeForStorage = GetEffectiveComboModeForStorage;
 
+-- Job-wide shared segment storage (Edit Full Palette: Job-Shared override). effectiveComboMode = GetEffectiveComboModeForStorage(mode).
+function M.BuildJobSegmentSharedStorageKey(jobId, effectiveComboMode)
+    local j = normalizeJobId(jobId);
+    local m = effectiveComboMode or 'L2x2';
+    return string.format('jobsegment:%d:%s', j, m);
+end
+
+-- FFXI main jobs 1..22 — segment override rows are keyed per job; Global [G] redirects must resolve for the *current* job id in-game.
+local SEGMENT_OVERRIDE_FALLBACK_JOB_MAX = 22;
+
+local function GetSegmentOverrideEntry(jobId, comboMode)
+    local cross = gConfig and gConfig.hotbarCrossbar;
+    if not cross or not cross.segmentOverrides then
+        return nil;
+    end
+    local eff = GetEffectiveComboModeForStorage(comboMode);
+    if eff == 'L2' or eff == 'R2' then
+        return nil;
+    end
+    local jidStr = tostring(normalizeJobId(jobId));
+    local modes = cross.segmentOverrides[jidStr];
+    local seg = modes and modes[eff];
+    if seg and seg.scope == 'jobShared' then
+        return seg, eff;
+    end
+    if seg and seg.scope == 'global' and type(seg.globalPalette) == 'string' and seg.globalPalette ~= '' then
+        return seg, eff;
+    end
+    -- Legacy / partial saves: Global was only stored on the job row open in Edit Full Palette; other job ids had no entry.
+    if not seg or not seg.scope then
+        local anyJobShared = false;
+        local globalPaletteName;
+        for j = 1, SEGMENT_OVERRIDE_FALLBACK_JOB_MAX do
+            local candidate = cross.segmentOverrides[tostring(j)] and cross.segmentOverrides[tostring(j)][eff];
+            if candidate and candidate.scope == 'jobShared' then
+                anyJobShared = true;
+            elseif candidate and candidate.scope == 'global' and type(candidate.globalPalette) == 'string' and candidate.globalPalette ~= '' then
+                globalPaletteName = candidate.globalPalette;
+            end
+        end
+        if not anyJobShared and globalPaletteName then
+            return { scope = 'global', globalPalette = globalPaletteName }, eff;
+        end
+    end
+    return nil;
+end
+
+-- Resolved slotActions key when a Job-Shared / Global segment override is active (nil if none).
+function M.GetSegmentOverrideResolvedStorageKey(jobId, comboMode)
+    local seg, eff = GetSegmentOverrideEntry(jobId, comboMode);
+    if not seg or not seg.scope then
+        return nil;
+    end
+    if seg.scope == 'jobShared' then
+        return M.BuildJobSegmentSharedStorageKey(jobId, eff);
+    end
+    if seg.scope == 'global' and type(seg.globalPalette) == 'string' and seg.globalPalette ~= '' then
+        return getPalette().BuildUniversalCrossbarStorageKey(seg.globalPalette);
+    end
+    return nil;
+end
+
+-- For Edit Full Palette warnings: { scope, globalPalette?, effectiveMode } or nil
+function M.GetSegmentOverrideDescriptorForJob(jobId, comboMode)
+    local seg, eff = GetSegmentOverrideEntry(jobId, comboMode);
+    if not seg or not seg.scope then
+        return nil;
+    end
+    return {
+        scope = seg.scope,
+        globalPalette = seg.globalPalette,
+        effectiveMode = eff,
+    };
+end
+
 -- ============================================
 -- Crossbar Storage Key Resolution (GLOBAL Palette)
 -- ============================================
 
+-- Per combo *segment* (L2, R2, …) pet type filter: comboModeSettings[mode].petPalettePetKeys, or fallback
+-- hotbarCrossbar.petPalettePetKeys, or nil = all. Not per named [J] palette.
+local function getCrossbarPetTypeKeysForMode(crossbarSettings, mode)
+    if not crossbarSettings or not mode then
+        return nil;
+    end
+    local cm = crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[mode];
+    if cm and cm.petPalettePetKeys ~= nil then
+        return cm.petPalettePetKeys;
+    end
+    if crossbarSettings.petPalettePetKeys ~= nil then
+        return crossbarSettings.petPalettePetKeys;
+    end
+    return nil;
+end
+
+-- Merge Crossbar defaults with optional per-named-palette overrides (Job [J] scope only)
+local function GetMergedCrossbarComboModeSettings(comboMode)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local base = crossbarSettings and crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[comboMode];
+    if not base then
+        base = { petAware = false, universalOverridePalette = nil };
+    end
+    local merged = {
+        petAware = base.petAware == true,
+        universalOverridePalette = base.universalOverridePalette,
+        petPalettePetKeys = getCrossbarPetTypeKeysForMode(crossbarSettings, comboMode),
+    };
+    local p = getPalette();
+    if not crossbarSettings or not p or not crossbarSettings.namedPaletteComboModeSettings then
+        return merged;
+    end
+    if crossbarSettings.enableUniversalCrossbarPalettes and p.GetCrossbarPaletteScope() == 'universal' then
+        return merged;
+    end
+    local jobId = M.jobId or 1;
+    local subjobId = M.subjobId or 0;
+    local palName = p.GetActivePaletteForCombo('L2');
+    if not palName or palName == '' then
+        return merged;
+    end
+    local tier = subjobId;
+    if subjobId ~= 0 and p.GetCrossbarActivePaletteStorageSubjobForResolution then
+        tier = p.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, subjobId);
+    end
+    local storageKey = p.BuildPaletteStorageKey(jobId, tier, palName);
+    local byPal = crossbarSettings.namedPaletteComboModeSettings[storageKey];
+    local ovr = byPal and byPal[comboMode];
+    if not ovr then
+        return merged;
+    end
+    -- Pet palette on/off and pet-type allowlist are job-wide, not per named palette.
+    if ovr.universalOverridePalette ~= nil then
+        local u = ovr.universalOverridePalette;
+        merged.universalOverridePalette = (type(u) == 'string' and u ~= '') and u or nil;
+    end
+    return merged;
+end
+
 -- Build full storage key for a crossbar combo mode, considering job, subjob, pet awareness, and palettes
--- NOTE: Crossbar now uses a SINGLE global palette for all combo modes (not per-combo-mode)
--- Returns: 'global', '{jobId}:{subjobId}' (base), '{jobId}:{subjobId}:{petKey}' (pet), or '{jobId}:{subjobId}:palette:{name}' (palette)
+-- Returns: 'global', 'global:palette:{name}', '{jobId}:{subjobId}', 'petpalette:{petKey}',
+--   or '{jobId}:{subjobId}:palette:{name}'
 function M.GetCrossbarStorageKeyForCombo(comboMode)
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
     if not crossbarSettings then
@@ -444,51 +1585,71 @@ function M.GetCrossbarStorageKeyForCombo(comboMode)
     local normalizedJobId = normalizeJobId(jobId);
     local normalizedSubjobId = normalizeJobId(subjobId);
 
-    -- Global mode (non-job-specific)
+    -- Global mode (non-job-specific single flat slot map)
     if crossbarSettings.jobSpecific == false then
         return GLOBAL_SLOT_KEY;
     end
 
-    -- Build base job:subjob key (used for base slots - subjob-specific)
     local baseKey = string.format('%d:%d', normalizedJobId, normalizedSubjobId);
+    local modeSettings = GetMergedCrossbarComboModeSettings(comboMode);
+    local p = getPalette();
 
-    -- Get per-combo-mode settings (still used for pet-aware, but not for palette)
-    local modeSettings = crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[comboMode];
+    -- [G] L1+R1 scope: all combos use all-jobs storage keys; pet never applies (including per-combo [G] attach)
+    if crossbarSettings.enableUniversalCrossbarPalettes and p and p.GetCrossbarPaletteScope() == 'universal' then
+        if modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+            return p.BuildUniversalCrossbarStorageKey(modeSettings.universalOverridePalette);
+        end
+        local uName = p.GetActiveUniversalCrossbarPalette();
+        if uName and uName ~= '' then
+            return p.BuildUniversalCrossbarStorageKey(uName);
+        end
+        return baseKey;
+    end
 
-    -- Check pet-aware mode for this combo mode
+    -- Temporary /xiui cpal summon: another job's named palette (flat layout; skips pet, segment overrides, per-mode [G] attach).
+    if p and p.GetCrossbarCliPreview then
+        local pv = p.GetCrossbarCliPreview();
+        if pv and pv.paletteName and pv.jobId then
+            local sfx = p.GetPaletteKeySuffix(pv.paletteName);
+            if sfx then
+                return string.format('%d:%d:%s', pv.jobId, pv.storageSubjob or 0, sfx);
+            end
+        end
+    end
+
+    -- [J] scope: pet can override job-tier storage, including when a combo uses an attached [G] palette name
     if modeSettings and modeSettings.petAware then
         local pp = getPetPalette();
         if pp then
             local effectivePetKey = pp.GetEffectivePetKeyForCombo(comboMode);
-            if effectivePetKey then
-                return string.format('%s:%s', baseKey, effectivePetKey);
+            if effectivePetKey and petAllowlist.Allows(modeSettings, effectivePetKey) then
+                return PETPALETTE_STORAGE_PREFIX .. effectivePetKey;
             end
         end
     end
 
-    -- Check for GLOBAL crossbar palette (shared across all combo modes)
-    -- Palettes use subjob-aware keys with fallback to shared (subjob 0) if no subjob-specific exist
-    local p = getPalette();
+    -- Per-job segment override (Edit Full Palette): Job-Shared bucket or Global [G] palette source — supersedes legacy per-palette [G] attach below
+    local segOvrKey = M.GetSegmentOverrideResolvedStorageKey(normalizedJobId, comboMode);
+    if segOvrKey then
+        return segOvrKey;
+    end
+
+    if p and modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+        return p.BuildUniversalCrossbarStorageKey(modeSettings.universalOverridePalette);
+    end
+
+    -- Named job / job+subjob crossbar palettes
     if p then
         local paletteSuffix = p.GetEffectivePaletteKeySuffixForCombo(comboMode);
         if paletteSuffix then
-            -- Determine which subjobId to use: check if using fallback to shared palettes
-            local effectiveSubjobId = normalizedSubjobId;
-            -- Use crossbar-specific fallback check
-            if p.IsUsingFallbackPalettes then
-                -- Check crossbar palettes specifically
-                local crossbarPalettes = p.GetCrossbarAvailablePalettes(normalizedJobId, normalizedSubjobId);
-                -- If no palettes found and we're not at subjob 0, we're likely using fallback
-                if #crossbarPalettes == 0 or (normalizedSubjobId ~= 0 and p.IsUsingFallbackPalettes(normalizedJobId, normalizedSubjobId)) then
-                    effectiveSubjobId = 0;  -- Use shared palette key
-                end
+            local tierSubjob = normalizedSubjobId;
+            if normalizedSubjobId ~= 0 and p.GetCrossbarActivePaletteStorageSubjobForResolution then
+                tierSubjob = p.GetCrossbarActivePaletteStorageSubjobForResolution(normalizedJobId, normalizedSubjobId);
             end
-            -- NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
-            return string.format('%d:%d:%s', normalizedJobId, effectiveSubjobId, paletteSuffix);
+            return string.format('%d:%d:%s', normalizedJobId, tierSubjob, paletteSuffix);
         end
     end
 
-    -- No pet or palette - fall back to base job:subjob key
     return baseKey;
 end
 
@@ -497,22 +1658,60 @@ end
 -- NOTE: Now uses GLOBAL crossbar palette instead of per-combo-mode
 function M.GetCrossbarPaletteDisplayName(comboMode)
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
-    local modeSettings = crossbarSettings and crossbarSettings.comboModeSettings and crossbarSettings.comboModeSettings[comboMode];
+    local modeSettings = GetMergedCrossbarComboModeSettings(comboMode);
     local jobId = M.jobId or 1;
+    local p = getPalette();
 
-    -- Check pet palette first (if pet-aware - still per-combo-mode)
+    -- [G] scope: universal keys only (no pet)
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes and p and p.GetCrossbarPaletteScope() == 'universal' then
+        if modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+            return modeSettings.universalOverridePalette;
+        end
+        local u = p.GetActiveUniversalCrossbarPalette();
+        if u and u ~= '' then
+            return u;
+        end
+    end
+
+    if p and p.GetCrossbarCliPreview and p.GetCrossbarPaletteScope() == 'job' then
+        local pv = p.GetCrossbarCliPreview();
+        if pv and pv.paletteName then
+            return pv.paletteName .. ' (preview)';
+        end
+    end
+
+    -- [J] scope: pet wins over attached [G] palette name and job palette
     if modeSettings and modeSettings.petAware then
         local pp = getPetPalette();
         if pp then
-            local petDisplayName = pp.GetCrossbarPaletteDisplayName(comboMode, jobId);
-            if petDisplayName and petDisplayName ~= 'Base' then
-                return petDisplayName;
+            local ek = pp.GetEffectivePetKeyForCombo(comboMode);
+            if ek and petAllowlist.Allows(modeSettings, ek) then
+                local petDisplayName = pp.GetCrossbarPaletteDisplayName(comboMode, jobId);
+                if petDisplayName and petDisplayName ~= 'Base' then
+                    return petDisplayName;
+                end
             end
         end
     end
 
-    -- Check GLOBAL crossbar palette (shared across all combo modes)
-    local p = getPalette();
+    local segDesc = M.GetSegmentOverrideDescriptorForJob(jobId, comboMode);
+    if segDesc then
+        if segDesc.scope == 'global' and type(segDesc.globalPalette) == 'string' and segDesc.globalPalette ~= '' then
+            return segDesc.globalPalette;
+        end
+        if segDesc.scope == 'jobShared' then
+            local n = p and p.GetActivePaletteForCombo('L2');
+            if n and n ~= '' then
+                return n .. ' (job-shared)';
+            end
+            return 'Job-shared';
+        end
+    end
+
+    if modeSettings and type(modeSettings.universalOverridePalette) == 'string' and modeSettings.universalOverridePalette ~= '' then
+        return modeSettings.universalOverridePalette;
+    end
+
     if p then
         local paletteName = p.GetActivePaletteForCombo(comboMode);
         if paletteName then
@@ -668,40 +1867,23 @@ function M.GetKeybindDisplay(barIndex, slotIndex)
     return '';
 end
 
--- Helper to look up a macro from macroDB by id
--- paletteKey can be a job ID (number) or composite key (string like "15:avatar:ifrit")
--- OPTIMIZED: Uses O(1) lookup map instead of linear search
--- Falls back to scanning all palettes for legacy slots that don't have macroPaletteKey set
+-- Look up a macro row: macroId is unique only within the given paletteKey bucket
+-- (not across jobs or global). paletteKey: job id, global/items/equipment/xiui/custom:*, or
+-- composite (e.g. "15:avatar:ifrit"). OPTIMIZED: O(1) via lookup + string/number key alias.
 local function GetMacroById(macroId, paletteKey)
     if not gConfig or not gConfig.macroDB then return nil; end
 
     -- Try the specific palette key first using O(1) lookup
-    if paletteKey ~= nil then
-        local macro = GetMacroFromLookup(macroId, paletteKey);
-        if macro then
-            return macro;
-        end
-
-        -- If paletteKey is a composite key and macro not found, try base job palette
-        if type(paletteKey) == 'string' then
-            local baseJobId = tonumber(paletteKey:match('^(%d+)'));
-            if baseJobId then
-                macro = GetMacroFromLookup(macroId, baseJobId);
-                if macro then
-                    return macro;
-                end
-            end
-        end
+    local macro = GetMacroFromLookup(macroId, paletteKey);
+    if macro then
+        return macro;
     end
 
-    -- Fallback for legacy slots missing macroPaletteKey: scan all palettes
-    -- (rebuild lookup if dirty OR if gConfig.macroDB was swapped under us)
-    if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
-        RebuildMacroLookup();
-    end
-    for key, paletteLookup in pairs(macroIdLookup) do
-        if key ~= paletteKey then
-            local macro = paletteLookup[macroId];
+    -- If paletteKey is a composite key and macro not found, try base job palette
+    if type(paletteKey) == 'string' then
+        local baseJobId = tonumber(paletteKey:match('^(%d+)'));
+        if baseJobId then
+            macro = GetMacroFromLookup(macroId, baseJobId);
             if macro then
                 return macro;
             end
@@ -711,6 +1893,9 @@ local function GetMacroById(macroId, paletteKey)
     return nil;
 end
 
+-- O(1) macro row lookup (paletteKey = job id, global key, or composite pet key)
+M.GetMacroById = GetMacroById;
+
 -- Get action assignment for a specific bar and slot
 function M.GetKeybindForSlot(barIndex, slotIndex)
     -- First check for custom slot actions in per-bar settings
@@ -719,56 +1904,29 @@ function M.GetKeybindForSlot(barIndex, slotIndex)
         local barSettings = gConfig[configKey];
         -- Use pet-aware storage key (handles global, job-specific, and pet palettes)
         local storageKey = M.GetStorageKeyForBar(barIndex);
-        local jobSlotActions = getSlotActionsForJob(barSettings.slotActions, storageKey);
+        local jobSlotActions = getSlotActionsForKey(barSettings.slotActions, storageKey);
 
         -- NOTE: Do NOT fall back to base job when pet palette is active
         -- If user has a pet out and petAware enabled, show the pet-specific palette (even if empty)
         -- This prevents the base job summon macros from showing when an avatar is summoned
         if jobSlotActions then
-            -- Handle both numeric and string keys (JSON serialization converts numeric keys to strings)
             local numericSlot = tonumber(slotIndex) or slotIndex;
             local slotAction = jobSlotActions[numericSlot] or jobSlotActions[tostring(numericSlot)];
             if slotAction then
-                -- Check for "cleared" marker - slot was explicitly emptied
                 if slotAction.cleared then
-                    return nil;  -- Don't fall back to defaults
+                    return nil;
                 end
 
-                -- If this slot has a macro reference, the macroDB is the single source of truth.
-                -- Old configs may have duplicated macro fields cached on the slot - we ignore them.
-                -- If the live lookup fails (orphaned macro), the slot is treated as unavailable.
-                local macroData;
-                if slotAction.macroRef then
-                    local paletteKey = slotAction.macroPaletteKey or M.jobId;
-                    macroData = GetMacroById(slotAction.macroRef, paletteKey);
-                    if not macroData then
-                        return nil;  -- Macro reference is orphaned
-                    end
-                else
-                    -- Custom non-macro slot - use inline fields directly
-                    macroData = slotAction;
+                local resolved = resolveSlotMacro(slotAction);
+                if not resolved then
+                    return nil;
                 end
-
-                -- Return slot action in the same format as parsed keybinds
-                return {
-                    context = 'battle',
-                    hotbar = barIndex,
-                    slot = slotIndex,
-                    actionType = macroData.actionType,
-                    action = macroData.action,
-                    target = macroData.target,
-                    displayName = macroData.displayName or macroData.action,
-                    equipSlot = macroData.equipSlot,
-                    macroText = macroData.macroText,
-                    itemId = macroData.itemId,
-                    customIconType = macroData.customIconType,
-                    customIconId = macroData.customIconId,
-                    customIconPath = macroData.customIconPath,
-                    -- Recast source override (for macros showing cooldown from different action)
-                    recastSourceType = macroData.recastSourceType,
-                    recastSourceAction = macroData.recastSourceAction,
-                    recastSourceItemId = macroData.recastSourceItemId,
-                };
+                local out = copySlotFields(resolved);
+                out.context = 'battle';
+                out.hotbar = barIndex;
+                out.slot = slotIndex;
+                out.displayName = out.displayName or resolved.action;
+                return out;
             end
         end
     end
@@ -780,69 +1938,7 @@ end
 -- Crossbar Slot Data Helpers
 -- ============================================
 
--- Helper to get the crossbar storage key based on jobSpecific setting
--- Returns 'global' or '{jobId}:{subjobId}' format
-local function getCrossbarStorageKey(crossbarSettings, jobId, subjobId)
-    if crossbarSettings.jobSpecific == false then
-        return GLOBAL_SLOT_KEY;
-    end
-    -- Always return composite key with job:subjob
-    local normalizedJobId = normalizeJobId(jobId);
-    local normalizedSubjobId = normalizeJobId(subjobId or 0);
-    return string.format('%d:%d', normalizedJobId, normalizedSubjobId);
-end
-
--- Helper to get crossbar slotActions with storage key
--- Handles: 'global' and composite keys ('15:10', '15:10:palette:Stuns', '15:10:avatar:ifrit')
--- Falls back to base job key (jobId:0) preserving any suffix if full job:subjob key doesn't exist
-local function getCrossbarSlotActionsForJob(slotActions, storageKey)
-    if not slotActions then return nil; end
-    -- Handle 'global' key specially
-    if storageKey == GLOBAL_SLOT_KEY then
-        return slotActions[GLOBAL_SLOT_KEY];
-    end
-    -- Try exact storage key first (e.g., '3:5' for WHM/RDM, '3:5:palette:Stuns')
-    local result = slotActions[storageKey];
-    if result then
-        return result;
-    end
-    -- Fallback: try base job key (jobId:0) for imported data without subjob
-    -- IMPORTANT: Preserve any suffix (palette:X, avatar:Y) in the fallback key
-    local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
-    if jobId and subjobId ~= '0' then
-        local fallbackKey = jobId .. ':0' .. (suffix or '');
-        if fallbackKey ~= storageKey then
-            return slotActions[fallbackKey];
-        end
-    end
-    return nil;
-end
-
--- Helper to ensure crossbar slotActions structure exists for a storage key and combo mode
--- Handles: 'global' and composite keys ('15:10')
-local function ensureCrossbarSlotActionsStructure(crossbarSettings, storageKey, comboMode)
-    if not crossbarSettings.slotActions then
-        crossbarSettings.slotActions = {};
-    end
-    -- Handle 'global' key specially
-    if storageKey == GLOBAL_SLOT_KEY then
-        if not crossbarSettings.slotActions[GLOBAL_SLOT_KEY] then
-            crossbarSettings.slotActions[GLOBAL_SLOT_KEY] = {};
-        end
-        if not crossbarSettings.slotActions[GLOBAL_SLOT_KEY][comboMode] then
-            crossbarSettings.slotActions[GLOBAL_SLOT_KEY][comboMode] = {};
-        end
-        return crossbarSettings.slotActions[GLOBAL_SLOT_KEY][comboMode];
-    end
-    -- All job-specific keys are composite strings (job:subjob format)
-    if not crossbarSettings.slotActions[storageKey] then
-        crossbarSettings.slotActions[storageKey] = {};
-    end
-    if not crossbarSettings.slotActions[storageKey][comboMode] then
-        crossbarSettings.slotActions[storageKey][comboMode] = {};
-    end
-    return crossbarSettings.slotActions[storageKey][comboMode];
-end
+-- (Crossbar uses the same shared helpers: resolveStorageKey, getSlotActionsForKey, ensureSlotActionsStructure with comboMode)
 
 -- Get slot data for a crossbar slot
 -- comboMode: 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', or 'Shared'
@@ -858,77 +1954,12 @@ function M.GetCrossbarSlotData(comboMode, slotIndex)
 
     -- Use per-combo-mode storage key (considers pet-aware and palette settings per combo)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
-    local jobSlotActions = getCrossbarSlotActionsForJob(gConfig.hotbarCrossbar.slotActions, storageKey);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
     if not jobSlotActions then return nil; end
     if not jobSlotActions[effectiveComboMode] then return nil; end
 
     local slotAction = jobSlotActions[effectiveComboMode][slotIndex];
-    if not slotAction then return nil; end
-
-    -- If this slot has a macro reference, the macroDB is the single source of truth.
-    -- Old configs may have duplicated macro fields cached on the slot - we ignore them.
-    -- If the live lookup fails (orphaned macro), the slot is treated as unavailable.
-    if slotAction.macroRef then
-        local paletteKey = slotAction.macroPaletteKey or jobId;
-        local liveMacro = GetMacroById(slotAction.macroRef, paletteKey);
-        if not liveMacro then
-            return nil;  -- Macro reference is orphaned
-        end
-        return {
-            actionType = liveMacro.actionType,
-            action = liveMacro.action,
-            target = liveMacro.target,
-            displayName = liveMacro.displayName,
-            equipSlot = liveMacro.equipSlot,
-            macroText = liveMacro.macroText,
-            itemId = liveMacro.itemId,
-            customIconType = liveMacro.customIconType,
-            customIconId = liveMacro.customIconId,
-            customIconPath = liveMacro.customIconPath,
-            macroRef = slotAction.macroRef,
-            macroPaletteKey = slotAction.macroPaletteKey,
-            -- Recast source override (for macros showing cooldown from different action)
-            recastSourceType = liveMacro.recastSourceType,
-            recastSourceAction = liveMacro.recastSourceAction,
-            recastSourceItemId = liveMacro.recastSourceItemId,
-        };
-    end
-
-    -- Custom non-macro slot - return inline data directly
-    return slotAction;
-end
-
--- Build the persisted form of slot data.
--- When the slot references a macro (macroRef or id), only the reference is stored;
--- the macroDB is the single source of truth for action/macroText/displayName/etc.
--- When the slot has no macro reference, inline fields are stored as-is (custom slots).
--- This is exposed on M so external writers (macropalette, migrations) can reuse it.
-function M.BuildSlotDataForWrite(slotData)
-    if not slotData then return nil; end
-
-    local macroRef = slotData.macroRef or slotData.id;
-    if macroRef then
-        return {
-            macroRef = macroRef,
-            macroPaletteKey = slotData.macroPaletteKey,
-        };
-    end
-
-    return {
-        actionType = slotData.actionType,
-        action = slotData.action,
-        target = slotData.target,
-        displayName = slotData.displayName,
-        equipSlot = slotData.equipSlot,
-        macroText = slotData.macroText,
-        itemId = slotData.itemId,
-        customIconType = slotData.customIconType,
-        customIconId = slotData.customIconId,
-        customIconPath = slotData.customIconPath,
-        recastSourceType = slotData.recastSourceType,
-        recastSourceAction = slotData.recastSourceAction,
-        recastSourceItemId = slotData.recastSourceItemId,
-    };
+    return resolveSlotMacro(slotAction);
 end
 
 -- Set slot data for a crossbar slot
@@ -951,12 +1982,15 @@ function M.SetCrossbarSlotData(comboMode, slotIndex, slotData)
     -- Map L2R2/R2L2 to Shared when shared expanded bar is enabled
     local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
 
-    -- Use per-combo-mode storage key (considers pet-aware and palette settings per combo)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
-    local comboSlots = ensureCrossbarSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
+    local comboSlots = ensureSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
 
-    comboSlots[slotIndex] = M.BuildSlotDataForWrite(slotData);
-
+    if isDualMacroSlotTable(slotData) then
+        comboSlots[slotIndex] = slotData;
+    else
+        comboSlots[slotIndex] = buildSlotRecord(slotData);
+    end
+    M.SyncDraftSlotFromLive(comboMode, slotIndex);
     NotifySlotDataChanged();
 end
 
@@ -970,16 +2004,408 @@ function M.ClearCrossbarSlotData(comboMode, slotIndex)
     -- Map L2R2/R2L2 to Shared when shared expanded bar is enabled
     local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
 
-    -- Use per-combo-mode storage key (considers pet-aware and palette settings per combo)
     local storageKey = M.GetCrossbarStorageKeyForCombo(effectiveComboMode);
-    local jobSlotActions = getCrossbarSlotActionsForJob(gConfig.hotbarCrossbar.slotActions, storageKey);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
     if not jobSlotActions then return; end
     if not jobSlotActions[effectiveComboMode] then return; end
 
-    -- Clear the slot
-    jobSlotActions[effectiveComboMode][slotIndex] = nil;
-
+    local raw = jobSlotActions[effectiveComboMode][slotIndex];
+    if isDualMacroSlotTable(raw) then
+        local sh = (gConfig.macroStorageScope or 'profile') == 'shared';
+        if sh then
+            raw[K_BIND_S] = nil;
+        else
+            raw[K_BIND_P] = nil;
+        end
+        if not raw[K_BIND_P] and not raw[K_BIND_S] then
+            jobSlotActions[effectiveComboMode][slotIndex] = nil;
+        else
+            raw.actionType = 'macro';
+        end
+    else
+        jobSlotActions[effectiveComboMode][slotIndex] = nil;
+    end
+    M.SyncDraftSlotFromLive(comboMode, slotIndex);
     NotifySlotDataChanged();
+end
+
+-- Direct read/write for a fixed storage key (palette editor / Edit Full Palette). Does not call GetCrossbarStorageKeyForCombo.
+function M.GetCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex)
+    if not gConfig or not gConfig.hotbarCrossbar or not storageKey then
+        return nil;
+    end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then
+        return nil;
+    end
+    return resolveSlotMacro(jobSlotActions[effectiveComboMode][slotIndex]);
+end
+
+function M.SetCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex, slotData)
+    if not storageKey then return; end
+    if not slotData then
+        M.ClearCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex);
+        return;
+    end
+    if not gConfig.hotbarCrossbar then
+        gConfig.hotbarCrossbar = {};
+    end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    local comboSlots = ensureSlotActionsStructure(gConfig.hotbarCrossbar, storageKey, effectiveComboMode);
+    if isDualMacroSlotTable(slotData) then
+        comboSlots[slotIndex] = slotData;
+    else
+        comboSlots[slotIndex] = buildSlotRecord(slotData);
+    end
+    NotifySlotDataChanged();
+end
+
+function M.ClearCrossbarSlotDataForStorageKey(storageKey, comboMode, slotIndex)
+    if not gConfig.hotbarCrossbar or not storageKey then return; end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    local jobSlotActions = getSlotActionsForKey(gConfig.hotbarCrossbar.slotActions, storageKey);
+    if not jobSlotActions or not jobSlotActions[effectiveComboMode] then return; end
+    jobSlotActions[effectiveComboMode][slotIndex] = nil;
+    NotifySlotDataChanged();
+end
+
+-- ============================================
+-- Draft Layer (Edit Full Palette)
+-- ============================================
+-- Edits stay in a draft buffer until the user clicks Apply. deepCopyTable, buildSlotRecord,
+-- resolveSlotMacro, and GetEffectiveComboModeForStorage are all defined above by this point.
+-- draftByKey can hold multiple storage keys when Job-Shared / Global segment overrides redirect combo modes.
+
+local function resolveDraftStorageKeyForCombo(comboMode)
+    if not draftForStorageKey or not draftByKey then
+        return nil;
+    end
+    if draftEditJobId then
+        local sk = M.GetSegmentOverrideResolvedStorageKey(draftEditJobId, comboMode);
+        if sk then
+            return sk;
+        end
+    end
+    return draftForStorageKey;
+end
+
+local function ensureDraftBucket(resolvedKey)
+    if not resolvedKey or not draftByKey then
+        return nil;
+    end
+    if not draftByKey[resolvedKey] then
+        if gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+            draftByKey[resolvedKey] = deepCopyTable(gConfig.hotbarCrossbar.slotActions[resolvedKey]) or {};
+        else
+            draftByKey[resolvedKey] = {};
+        end
+    end
+    return draftByKey[resolvedKey];
+end
+
+--- After live `gConfig` crossbar mutations while Edit Full Palette draft is open, copy the affected slot into the draft
+--- blob so the palette row matches HUD (HUD stays authoritative for gameplay binds during the session).
+--- When the HUD is showing a different palette than `rk`, skips — otherwise active-palette hops overwrite the draft.
+function M.SyncDraftSlotFromLive(comboMode, slotIndex)
+    if not draftForStorageKey or not draftByKey then
+        return;
+    end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then
+        return;
+    end
+    local effectiveComboModeForHud = M.GetEffectiveComboModeForStorage(comboMode);
+    local liveKey = M.GetCrossbarStorageKeyForCombo(effectiveComboModeForHud);
+    if liveKey ~= rk then
+        return;
+    end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then
+        return;
+    end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then
+        bucket[effectiveComboMode] = {};
+    end
+    draftTouchedKeys[rk] = true;
+    local liveRaw = M.GetRawCrossbarSlotAction(comboMode, slotIndex);
+    if liveRaw == nil then
+        bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+    else
+        bucket[effectiveComboMode][slotIndex] = deepCopyTable(liveRaw);
+    end
+    draftDirty = true;
+end
+
+--- Dual macro slots: clearing only the active arm can leave the inactive arm in the bucket while resolveSlotMacro shows empty.
+--- Only dual-layout blobs need this — never run on freshly written single-arm macros (profile vs shared visibility differs).
+local function scrubDraftBucketSlotIfInvisible(bucket, rk, effectiveComboMode, slotIndex)
+    if not bucket or not bucket[effectiveComboMode] then
+        return false;
+    end
+    local raw = bucket[effectiveComboMode][slotIndex];
+    if raw == nil or not isDualMacroSlotTable(raw) then
+        return false;
+    end
+    if resolveSlotMacro(raw) ~= nil then
+        return false;
+    end
+    bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+    draftTouchedKeys[rk] = true;
+    return true;
+end
+
+local function pushDraftUndo()
+    if draftUndoGroupActive then return; end
+    if not draftByKey then return; end
+    local touchedCopy = {};
+    if draftTouchedKeys then
+        for k, v in pairs(draftTouchedKeys) do
+            touchedCopy[k] = v;
+        end
+    end
+    table.insert(draftUndoStack, {
+        blob = deepCopyTable(draftByKey),
+        touched = touchedCopy,
+    });
+    if #draftUndoStack > DRAFT_MAX_UNDO then
+        table.remove(draftUndoStack, 1);
+    end
+end
+
+function M.BeginDraftUndoGroup()
+    pushDraftUndo();
+    draftUndoGroupActive = true;
+end
+
+function M.EndDraftUndoGroup()
+    draftUndoGroupActive = false;
+end
+
+function M.BeginCrossbarPaletteEditSession(storageKey, editJobId)
+    crossbarPaletteEditStorageKey = storageKey;
+    local ej = editJobId;
+    if draftForStorageKey == storageKey and draftByKey and draftEditJobId == ej then
+        return;
+    end
+    draftForStorageKey = storageKey;
+    draftEditJobId = ej;
+    draftDirty = false;
+    draftUndoStack = {};
+    draftTouchedKeys = {};
+    draftByKey = {};
+    if gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions and storageKey then
+        draftByKey[storageKey] = deepCopyTable(gConfig.hotbarCrossbar.slotActions[storageKey]) or {};
+    elseif storageKey then
+        draftByKey[storageKey] = {};
+    end
+end
+
+-- Segment override toggles used to clear draftForStorageKey here; that breaks GetDraftSlotData for the
+-- rest of the frame and forces a full draft re-init next frame (scroll jumps, wrong row heights, data risk).
+-- Resolved storage keys already update via GetSegmentOverrideResolvedStorageKey + ensureDraftBucket.
+function M.InvalidateCrossbarDraftLayout()
+end
+
+function M.EndCrossbarPaletteEditSession()
+    crossbarPaletteEditStorageKey = nil;
+end
+
+function M.FullyClosePaletteEditSession()
+    crossbarPaletteEditStorageKey = nil;
+    draftForStorageKey = nil;
+    draftEditJobId = nil;
+    draftByKey = nil;
+    draftTouchedKeys = nil;
+    draftDirty = false;
+    draftUndoStack = {};
+end
+
+function M.GetDraftSlotData(comboMode, slotIndex)
+    if not draftByKey then return nil; end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return nil; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return nil; end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then return nil; end
+    local cell = bucket[effectiveComboMode][slotIndex];
+    if cell == DRAFT_CROSSBAR_SLOT_EMPTY then
+        return nil;
+    end
+    return resolveSlotMacro(cell);
+end
+
+function M.GetDraftRawSlotData(comboMode, slotIndex)
+    if not draftByKey then return nil; end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return nil; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return nil; end
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then return nil; end
+    local v = bucket[effectiveComboMode][slotIndex];
+    if v == DRAFT_CROSSBAR_SLOT_EMPTY then
+        return nil;
+    end
+    return v;
+end
+
+--- Swap/drag reads: draft cell wins when present; explicit draft empty beats inherit; missing cell inherits
+--- persisted `gConfig` for the palette being edited (`rk`), not the HUD active palette (see GetRawCrossbarSlotAction).
+function M.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex)
+    if not draftForStorageKey or not draftByKey then
+        return M.GetRawCrossbarSlotAction(comboMode, slotIndex);
+    end
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then
+        return M.GetRawCrossbarSlotAction(comboMode, slotIndex);
+    end
+    local blob = draftByKey[rk];
+    if not blob then
+        return M.GetRawCrossbarSlotActionForStorageKey(rk, comboMode, slotIndex);
+    end
+    local eff = GetEffectiveComboModeForStorage(comboMode);
+    local row = blob[eff];
+    if not row then
+        return M.GetRawCrossbarSlotActionForStorageKey(rk, comboMode, slotIndex);
+    end
+    local v = row[slotIndex];
+    if v == DRAFT_CROSSBAR_SLOT_EMPTY then
+        return nil;
+    end
+    if v ~= nil then
+        return v;
+    end
+    return M.GetRawCrossbarSlotActionForStorageKey(rk, comboMode, slotIndex);
+end
+
+function M.SetDraftSlotData(comboMode, slotIndex, slotData)
+    if not draftByKey then return; end
+    if not slotData then
+        M.ClearDraftSlotData(comboMode, slotIndex);
+        return;
+    end
+    pushDraftUndo();
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return; end
+    draftTouchedKeys[rk] = true;
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then
+        bucket[effectiveComboMode] = {};
+    end
+    if isDualMacroSlotTable(slotData) then
+        bucket[effectiveComboMode][slotIndex] = slotData;
+    else
+        bucket[effectiveComboMode][slotIndex] = buildSlotRecord(slotData);
+    end
+    draftDirty = true;
+end
+
+function M.ClearDraftSlotData(comboMode, slotIndex)
+    if not draftByKey then return; end
+    pushDraftUndo();
+    local rk = resolveDraftStorageKeyForCombo(comboMode);
+    if not rk then return; end
+    local bucket = ensureDraftBucket(rk);
+    if not bucket then return; end
+    draftTouchedKeys[rk] = true;
+    local effectiveComboMode = GetEffectiveComboModeForStorage(comboMode);
+    if not bucket[effectiveComboMode] then return; end
+    local raw = bucket[effectiveComboMode][slotIndex];
+    if isDualMacroSlotTable(raw) then
+        local sh = gConfig and (gConfig.macroStorageScope or 'profile') == 'shared';
+        if sh then
+            raw[K_BIND_S] = nil;
+        else
+            raw[K_BIND_P] = nil;
+        end
+        if not raw[K_BIND_P] and not raw[K_BIND_S] then
+            bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+        else
+            raw.actionType = 'macro';
+        end
+    else
+        bucket[effectiveComboMode][slotIndex] = DRAFT_CROSSBAR_SLOT_EMPTY;
+    end
+    scrubDraftBucketSlotIfInvisible(bucket, rk, effectiveComboMode, slotIndex);
+    draftDirty = true;
+end
+
+function M.UndoDraft()
+    if #draftUndoStack == 0 then return false; end
+    local prev = table.remove(draftUndoStack);
+    draftByKey = prev.blob;
+    draftTouchedKeys = prev.touched or {};
+    draftDirty = #draftUndoStack > 0;
+    return true;
+end
+
+function M.CanUndoDraft()
+    return #draftUndoStack > 0;
+end
+
+local function prepareDraftBlobForApply(blob)
+    local out = {};
+    for comboMode, row in pairs(blob) do
+        out[comboMode] = {};
+        for slotIndex, cell in pairs(row) do
+            if cell ~= DRAFT_CROSSBAR_SLOT_EMPTY then
+                out[comboMode][slotIndex] = deepCopyTable(cell);
+            end
+        end
+    end
+    return out;
+end
+
+function M.ApplyDraft()
+    if not draftForStorageKey or not draftByKey then return; end
+    if not gConfig.hotbarCrossbar then gConfig.hotbarCrossbar = {}; end
+    if not gConfig.hotbarCrossbar.slotActions then gConfig.hotbarCrossbar.slotActions = {}; end
+    for key, _ in pairs(draftTouchedKeys or {}) do
+        local blob = draftByKey[key];
+        if blob then
+            gConfig.hotbarCrossbar.slotActions[key] = prepareDraftBlobForApply(blob);
+        end
+    end
+    draftDirty = false;
+    draftUndoStack = {};
+    draftTouchedKeys = {};
+    M.InvalidateStorageKeyCache();
+    NotifySlotDataChanged();
+end
+
+function M.DiscardDraft()
+    local key = crossbarPaletteEditStorageKey or draftForStorageKey;
+    if not key then return; end
+    draftByKey = {};
+    draftTouchedKeys = {};
+    if gConfig and gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        draftByKey[key] = deepCopyTable(gConfig.hotbarCrossbar.slotActions[key]) or {};
+    else
+        draftByKey[key] = {};
+    end
+    draftDirty = false;
+    draftUndoStack = {};
+end
+
+function M.IsDraftDirty()
+    return draftDirty;
+end
+
+local pendingPaletteSlotEdit = nil;
+
+function M.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex)
+    pendingPaletteSlotEdit = { slotData = slotData, comboMode = comboMode, slotIndex = slotIndex };
+end
+
+function M.ConsumePendingPaletteSlotEdit()
+    local edit = pendingPaletteSlotEdit;
+    pendingPaletteSlotEdit = nil;
+    return edit;
 end
 
 -- Clear all slot actions for a hotbar (used when switching between job-specific and global modes)
@@ -1014,9 +2440,12 @@ function M.SetSlotData(barIndex, slotIndex, slotData)
     local jobSlotActions = ensureSlotActionsStructure(barSettings, storageKey);
 
     if slotData then
-        jobSlotActions[slotIndex] = M.BuildSlotDataForWrite(slotData);
+        if isDualMacroSlotTable(slotData) then
+            jobSlotActions[slotIndex] = slotData;
+        else
+            jobSlotActions[slotIndex] = buildSlotRecord(slotData);
+        end
     else
-        -- Mark as explicitly cleared
         jobSlotActions[slotIndex] = { cleared = true };
     end
 
@@ -1030,11 +2459,33 @@ function M.ClearSlotData(barIndex, slotIndex)
 
     local barSettings = gConfig[configKey];
     local storageKey = M.GetStorageKeyForBar(barIndex);
-    local jobSlotActions = getSlotActionsForJob(barSettings.slotActions, storageKey);
+    local jobSlotActions = getSlotActionsForKey(barSettings.slotActions, storageKey);
 
     if jobSlotActions then
-        -- Mark as explicitly cleared
-        jobSlotActions[slotIndex] = { cleared = true };
+        local num = tonumber(slotIndex) or slotIndex;
+        local raw = jobSlotActions[num] or jobSlotActions[tostring(num)];
+        if isDualMacroSlotTable(raw) then
+            local sh = (gConfig.macroStorageScope or 'profile') == 'shared';
+            if sh then
+                raw[K_BIND_S] = nil;
+            else
+                raw[K_BIND_P] = nil;
+            end
+            if not raw[K_BIND_P] and not raw[K_BIND_S] then
+                jobSlotActions[num] = { cleared = true };
+                if jobSlotActions[tostring(num)] then
+                    jobSlotActions[tostring(num)] = { cleared = true };
+                end
+            else
+                raw.actionType = 'macro';
+                jobSlotActions[num] = raw;
+            end
+        else
+            jobSlotActions[num] = { cleared = true };
+            if jobSlotActions[tostring(num)] then
+                jobSlotActions[tostring(num)] = { cleared = true };
+            end
+        end
         NotifySlotDataChanged();
     end
 end
@@ -1059,6 +2510,32 @@ function M.InvalidateStorageKeyCache()
     storageKeyCache = {};
 end
 
+-- Call whenever the global gConfig table is replaced (profile switch, settings reload, reset).
+-- macroIdLookup holds references into gConfig.macroDB; if gConfig is swapped without invalidating,
+-- lookups can return macro rows from the previous profile in memory (wrong name/icon for macroRef).
+function M.InvalidateConfigDerivedCaches()
+    macroIdLookupDirty = true;
+    macroDbCoherenceIdentity = nil;
+    M.InvalidateStorageKeyCache();
+end
+
+-- ============================================
+-- Font Visibility Helpers
+-- ============================================
+-- REMOVED in 1.8.0 (and intentionally preserved-deleted here during migration):
+--   M.RebuildAllFonts, M.SetAllFontsVisible, M.SetBarFontsVisible
+-- These managed the GDI font lifecycle (`primitives` + `FontManager`) for per-slot keybind/
+-- label/timer/MP/quantity/abbreviation text. 1.8.0 replaced the entire rendering pipeline
+-- with libs/imtext.lua which is stateless per-frame — no font objects to create, hide,
+-- or rebuild. The old per-bar font tables (M.keybindFonts / M.labelFonts / M.timerFonts /
+-- M.mpCostFonts / M.quantityFonts / M.abbreviationFonts / M.hotbarNumberFonts / M.allFonts)
+-- are no longer populated; any lingering refs would also be obsolete.
+--
+-- Any caller of the dropped functions should be considered dead code from 1.7.5; the
+-- imtext path needs no per-bar visibility toggling because un-emitted draw calls don't
+-- render. If a caller still exists in macropalette.lua / crossbar.lua, it should be
+-- removed when that file is migrated (no replacement needed).
+
 -- ============================================
 -- Preview Mode (stub for compatibility)
 -- ============================================
@@ -1070,6 +2547,57 @@ function M.ClearPreview()
 end
 
 function M.ClearError()
+end
+
+-- ============================================
+-- Profile duplicate (no macro library): strip bar binds to palette macros
+-- ============================================
+
+-- Clears actionType == 'macro' slots in settings (in-memory copy) so a duplicated profile
+-- that dropped the macro library does not show ghost bindings to missing macroRef rows.
+function M.StripPaletteMacroBindsFromSettings(settings)
+    if not settings or type(settings) ~= 'table' then
+        return;
+    end
+    local function isPaletteMacro(slot)
+        if not slot or type(slot) ~= 'table' or slot.cleared then
+            return false;
+        end
+        if isDualMacroSlotTable(slot) then
+            return slot.actionType == 'macro' or slot[K_BIND_P] ~= nil or slot[K_BIND_S] ~= nil;
+        end
+        return slot.actionType == 'macro';
+    end
+    for bar = 1, 6 do
+        local configKey = 'hotbarBar' .. bar;
+        local barSettings = settings[configKey];
+        if barSettings and type(barSettings.slotActions) == 'table' then
+            for _, jobSlotActions in pairs(barSettings.slotActions) do
+                if type(jobSlotActions) == 'table' then
+                    for si, slot in pairs(jobSlotActions) do
+                        if isPaletteMacro(slot) then
+                            jobSlotActions[si] = { cleared = true };
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if settings.hotbarCrossbar and type(settings.hotbarCrossbar.slotActions) == 'table' then
+        for _, jobSlotActions in pairs(settings.hotbarCrossbar.slotActions) do
+            if type(jobSlotActions) == 'table' then
+                for _, comboSlots in pairs(jobSlotActions) do
+                    if type(comboSlots) == 'table' then
+                        for si, slot in pairs(comboSlots) do
+                            if isPaletteMacro(slot) then
+                                comboSlots[si] = nil;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
 end
 
 -- ============================================
@@ -1097,6 +2625,10 @@ function M.SetPlayerJob()
     -- Invalidate caches if job changed
     if M.jobId ~= currentJobId or M.subjobId ~= currentSubjobId then
         M.InvalidateStorageKeyCache();
+        local okPal, palMod = pcall(require, 'modules.hotbar.palette');
+        if okPal and palMod and palMod.ClearCrossbarCliPreview then
+            palMod.ClearCrossbarCliPreview();
+        end
     end
 
     M.jobId = currentJobId;
@@ -1111,6 +2643,19 @@ end
 -- Cleanup (call on addon unload)
 function M.Cleanup()
     M.Clear();
+    M.bgHandles = {};
+    M.slotPrims = {};
+    M.iconPrims = {};
+    M.cooldownPrims = {};
+    M.framePrims = {};
+    M.keybindFonts = {};
+    M.labelFonts = {};
+    M.timerFonts = {};
+    M.mpCostFonts = {};
+    M.quantityFonts = {};
+    M.abbreviationFonts = {};
+    M.hotbarNumberFonts = {};
+    M.allFonts = nil;
 end
 
 return M;

--- a/XIUI/modules/hotbar/palette.lua
+++ b/XIUI/modules/hotbar/palette.lua
@@ -27,6 +27,8 @@ local M = {};
 
 M.DEFAULT_PALETTE_NAME = 'Default';  -- Name for auto-created palettes
 M.PALETTE_KEY_PREFIX = 'palette:';
+-- All-jobs crossbar palettes (slotActions key prefix: global:palette:{name})
+M.UNIVERSAL_CROSSBAR_PREFIX = 'global:palette:';
 
 -- Deferred save state for palette selection changes
 -- Instead of saving immediately, track dirty state and save at natural pause points
@@ -45,9 +47,42 @@ local state = {
     -- NOTE: Crossbar can have 0 palettes and use default slots
     crossbarActivePalette = nil,
 
+    -- All-jobs universal crossbar sets (enableUniversalCrossbarPalettes in config)
+    crossbarPaletteScope = 'job', -- 'job' | 'universal'
+    crossbarActiveUniversalPalette = nil,
+
+    -- Job-scope crossbar: which storage tier is active — 0 = Job-wide (all subjobs), N = that subjob only
+    -- Only meaningful when the character has a support job (live subjob ~= 0)
+    crossbarActiveStorageSubjob = nil,
+
+    -- /xiui cpal preview of another job's named palette (off-job). Cleared on cycle, commit, scope/job change.
+    crossbarCliPreview = nil, -- { jobId, storageSubjob, paletteName }
+
+    -- /xiui cpal return-to-origin anchors (set on first cpal switch per scope, cleared on R1 double-tap return or job change)
+    cpalJobAnchor = nil,        -- { name, storageSubjob, jobId }
+    cpalUniversalAnchor = nil,  -- string palette name
+
     -- Callbacks for palette change events
     onPaletteChangedCallbacks = {},
 };
+
+-- Pending: profile/gConfig was swapped before player job was readable (addon startup). Consumed by hotbar init.
+local pendingApplyDefaultCrossbarScopeFromProfile = false;
+
+function M.NotifyProfileSettingsLoaded()
+    pendingApplyDefaultCrossbarScopeFromProfile = true;
+end
+
+function M.ConsumePendingApplyDefaultCrossbarScopeFromProfile()
+    if pendingApplyDefaultCrossbarScopeFromProfile then
+        pendingApplyDefaultCrossbarScopeFromProfile = false;
+        return true;
+    end
+    return false;
+end
+
+-- After hotbarCrossbar exists: seed one blank Job [J] Default palette per job (1–22) without touching live active palette.
+local crossbarBlankDefaultsSeeded = false;
 
 -- ============================================
 -- Performance: Palette List Cache
@@ -67,6 +102,64 @@ local function InvalidatePaletteListCache()
     paletteListCache = {};
     crossbarPaletteListCache = {};
 end
+
+-- Prefer the palette that was next in list after delete (below), else above (typical "stay nearby" UX)
+local function PickNeighborPaletteName(orderedList, deletedName)
+    if not orderedList or not deletedName then
+        return nil;
+    end
+    local idx = nil;
+    for i, n in ipairs(orderedList) do
+        if n == deletedName then
+            idx = i;
+            break;
+        end
+    end
+    if not idx then
+        return nil;
+    end
+    if orderedList[idx + 1] then
+        return orderedList[idx + 1];
+    end
+    if orderedList[idx - 1] then
+        return orderedList[idx - 1];
+    end
+    return nil;
+end
+
+-- Token for GetCrossbarAvailablePalettes when live subjob ~= 0: tier + palette name (names cannot contain ':')
+local CROSSBAR_ENTRY_SEP = '\1';
+
+function M.EncodeCrossbarEntryToken(storageSubjob, name)
+    return tostring(storageSubjob or 0) .. CROSSBAR_ENTRY_SEP .. (name or '');
+end
+
+-- Returns storageSubjob, name or nil, plainToken if not an encoded entry
+function M.DecodeCrossbarEntryToken(token)
+    if not token or type(token) ~= 'string' then
+        return nil, nil;
+    end
+    local st, name = token:match('^(%d+)' .. CROSSBAR_ENTRY_SEP .. '(.+)$');
+    if st then
+        return tonumber(st), name;
+    end
+    return nil, token;
+end
+
+-- Display suffix: Job-wide vs Subjob-specific tier (not Global [G], which is separate scope)
+function M.FormatCrossbarTierSuffixLabel(storageSubjob, liveSubjobId)
+    local live = liveSubjobId or 0;
+    if live == 0 then
+        return ' (J)';
+    end
+    if (storageSubjob or 0) == 0 then
+        return ' (J)';
+    end
+    return ' (SJ)';
+end
+
+-- Crossbar combo modes (single list for callbacks / universal scope)
+local CROSSBAR_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
 
 -- ============================================
 -- Config Structure Helpers
@@ -278,6 +371,108 @@ local function IsValidPaletteName(name)
     return true;
 end
 
+-- Key for hotbar RB-cycle exclude map: matches palette order when using shared fallback (subjob 0)
+local function GetEffectiveHotbarPaletteMetaKey(jobId, subjobId)
+    local jid = jobId or 1;
+    local sj = subjobId or 0;
+    if sj ~= 0 and M.IsUsingFallbackPalettes(jid, sj) then
+        return BuildJobSubjobKey(jid, 0);
+    end
+    return BuildJobSubjobKey(jid, sj);
+end
+
+local function PrunePaletteExcludeSubtable(root, key)
+    if not root or not root[key] then
+        return;
+    end
+    local empty = true;
+    for _ in pairs(root[key]) do
+        empty = false;
+        break;
+    end
+    if empty then
+        root[key] = nil;
+    end
+end
+
+-- When true, palette is included in RB+D-pad / keyboard palette cycling for hotbars
+function M.IsHotbarPaletteInRbCycle(jobId, subjobId, paletteName)
+    if not paletteName then
+        return true;
+    end
+    local key = GetEffectiveHotbarPaletteMetaKey(jobId, subjobId);
+    local t = gConfig and gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[key];
+    if t and t[paletteName] then
+        return false;
+    end
+    return true;
+end
+
+function M.SetHotbarPaletteInRbCycle(jobId, subjobId, paletteName, inCycle)
+    if not paletteName or not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    if not EnsureHotbarConfigExists() then
+        return false, 'Config unavailable';
+    end
+    if not gConfig.hotbar.paletteExcludeFromCycle then
+        gConfig.hotbar.paletteExcludeFromCycle = {};
+    end
+    local key = GetEffectiveHotbarPaletteMetaKey(jobId, subjobId);
+    if not gConfig.hotbar.paletteExcludeFromCycle[key] then
+        gConfig.hotbar.paletteExcludeFromCycle[key] = {};
+    end
+    local ex = gConfig.hotbar.paletteExcludeFromCycle[key];
+    if inCycle then
+        ex[paletteName] = nil;
+        PrunePaletteExcludeSubtable(gConfig.hotbar.paletteExcludeFromCycle, key);
+    else
+        ex[paletteName] = true;
+    end
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Job crossbar (non-universal): per storage tier orderKey job:tier
+function M.IsCrossbarPaletteInRbCycle(jobId, tierStorageSubjob, paletteName)
+    if not paletteName then
+        return true;
+    end
+    local key = BuildJobSubjobKey(jobId or 1, tierStorageSubjob or 0);
+    local cbs = gConfig.hotbarCrossbar;
+    local t = cbs and cbs.crossbarPaletteExcludeFromCycle and cbs.crossbarPaletteExcludeFromCycle[key];
+    if t and t[paletteName] then
+        return false;
+    end
+    return true;
+end
+
+function M.SetCrossbarPaletteInRbCycle(jobId, tierStorageSubjob, paletteName, inCycle)
+    if not paletteName or not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    local cbs = gConfig.hotbarCrossbar;
+    if not cbs then
+        return false, 'Crossbar settings not found';
+    end
+    if not cbs.crossbarPaletteExcludeFromCycle then
+        cbs.crossbarPaletteExcludeFromCycle = {};
+    end
+    local key = BuildJobSubjobKey(jobId or 1, tierStorageSubjob or 0);
+    if not cbs.crossbarPaletteExcludeFromCycle[key] then
+        cbs.crossbarPaletteExcludeFromCycle[key] = {};
+    end
+    local ex = cbs.crossbarPaletteExcludeFromCycle[key];
+    if inCycle then
+        ex[paletteName] = nil;
+        PrunePaletteExcludeSubtable(cbs.crossbarPaletteExcludeFromCycle, key);
+    else
+        ex[paletteName] = true;
+    end
+    SaveSettingsToDisk();
+    return true;
+end
+
 -- ============================================
 -- Palette Key Generation
 -- ============================================
@@ -311,17 +506,7 @@ function M.BuildSharedPaletteStorageKey(jobId, paletteName)
     return M.BuildPaletteStorageKey(jobId, 0, paletteName);
 end
 
--- DEPRECATED: Old format - kept for backwards compatibility during migration
--- Build full storage key for a palette using old format (includes subjob)
--- baseKey: '{jobId}:{subjobId}' format
--- paletteName: palette name or nil for default slot data
-function M.BuildStorageKey(baseKey, paletteName)
-    local suffix = M.GetPaletteKeySuffix(paletteName);
-    if not suffix then
-        return baseKey;
-    end
-    return string.format('%s:%s', baseKey, suffix);
-end
+-- REMOVED: BuildStorageKey — was deprecated, no callers remain. Use BuildPaletteStorageKey instead.
 
 -- Parse a storage key to extract palette name
 -- Returns nil if no palette suffix (default slots)
@@ -554,9 +739,15 @@ end
 function M.CyclePalette(barIndex, direction, jobId, subjobId)
     direction = direction or 1;
 
-    local palettes = M.GetAvailablePalettes(barIndex, jobId, subjobId);
+    local all = M.GetAvailablePalettes(barIndex, jobId, subjobId);
+    local palettes = {};
+    for _, name in ipairs(all) do
+        if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+            table.insert(palettes, name);
+        end
+    end
     if #palettes <= 1 then
-        return nil;  -- No palettes to cycle (0 or 1 palette)
+        return nil;  -- No palettes to cycle (0 or 1 in RB cycle list)
     end
 
     local currentName = state.activePalette;
@@ -724,6 +915,7 @@ function M.DeletePalette(barIndex, paletteName, jobId, subjobId)
     if #availablePalettes <= 1 then
         return false, 'Cannot delete the last palette';
     end
+    local neighborName = PickNeighborPaletteName(availablePalettes, paletteName);
 
     -- Find the storage key (could be subjob-specific or shared)
     local storageKey = FindPaletteStorageKey(1, paletteName, normalizedJobId, normalizedSubjobId);
@@ -767,17 +959,40 @@ function M.DeletePalette(barIndex, paletteName, jobId, subjobId)
         end
     end
 
+    if gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[orderKey] then
+        gConfig.hotbar.paletteExcludeFromCycle[orderKey][paletteName] = nil;
+        PrunePaletteExcludeSubtable(gConfig.hotbar.paletteExcludeFromCycle, orderKey);
+    end
+
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
 
-    -- If this was the active palette, switch to the first available palette
+    -- If this was the active palette, switch to a nearby palette in the old order (below, else above)
     if state.activePalette == paletteName then
-        -- Get updated list after deletion
         local remainingPalettes = M.GetAvailablePalettes(barIndex, normalizedJobId, normalizedSubjobId);
-        local newActive = remainingPalettes[1];  -- First palette becomes active
-        M.SetActivePalette(1, newActive, normalizedJobId, normalizedSubjobId);
+        local newActive = nil;
+        if neighborName then
+            for _, n in ipairs(remainingPalettes) do
+                if n == neighborName then
+                    newActive = n;
+                    break;
+                end
+            end
+        end
+        if not newActive and #remainingPalettes > 0 then
+            newActive = remainingPalettes[1];
+        end
+        if newActive then
+            local changed = M.SetActivePalette(1, newActive, normalizedJobId, normalizedSubjobId);
+            if not changed then
+                for i = 1, 6 do
+                    M.FirePaletteChangedCallbacks(i, newActive, newActive);
+                end
+            end
+        end
     end
 
+    InvalidateAllVisualCachesAfterPaletteListMutation();
     SaveSettingsToDisk();
     return true;
 end
@@ -852,6 +1067,14 @@ function M.RenamePalette(barIndex, oldName, newName, jobId, subjobId)
         end
     end
 
+    if gConfig.hotbar and gConfig.hotbar.paletteExcludeFromCycle and gConfig.hotbar.paletteExcludeFromCycle[orderKey] then
+        local ex = gConfig.hotbar.paletteExcludeFromCycle[orderKey];
+        if ex[oldName] then
+            ex[oldName] = nil;
+            ex[newName] = true;
+        end
+    end
+
     -- Update active palette if this was active
     if state.activePalette == oldName then
         state.activePalette = newName;
@@ -887,20 +1110,18 @@ function M.MovePalette(barIndex, paletteName, direction, jobId, subjobId)
     end
     local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
 
-    -- Ensure paletteOrder exists and is populated
     if not gConfig.hotbar then
         gConfig.hotbar = {};
     end
     if not gConfig.hotbar.paletteOrder then
         gConfig.hotbar.paletteOrder = {};
     end
-    if not gConfig.hotbar.paletteOrder[orderKey] then
-        -- Initialize paletteOrder from current available palettes
-        gConfig.hotbar.paletteOrder[orderKey] = {};
-        local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-        for _, name in ipairs(available) do
-            table.insert(gConfig.hotbar.paletteOrder[orderKey], name);
-        end
+
+    -- Match the merged list used by the Palette Manager / cycling (stored order can omit new palettes)
+    local canonical = M.GetAvailablePalettes(barIndex, normalizedJobId, normalizedSubjobId);
+    gConfig.hotbar.paletteOrder[orderKey] = {};
+    for _, name in ipairs(canonical) do
+        table.insert(gConfig.hotbar.paletteOrder[orderKey], name);
     end
 
     local order = gConfig.hotbar.paletteOrder[orderKey];
@@ -969,17 +1190,26 @@ function M.SetPaletteOrder(barIndex, palettes, jobId, subjobId)
     return true;
 end
 
--- Get the index of a palette in the order (1-based) (GLOBAL)
--- barIndex param kept for backwards compatibility but ignored
--- subjobId param kept for backwards compatibility but ignored
--- Returns the index, or nil if not found
+-- Ordered palette names included in RB / keyboard cycling (excludes "Inactive" in Palette Manager).
+function M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId)
+    local out = {};
+    for _, name in ipairs(M.GetAvailablePalettes(barIndex, jobId, subjobId)) do
+        if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+            table.insert(out, name);
+        end
+    end
+    return out;
+end
+
+-- Get the index of a palette within RB-cycle order only (1-based) (GLOBAL)
+-- Returns nil if the palette is not in the cycle list (e.g. marked Inactive).
 function M.GetPaletteIndex(barIndex, paletteName, jobId, subjobId)
     if not paletteName then
         return nil;
     end
 
-    local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-    for i, name in ipairs(available) do
+    local cycle = M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId);
+    for i, name in ipairs(cycle) do
         if name == paletteName then
             return i;
         end
@@ -987,12 +1217,9 @@ function M.GetPaletteIndex(barIndex, paletteName, jobId, subjobId)
     return nil;
 end
 
--- Get the total number of palettes (GLOBAL)
--- barIndex param kept for backwards compatibility but ignored
--- subjobId param kept for backwards compatibility but ignored
+-- Count of palettes that participate in RB / keyboard cycling (not total defined palettes).
 function M.GetPaletteCount(barIndex, jobId, subjobId)
-    local available = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-    return #available;
+    return #M.GetHotbarPaletteNamesInRbCycle(barIndex, jobId, subjobId);
 end
 
 -- ============================================
@@ -1038,12 +1265,79 @@ function M.FirePaletteChangedCallbacks(barIndex, oldPalette, newPalette)
     end
 end
 
+-- SetActive* skips callbacks when name (and tier) match current state, but storage may still
+-- have changed (e.g. same palette name on another tier, or recreated empty Default).
+local function FireCrossbarComboRefreshNoop(displayName)
+    if not displayName then
+        return;
+    end
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, displayName, displayName);
+    end
+end
+
+-- Palette OnPaletteChanged only clears slotrenderer rendering cache + crossbar icons; hotbar also uses
+-- display-layer icon cache. After delete + redirect, force a full flush so binds resolve to the new storage key.
+local function InvalidateAllVisualCachesAfterPaletteListMutation()
+    local ok, dataMod = pcall(require, 'modules.hotbar.data');
+    if ok and dataMod and dataMod.InvalidateStorageKeyCache then
+        dataMod.InvalidateStorageKeyCache();
+    end
+    local ok2, sr = pcall(require, 'modules.hotbar.slotrenderer');
+    if ok2 and sr and sr.ClearAllCache then
+        sr.ClearAllCache();
+    end
+    pcall(function()
+        local disp = require('modules.hotbar.display');
+        if disp.ClearIconCache then
+            disp.ClearIconCache();
+        end
+    end);
+    pcall(function()
+        local xb = require('modules.hotbar.crossbar');
+        if xb.ClearIconCache then
+            xb.ClearIconCache();
+        end
+    end);
+end
+
+--- Re-run palette validation (active names vs lists) then fire a no-op palette change per bar/combo so
+--- hotbar/crossbar UIs reload binds from gConfig (JSON import changes data under the same palette name).
+function M.RefreshActivePaletteVisualsAfterExternalEdit()
+    local okData, dataMod = pcall(require, 'modules.hotbar.data');
+    if okData and dataMod and dataMod.jobId then
+        pcall(function()
+            M.ValidatePalettesForJob(dataMod.jobId, dataMod.subjobId or 0, { applyDefaultCrossbarScope = false });
+        end);
+    end
+    local hotbarName = state.activePalette;
+    if hotbarName then
+        for i = 1, 6 do
+            M.FirePaletteChangedCallbacks(i, hotbarName, hotbarName);
+        end
+    end
+    if state.crossbarActivePalette then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            M.FirePaletteChangedCallbacks('crossbar:' .. mode, state.crossbarActivePalette, state.crossbarActivePalette);
+        end
+    end
+    if state.crossbarActiveUniversalPalette then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            M.FirePaletteChangedCallbacks('crossbar:' .. mode, state.crossbarActiveUniversalPalette, state.crossbarActiveUniversalPalette);
+        end
+    end
+end
+
+--- Called after tools import or replace slot data outside normal palette APIs (e.g. JSON import).
+function M.InvalidateCachesAfterExternalSlotMutation()
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    M.RefreshActivePaletteVisualsAfterExternalEdit();
+end
+
 -- ============================================
 -- Crossbar Palette Management
 -- ============================================
-
--- Crossbar combo modes for iteration
-local CROSSBAR_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
 
 -- Helper: Scan crossbar for palettes matching a pattern prefix
 -- Returns: table of { [paletteName] = true }
@@ -1069,17 +1363,81 @@ local function ScanCrossbarForPalettes(patternPrefix)
     return existingPalettes;
 end
 
--- Get all available palette names for crossbar only
--- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
--- Fallback: If no subjob-specific palettes exist, falls back to shared palettes (subjob 0)
--- Returns: { 'Stuns', 'Heals', ... } - palettes available ONLY for crossbar (empty if none defined)
--- Crossbar palettes are SEPARATE from hotbar palettes
--- OPTIMIZED: Results are cached with TTL
+-- Build ordered list of crossbar palette rows for a job + live subjob context (no Either/Or hiding).
+-- storageSubjob 0 = Job-wide [J]; storageSubjob == subjobId (when ~=0) = Subjob-only [SJ] entries.
+local function BuildCrossbarMergedRowsInternal(jobId, subjobId)
+    local jid = jobId or 1;
+    local sj = subjobId or 0;
+    local rows = {};
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+
+    local function orderedNamesForTier(tierSj, existingSet)
+        local orderKey = BuildJobSubjobKey(jid, tierSj);
+        local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+            and crossbarSettings.crossbarPaletteOrder[orderKey];
+        local out = {};
+        local seen = {};
+        if storedOrder then
+            for _, paletteName in ipairs(storedOrder) do
+                if existingSet[paletteName] and not seen[paletteName] then
+                    seen[paletteName] = true;
+                    table.insert(out, paletteName);
+                end
+            end
+        end
+        local remaining = {};
+        for paletteName, _ in pairs(existingSet) do
+            if not seen[paletteName] then
+                table.insert(remaining, paletteName);
+            end
+        end
+        table.sort(remaining);
+        for _, paletteName in ipairs(remaining) do
+            table.insert(out, paletteName);
+        end
+        return out;
+    end
+
+    if sj == 0 then
+        local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+        local set0 = ScanCrossbarForPalettes(pattern0);
+        for _, n in ipairs(orderedNamesForTier(0, set0)) do
+            table.insert(rows, { name = n, storageSubjob = 0 });
+        end
+        return rows;
+    end
+
+    local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+    local set0 = ScanCrossbarForPalettes(pattern0);
+    local seen = {};
+    for _, n in ipairs(orderedNamesForTier(0, set0)) do
+        seen[n] = true;
+        table.insert(rows, { name = n, storageSubjob = 0 });
+    end
+
+    local subPattern = string.format('%d:%d:%s', jid, sj, M.PALETTE_KEY_PREFIX);
+    local setS = ScanCrossbarForPalettes(subPattern);
+    local extraSet = {};
+    for name, _ in pairs(setS) do
+        if not seen[name] then
+            extraSet[name] = true;
+        end
+    end
+    for _, n in ipairs(orderedNamesForTier(sj, extraSet)) do
+        table.insert(rows, { name = n, storageSubjob = sj });
+    end
+
+    return rows;
+end
+
+-- Get all available crossbar entries for the current job/subjob context.
+-- When live subjob is 0: returns plain palette names (Job [J] tier only).
+-- When live subjob ~= 0: returns encoded tokens 'storageSubjob' .. sep .. 'name' so Job + Subjob tiers stay distinct.
+-- Crossbar palettes are SEPARATE from hotbar palettes. OPTIMIZED: cached with TTL.
 function M.GetCrossbarAvailablePalettes(jobId, subjobId)
     local normalizedJobId = jobId or 1;
     local normalizedSubjobId = subjobId or 0;
 
-    -- Check cache first
     local cacheKey = BuildPaletteCacheKey(normalizedJobId, normalizedSubjobId);
     local cached = crossbarPaletteListCache[cacheKey];
     local now = os.clock();
@@ -1088,162 +1446,757 @@ function M.GetCrossbarAvailablePalettes(jobId, subjobId)
     end
 
     local palettes = {};
-
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
     if not crossbarSettings or not crossbarSettings.slotActions then
         crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
         return palettes;
     end
 
-    -- Check subjob-specific palettes first: '{jobId}:{subjobId}:palette:{name}'
-    local subjobPattern = string.format('%d:%d:%s', normalizedJobId, normalizedSubjobId, M.PALETTE_KEY_PREFIX);
-    local existingPalettes = ScanCrossbarForPalettes(subjobPattern);
-
-    -- Count subjob-specific palettes
-    local subjobPaletteCount = 0;
-    for _ in pairs(existingPalettes) do
-        subjobPaletteCount = subjobPaletteCount + 1;
-    end
-
-    -- Fallback to shared palettes (subjob 0) if no subjob-specific palettes exist
-    local usingFallback = false;
-    if subjobPaletteCount == 0 and normalizedSubjobId ~= 0 then
-        local sharedPattern = string.format('%d:0:%s', normalizedJobId, M.PALETTE_KEY_PREFIX);
-        existingPalettes = ScanCrossbarForPalettes(sharedPattern);
-        usingFallback = true;
-    end
-
-    -- Get the stored palette order (keyed by job:subjob or fallback to job:0)
-    local orderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
-    local storedOrder = crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[orderKey];
-
-    -- If using fallback, also check for shared order
-    if not storedOrder and usingFallback then
-        local sharedOrderKey = BuildJobSubjobKey(normalizedJobId, 0);
-        storedOrder = crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[sharedOrderKey];
-    end
-
-    -- Build ordered result: first add palettes from storedOrder that exist
-    local seen = {};
-    if storedOrder then
-        for _, paletteName in ipairs(storedOrder) do
-            if existingPalettes[paletteName] and not seen[paletteName] then
-                seen[paletteName] = true;
-                table.insert(palettes, paletteName);
-            end
+    if normalizedSubjobId == 0 then
+        local rows = BuildCrossbarMergedRowsInternal(normalizedJobId, 0);
+        for _, r in ipairs(rows) do
+            table.insert(palettes, r.name);
+        end
+    else
+        local rows = BuildCrossbarMergedRowsInternal(normalizedJobId, normalizedSubjobId);
+        for _, r in ipairs(rows) do
+            table.insert(palettes, M.EncodeCrossbarEntryToken(r.storageSubjob, r.name));
         end
     end
 
-    -- Collect any remaining palettes not in the stored order
+    crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
+    return palettes;
+end
+
+-- Rows for Manage / embedded Palette Manager (and cycle order): Job [J] then Subjob [SJ]-only names.
+function M.GetCrossbarManagePaletteRows(jobId, subjobId)
+    return BuildCrossbarMergedRowsInternal(jobId or 1, subjobId or 0);
+end
+
+-- SJ-only palette names in the same order as (SJ) rows in Manage: job:sj:palette:* names that are NOT
+-- also on job:0:palette:* for the same main job (excludes empty duplicate SJ buckets that shadow [J] names).
+function M.GetCrossbarSjOnlyPaletteNamesOrdered(jobId, liveSubjobId)
+    local jid = jobId or 1;
+    local sj = liveSubjobId or 0;
+    if sj == 0 then
+        return {};
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local pattern0 = string.format('%d:0:%s', jid, M.PALETTE_KEY_PREFIX);
+    local set0 = ScanCrossbarForPalettes(pattern0);
+    local jNames = {};
+    for name, _ in pairs(set0) do
+        jNames[name] = true;
+    end
+    local subPattern = string.format('%d:%d:%s', jid, sj, M.PALETTE_KEY_PREFIX);
+    local setS = ScanCrossbarForPalettes(subPattern);
+    local extraSet = {};
+    for name, _ in pairs(setS) do
+        if not jNames[name] then
+            extraSet[name] = true;
+        end
+    end
+    local orderKey = BuildJobSubjobKey(jid, sj);
+    local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+        and crossbarSettings.crossbarPaletteOrder[orderKey];
+    local out = {};
+    local seen = {};
+    if storedOrder then
+        for _, paletteName in ipairs(storedOrder) do
+            if extraSet[paletteName] and not seen[paletteName] then
+                seen[paletteName] = true;
+                table.insert(out, paletteName);
+            end
+        end
+    end
     local remaining = {};
-    for paletteName, _ in pairs(existingPalettes) do
+    for paletteName, _ in pairs(extraSet) do
         if not seen[paletteName] then
             table.insert(remaining, paletteName);
         end
     end
-
-    -- Sort remaining palettes alphabetically and append
     table.sort(remaining);
     for _, paletteName in ipairs(remaining) do
-        table.insert(palettes, paletteName);
+        table.insert(out, paletteName);
     end
-
-    -- Cache the result
-    crossbarPaletteListCache[cacheKey] = { palettes = palettes, timestamp = now };
-
-    return palettes;
+    return out;
 end
 
--- Check if crossbar palettes are using fallback (shared) mode
--- Returns true if using shared palettes because no subjob-specific ones exist
-function M.IsUsingCrossbarFallbackPalettes(jobId, subjobId)
-    local normalizedJobId = jobId or 1;
-    local normalizedSubjobId = subjobId or 0;
-
-    if normalizedSubjobId == 0 then
-        return false;  -- Already using shared palettes
-    end
-
+-- Ordered palette names for a single storage tier (used when reordering within that tier)
+function M.GetCrossbarPaletteNamesForOrderTier(jobId, tierSubjob)
+    local jid = jobId or 1;
+    local tier = tierSubjob or 0;
+    local pattern = string.format('%d:%d:%s', jid, tier, M.PALETTE_KEY_PREFIX);
+    local existing = ScanCrossbarForPalettes(pattern);
     local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
-    if not crossbarSettings or not crossbarSettings.slotActions then
-        return true;  -- No settings, would use fallback
-    end
-
-    -- Check for subjob-specific palettes
-    local subjobPattern = string.format('%d:%d:%s', normalizedJobId, normalizedSubjobId, M.PALETTE_KEY_PREFIX);
-    for storageKey, _ in pairs(crossbarSettings.slotActions) do
-        if type(storageKey) == 'string' and storageKey:find(subjobPattern, 1, true) == 1 then
-            return false;  -- Found at least one subjob-specific palette
-        end
-    end
-
-    return true;  -- Using fallback
-end
-
--- Unified fallback check for both hotbar and crossbar
--- paletteType: 'hotbar' or 'crossbar'
-function M.IsUsingFallback(jobId, subjobId, paletteType)
-    if subjobId == 0 then return false; end
-    if paletteType == 'crossbar' then
-        return M.IsUsingCrossbarFallbackPalettes(jobId, subjobId);
-    else
-        return M.IsUsingFallbackPalettes(jobId, subjobId);
-    end
-end
-
--- DEPRECATED: GetAllAvailablePalettes - kept for backwards compatibility
--- Now just returns hotbar palettes since crossbar has its own separate palettes
-function M.GetAllAvailablePalettes(jobId, subjobId)
-    local palettes = {};
+    local orderKey = BuildJobSubjobKey(jid, tier);
+    local storedOrder = crossbarSettings and crossbarSettings.crossbarPaletteOrder
+        and crossbarSettings.crossbarPaletteOrder[orderKey];
+    local out = {};
     local seen = {};
-
-    -- Scan all 6 hotbar bars only (NOT crossbar - they are separate now)
-    for barIndex = 1, 6 do
-        local barPalettes = M.GetAvailablePalettes(barIndex, jobId, subjobId);
-        for _, paletteName in ipairs(barPalettes) do
-            if not seen[paletteName] then
+    if storedOrder then
+        for _, paletteName in ipairs(storedOrder) do
+            if existing[paletteName] and not seen[paletteName] then
                 seen[paletteName] = true;
-                table.insert(palettes, paletteName);
+                table.insert(out, paletteName);
             end
         end
     end
-
-    return palettes;
+    local remaining = {};
+    for paletteName, _ in pairs(existing) do
+        if not seen[paletteName] then
+            table.insert(remaining, paletteName);
+        end
+    end
+    table.sort(remaining);
+    for _, paletteName in ipairs(remaining) do
+        table.insert(out, paletteName);
+    end
+    return out;
 end
 
--- Get active palette name for crossbar (GLOBAL - single palette for all combo modes)
+-- ============================================
+-- Universal (all-jobs) crossbar palettes
+-- Storage key: global:palette:{name} in hotbarCrossbar.slotActions
+-- Pet overlays never apply to these keys (handled in data.lua).
+-- ============================================
+
+function M.BuildUniversalCrossbarStorageKey(paletteName)
+    if not paletteName or paletteName == '' then
+        return nil;
+    end
+    return M.UNIVERSAL_CROSSBAR_PREFIX .. paletteName;
+end
+
+local function ScanUniversalCrossbarPaletteNames()
+    local existing = {};
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return existing;
+    end
+    local prefix = M.UNIVERSAL_CROSSBAR_PREFIX;
+    for storageKey, _ in pairs(crossbarSettings.slotActions) do
+        if type(storageKey) == 'string' and storageKey:sub(1, #prefix) == prefix then
+            local name = storageKey:sub(#prefix + 1);
+            if name and name ~= '' then
+                existing[name] = true;
+            end
+        end
+    end
+    return existing;
+end
+
+--- Ordered list of all universal crossbar palette names (for UI).
+function M.GetUniversalCrossbarPaletteNamesOrdered()
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return {};
+    end
+    local existing = ScanUniversalCrossbarPaletteNames();
+    local ordered = {};
+    local seen = {};
+    local orderList = crossbarSettings.universalCrossbarPaletteOrder;
+    if orderList then
+        for _, name in ipairs(orderList) do
+            if existing[name] and not seen[name] then
+                seen[name] = true;
+                table.insert(ordered, name);
+            end
+        end
+    end
+    local rest = {};
+    for name, _ in pairs(existing) do
+        if not seen[name] then
+            table.insert(rest, name);
+        end
+    end
+    table.sort(rest);
+    for _, name in ipairs(rest) do
+        table.insert(ordered, name);
+    end
+    return ordered;
+end
+
+function M.GetUniversalPaletteIncludeInCycle(name)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    local meta = crossbarSettings and crossbarSettings.crossbarUniversalPaletteMeta;
+    if not meta or not meta[name] then
+        return true;
+    end
+    if meta[name].includeInCycle == false then
+        return false;
+    end
+    return true;
+end
+
+function M.SetUniversalPaletteIncludeInCycle(name, includeInCycle)
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false;
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta = {};
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta[name] then
+        crossbarSettings.crossbarUniversalPaletteMeta[name] = {};
+    end
+    crossbarSettings.crossbarUniversalPaletteMeta[name].includeInCycle = includeInCycle and true or false;
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Palettes RB+D-pad cycles when scope is universal (respects includeInCycle).
+function M.GetUniversalCrossbarPalettesForCycle()
+    local all = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local out = {};
+    for _, name in ipairs(all) do
+        if M.GetUniversalPaletteIncludeInCycle(name) then
+            table.insert(out, name);
+        end
+    end
+    return out;
+end
+
+function M.CreateUniversalCrossbarPalette(paletteName)
+    if not IsValidPaletteName(paletteName) then
+        return false, 'Invalid palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local key = M.BuildUniversalCrossbarStorageKey(paletteName);
+    if crossbarSettings.slotActions[key] then
+        return false, 'Palette already exists';
+    end
+    crossbarSettings.slotActions[key] = {};
+    if not crossbarSettings.universalCrossbarPaletteOrder then
+        crossbarSettings.universalCrossbarPaletteOrder = {};
+    end
+    table.insert(crossbarSettings.universalCrossbarPaletteOrder, paletteName);
+    if not crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta = {};
+    end
+    if not crossbarSettings.crossbarUniversalPaletteMeta[paletteName] then
+        crossbarSettings.crossbarUniversalPaletteMeta[paletteName] = { includeInCycle = true };
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.EnsureUniversalCrossbarDefaultExists()
+    local names = M.GetUniversalCrossbarPaletteNamesOrdered();
+    if #names > 0 then
+        return names[1];
+    end
+    local ok = M.CreateUniversalCrossbarPalette(M.DEFAULT_PALETTE_NAME);
+    if ok == true then
+        return M.DEFAULT_PALETTE_NAME;
+    end
+    return nil;
+end
+
+function M.DeleteUniversalCrossbarPalette(paletteName)
+    if not paletteName or paletteName == '' then
+        return false, 'No palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return false, 'Not found';
+    end
+    local key = M.BuildUniversalCrossbarStorageKey(paletteName);
+    if not crossbarSettings.slotActions[key] then
+        return false, 'Palette not found';
+    end
+    local orderedBefore = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local neighborName = PickNeighborPaletteName(orderedBefore, paletteName);
+    crossbarSettings.slotActions[key] = nil;
+    if crossbarSettings.universalCrossbarPaletteOrder then
+        for i, n in ipairs(crossbarSettings.universalCrossbarPaletteOrder) do
+            if n == paletteName then
+                table.remove(crossbarSettings.universalCrossbarPaletteOrder, i);
+                break;
+            end
+        end
+    end
+    if crossbarSettings.crossbarUniversalPaletteMeta then
+        crossbarSettings.crossbarUniversalPaletteMeta[paletteName] = nil;
+    end
+    M.EnsureUniversalCrossbarDefaultExists();
+    if state.crossbarActiveUniversalPalette == paletteName then
+        local rest = M.GetUniversalCrossbarPaletteNamesOrdered();
+        local pickName = nil;
+        if neighborName then
+            for _, n in ipairs(rest) do
+                if n == neighborName then
+                    pickName = n;
+                    break;
+                end
+            end
+        end
+        if not pickName and #rest > 0 then
+            pickName = rest[1];
+        end
+        if pickName then
+            local changed = M.SetActiveUniversalCrossbarPalette(pickName);
+            if not changed then
+                FireCrossbarComboRefreshNoop(pickName);
+            end
+        end
+    end
+    if crossbarSettings.comboModeSettings then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            local ms = crossbarSettings.comboModeSettings[mode];
+            if ms and ms.universalOverridePalette == paletteName then
+                ms.universalOverridePalette = nil;
+            end
+        end
+    end
+    if crossbarSettings.namedPaletteComboModeSettings then
+        for _, perPal in pairs(crossbarSettings.namedPaletteComboModeSettings) do
+            if type(perPal) == 'table' then
+                for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+                    local o = perPal[mode];
+                    if o and o.universalOverridePalette == paletteName then
+                        o.universalOverridePalette = nil;
+                    end
+                end
+            end
+        end
+    end
+    if crossbarSettings.segmentOverrides then
+        for jid, modes in pairs(crossbarSettings.segmentOverrides) do
+            if type(modes) == 'table' then
+                for mode, seg in pairs(modes) do
+                    if type(seg) == 'table' and seg.scope == 'global' and seg.globalPalette == paletteName then
+                        modes[mode] = nil;
+                    end
+                end
+                if next(modes) == nil then
+                    crossbarSettings.segmentOverrides[jid] = nil;
+                end
+            end
+        end
+        if next(crossbarSettings.segmentOverrides) == nil then
+            crossbarSettings.segmentOverrides = nil;
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.RenameUniversalCrossbarPalette(oldName, newName)
+    if not oldName or oldName == '' then
+        return false, 'No palette name';
+    end
+    if not newName or newName == '' then
+        return false, 'No new name';
+    end
+    if oldName == newName then
+        return false, 'New name is the same as the old name';
+    end
+    if not IsValidPaletteName(newName) then
+        return false, 'Invalid new palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings or not crossbarSettings.slotActions then
+        return false, 'Crossbar settings not found';
+    end
+    local oldKey = M.BuildUniversalCrossbarStorageKey(oldName);
+    local newKey = M.BuildUniversalCrossbarStorageKey(newName);
+    if not crossbarSettings.slotActions[oldKey] then
+        return false, 'Palette not found';
+    end
+    if crossbarSettings.slotActions[newKey] then
+        return false, 'A palette with that name already exists';
+    end
+    crossbarSettings.slotActions[newKey] = crossbarSettings.slotActions[oldKey];
+    crossbarSettings.slotActions[oldKey] = nil;
+    if crossbarSettings.universalCrossbarPaletteOrder then
+        for i, n in ipairs(crossbarSettings.universalCrossbarPaletteOrder) do
+            if n == oldName then
+                crossbarSettings.universalCrossbarPaletteOrder[i] = newName;
+                break;
+            end
+        end
+    end
+    if crossbarSettings.crossbarUniversalPaletteMeta then
+        if crossbarSettings.crossbarUniversalPaletteMeta[oldName] then
+            crossbarSettings.crossbarUniversalPaletteMeta[newName] = crossbarSettings.crossbarUniversalPaletteMeta[oldName];
+            crossbarSettings.crossbarUniversalPaletteMeta[oldName] = nil;
+        end
+    end
+    if state.crossbarActiveUniversalPalette == oldName then
+        state.crossbarActiveUniversalPalette = newName;
+    end
+    if crossbarSettings.comboModeSettings then
+        for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+            local ms = crossbarSettings.comboModeSettings[mode];
+            if ms and ms.universalOverridePalette == oldName then
+                ms.universalOverridePalette = newName;
+            end
+        end
+    end
+    if crossbarSettings.namedPaletteComboModeSettings then
+        for _, perPal in pairs(crossbarSettings.namedPaletteComboModeSettings) do
+            if type(perPal) == 'table' then
+                for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+                    local o = perPal[mode];
+                    if o and o.universalOverridePalette == oldName then
+                        o.universalOverridePalette = newName;
+                    end
+                end
+            end
+        end
+    end
+    if crossbarSettings.segmentOverrides then
+        for _, modes in pairs(crossbarSettings.segmentOverrides) do
+            if type(modes) == 'table' then
+                for _, seg in pairs(modes) do
+                    if type(seg) == 'table' and seg.scope == 'global' and seg.globalPalette == oldName then
+                        seg.globalPalette = newName;
+                    end
+                end
+            end
+        end
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Reorder Global [G] crossbar palettes (same list as GetUniversalCrossbarPaletteNamesOrdered).
+function M.MoveUniversalCrossbarPalette(paletteName, direction)
+    if not paletteName or paletteName == '' then
+        return false, 'No palette specified';
+    end
+    if direction ~= -1 and direction ~= 1 then
+        return false, 'Invalid direction';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    local ordered = M.GetUniversalCrossbarPaletteNamesOrdered();
+    local currentIndex = nil;
+    for i, name in ipairs(ordered) do
+        if name == paletteName then
+            currentIndex = i;
+            break;
+        end
+    end
+    if not currentIndex then
+        return false, 'Palette not found in order';
+    end
+    local newIndex = currentIndex + direction;
+    if newIndex < 1 or newIndex > #ordered then
+        return false, 'Cannot move palette further';
+    end
+    ordered[currentIndex], ordered[newIndex] = ordered[newIndex], ordered[currentIndex];
+    crossbarSettings.universalCrossbarPaletteOrder = {};
+    for _, n in ipairs(ordered) do
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, n);
+    end
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+--- Deep-copy one Global [G] palette's slot data to a new or existing palette name.
+function M.CopyUniversalCrossbarPalette(sourceName, destName, overwriteExisting)
+    if not sourceName or sourceName == '' then
+        return false, 'No palette specified';
+    end
+    local dest = destName or sourceName;
+    if not IsValidPaletteName(dest) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local sourceKey = M.BuildUniversalCrossbarStorageKey(sourceName);
+    local destKey = M.BuildUniversalCrossbarStorageKey(dest);
+    if not crossbarSettings.slotActions[sourceKey] then
+        return false, 'Source palette not found';
+    end
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    local copiedData = {};
+    for comboMode, modeData in pairs(sourceData) do
+        if type(modeData) == 'table' then
+            copiedData[comboMode] = {};
+            for slotIdx, slotData in pairs(modeData) do
+                if type(slotData) == 'table' then
+                    copiedData[comboMode][slotIdx] = {};
+                    for k, v in pairs(slotData) do
+                        copiedData[comboMode][slotIdx][k] = v;
+                    end
+                else
+                    copiedData[comboMode][slotIdx] = slotData;
+                end
+            end
+        else
+            copiedData[comboMode] = modeData;
+        end
+    end
+    crossbarSettings.slotActions[destKey] = copiedData;
+    if not destExists then
+        if not crossbarSettings.universalCrossbarPaletteOrder then
+            crossbarSettings.universalCrossbarPaletteOrder = {};
+        end
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, dest);
+        if not crossbarSettings.crossbarUniversalPaletteMeta then
+            crossbarSettings.crossbarUniversalPaletteMeta = {};
+        end
+        if not crossbarSettings.crossbarUniversalPaletteMeta[dest] then
+            crossbarSettings.crossbarUniversalPaletteMeta[dest] = { includeInCycle = true };
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+function M.GetCrossbarPaletteScope()
+    return state.crossbarPaletteScope or 'job';
+end
+
+--- Temporary /xiui cpal summon of another job's palette (job storage only). See data.GetCrossbarStorageKeyForCombo.
+function M.GetCrossbarCliPreview()
+    return state.crossbarCliPreview;
+end
+
+function M.ClearCrossbarCliPreview()
+    if not state.crossbarCliPreview then
+        return;
+    end
+    state.crossbarCliPreview = nil;
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, nil);
+    end
+end
+
+function M.SetCrossbarCliPreview(jobId, storageSubjob, paletteName)
+    state.crossbarCliPreview = {
+        jobId = jobId,
+        storageSubjob = storageSubjob or 0,
+        paletteName = paletteName,
+    };
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, paletteName);
+    end
+end
+
+function M.SetCrossbarPaletteScope(scope)
+    if scope ~= 'job' and scope ~= 'universal' then
+        return false;
+    end
+    if state.crossbarPaletteScope == scope then
+        return false;
+    end
+    state.crossbarPaletteScope = scope;
+    state.crossbarCliPreview = nil;
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, nil);
+    end
+    return true;
+end
+
+local lastCrossbarScopeToggleClock = 0;
+
+function M.ToggleCrossbarPaletteScope()
+    local now = os.clock();
+    if now - lastCrossbarScopeToggleClock < 0.25 then
+        return false;
+    end
+    lastCrossbarScopeToggleClock = now;
+    local nextScope = (state.crossbarPaletteScope == 'universal') and 'job' or 'universal';
+    return M.SetCrossbarPaletteScope(nextScope);
+end
+
+function M.GetActiveUniversalCrossbarPalette()
+    return state.crossbarActiveUniversalPalette;
+end
+
+function M.SetActiveUniversalCrossbarPalette(paletteName)
+    state.crossbarCliPreview = nil;
+    local old = state.crossbarActiveUniversalPalette;
+    if old == paletteName then
+        return false;
+    end
+    state.crossbarActiveUniversalPalette = paletteName;
+    state.crossbarPaletteScope = 'universal';
+    for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
+        M.FirePaletteChangedCallbacks('crossbar:' .. mode, old, paletteName);
+    end
+    return true;
+end
+
+-- Unified fallback check: crossbar never uses fallback (both J and SJ tiers are visible).
+function M.IsUsingFallback(jobId, subjobId, paletteType)
+    if subjobId == 0 then return false; end
+    if paletteType == 'crossbar' then
+        return false;
+    end
+    return M.IsUsingFallbackPalettes(jobId, subjobId);
+end
+
+-- Get active palette name for crossbar (job-tier or universal-tier depending on scope)
 -- comboMode param kept for backwards compatibility but ignored
 -- Returns nil if no palette (using default slots)
 function M.GetActivePaletteForCombo(comboMode)
+    if state.crossbarPaletteScope == 'universal' then
+        return state.crossbarActiveUniversalPalette;
+    end
     return state.crossbarActivePalette;
 end
 
--- Get active palette display name for crossbar (GLOBAL)
+-- Get active palette display name for crossbar
 -- comboMode param kept for backwards compatibility but ignored
 -- Returns nil if no palette is active
 function M.GetActivePaletteDisplayNameForCombo(comboMode)
+    if state.crossbarPaletteScope == 'universal' then
+        return state.crossbarActiveUniversalPalette;
+    end
     return state.crossbarActivePalette;
 end
 
--- Set active palette for crossbar (GLOBAL - affects all combo modes)
+-- Set active palette for crossbar (job / job+subjob tier — affects all combo modes)
 -- comboMode param kept for backwards compatibility but ignored
 -- paletteName: name to activate, or nil to clear
-function M.SetActivePaletteForCombo(comboMode, paletteName)
+-- storageSubjob: 0 = Job [J] tier; live subjob id = Subjob [SJ] tier (omit/nil = infer from merged list later)
+function M.SetActivePaletteForCombo(comboMode, paletteName, storageSubjob)
+    state.crossbarCliPreview = nil;
     local oldPalette = state.crossbarActivePalette;
+    local oldScope = state.crossbarPaletteScope;
+    local oldSt = state.crossbarActiveStorageSubjob;
 
-    -- Skip if no change
-    if oldPalette == paletteName then
+    state.crossbarPaletteScope = 'job';
+    state.crossbarActivePalette = paletteName;
+    if storageSubjob ~= nil then
+        state.crossbarActiveStorageSubjob = storageSubjob;
+    elseif paletteName == nil or oldPalette ~= paletteName then
+        state.crossbarActiveStorageSubjob = nil;
+    end
+
+    if oldPalette == paletteName and oldScope == 'job' and oldSt == state.crossbarActiveStorageSubjob then
         return false;
     end
 
-    state.crossbarActivePalette = paletteName;
-
-    -- Fire callbacks for all combo modes (they all share the same palette now)
     for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
         M.FirePaletteChangedCallbacks('crossbar:' .. mode, oldPalette, paletteName);
     end
 
     return true;
+end
+
+-- Persisted / current Job-scope storage tier (nil = infer from merged list by name)
+function M.GetCrossbarActiveStorageSubjob()
+    return state.crossbarActiveStorageSubjob;
+end
+
+-- ── /xiui cpal return-to-origin anchor API ──────────────────────────────────
+
+-- Save the job-scope anchor only if one isn't already set.
+-- Call this BEFORE switching the active palette via a cpal command.
+function M.SetCpalJobAnchorIfUnset(currentName, currentStorageSubjob, currentJobId)
+    if state.cpalJobAnchor ~= nil then return; end
+    state.cpalJobAnchor = {
+        name           = currentName,
+        storageSubjob  = currentStorageSubjob or 0,
+        jobId          = currentJobId,
+    };
+end
+
+-- Save the universal/global-scope anchor only if one isn't already set.
+function M.SetCpalUniversalAnchorIfUnset(currentName)
+    if state.cpalUniversalAnchor ~= nil then return; end
+    state.cpalUniversalAnchor = currentName;
+end
+
+-- Return the anchor for the given scope ('job' or 'universal').
+-- For job scope, lazily validates the anchor against the current live job; clears and returns nil if stale.
+function M.GetCpalAnchor(scope)
+    if scope == 'universal' then
+        return state.cpalUniversalAnchor;
+    end
+    local a = state.cpalJobAnchor;
+    if not a then return nil; end
+    local ok, datamod = pcall(require, 'modules.hotbar.data');
+    if ok and datamod and datamod.jobId and a.jobId ~= datamod.jobId then
+        state.cpalJobAnchor = nil;
+        return nil;
+    end
+    return a;
+end
+
+-- Clear the anchor for the given scope without restoring.
+function M.ClearCpalAnchor(scope)
+    if scope == 'universal' then
+        state.cpalUniversalAnchor = nil;
+    else
+        state.cpalJobAnchor = nil;
+    end
+end
+
+-- Restore the anchor for the given scope: switches the active palette back to the saved value
+-- and then clears the anchor.
+function M.RestoreCpalAnchor(scope)
+    if scope == 'universal' then
+        local a = state.cpalUniversalAnchor;
+        if a then
+            state.cpalUniversalAnchor = nil;
+            M.SetActiveUniversalCrossbarPalette(a);
+        end
+    else
+        local a = state.cpalJobAnchor;
+        if a then
+            state.cpalJobAnchor = nil;
+            M.SetActivePaletteForCombo(nil, a.name, a.storageSubjob);
+        end
+    end
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Storage tier for slot key resolution when [J] scope (not Global [G])
+function M.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, liveSubjobId)
+    local lj = liveSubjobId or 0;
+    if lj == 0 then
+        return 0;
+    end
+    local st = state.crossbarActiveStorageSubjob;
+    if st ~= nil then
+        return st;
+    end
+    if state.crossbarActivePalette then
+        local rows = M.GetCrossbarManagePaletteRows(jobId, lj);
+        for _, r in ipairs(rows) do
+            if r.name == state.crossbarActivePalette then
+                return r.storageSubjob;
+            end
+        end
+    end
+    return 0;
 end
 
 -- Clear active palette for crossbar (uses default slot data)
@@ -1252,46 +2205,76 @@ function M.ClearActivePaletteForCombo(comboMode)
     return M.SetActivePaletteForCombo(comboMode, nil);
 end
 
--- Cycle through palettes for crossbar (GLOBAL - affects all combo modes)
+-- Cycle through palettes for crossbar (job tier or all-jobs universal tier)
 -- comboMode param kept for backwards compatibility but ignored
 -- direction: 1 for next, -1 for previous
 function M.CyclePaletteForCombo(comboMode, direction, jobId, subjobId)
     direction = direction or 1;
 
-    -- Use crossbar-only palette list (separate from hotbar)
-    local palettes = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    if #palettes == 0 then
-        return nil, false;  -- No palettes defined, second return = no palettes exist
-    end
+    M.ClearCrossbarCliPreview();
 
-    if #palettes == 1 then
-        -- Only one palette, just make sure it's active
-        M.SetActivePaletteForCombo(comboMode, palettes[1]);
-        return palettes[1], true;
-    end
-
-    local currentName = state.crossbarActivePalette;
-    local currentIndex = 1;  -- Default to first palette
-
-    -- Find current palette index
-    if currentName then
-        for i, name in ipairs(palettes) do
-            if name == currentName then
-                currentIndex = i;
-                break;
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes and state.crossbarPaletteScope == 'universal' then
+        local palettes = M.GetUniversalCrossbarPalettesForCycle();
+        if #palettes == 0 then
+            return nil, false;
+        end
+        if #palettes == 1 then
+            M.SetActiveUniversalCrossbarPalette(palettes[1]);
+            return palettes[1], true;
+        end
+        local currentName = state.crossbarActiveUniversalPalette;
+        local currentIndex = 1;
+        if currentName then
+            for i, name in ipairs(palettes) do
+                if name == currentName then
+                    currentIndex = i;
+                    break;
+                end
             end
+        end
+        local newIndex = currentIndex + direction;
+        if newIndex < 1 then newIndex = #palettes; end
+        if newIndex > #palettes then newIndex = 1; end
+        local newPalette = palettes[newIndex];
+        M.SetActiveUniversalCrossbarPalette(newPalette);
+        return newPalette, true;
+    end
+
+    local rowsAll = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local rows = {};
+    for _, r in ipairs(rowsAll) do
+        if M.IsCrossbarPaletteInRbCycle(jobId, r.storageSubjob, r.name) then
+            table.insert(rows, r);
+        end
+    end
+    if #rows == 0 then
+        return nil, false;
+    end
+
+    local currentIndex = 1;
+    for i, r in ipairs(rows) do
+        if r.name == state.crossbarActivePalette
+            and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == r.storageSubjob) then
+            currentIndex = i;
+            break;
         end
     end
 
-    -- Calculate new index with wrap-around (1..#palettes only, no "empty" state)
+    if #rows == 1 then
+        local r = rows[1];
+        M.SetActivePaletteForCombo(comboMode, r.name, r.storageSubjob);
+        return r.name, true;
+    end
+
     local newIndex = currentIndex + direction;
-    if newIndex < 1 then newIndex = #palettes; end
-    if newIndex > #palettes then newIndex = 1; end
+    if newIndex < 1 then newIndex = #rows; end
+    if newIndex > #rows then newIndex = 1; end
 
-    local newPalette = palettes[newIndex];
-    M.SetActivePaletteForCombo(comboMode, newPalette);
+    local pick = rows[newIndex];
+    M.SetActivePaletteForCombo(comboMode, pick.name, pick.storageSubjob);
 
-    return newPalette, true;  -- Second return = palettes exist
+    return pick.name, true;
 end
 
 -- Get the palette key suffix for crossbar (GLOBAL - same for all combo modes)
@@ -1304,8 +2287,9 @@ end
 
 -- Create a new palette for crossbar (stores in crossbar slotActions)
 -- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
+-- skipSave: when true, caller batches SaveSettingsToDisk (e.g. multi-job seed)
 -- Returns true on success, false with error message on failure
-function M.CreateCrossbarPalette(paletteName, jobId, subjobId)
+function M.CreateCrossbarPalette(paletteName, jobId, subjobId, skipSave)
     if not IsValidPaletteName(paletteName) then
         return false, 'Invalid palette name';
     end
@@ -1347,42 +2331,38 @@ function M.CreateCrossbarPalette(paletteName, jobId, subjobId)
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
 
-    SaveSettingsToDisk();
+    if not skipSave then
+        SaveSettingsToDisk();
+    end
     return true;
 end
 
 -- Ensure at least one crossbar palette exists for a job
--- Creates a "Default" palette if none exist
--- Returns the name of the first available palette
+-- Creates a "Default" palette at Job [J] tier if none exist
+-- Does not change the live active crossbar palette (config must not flip in-game scope)
+-- Returns the name of the first palette in merged order for this context
 function M.EnsureCrossbarDefaultPaletteExists(jobId, subjobId)
     local normalizedJobId = jobId or 1;
+    local sj = subjobId or 0;
 
-    -- Check if any palettes exist for this job
-    local availablePalettes = M.GetCrossbarAvailablePalettes(normalizedJobId, subjobId);
+    local rows = M.GetCrossbarManagePaletteRows(normalizedJobId, sj);
 
-    if #availablePalettes == 0 then
-        -- No palettes exist, create the default one at subjob 0 (shared)
-        -- This ensures imported data at subjob 0 isn't shadowed by empty subjob-specific palettes
+    if #rows == 0 then
         local success, err = M.CreateCrossbarPalette(M.DEFAULT_PALETTE_NAME, normalizedJobId, 0);
         if success then
-            -- Auto-activate the new palette
-            M.SetActivePaletteForCombo('L2', M.DEFAULT_PALETTE_NAME);
             return M.DEFAULT_PALETTE_NAME;
-        else
-            -- If "Default" already exists somehow, try numbered names
-            for i = 1, 99 do
-                local name = 'Palette ' .. i;
-                success, err = M.CreateCrossbarPalette(name, normalizedJobId, 0);
-                if success then
-                    M.SetActivePaletteForCombo('L2', name);
-                    return name;
-                end
+        end
+        for i = 1, 99 do
+            local name = 'Palette ' .. i;
+            success, err = M.CreateCrossbarPalette(name, normalizedJobId, 0);
+            if success then
+                return name;
             end
         end
-        return nil;  -- Failed to create
+        return nil;
     end
 
-    return availablePalettes[1];  -- Return first existing palette
+    return rows[1].name;
 end
 
 -- Helper: Find the actual crossbar storage key for a palette
@@ -1415,6 +2395,51 @@ local function FindCrossbarPaletteStorageKey(paletteName, jobId, subjobId)
     return nil;
 end
 
+-- If a Job [J] shared storage tier (tier 0) has zero palettes, create one blank Default (or Palette N).
+-- Subjob [SJ] tiers may be empty; gameplay falls back to shared job palettes.
+local function EnsureCrossbarStorageTierHasDefaultPalette(jobId, storageTier, skipSave)
+    local jid = jobId or 1;
+    local tier = storageTier or 0;
+    if #M.GetCrossbarPaletteNamesForOrderTier(jid, tier) > 0 then
+        return;
+    end
+    local ok, err = M.CreateCrossbarPalette(M.DEFAULT_PALETTE_NAME, jid, tier, skipSave);
+    if ok then
+        return;
+    end
+    for i = 1, 99 do
+        ok, err = M.CreateCrossbarPalette('Palette ' .. i, jid, tier, skipSave);
+        if ok then
+            return;
+        end
+    end
+end
+
+local CROSSBAR_JOB_SEED_MAX = 22;
+
+local function MaybeSeedBlankCrossbarDefaultPalettesForAllJobs()
+    if crossbarBlankDefaultsSeeded then
+        return;
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return;
+    end
+    crossbarBlankDefaultsSeeded = true;
+
+    local any = false;
+    for jid = 1, CROSSBAR_JOB_SEED_MAX do
+        if #M.GetCrossbarManagePaletteRows(jid, 0) == 0 then
+            EnsureCrossbarStorageTierHasDefaultPalette(jid, 0, true);
+            any = true;
+        end
+    end
+    if any then
+        InvalidatePaletteListCache();
+        SaveSettingsToDisk();
+    end
+end
+
 -- Delete a crossbar palette
 -- Uses NEW FORMAT: '{jobId}:{subjobId}:palette:{name}'
 -- Returns true on success, false with error message on failure
@@ -1437,8 +2462,18 @@ function M.DeleteCrossbarPalette(paletteName, jobId, subjobId)
         return false, 'Palette not found';
     end
 
+    local keyJobId, keySubjobId = storageKey:match('^(%d+):(%d+):');
+    local jidOrder = (keyJobId and tonumber(keyJobId)) or normalizedJobId;
+    local tierForOrder = (keySubjobId and tonumber(keySubjobId)) or normalizedSubjobId;
+    local orderedBefore = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, tierForOrder);
+    local neighborName = PickNeighborPaletteName(orderedBefore, paletteName);
+
     -- Delete the palette
     crossbarSettings.slotActions[storageKey] = nil;
+
+    if crossbarSettings.namedPaletteComboModeSettings then
+        crossbarSettings.namedPaletteComboModeSettings[storageKey] = nil;
+    end
 
     -- Determine which order key to use based on the storage key found
     local orderKey;
@@ -1459,13 +2494,52 @@ function M.DeleteCrossbarPalette(paletteName, jobId, subjobId)
         end
     end
 
-    -- If the GLOBAL crossbar palette was this palette, clear it
-    if state.crossbarActivePalette == paletteName then
-        state.crossbarActivePalette = nil;
+    if crossbarSettings.crossbarPaletteExcludeFromCycle and crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey] then
+        crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey][paletteName] = nil;
+        PrunePaletteExcludeSubtable(crossbarSettings.crossbarPaletteExcludeFromCycle, orderKey);
+    end
+
+    -- Only auto-fill Job [J] shared tier; SJ tiers can remain empty.
+    if tierForOrder == 0 then
+        EnsureCrossbarStorageTierHasDefaultPalette(jidOrder, tierForOrder);
+    end
+
+    if state.crossbarActivePalette == paletteName
+        and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == tierForOrder) then
+        local rest = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, tierForOrder);
+        local pickName = nil;
+        local pickTier = tierForOrder;
+        if neighborName then
+            for _, n in ipairs(rest) do
+                if n == neighborName then
+                    pickName = n;
+                    break;
+                end
+            end
+        end
+        if not pickName and #rest > 0 then
+            pickName = rest[1];
+        end
+        -- Last SJ palette removed: move active selection to Job [J] shared tier.
+        if not pickName and tierForOrder ~= 0 then
+            EnsureCrossbarStorageTierHasDefaultPalette(jidOrder, 0, true);
+            local jrest = M.GetCrossbarPaletteNamesForOrderTier(jidOrder, 0);
+            if #jrest > 0 then
+                pickName = jrest[1];
+                pickTier = 0;
+            end
+        end
+        if pickName then
+            local changed = M.SetActivePaletteForCombo('L2', pickName, pickTier);
+            if not changed then
+                FireCrossbarComboRefreshNoop(pickName);
+            end
+        end
     end
 
     -- Invalidate cache since palettes changed
     InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
 
     SaveSettingsToDisk();
     return true;
@@ -1518,6 +2592,14 @@ function M.RenameCrossbarPalette(oldName, newName, jobId, subjobId)
     crossbarSettings.slotActions[newStorageKey] = crossbarSettings.slotActions[oldStorageKey];
     crossbarSettings.slotActions[oldStorageKey] = nil;
 
+    if crossbarSettings.namedPaletteComboModeSettings then
+        local np = crossbarSettings.namedPaletteComboModeSettings;
+        if np[oldStorageKey] then
+            np[newStorageKey] = np[oldStorageKey];
+            np[oldStorageKey] = nil;
+        end
+    end
+
     -- Update crossbarPaletteOrder
     local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
     if crossbarSettings.crossbarPaletteOrder and crossbarSettings.crossbarPaletteOrder[orderKey] then
@@ -1529,8 +2611,16 @@ function M.RenameCrossbarPalette(oldName, newName, jobId, subjobId)
         end
     end
 
-    -- Update GLOBAL crossbar active palette if this was the active one
-    if state.crossbarActivePalette == oldName then
+    if crossbarSettings.crossbarPaletteExcludeFromCycle and crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey] then
+        local ex = crossbarSettings.crossbarPaletteExcludeFromCycle[orderKey];
+        if ex[oldName] then
+            ex[oldName] = nil;
+            ex[newName] = true;
+        end
+    end
+
+    if state.crossbarActivePalette == oldName
+        and (state.crossbarActiveStorageSubjob == nil or state.crossbarActiveStorageSubjob == effectiveSubjobId) then
         state.crossbarActivePalette = newName;
     end
 
@@ -1562,24 +2652,18 @@ function M.MoveCrossbarPalette(paletteName, direction, jobId, subjobId)
     local normalizedJobId = jobId or 1;
     local normalizedSubjobId = subjobId or 0;
 
-    -- If using fallback palettes, modify the shared order (subjob 0) instead
-    local effectiveSubjobId = normalizedSubjobId;
-    if normalizedSubjobId ~= 0 and M.IsUsingCrossbarFallbackPalettes(normalizedJobId, normalizedSubjobId) then
-        effectiveSubjobId = 0;
-    end
-    local orderKey = BuildJobSubjobKey(normalizedJobId, effectiveSubjobId);
+    -- subjobId is the storage tier for this palette (0 = Job [J], N = Subjob [SJ])
+    local orderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
 
-    -- Ensure crossbarPaletteOrder exists and is populated
     if not crossbarSettings.crossbarPaletteOrder then
         crossbarSettings.crossbarPaletteOrder = {};
     end
-    if not crossbarSettings.crossbarPaletteOrder[orderKey] then
-        -- Initialize crossbarPaletteOrder from current available palettes
-        crossbarSettings.crossbarPaletteOrder[orderKey] = {};
-        local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-        for _, name in ipairs(available) do
-            table.insert(crossbarSettings.crossbarPaletteOrder[orderKey], name);
-        end
+
+    -- Same merged order the UI lists (raw crossbarPaletteOrder can be stale or missing names)
+    local canonical = M.GetCrossbarPaletteNamesForOrderTier(normalizedJobId, normalizedSubjobId);
+    crossbarSettings.crossbarPaletteOrder[orderKey] = {};
+    for _, name in ipairs(canonical) do
+        table.insert(crossbarSettings.crossbarPaletteOrder[orderKey], name);
     end
 
     local order = crossbarSettings.crossbarPaletteOrder[orderKey];
@@ -1614,41 +2698,67 @@ function M.MoveCrossbarPalette(paletteName, direction, jobId, subjobId)
     return true;
 end
 
--- Check if a specific crossbar palette exists
-function M.CrossbarPaletteExists(paletteName, jobId, subjobId)
+-- Check if a specific crossbar palette exists (optional storage tier: 0 = Job [J], else Subjob [SJ])
+function M.CrossbarPaletteExists(paletteName, jobId, subjobId, storageTier)
     if not paletteName then
         return false;
     end
 
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    for _, name in ipairs(available) do
-        if name == paletteName then
+    local rows = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    for _, r in ipairs(rows) do
+        if r.name == paletteName and (storageTier == nil or r.storageSubjob == storageTier) then
             return true;
         end
     end
     return false;
 end
 
--- Get the index of a crossbar palette in the order list
--- Returns nil if palette not found
-function M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId)
+-- Crossbar rows that participate in RB+D-pad cycling (excludes Inactive in Palette Manager).
+function M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId)
+    local out = {};
+    for _, r in ipairs(M.GetCrossbarManagePaletteRows(jobId, subjobId)) do
+        if M.IsCrossbarPaletteInRbCycle(jobId, r.storageSubjob, r.name) then
+            table.insert(out, r);
+        end
+    end
+    return out;
+end
+
+-- Index in RB-cycle order only (1-based). Nil if palette is inactive or not found.
+function M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId, storageTier)
     if not paletteName then
         return nil;
     end
 
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    for i, name in ipairs(available) do
-        if name == paletteName then
+    local rows = M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+    for i, r in ipairs(rows) do
+        if r.name == paletteName and (storageTier == nil or r.storageSubjob == storageTier) then
             return i;
         end
     end
     return nil;
 end
 
--- Get the total number of crossbar palettes
 function M.GetCrossbarPaletteCount(jobId, subjobId)
-    local available = M.GetCrossbarAvailablePalettes(jobId, subjobId);
-    return #available;
+    return #M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+end
+
+--- Index and total for the on-screen palette label (RB cycle): universal [G] uses universal cycle; job [J] uses job rows.
+function M.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId)
+    if not paletteName then
+        return nil, nil;
+    end
+    if M.GetCrossbarPaletteScope() == 'universal' then
+        local cycle = M.GetUniversalCrossbarPalettesForCycle();
+        local total = #cycle;
+        for i, n in ipairs(cycle) do
+            if n == paletteName then
+                return i, total;
+            end
+        end
+        return nil, (total > 0) and total or nil;
+    end
+    return M.GetCrossbarPaletteIndex(paletteName, jobId, subjobId), M.GetCrossbarPaletteCount(jobId, subjobId);
 end
 
 -- ============================================
@@ -1657,8 +2767,9 @@ end
 
 -- Validate active palettes against current job's available palettes
 -- Ensures at least one palette exists, and auto-selects the first palette if none is active
--- Should be called on job change
-function M.ValidatePalettesForJob(jobId, subjobId)
+-- opts.applyDefaultCrossbarScope: only pass true when loading/reloading a profile (see XIUI xiuiApplyDefaultCrossbarPaletteScopeAfterProfileLoad).
+-- Zone/job packets and leveling must not flip scope — user toggles L1+R1 for that session.
+function M.ValidatePalettesForJob(jobId, subjobId, opts)
     -- Ensure gConfig.hotbar structure exists before any palette operations
     if not EnsureHotbarConfigExists() then
         print('[XIUI palette] Warning: gConfig not available, skipping palette validation');
@@ -1669,6 +2780,9 @@ function M.ValidatePalettesForJob(jobId, subjobId)
     if NeedsPaletteMigration() then
         RunPaletteMigration();
     end
+
+    -- Blank Default crossbar palette per job (no live palette activation; avoids config/job clicks)
+    MaybeSeedBlankCrossbarDefaultPalettesForAllJobs();
 
     -- Ensure at least one palette exists for this job
     local firstPalette = M.EnsureDefaultPaletteExists(jobId, subjobId);
@@ -1683,56 +2797,59 @@ function M.ValidatePalettesForJob(jobId, subjobId)
     -- Try to restore saved palette state for this job:subjob
     local savedPalette = LoadPaletteState(jobId, subjobId);
 
-    -- Check if current hotbar palette is valid
+    -- First palette that participates in RB / keyboard cycling (Palette Manager "Active")
+    local function firstHotbarPaletteInCycle()
+        for _, name in ipairs(availablePalettes) do
+            if M.IsHotbarPaletteInRbCycle(jobId, subjobId, name) then
+                return name;
+            end
+        end
+        if #availablePalettes > 0 then
+            return availablePalettes[1];
+        end
+        return firstPalette;
+    end
+
+    local function savedHotbarPaletteIfInCycle(name)
+        if not name then
+            return nil;
+        end
+        for _, n in ipairs(availablePalettes) do
+            if n == name and M.IsHotbarPaletteInRbCycle(jobId, subjobId, n) then
+                return name;
+            end
+        end
+        return nil;
+    end
+
+    -- Hotbar: do not keep a palette marked Inactive as the active palette after load / job change
+    local oldHotbarPalette = state.activePalette;
+    local desiredHotbar = nil;
     if state.activePalette then
-        local found = false;
+        local exists = false;
         for _, name in ipairs(availablePalettes) do
             if name == state.activePalette then
-                found = true;
+                exists = true;
                 break;
             end
         end
-        if not found then
-            -- Palette doesn't exist for this job, try saved state or use first available
-            local oldPalette = state.activePalette;
-            local newPalette = nil;
-
-            -- Check if saved palette exists for this job
-            if savedPalette then
-                for _, name in ipairs(availablePalettes) do
-                    if name == savedPalette then
-                        newPalette = savedPalette;
-                        break;
-                    end
-                end
-            end
-
-            state.activePalette = newPalette or firstPalette;
-            -- Fire callbacks for all bars
-            for i = 1, 6 do
-                M.FirePaletteChangedCallbacks(i, oldPalette, state.activePalette);
-            end
+        if exists and M.IsHotbarPaletteInRbCycle(jobId, subjobId, state.activePalette) then
+            desiredHotbar = state.activePalette;
+        else
+            desiredHotbar = savedHotbarPaletteIfInCycle(savedPalette) or firstHotbarPaletteInCycle();
         end
     else
-        -- No palette active, try saved state or select the first one
-        local newPalette = nil;
+        desiredHotbar = savedHotbarPaletteIfInCycle(savedPalette) or firstHotbarPaletteInCycle();
+    end
 
-        -- Check if saved palette exists for this job
-        if savedPalette then
-            for _, name in ipairs(availablePalettes) do
-                if name == savedPalette then
-                    newPalette = savedPalette;
-                    break;
-                end
-            end
-        end
-
-        state.activePalette = newPalette or firstPalette;
-        -- Fire callbacks for all bars
+    if oldHotbarPalette ~= desiredHotbar then
+        state.activePalette = desiredHotbar;
         for i = 1, 6 do
-            M.FirePaletteChangedCallbacks(i, nil, state.activePalette);
+            M.FirePaletteChangedCallbacks(i, oldHotbarPalette, desiredHotbar);
         end
     end
+
+    SavePaletteState(jobId, subjobId);
 
     -- Ensure at least one crossbar palette exists for this job
     local firstCrossbarPalette = M.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
@@ -1740,32 +2857,103 @@ function M.ValidatePalettesForJob(jobId, subjobId)
         print('[XIUI palette] Warning: Failed to create default crossbar palette for job ' .. tostring(jobId));
     end
 
-    -- Get available crossbar palettes
-    local availableCrossbarPalettes = M.GetCrossbarAvailablePalettes(jobId, subjobId);
+    -- Merge factory crossbar defaults into gConfig so keys like defaultCrossbarPaletteScope and
+    -- enableUniversalCrossbarPalettes always resolve (older/partial profiles omit nested fields).
+    if not gConfig.hotbarCrossbar then
+        gConfig.hotbarCrossbar = {};
+    end
+    local factories = require('core.settings.factories');
+    DeepMergeWithDefaults(gConfig.hotbarCrossbar, factories.createCrossbarDefaults());
 
-    -- Check if current crossbar palette is valid
-    if state.crossbarActivePalette then
-        local found = false;
-        for _, name in ipairs(availableCrossbarPalettes) do
-            if name == state.crossbarActivePalette then
-                found = true;
-                break;
+    local function ProfileDefaultWantsUniversalCrossbar(cs)
+        local v = cs and cs.defaultCrossbarPaletteScope;
+        if type(v) ~= 'string' then
+            return false;
+        end
+        local l = (v:lower():match('^%s*(.-)%s*$')) or '';
+        return l == 'universal' or l == 'global';
+    end
+
+    local crossbarSettings = gConfig.hotbarCrossbar;
+    local firstUniversal = nil;
+    -- Apply Job vs Global [G] scope from profile before reconciling [J] tier palettes so callbacks see correct scope.
+    if crossbarSettings and crossbarSettings.enableUniversalCrossbarPalettes then
+        firstUniversal = M.EnsureUniversalCrossbarDefaultExists();
+        if opts and opts.applyDefaultCrossbarScope == true then
+            pendingApplyDefaultCrossbarScopeFromProfile = false;
+            if ProfileDefaultWantsUniversalCrossbar(crossbarSettings) then
+                state.crossbarPaletteScope = 'universal';
+            else
+                state.crossbarPaletteScope = 'job';
             end
         end
-        if not found then
-            -- Palette doesn't exist for this job, use first available
+        if state.crossbarActiveUniversalPalette then
+            local ulist = M.GetUniversalCrossbarPaletteNamesOrdered();
+            local ufound = false;
+            for _, n in ipairs(ulist) do
+                if n == state.crossbarActiveUniversalPalette then
+                    ufound = true;
+                    break;
+                end
+            end
+            if not ufound then
+                local cyc = M.GetUniversalCrossbarPalettesForCycle();
+                state.crossbarActiveUniversalPalette = (cyc[1] or firstUniversal);
+            end
+        elseif firstUniversal and state.crossbarPaletteScope == 'universal' then
+            state.crossbarActiveUniversalPalette = firstUniversal;
+        end
+    elseif crossbarSettings then
+        -- Feature explicitly disabled in profile — scope must be job tier only.
+        state.crossbarPaletteScope = 'job';
+    end
+
+    local crossbarRowsAll = M.GetCrossbarManagePaletteRows(jobId, subjobId);
+    local crossbarRowsCycle = M.GetCrossbarManagePaletteRowsInRbCycle(jobId, subjobId);
+
+    local function pickFirstCrossbarRowInCycle()
+        if #crossbarRowsCycle > 0 then
+            return crossbarRowsCycle[1];
+        end
+        if #crossbarRowsAll > 0 then
+            return crossbarRowsAll[1];
+        end
+        return nil;
+    end
+
+    if state.crossbarActivePalette then
+        local matchRow = nil;
+        for _, r in ipairs(crossbarRowsAll) do
+            if r.name == state.crossbarActivePalette then
+                if state.crossbarActiveStorageSubjob == nil then
+                    state.crossbarActiveStorageSubjob = r.storageSubjob;
+                end
+                if r.storageSubjob == state.crossbarActiveStorageSubjob then
+                    matchRow = r;
+                    break;
+                end
+            end
+        end
+        local ok = matchRow and M.IsCrossbarPaletteInRbCycle(jobId, matchRow.storageSubjob, matchRow.name);
+        if not ok then
             local oldPalette = state.crossbarActivePalette;
-            state.crossbarActivePalette = firstCrossbarPalette;
-            -- Fire callbacks for all combo modes
+            local pick = pickFirstCrossbarRowInCycle();
+            if pick then
+                state.crossbarActivePalette = pick.name;
+                state.crossbarActiveStorageSubjob = pick.storageSubjob;
+            elseif firstCrossbarPalette then
+                state.crossbarActivePalette = firstCrossbarPalette;
+                state.crossbarActiveStorageSubjob = 0;
+            end
             for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
                 M.FirePaletteChangedCallbacks('crossbar:' .. mode, oldPalette, state.crossbarActivePalette);
             end
         end
     else
-        -- No crossbar palette active, select the first one
-        if firstCrossbarPalette then
-            state.crossbarActivePalette = firstCrossbarPalette;
-            -- Fire callbacks for all combo modes
+        local pick = pickFirstCrossbarRowInCycle();
+        if pick then
+            state.crossbarActivePalette = pick.name;
+            state.crossbarActiveStorageSubjob = pick.storageSubjob;
             for _, mode in ipairs(CROSSBAR_COMBO_MODES) do
                 M.FirePaletteChangedCallbacks('crossbar:' .. mode, nil, state.crossbarActivePalette);
             end
@@ -1777,6 +2965,9 @@ end
 function M.Reset()
     state.activePalette = nil;
     state.crossbarActivePalette = nil;
+    state.crossbarActiveStorageSubjob = nil;
+    state.crossbarPaletteScope = 'job';
+    state.crossbarActiveUniversalPalette = nil;
 end
 
 -- Get state for persistence (if needed)
@@ -1784,6 +2975,9 @@ function M.GetState()
     return {
         activePalette = state.activePalette,
         crossbarActivePalette = state.crossbarActivePalette,
+        crossbarActiveStorageSubjob = state.crossbarActiveStorageSubjob,
+        crossbarPaletteScope = state.crossbarPaletteScope,
+        crossbarActiveUniversalPalette = state.crossbarActiveUniversalPalette,
     };
 end
 
@@ -1792,6 +2986,11 @@ function M.RestoreState(savedState)
     if savedState then
         state.activePalette = savedState.activePalette;
         state.crossbarActivePalette = savedState.crossbarActivePalette;
+        state.crossbarActiveStorageSubjob = savedState.crossbarActiveStorageSubjob;
+        if savedState.crossbarPaletteScope == 'job' or savedState.crossbarPaletteScope == 'universal' then
+            state.crossbarPaletteScope = savedState.crossbarPaletteScope;
+        end
+        state.crossbarActiveUniversalPalette = savedState.crossbarActiveUniversalPalette;
     end
 end
 
@@ -1800,8 +2999,9 @@ end
 -- ============================================
 
 -- Copy a hotbar palette to a different job:subjob combination
--- Returns true on success, false with error message on failure
-function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName)
+-- newName: destination palette name (nil = same as source name)
+-- overwriteExisting: if true, replace data on an existing destination palette (slot actions / macros on all 6 bars)
+function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName, overwriteExisting)
     if not paletteName then
         return false, 'No palette specified';
     end
@@ -1820,13 +3020,23 @@ function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId
     -- Build destination storage key
     local destKey = M.BuildPaletteStorageKey(toJobId, toSubjobId, destName);
 
-    -- Check if destination already exists
+    local destExists = false;
     for barIdx = 1, 6 do
         local configKey = 'hotbarBar' .. barIdx;
         local barSettings = gConfig and gConfig[configKey];
         if barSettings and barSettings.slotActions and barSettings.slotActions[destKey] then
+            destExists = true;
+            break;
+        end
+    end
+
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
             return false, 'Palette already exists at destination';
         end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
     end
 
     -- Copy palette data to all bars
@@ -1858,26 +3068,29 @@ function M.CopyPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId
         end
     end
 
-    -- Add to destination's palette order
-    local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
-    if not gConfig.hotbar then
-        gConfig.hotbar = {};
+    -- Add to destination's palette order (new palette only)
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
+        if not gConfig.hotbar then
+            gConfig.hotbar = {};
+        end
+        if not gConfig.hotbar.paletteOrder then
+            gConfig.hotbar.paletteOrder = {};
+        end
+        if not gConfig.hotbar.paletteOrder[destOrderKey] then
+            gConfig.hotbar.paletteOrder[destOrderKey] = {};
+        end
+        table.insert(gConfig.hotbar.paletteOrder[destOrderKey], destName);
     end
-    if not gConfig.hotbar.paletteOrder then
-        gConfig.hotbar.paletteOrder = {};
-    end
-    if not gConfig.hotbar.paletteOrder[destOrderKey] then
-        gConfig.hotbar.paletteOrder[destOrderKey] = {};
-    end
-    table.insert(gConfig.hotbar.paletteOrder[destOrderKey], destName);
 
+    InvalidatePaletteListCache();
     SaveSettingsToDisk();
     return true;
 end
 
 -- Copy a crossbar palette to a different job:subjob combination
--- Returns true on success, false with error message on failure
-function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName)
+-- overwriteExisting: replace slot data on an existing destination palette
+function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, toSubjobId, newName, overwriteExisting)
     if not paletteName then
         return false, 'No palette specified';
     end
@@ -1901,9 +3114,14 @@ function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, to
     -- Build destination storage key
     local destKey = M.BuildPaletteStorageKey(toJobId, toSubjobId, destName);
 
-    -- Check if destination already exists
-    if crossbarSettings.slotActions and crossbarSettings.slotActions[destKey] then
-        return false, 'Palette already exists at destination';
+    local destExists = crossbarSettings.slotActions and crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
     end
 
     -- Ensure slotActions structure
@@ -1937,16 +3155,166 @@ function M.CopyCrossbarPalette(paletteName, fromJobId, fromSubjobId, toJobId, to
         crossbarSettings.slotActions[destKey] = {};
     end
 
-    -- Add to destination's palette order
-    local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
-    if not crossbarSettings.crossbarPaletteOrder then
-        crossbarSettings.crossbarPaletteOrder = {};
+    -- Add to destination's palette order (new palette only)
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(toJobId, toSubjobId);
+        if not crossbarSettings.crossbarPaletteOrder then
+            crossbarSettings.crossbarPaletteOrder = {};
+        end
+        if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
+            crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
+        end
+        table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], destName);
     end
-    if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
-        crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
-    end
-    table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], destName);
 
+    InvalidatePaletteListCache();
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Copy a Job [J]/Subjob-tier crossbar palette into the Global [G] (all-jobs universal) namespace.
+function M.CopyCrossbarPaletteToUniversal(paletteName, fromJobId, fromSubjobId, destName, overwriteExisting)
+    if not paletteName then
+        return false, 'No palette specified';
+    end
+    local outName = destName or paletteName;
+    if not IsValidPaletteName(outName) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    local sourceKey = FindCrossbarPaletteStorageKey(paletteName, fromJobId, fromSubjobId);
+    if not sourceKey then
+        return false, 'Source palette not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local destKey = M.BuildUniversalCrossbarStorageKey(outName);
+    if not destKey then
+        return false, 'Invalid destination key';
+    end
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    if sourceData then
+        local copiedData = {};
+        for comboMode, modeData in pairs(sourceData) do
+            if type(modeData) == 'table' then
+                copiedData[comboMode] = {};
+                for slotIdx, slotData in pairs(modeData) do
+                    if type(slotData) == 'table' then
+                        copiedData[comboMode][slotIdx] = {};
+                        for k, v in pairs(slotData) do
+                            copiedData[comboMode][slotIdx][k] = v;
+                        end
+                    else
+                        copiedData[comboMode][slotIdx] = slotData;
+                    end
+                end
+            else
+                copiedData[comboMode] = modeData;
+            end
+        end
+        crossbarSettings.slotActions[destKey] = copiedData;
+    else
+        crossbarSettings.slotActions[destKey] = {};
+    end
+    if not destExists then
+        if not crossbarSettings.universalCrossbarPaletteOrder then
+            crossbarSettings.universalCrossbarPaletteOrder = {};
+        end
+        table.insert(crossbarSettings.universalCrossbarPaletteOrder, outName);
+        if not crossbarSettings.crossbarUniversalPaletteMeta then
+            crossbarSettings.crossbarUniversalPaletteMeta = {};
+        end
+        if not crossbarSettings.crossbarUniversalPaletteMeta[outName] then
+            crossbarSettings.crossbarUniversalPaletteMeta[outName] = { includeInCycle = true };
+        end
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
+    SaveSettingsToDisk();
+    return true;
+end
+
+-- Copy a Global [G] universal crossbar palette into a Job [J]/Subjob-tier palette.
+function M.CopyUniversalCrossbarPaletteToJob(sourceName, destName, toJobId, toSubjobId, overwriteExisting)
+    if not sourceName or sourceName == '' then
+        return false, 'No palette specified';
+    end
+    local outName = destName or sourceName;
+    if not IsValidPaletteName(outName) then
+        return false, 'Invalid destination palette name';
+    end
+    local crossbarSettings = gConfig and gConfig.hotbarCrossbar;
+    if not crossbarSettings then
+        return false, 'Crossbar settings not found';
+    end
+    if not crossbarSettings.slotActions then
+        crossbarSettings.slotActions = {};
+    end
+    local sourceKey = M.BuildUniversalCrossbarStorageKey(sourceName);
+    if not crossbarSettings.slotActions[sourceKey] then
+        return false, 'Source palette not found';
+    end
+    local normalizedJobId = toJobId or 1;
+    local normalizedSubjobId = toSubjobId or 0;
+    local destKey = M.BuildPaletteStorageKey(normalizedJobId, normalizedSubjobId, outName);
+    local destExists = crossbarSettings.slotActions[destKey] ~= nil;
+    overwriteExisting = overwriteExisting == true;
+    if destExists then
+        if not overwriteExisting then
+            return false, 'Palette already exists at destination';
+        end
+    elseif overwriteExisting then
+        return false, 'No palette at that destination to overwrite';
+    end
+    local sourceData = crossbarSettings.slotActions[sourceKey];
+    if sourceData then
+        local copiedData = {};
+        for comboMode, modeData in pairs(sourceData) do
+            if type(modeData) == 'table' then
+                copiedData[comboMode] = {};
+                for slotIdx, slotData in pairs(modeData) do
+                    if type(slotData) == 'table' then
+                        copiedData[comboMode][slotIdx] = {};
+                        for k, v in pairs(slotData) do
+                            copiedData[comboMode][slotIdx][k] = v;
+                        end
+                    else
+                        copiedData[comboMode][slotIdx] = slotData;
+                    end
+                end
+            else
+                copiedData[comboMode] = modeData;
+            end
+        end
+        crossbarSettings.slotActions[destKey] = copiedData;
+    else
+        crossbarSettings.slotActions[destKey] = {};
+    end
+    if not destExists then
+        local destOrderKey = BuildJobSubjobKey(normalizedJobId, normalizedSubjobId);
+        if not crossbarSettings.crossbarPaletteOrder then
+            crossbarSettings.crossbarPaletteOrder = {};
+        end
+        if not crossbarSettings.crossbarPaletteOrder[destOrderKey] then
+            crossbarSettings.crossbarPaletteOrder[destOrderKey] = {};
+        end
+        table.insert(crossbarSettings.crossbarPaletteOrder[destOrderKey], outName);
+    end
+    InvalidatePaletteListCache();
+    InvalidateAllVisualCachesAfterPaletteListMutation();
     SaveSettingsToDisk();
     return true;
 end


### PR DESCRIPTION
…me/delete sync, and copy paths

What changed
- data.lua: hotbarCrossbar.segmentOverrides keyed by job and effective combo mode. Job-Shared (jobsegment:...) and Global palette sources resolve before legacy universal override. Draft editing uses draftByKey + draftTouchedKeys for redirected segment buckets; undo tracks touched keys. GetCrossbarStorageKeyForCombo and display name respect CLI preview state. Clear CLI preview on job change.
- palette.lua: When a universal crossbar palette is renamed or deleted, segmentOverrides entries that referenced it (scope=global + globalPalette) are updated or cleared so stale names cannot linger. CopyCrossbarPaletteToUniversal: copy a Job/Subjob-tier palette into the all-jobs universal [G] namespace (overwrite optional). CopyUniversalCrossbarPaletteToJob: copy a Global [G] palette into a specific Job/Subjob-tier palette (overwrite optional). Cycle ordering for segment override palettes. GetCrossbarSjOnlyPaletteNamesOrdered. crossbarCliPreview state.
- core/settings/factories.lua: segmentOverrides = {} default; mpCostAnchor top-left for new configs.
- core/settings/migration.lua: Crossbar segment override migration steps.

Why
- Lets per-job crossbar segments point at shared tiers or global palettes without duplicating slot data. Rename/delete stays consistent with segment UI. New copy paths support moving palettes between per-job storage and global crossbar storage without manual file editing. Draft/undo works correctly for segment-redirected slots.