### PR TITLE
Segment overrides EFP UI: override rows, crossbar editor segment inte…

### DIFF
--- a/XIUI/config/palettemanager.lua
+++ b/XIUI/config/palettemanager.lua
@@ -1,16 +1,25 @@
---[[
+﻿--[[
 * XIUI Config - Palette Manager
-* A separate modal window for managing palettes across job/subjob combinations
-* Supports creating, renaming, deleting, reordering, and copying palettes
+* Floating "Palette Manager" window (hotbar + crossbar list) and shared create/rename/copy modals.
+* Crossbar-only embed (Manage Palettes strip under XIUI Config) also lives here so modals stay one place;
+* the Crossbar *settings* shell is config/crossbar_settings.lua â€” that file calls into this module.
+* Keyboard hotbar palettes: Hotbar category. Controller crossbar palettes: Crossbar category â€” separate edit paths.
 ]]--
 
 require('common');
 require('handlers.helpers');
+local ffi = require('ffi');
 local imgui = require('imgui');
 local jobs = require('libs.jobs');
+local TextureManager = require('libs.texturemanager');
 local palette = require('modules.hotbar.palette');
 local data = require('modules.hotbar.data');
+local crossbar = require('modules.hotbar.crossbar');
+local macropalette = require('modules.hotbar.macropalette');
+local dragdrop = require('libs.dragdrop');
 local components = require('config.components');
+local petAllowlist = require('modules.hotbar.pet_palette_allowlist');
+local efpPets = require('config.efp_pets_tab');
 
 local M = {};
 
@@ -21,6 +30,8 @@ local windowState = {
     selectedSubjobId = nil,  -- 0 = shared
     selectedPaletteType = 'hotbar',  -- 'hotbar' or 'crossbar'
     selectedPaletteName = nil,
+    -- Crossbar floating list: which storage tier (0 = Job [J], N = Subjob [SJ]) is selected
+    selectedCrossbarStorageSubjob = nil,
     statusMessage = nil,  -- Brief status feedback for operations
     statusMessageTime = 0,  -- Time when status was set
 };
@@ -36,12 +47,1789 @@ local modalState = {
     copyTargetSubjobId = nil,
     -- For delete confirmation
     deletePaletteName = nil,
+    -- Crossbar embedded Manage: storage tier for rename/delete/move (merged Shared + subjob view)
+    crossbarOperationSubjob = nil,
+    crossbarCopyFromSubjob = nil,
+    -- Copy: overwrite existing destination palette (same name resolution as palette.lua)
+    copyOverwriteExisting = false,
+    copyDestExistingIndex = 1,
+    -- Crossbar Copy To: destination is Job [J]/Subjob storage vs Global [G] (universal)
+    copyDestScope = 'job', -- 'job' | 'universal'
+    -- Crossbar Job [J]/Subjob [SJ] create: job + storage tier (non-modal; see Copy Toâ€¦ popup)
+    crossbarCreateJobId = nil,
+    crossbarCreateStorageSubjob = nil,
 };
+
+-- Status icons for palette active/inactive display.
+local STATUS_ICON_SIZE = 18;
+local STATUS_COL_W     = 32;
+local COPY_COL_W       = 52;
+-- Status icons (Active/Inactive palette indicators) live at the addon's `assets/` root:
+-- `<addon>/assets/checkmark.png` and `<addon>/assets/x.png`. Loaded via getFileTexture so
+-- `loadTextureFromFile` resolves them under `assets/` and auto-appends the .png extension.
+-- Lazy-cached on first draw and held in module locals so the lookup happens once per session.
+local statusIconCheck  = nil;
+local statusIconX      = nil;
+
+local function DrawStatusIcon(isActive)
+    if isActive then
+        statusIconCheck = statusIconCheck or TextureManager.getFileTexture('checkmark');
+    else
+        statusIconX = statusIconX or TextureManager.getFileTexture('x');
+    end
+    local tex = isActive and statusIconCheck or statusIconX;
+    -- Center within column 0: use offset of separator 0→1 for the true pixel span.
+    local colStart = imgui.GetColumnOffset(0);
+    local colEnd   = imgui.GetColumnOffset(1);
+    local iconX    = colStart + math.floor((colEnd - colStart - STATUS_ICON_SIZE) / 2);
+    imgui.SetCursorPosX(math.max(colStart, iconX));
+    if tex and tex.image then
+        local ptr = tonumber(ffi.cast('uint32_t', tex.image));
+        if ptr then
+            imgui.Image(ptr, { STATUS_ICON_SIZE, STATUS_ICON_SIZE }, { 0, 0 }, { 1, 1 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 });
+            return;
+        end
+    end
+    -- Fallback if texture not available
+    if isActive then
+        imgui.TextColored({ 0.3, 0.9, 0.3, 1.0 }, 'v');
+    else
+        imgui.TextColored({ 0.9, 0.3, 0.3, 1.0 }, 'x');
+    end
+end
+
+local function DrawCreateMacroButton(cmd, displayName, uniqueId)
+    imgui.PushStyleColor(ImGuiCol_Button,        { 0.15, 0.30, 0.50, 0.80 });
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.25, 0.45, 0.70, 0.95 });
+    imgui.PushStyleColor(ImGuiCol_ButtonActive,  { 0.10, 0.35, 0.60, 1.00 });
+    if imgui.SmallButton('+M##' .. uniqueId) then
+        macropalette.OpenNewMacroWithText(cmd, displayName);
+    end
+    imgui.PopStyleColor(3);
+    if imgui.IsItemHovered() then
+        imgui.BeginTooltip();
+        imgui.Text('Create macro with command:');
+        imgui.TextColored({ 0.85, 0.85, 0.35, 1.0 }, cmd);
+        imgui.EndTooltip();
+    end
+end
+
+-- One-shot open flags: imgui.OpenPopup must be called exactly once (not every frame).
+-- If called every frame it overrides ImGui's close-on-click-outside, causing popups to
+-- reposition to the cursor instead of closing.
+local xbJobCreatePopupPending  = false;
+local createRenamePopupPendingId = nil;
+local copyPopupPending         = false;
+local deletePopupPending       = false;
+local useSharedPopupPending    = false;
+
+-- Persists the last-selected job/storageSubjob in the crossbar New popup across opens.
+-- Resets to live character job/sj only when the actual job or subjob changes.
+local xbCreatePersisted = {
+    jobId = nil,
+    storageSubjob = nil,
+    lastSeenJobId = nil,
+    lastSeenSubjobId = nil,
+};
+
+local function GetOrResetXbCreateDefaults()
+    local liveJob = data.jobId or 1;
+    local liveSj  = data.subjobId or 0;
+    if xbCreatePersisted.lastSeenJobId ~= liveJob or xbCreatePersisted.lastSeenSubjobId ~= liveSj then
+        xbCreatePersisted.jobId          = liveJob;
+        xbCreatePersisted.storageSubjob  = liveSj;
+        xbCreatePersisted.lastSeenJobId  = liveJob;
+        xbCreatePersisted.lastSeenSubjobId = liveSj;
+    end
+    return xbCreatePersisted.jobId, xbCreatePersisted.storageSubjob;
+end
+
+-- Embedded Crossbar Palette Manager (Manage Palettes & Crossbar tab â€” no floating window)
+local embedCrossbarJobContext = {
+    selectedPaletteName = nil,
+    selectedStorageSubjob = nil,
+};
+
+local embedCrossbarUniversalContext = {
+    selectedPaletteName = nil,
+};
+
+-- "Edit Full Palette": large floating window (same idea as Palette Manager, not a dimming modal)
+-- ctx: { kind = 'job'|'universal', name, jobId?, subjobId?, st? } (legacy: missing kind => job)
+local embedCrossbarComboCtx = nil;
+local embedCrossbarComboWinOpen = { false };
+-- After "Edit Full Palette" click: avoid clearing ctx on the first frame before Begin() succeeds (some ImGui builds).
+local embedCrossbarComboWinGraceFrames = 0;
+local embedCrossbarComboHasDrawn = false;
+-- Stable height for ##xbFullPalScroll: recomputing GetContentRegionAvail() every frame can jitter 1px and reset scroll.
+local editFullPaletteScrollHCached = nil;
+local EDIT_FULL_PALETTE_WINDOW_KEY = 'EditFullPalette';
+-- Default / clamp width for the embedded Edit Full Palette window (was 680; wider helps L2/R2 footer columns)
+local EDIT_FULL_PALETTE_WIN_W = 700;
+-- When true, horizontal size is fixed to EDIT_FULL_PALETTE_WIN_W (constraints min/max width equal); height still obeys limits below.
+local EDIT_FULL_PALETTE_WIN_LOCK_WIDTH = false;
+local EDIT_FULL_PALETTE_WIN_W_MIN = 700;
+local EDIT_FULL_PALETTE_WIN_W_MAX = 1400;
+-- Default height: inner area scrolls; do not drive window height from content (that caused scroll â€œjumpingâ€).
+local EDIT_FULL_PALETTE_WIN_H_DEFAULT = 760;
+-- Resizable height range (constraints). When LOCK_HEIGHT is true, min/max height both use H_DEFAULT (fixed height).
+local EDIT_FULL_PALETTE_WIN_H_MIN = 400;
+local EDIT_FULL_PALETTE_WIN_H_MAX = 1150;
+local EDIT_FULL_PALETTE_WIN_LOCK_HEIGHT = false;
+-- Vertical slice reserved for the gap after the scroll child + Undo/Apply/Close row (must stay fixed frame-to-frame).
+local EDIT_FULL_PALETTE_FOOTER_BLOCK_H = 44;
+-- Per-segment work copies for inline pet type editor (Edit Full Palette); reset when embedded window reopens
+local petEfpModeWork = nil;
+
+-- User closed XIUI Config while Edit Full Palette was open: show confirm on next palette draw.
+local openCloseConfigConfirmPopup = false;
+local openUnsavedChangesPopup = false;
+-- Pending palette switch: when the user picks a different palette from the dropdown but has unsaved changes.
+local pendingPaletteSwitchName = nil;
+-- Edit Full Palette: Slots (0) vs Pets (1) for job palettes; set when a tab change needs Apply/Discard.
+local embedEfpSubTab = 0;
+local pendingEfpSubTab = nil;
+
+-- Embedded Palette Manager (Crossbar tab): fixed list viewport = column headers + N rows, then scroll.
+local EMBED_CROSSBAR_PAL_LIST_VISIBLE_ROWS = 3;
+
+local function GetItemSpacingY()
+    local st = imgui.GetStyle and imgui.GetStyle();
+    if not st or not st.ItemSpacing then
+        return 8;
+    end
+    local is = st.ItemSpacing;
+    if type(is) == 'table' then
+        return math.floor((is[2] or is.y or 8) + 0.5);
+    end
+    return math.floor((tonumber(is) or 8) + 0.5);
+end
+
+local function GetContentRegionAvailHeight()
+    if not imgui.GetContentRegionAvail then
+        return 200;
+    end
+    local a, b = imgui.GetContentRegionAvail();
+    local h = 200;
+    if type(a) == 'table' then
+        h = a[2] or a.y or 200;
+    elseif type(b) == 'number' then
+        h = b;
+    end
+    -- Whole pixels: sub-pixel avail jitter changes BeginChild height and fights scroll at the bottom.
+    return math.floor(h + 0.5);
+end
+
+-- Two button rows + spacing (New/Rename/Copy/Delete/Up/Down, Enable/Disable + Edit Full Palette).
+local function GetEmbedCrossbarPalMgrActionBlockH()
+    local lineH = imgui.GetTextLineHeightWithSpacing();
+    local frameH = (imgui.GetFrameHeight and imgui.GetFrameHeight()) or (lineH * 1.45);
+    local gap = GetItemSpacingY();
+    return math.ceil(frameH * 2 + gap);
+end
+
+local function ForceCloseEditFullPaletteWindow()
+    embedCrossbarComboWinOpen[1] = false;
+    embedCrossbarComboCtx = nil;
+    embedCrossbarComboWinGraceFrames = 0;
+    embedCrossbarComboHasDrawn = false;
+    editFullPaletteScrollHCached = nil;
+    data.FullyClosePaletteEditSession();
+    crossbar.HidePaletteEditorPrimitives();
+end
+
+-- Called from config.lua when the user dismisses the main XIUI Config window.
+function M.DeferConfigCloseIfEditFullPaletteOpen()
+    -- Only block when the Edit Full Palette *window* is still open (not just grace-held ctx after close).
+    if not embedCrossbarComboWinOpen[1] then
+        return false;
+    end
+    -- No unsaved crossbar draft: close the editor and allow config to close without a modal.
+    if not data.IsDraftDirty() then
+        ForceCloseEditFullPaletteWindow();
+        return false;
+    end
+    openCloseConfigConfirmPopup = true;
+    return true;
+end
+
+local function BuildEditFullPaletteViewSettings(cross)
+    local v = {};
+    -- Copy all non-visual properties (palette data, mode toggles, overrides, etc.)
+    for k, val in pairs(cross or {}) do
+        v[k] = val;
+    end
+    -- Fixed visual constants â€” not derived from the user's crossbar display config.
+    -- Every user sees an identical editor layout regardless of their gameplay crossbar settings.
+    v.slotSize            = 38;
+    v.buttonIconSize      = 20;
+    v.labelFontSize       = 13;
+    v.recastTimerFontSize = 9;
+    v.mpCostFontSize      = 9;
+    v.quantityFontSize    = 9;
+    v.slotGapV            = 6;
+    v.slotGapH            = 6;
+    v.diamondSpacing      = 20;
+    v.groupSpacing        = 40;
+    return v;
+end
+
+-- Storage tier for named job palettes (0 = Job [J] shared tier, N = that subjob's tier).
+-- Must match data.GetCrossbarStorageKeyForCombo / palette.GetCrossbarActivePaletteStorageSubjobForResolution,
+-- not raw live subjob id â€” otherwise "shared" palettes used while /SJ is equipped resolve to an empty bucket.
+local function GetEmbedJobPaletteStorageTier(jobId, liveSubjobId)
+    local lj = liveSubjobId or 0;
+    if lj == 0 then
+        return 0;
+    end
+    if palette.GetCrossbarActivePaletteStorageSubjobForResolution then
+        return palette.GetCrossbarActivePaletteStorageSubjobForResolution(jobId, lj) or 0;
+    end
+    return 0;
+end
+
+function M.ToggleEditFullPaletteForCurrent()
+    if embedCrossbarComboWinOpen[1] and embedCrossbarComboCtx then
+        ForceCloseEditFullPaletteWindow();
+        return false;
+    end
+    local activeName = palette.GetActivePaletteForCombo and palette.GetActivePaletteForCombo('L2') or nil;
+    if not activeName or activeName == '' then
+        return nil;
+    end
+    local scope = palette.GetCrossbarPaletteScope and palette.GetCrossbarPaletteScope() or 'job';
+    if scope == 'universal' then
+        embedCrossbarComboCtx = { kind = 'universal', name = activeName };
+    else
+        local jid = data.jobId or 1;
+        local sj = data.subjobId or 0;
+        embedCrossbarComboCtx = {
+            kind = 'job',
+            jobId = jid,
+            subjobId = sj,
+            name = activeName,
+            st = GetEmbedJobPaletteStorageTier(jid, sj),
+        };
+    end
+    embedCrossbarComboWinOpen[1] = true;
+    embedCrossbarComboWinGraceFrames = 0;
+    embedCrossbarComboHasDrawn = false;
+    return true;
+end
+
+local function GetEmbedFullPaletteStorageKey(ctx)
+    local kind = ctx.kind or 'job';
+    if kind == 'universal' then
+        return palette.BuildUniversalCrossbarStorageKey(ctx.name);
+    end
+    local jobId = ctx.jobId or 1;
+    local tier = tonumber(ctx.st) or 0;
+    return palette.BuildPaletteStorageKey(jobId, tier, ctx.name);
+end
+
+local function JobNameShort(jobId)
+    if jobId == nil or jobId == 0 then
+        return 'Shared';
+    end
+    return jobs[jobId] or ('Job ' .. tostring(jobId));
+end
+
+local function BuildEmbedFullPaletteScopeLine(ctx, kind)
+    if kind == 'universal' then
+        return 'Global [G] - "' .. (ctx.name or '?') .. '"';
+    end
+    local jid = ctx.jobId or 1;
+    local st = tonumber(ctx.st) or 0;
+    local tier = (st == 0) and 'Shared (J)' or string.format('%s (SJ)', JobNameShort(st));
+    if st == 0 then
+        return string.format('%s - %s - "%s"', JobNameShort(jid), tier, ctx.name or '?');
+    else
+        local tabSj = ctx.subjobId or 0;
+        return string.format(
+            '%s/%s - %s - "%s"',
+            JobNameShort(jid),
+            (tabSj == 0) and 'Shared' or JobNameShort(tabSj),
+            tier,
+            ctx.name or '?'
+        );
+    end
+end
+
+-- Screen-space AABB of the current window's content region (for clipping embedded D3D / GDI crossbar draws).
+local function GetCurrentWindowContentScreenRect()
+    if not imgui.GetWindowPos or not imgui.GetWindowContentRegionMin or not imgui.GetWindowContentRegionMax then
+        return nil;
+    end
+    local wx, wy = imgui.GetWindowPos();
+    local cminX, cminY = imgui.GetWindowContentRegionMin();
+    local cmaxX, cmaxY = imgui.GetWindowContentRegionMax();
+    if wx == nil or cminX == nil or cmaxX == nil then
+        return nil;
+    end
+    return wx + cminX, wy + cminY, wx + cmaxX, wy + cmaxY;
+end
+
+local function GetCurrentWindowScreenRect()
+    if not imgui.GetWindowPos or not imgui.GetWindowSize then
+        return nil;
+    end
+    local wx, wy = imgui.GetWindowPos();
+    local ww, wh = imgui.GetWindowSize();
+    if wx == nil or ww == nil then
+        return nil;
+    end
+    return wx, wy, wx + ww, wy + wh;
+end
+
+local function IntersectRect(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2)
+    if not ax1 or not bx1 then
+        return nil;
+    end
+    local x1 = math.max(ax1, bx1);
+    local y1 = math.max(ay1, by1);
+    local x2 = math.min(ax2, bx2);
+    local y2 = math.min(ay2, by2);
+    if x1 >= x2 or y1 >= y2 then
+        return nil;
+    end
+    return x1, y1, x2, y2;
+end
+
+local function copyAllowlistTbl(v)
+    if v == nil then return nil; end
+    local c = {};
+    for i = 1, #v do
+        c[i] = v[i];
+    end
+    return c;
+end
+
+-- Resolve pet type list for a segment: per-mode, else default on crossbar, else all (nil).
+local function getEffectiveSegPetKeys(cross, mode)
+    if not cross or not mode then
+        return nil;
+    end
+    local cm = cross.comboModeSettings and cross.comboModeSettings[mode];
+    if cm and cm.petPalettePetKeys ~= nil then
+        return cm.petPalettePetKeys;
+    end
+    if cross.petPalettePetKeys ~= nil then
+        return cross.petPalettePetKeys;
+    end
+    return nil;
+end
+
+-- Edit Full Palette Pets tab: which segments map to the chosen pet and Pet Palette / allowlist (Slots tab).
+local function petEfpSegmentRowVisible(cross, mode, petKey)
+    if not cross or not mode or not petKey or petKey == '' then
+        return false;
+    end
+    local m = cross.comboModeSettings and cross.comboModeSettings[mode];
+    if not m or m.petAware ~= true then
+        return false;
+    end
+    return petAllowlist.Allows({ petPalettePetKeys = getEffectiveSegPetKeys(cross, mode) }, petKey);
+end
+
+local function stripNamedPalettePetFields(cross)
+    if not cross or not cross.namedPaletteComboModeSettings then
+        return;
+    end
+    for sk, row in pairs(cross.namedPaletteComboModeSettings) do
+        if type(row) == 'table' then
+            for _, m in ipairs({ 'L2', 'R2', 'L2x2', 'R2x2', 'L2R2', 'R2L2' }) do
+                local c = row[m];
+                if c and type(c) == 'table' then
+                    c.petPalettePetKeys = nil;
+                    c.petAware = nil;
+                    if next(c) == nil then
+                        row[m] = nil;
+                    end
+                end
+            end
+            if next(row) == nil then
+                cross.namedPaletteComboModeSettings[sk] = nil;
+            end
+        end
+    end
+end
+
+local function applySegmentPetTypeKeys(cross, mode, newList)
+    if not cross or not mode then
+        return;
+    end
+    if not cross.comboModeSettings then
+        cross.comboModeSettings = {};
+    end
+    if not cross.comboModeSettings[mode] then
+        cross.comboModeSettings[mode] = {};
+    end
+    if petAllowlist.IsEffectivelyAllTypes(newList) then
+        cross.comboModeSettings[mode].petPalettePetKeys = nil;
+    else
+        cross.comboModeSettings[mode].petPalettePetKeys = copyAllowlistTbl(newList) or {};
+    end
+    stripNamedPalettePetFields(cross);
+    if petEfpModeWork then
+        petEfpModeWork[mode] = nil;
+    end
+end
+
+local function drawJobSegmentInlinePetTypes(cross, mode, _maxWidth, idSuffix, jobId)
+    if not cross or not mode or not jobId then
+        return;
+    end
+    local baseM = cross.comboModeSettings and cross.comboModeSettings[mode];
+    if not baseM or not baseM.petAware then
+        return;
+    end
+    if not petEfpModeWork then
+        petEfpModeWork = {};
+    end
+    if not petEfpModeWork[mode] then
+        petEfpModeWork[mode] = { petPalettePetKeys = petAllowlist.CopyAllowlistForEditor(getEffectiveSegPetKeys(cross, mode)) };
+    end
+    local wk = petEfpModeWork[mode];
+    local function onInv()
+        if data.InvalidateStorageKeyCache then
+            data.InvalidateStorageKeyCache();
+        end
+        if data.InvalidateCrossbarDraftLayout then
+            data.InvalidateCrossbarDraftLayout();
+        end
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+    local function onSave()
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+    end
+    local function onApply(w)
+        applySegmentPetTypeKeys(cross, mode, w.petPalettePetKeys);
+    end
+    -- ASCII-only labels: game fonts often render em dash / ellipsis as "?"
+    local popupId = 'pet_type_cfg_' .. (tostring(idSuffix or 'x') .. '_' .. tostring(mode)):gsub('%W', '_');
+    imgui.Dummy({ 0, 6 });
+    imgui.PushID('petinline_' .. popupId);
+    imgui.TextColored(components.TAB_STYLE.gold, 'Pet types: ' .. tostring(mode));
+    imgui.SameLine(0, 10);
+    if imgui.SmallButton('Configure##' .. popupId) then
+        if imgui.SetNextWindowSize and ImGuiCond_Appearing ~= nil then
+            imgui.SetNextWindowSize({ 400, 0 }, ImGuiCond_Appearing);
+        end
+        imgui.OpenPopup(popupId);
+    end
+    if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
+        imgui.TextWrapped(
+            'Applies to this trigger segment for every [J] named palette. If you leave a segment empty here, the crossbar-wide default list is used (if you set one). L2, R2, L2x2, and chord rows can each be different.'
+        );
+        imgui.Spacing();
+        petAllowlist.DrawEditorPanel(wk, jobId, onSave, onInv, onApply);
+        imgui.EndPopup();
+    end
+    imgui.PopID();
+end
+
+-- Pet Palette toggle per combo-mode segment: stored on comboModeSettings[mode] only (job-wide, not per named palette).
+local function DrawJobSegmentPetGlobalControls(_storageKey, mode, label, cross, _named, opts)
+    opts = opts or {};
+    local showGoldLabel = opts.showGoldLabel ~= false;
+    if not cross or not cross.comboModeSettings then
+        return;
+    end
+    if not cross.comboModeSettings[mode] then
+        cross.comboModeSettings[mode] = {};
+    end
+    local baseM = cross.comboModeSettings[mode];
+    if baseM.petAware == nil then
+        baseM.petAware = false;
+    end
+    local effPet = baseM.petAware == true;
+
+    if showGoldLabel and label and label ~= '' then
+        imgui.TextColored(components.TAB_STYLE.gold, label);
+    end
+    local petBuf = { effPet };
+    if imgui.Checkbox('Pet Palette##petxb_' .. mode, petBuf) then
+        baseM.petAware = not effPet;
+        if not baseM.petAware and petEfpModeWork then
+            petEfpModeWork[mode] = nil;
+        end
+        if SaveSettingsOnly then SaveSettingsOnly(); end
+        if data.InvalidateStorageKeyCache then data.InvalidateStorageKeyCache(); end
+        if data.InvalidateCrossbarDraftLayout then data.InvalidateCrossbarDraftLayout(); end
+        if DeferredUpdateVisuals then DeferredUpdateVisuals(); end
+    end
+    imgui.ShowHelp(
+        'When enabled, this 8-slot group can use pet/avatar hotbar storage while a matching pet is out. '
+            .. 'Set which pet types count per segment in the â€œPet typesâ€ block below. Same for every [J] named palette, not per palette name.'
+    );
+end
+
+-- Job [J] Edit Full Palette: segment override (Job-shared storage or Global [G] source). Primary L2/R2 omit via caller.
+local SEGMENT_OVERRIDE_COMBO_W = 220;
+-- Segment overrides are keyed per job in settings, but gameplay resolves using the *current* job id.
+-- Global [G] redirects must therefore exist for every job id, or only the row you edited would work in-game.
+local SEGMENT_OVERRIDE_JOB_MAX = 22;
+
+local function ClearSegmentOverrideModeForAllJobs(cross, eff)
+    if not cross or not cross.segmentOverrides or not eff then
+        return;
+    end
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local jks = tostring(jid);
+        local modes = cross.segmentOverrides[jks];
+        if modes and modes[eff] then
+            modes[eff] = nil;
+            if next(modes) == nil then
+                cross.segmentOverrides[jks] = nil;
+            end
+        end
+    end
+    if cross.segmentOverrides and next(cross.segmentOverrides) == nil then
+        cross.segmentOverrides = nil;
+    end
+end
+
+-- One shared table for all jobs so palette name edits stay in sync in the UI.
+local function ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, globalPaletteName)
+    if not cross then
+        return;
+    end
+    if not cross.segmentOverrides then
+        cross.segmentOverrides = {};
+    end
+    local gp = (type(globalPaletteName) == 'string' and globalPaletteName ~= '') and globalPaletteName or nil;
+    local ent = { scope = 'global', globalPalette = gp };
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local jks = tostring(jid);
+        if not cross.segmentOverrides[jks] then
+            cross.segmentOverrides[jks] = {};
+        end
+        cross.segmentOverrides[jks][eff] = ent;
+    end
+end
+
+-- Switching one job from Global to Job-shared must not mutate the shared global table (same ref on all jobs).
+local function SplitGlobalSegmentToJobSharedForOneJob(cross, eff, editedJkStr, globalPaletteName)
+    if not cross then
+        return;
+    end
+    if not cross.segmentOverrides then
+        cross.segmentOverrides = {};
+    end
+    local gp = (type(globalPaletteName) == 'string' and globalPaletteName ~= '') and globalPaletteName or nil;
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local jks = tostring(jid);
+        if not cross.segmentOverrides[jks] then
+            cross.segmentOverrides[jks] = {};
+        end
+        if jks == editedJkStr then
+            cross.segmentOverrides[jks][eff] = { scope = 'jobShared' };
+        else
+            cross.segmentOverrides[jks][eff] = { scope = 'global', globalPalette = gp };
+        end
+    end
+end
+
+-- Persist full job rows for legacy configs that only stored Global on one job id.
+-- Do not run when any job uses Job-shared for this segment (valid per-job mix with others on Global).
+local function ReconcileGlobalSegmentOverrideRows(cross, eff)
+    if not cross or not eff then
+        return;
+    end
+    if not cross.segmentOverrides then
+        return;
+    end
+    local gp;
+    local anyJobShared = false;
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local s = cross.segmentOverrides[tostring(jid)] and cross.segmentOverrides[tostring(jid)][eff];
+        if s and s.scope == 'jobShared' then
+            anyJobShared = true;
+        elseif s and s.scope == 'global' and type(s.globalPalette) == 'string' and s.globalPalette ~= '' then
+            gp = s.globalPalette;
+        end
+    end
+    if anyJobShared or not gp then
+        return;
+    end
+    for jid = 1, SEGMENT_OVERRIDE_JOB_MAX do
+        local s = cross.segmentOverrides[tostring(jid)] and cross.segmentOverrides[tostring(jid)][eff];
+        if not s or s.scope ~= 'global' or s.globalPalette ~= gp then
+            ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, gp);
+            if SaveSettingsOnly then
+                SaveSettingsOnly();
+            end
+            return;
+        end
+    end
+end
+
+local function DrawJobSegmentOverrideCheckboxRow(jobId, comboMode, cross, idSuffix, _columnMaxW)
+    if not jobId or not cross then
+        return;
+    end
+    local eff = data.GetEffectiveComboModeForStorage(comboMode);
+    if eff == 'L2' or eff == 'R2' then
+        return;
+    end
+    if not cross.segmentOverrides then
+        cross.segmentOverrides = {};
+    end
+    local jk = tostring(jobId);
+    if not cross.segmentOverrides[jk] then
+        cross.segmentOverrides[jk] = {};
+    end
+    local ent = cross.segmentOverrides[jk][eff];
+    local enabled = ent ~= nil and ent.scope ~= nil;
+
+    imgui.PushID('segov_' .. (idSuffix or 'm') .. '_' .. eff);
+    local ovBuf = { enabled };
+    if imgui.Checkbox('Override##ovren', ovBuf) then
+        if ovBuf[1] then
+            cross.segmentOverrides[jk][eff] = { scope = 'jobShared' };
+        else
+            if ent and ent.scope == 'global' then
+                ClearSegmentOverrideModeForAllJobs(cross, eff);
+            else
+                cross.segmentOverrides[jk][eff] = nil;
+                if next(cross.segmentOverrides[jk]) == nil then
+                    cross.segmentOverrides[jk] = nil;
+                end
+                if next(cross.segmentOverrides) == nil then
+                    cross.segmentOverrides = nil;
+                end
+            end
+        end
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+        data.InvalidateCrossbarDraftLayout();
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+    imgui.SameLine();
+    imgui.ShowHelp(
+        'Override: use one shared bar for this trigger segment across palettes (job-wide), or bind to a Global [G] palette so the same slots appear on every job. Global [G] applies to all jobs in-game (same redirect for every job id). Does not duplicate palette data; it redirects where slots load and save.'
+    );
+    imgui.PopID();
+end
+
+local function DrawJobSegmentOverrideDetailBlock(jobId, comboMode, cross, idSuffix, columnMaxW)
+    if not jobId or not cross then
+        return;
+    end
+    local comboW = SEGMENT_OVERRIDE_COMBO_W;
+    if columnMaxW and columnMaxW > 40 then
+        comboW = math.min(SEGMENT_OVERRIDE_COMBO_W, columnMaxW - 8);
+    end
+    local eff = data.GetEffectiveComboModeForStorage(comboMode);
+    if eff == 'L2' or eff == 'R2' then
+        return;
+    end
+    local jk = tostring(jobId);
+    local ent = cross.segmentOverrides and cross.segmentOverrides[jk] and cross.segmentOverrides[jk][eff];
+    if not ent or not ent.scope then
+        return;
+    end
+
+    imgui.PushID('segdet_' .. (idSuffix or 'm') .. '_' .. eff);
+    imgui.Dummy({ 0, 2 });
+    if imgui.RadioButton('Job-shared##rj_' .. eff, ent.scope == 'jobShared') then
+        if ent.scope == 'global' then
+            local gp = (type(ent.globalPalette) == 'string' and ent.globalPalette ~= '') and ent.globalPalette or nil;
+            local names = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+            if (not gp or gp == '') and names[1] then
+                gp = names[1];
+            end
+            SplitGlobalSegmentToJobSharedForOneJob(cross, eff, jk, gp);
+        else
+            ent.scope = 'jobShared';
+            ent.globalPalette = nil;
+        end
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+        data.InvalidateCrossbarDraftLayout();
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+    imgui.SameLine(0, 12);
+    if imgui.RadioButton('Global [G]##rg_' .. eff, ent.scope == 'global') then
+        local names = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+        local gp = (type(ent.globalPalette) == 'string' and ent.globalPalette ~= '') and ent.globalPalette or nil;
+        if (not gp or gp == '') and names[1] then
+            gp = names[1];
+        end
+        ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, gp);
+        if SaveSettingsOnly then
+            SaveSettingsOnly();
+        end
+        data.InvalidateCrossbarDraftLayout();
+        if DeferredUpdateVisuals then
+            DeferredUpdateVisuals();
+        end
+    end
+
+    if ent.scope == 'global' then
+        imgui.Dummy({ 0, 4 });
+        imgui.PushItemWidth(comboW);
+        local names = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+        local preview = (type(ent.globalPalette) == 'string' and ent.globalPalette ~= '') and ent.globalPalette or '(select)';
+        if imgui.BeginCombo('Palette##gp_' .. eff, preview, 0) then
+            for _, nm in ipairs(names) do
+                if imgui.Selectable(nm, nm == ent.globalPalette) then
+                    ReplicateGlobalSegmentOverrideToAllJobs(cross, eff, nm);
+                    if SaveSettingsOnly then
+                        SaveSettingsOnly();
+                    end
+                    data.InvalidateCrossbarDraftLayout();
+                    if DeferredUpdateVisuals then
+                        DeferredUpdateVisuals();
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        imgui.PopItemWidth();
+        imgui.SameLine(0, 8);
+        imgui.TextColored({ 0.7, 0.68, 0.6, 1.0 }, 'Palette');
+    end
+
+    imgui.Dummy({ 0, 4 });
+    -- Job-shared: short manual lines only. Even with \n, a long first line still *soft-wraps* in narrow
+    -- double-tap columns; when L2x2 and R2x2 both show this, line count could flicker and bounce scroll.
+    if ent.scope == 'jobShared' then
+        imgui.TextColored(
+            { 0.92, 0.32, 0.32, 1.0 },
+            'Job-shared crossbar:\nEdits apply to all\nnamed palettes\nfor this job on\nthis segment.'
+        );
+    elseif ent.scope == 'global' and type(ent.globalPalette) == 'string' and ent.globalPalette ~= '' then
+        local wrapPushed = false;
+        if columnMaxW and columnMaxW > 40 and imgui.PushTextWrapPos and imgui.GetCursorPosX then
+            local cx = math.floor(imgui.GetCursorPosX() + 0.5);
+            local w = math.floor(columnMaxW + 0.5) - 6;
+            if w > 40 then
+                imgui.PushTextWrapPos(cx + w);
+                wrapPushed = true;
+            end
+        end
+        imgui.PushStyleColor(ImGuiCol_Text, { 0.92, 0.32, 0.32, 1.0 });
+        if imgui.TextWrapped then
+            imgui.TextWrapped(
+                'Global palette "'
+                    .. ent.globalPalette
+                    .. '": edits change that [G] set for everyone using it (including Universal crossbar when active).'
+            );
+        else
+            imgui.TextColored(
+                { 0.92, 0.32, 0.32, 1.0 },
+                'Global palette "'
+                    .. ent.globalPalette
+                    .. '": edits change that [G] palette for everyone using it (including Universal crossbar when this set is active).'
+            );
+        end
+        imgui.PopStyleColor(1);
+        if wrapPushed and imgui.PopTextWrapPos then
+            imgui.PopTextWrapPos();
+        end
+    end
+    imgui.PopID();
+end
+
+-- Override + Pet on one row; when Override is on, Job/Global on the next row; Global adds palette row + warnings below.
+-- maxWidth = that columnâ€™s usable width (keeps text/combo from spilling into the other half).
+local function DrawJobSegmentFooterOverrideAndPet(storageKey, mode, cross, named, jobId, showOverride, idTag, maxWidth)
+    maxWidth = maxWidth or 400;
+    if not showOverride or not jobId then
+        DrawJobSegmentPetGlobalControls(storageKey, mode, '', cross, named, { showGoldLabel = false, jobId = jobId or data.jobId or 1 });
+        if jobId and cross and cross.comboModeSettings and cross.comboModeSettings[mode] and cross.comboModeSettings[mode].petAware == true then
+            drawJobSegmentInlinePetTypes(cross, mode, maxWidth, idTag or 'pet1', jobId);
+        end
+        return;
+    end
+
+    imgui.PushID('ovpetblk_' .. idTag);
+    if showOverride and jobId then
+        local eff = data.GetEffectiveComboModeForStorage(mode);
+        if eff ~= 'L2' and eff ~= 'R2' then
+            ReconcileGlobalSegmentOverrideRows(cross, eff);
+        end
+    end
+    -- Override | Pet on one row. Do not use imgui.Columns here (breaks the outer L2/R2 pair Columns).
+    -- Height must NOT be 0: in ImGui, BeginChild(..., { w, 0 }) uses remaining vertical space and stretches
+    -- the row to the bottom of the parent, leaving a huge empty band before Job/Global below.
+    local gap = 6;
+    local half = math.max(96, math.floor(((maxWidth - gap) * 0.5) + 0.5));
+    local wRight = math.max(80, maxWidth - half - gap);
+    local fh = (imgui.GetFrameHeightWithSpacing and imgui.GetFrameHeightWithSpacing())
+        or ((imgui.GetFrameHeight and imgui.GetFrameHeight()) + GetItemSpacingY())
+        or 26;
+    -- Right column: Pet Palette only (Petsâ€¦ moved to Edit Full Palette Pets tab).
+    local row1H = math.ceil(math.max(24, fh + 4));
+
+    imgui.BeginChild('##ovpetL_' .. idTag, { half, row1H }, false);
+    DrawJobSegmentOverrideCheckboxRow(jobId, mode, cross, idTag, half);
+    imgui.EndChild();
+    imgui.SameLine(0, gap);
+    imgui.BeginChild('##ovpetR_' .. idTag, { wRight, row1H }, false);
+    DrawJobSegmentPetGlobalControls(storageKey, mode, '', cross, named, { showGoldLabel = false, jobId = jobId });
+    imgui.EndChild();
+
+    if jobId and cross and cross.comboModeSettings and cross.comboModeSettings[mode] and cross.comboModeSettings[mode].petAware == true then
+        drawJobSegmentInlinePetTypes(cross, mode, maxWidth, idTag, jobId);
+    end
+
+    DrawJobSegmentOverrideDetailBlock(jobId, mode, cross, idTag, maxWidth);
+
+    imgui.PopID();
+end
+
+-- Full crossbar row using the same DrawSlot / slotrenderer path as the in-game crossbar (requires data.BeginCrossbarPaletteEditSession).
+-- Clip rect is taken *inside* each row BeginChild only. Do not intersect with a scroll snapshot from before layout:
+-- ContentRegionMax at the top of an empty scroll pane is wrong and would drop every row after the first.
+local function DrawFullPaletteCrossbarPair(storageKey, modeLeft, modeRight, idFix, cs, parentClipX1, parentClipY1, parentClipX2, parentClipY2, drawPetFooters, cross, named, segmentOverrideJobId)
+    local w, h, gw, ghgt = crossbar.GetEditorCrossbarRowDimensions(cs);
+    local gs = w - 2 * gw;
+    -- Action names render on top of slot icons (not above/below the grid); keep row padding compact.
+    local rowPadTop = 14;
+    local rowPadBottom = 14;
+    local rowPadH = (cs.labelFontSize or 10) + 22;
+    local rowPadLeft = rowPadH;
+    local rowPadRight = rowPadH + 16;
+    local rowHeight = ghgt + rowPadTop + rowPadBottom;
+    local rowWidth = w + rowPadLeft + rowPadRight;
+    local flags = 0;
+    if ImGuiWindowFlags_NoScrollbar ~= nil then
+        flags = ImGuiWindowFlags_NoScrollbar;
+    end
+    imgui.PushStyleColor(ImGuiCol_ChildBg, { 0.176, 0.161, 0.137, 0.95 });
+    imgui.BeginChild('##xbpair_' .. idFix, { rowWidth, rowHeight }, true, flags);
+    do
+        local dlBg = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+        local wx, wy = imgui.GetWindowPos();
+        local ww, wh = imgui.GetWindowSize();
+        if dlBg and wx and ww then
+            dlBg:AddRectFilled({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32({ 0.176, 0.161, 0.137, 0.95 }), 4);
+            dlBg:AddRect({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32(components.TAB_STYLE.gold), 4, 0, 1.5);
+        end
+    end
+    local rowX1, rowY1, rowX2, rowY2 = GetCurrentWindowContentScreenRect();
+    local dl = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+    local pushedClip = false;
+    local cx1, cy1, cx2, cy2 = rowX1, rowY1, rowX2, rowY2;
+    if parentClipX1 then
+        cx1, cy1, cx2, cy2 = IntersectRect(rowX1, rowY1, rowX2, rowY2, parentClipX1, parentClipY1, parentClipX2, parentClipY2);
+    end
+    if cx1 and dl and dl.PushClipRect then
+        dl:PushClipRect({ cx1, cy1 }, { cx2, cy2 }, true);
+        pushedClip = true;
+    end
+    local slotGridLeftScreenX = nil;
+    local slotGridRightScreenX = nil;
+    if cx1 then
+        local px, py = imgui.GetCursorScreenPos();
+        local drawOriginX = px + rowPadLeft;
+        slotGridLeftScreenX = drawOriginX;
+        slotGridRightScreenX = drawOriginX + gw + gs;
+        local drawOriginY = py + rowPadTop;
+        if modeLeft and modeRight then
+            local dividerX = drawOriginX + (w / 2);
+            if dl and dl.AddLine then
+                dl:AddLine(
+                    { dividerX, drawOriginY + 10 },
+                    { dividerX, drawOriginY + ghgt - 10 },
+                    imgui.GetColorU32({ 1, 1, 1, 0.3 }),
+                    2
+                );
+            end
+        end
+        local glyphMode = (idFix == 'dbl') and 'doubleTap' or (idFix == 'chord') and 'chordCombo' or 'primary';
+        local gSides = { l = (modeLeft ~= nil), r = (modeRight ~= nil) };
+        crossbar.DrawPaletteEditorL2R2TriggerGlyphs(drawOriginX, drawOriginY, cs, glyphMode, gSides);
+        crossbar.DrawPaletteEditorL2R2Row(drawOriginX, drawOriginY, cs, modeLeft, modeRight, cx1, cy1, cx2, cy2);
+    end
+    if pushedClip and dl and dl.PopClipRect then
+        dl:PopClipRect();
+    end
+    imgui.EndChild();
+    imgui.PopStyleColor(1);
+    if drawPetFooters and cross and named and slotGridLeftScreenX then
+        imgui.Dummy({ 0, 6 });
+        imgui.PushID('petfoot_' .. idFix);
+        local haveBoth = (modeLeft ~= nil and modeRight ~= nil);
+        if haveBoth then
+            -- Match slot row width so L2/R2 footers align with the diamonds; ImGui columns draw the vertical separator between them
+            local leftColW = rowPadLeft + (w / 2);
+            local rightColW = rowWidth - leftColW;
+            local cellPad = 10;
+            local leftInner = math.max(120, leftColW - cellPad);
+            local rightInner = math.max(120, rightColW - cellPad);
+
+            -- Avoid nested BeginChild(..., height 0) inside the main scroll: auto-height stacking bugs / huge gaps on some ImGui builds.
+            imgui.Columns(2, '##pairFootCols_' .. idFix, true);
+            imgui.SetColumnWidth(0, leftColW);
+            imgui.SetColumnWidth(1, rightColW);
+
+            DrawJobSegmentFooterOverrideAndPet(
+                storageKey,
+                modeLeft,
+                cross,
+                named,
+                segmentOverrideJobId,
+                drawPetFooters and segmentOverrideJobId and idFix ~= 'pri',
+                'L_' .. idFix,
+                leftInner
+            );
+            imgui.NextColumn();
+            DrawJobSegmentFooterOverrideAndPet(
+                storageKey,
+                modeRight,
+                cross,
+                named,
+                segmentOverrideJobId,
+                drawPetFooters and segmentOverrideJobId and idFix ~= 'pri',
+                'R_' .. idFix,
+                rightInner
+            );
+            imgui.Columns(1);
+        else
+            local m = modeLeft or modeRight;
+            local tag = (modeLeft and 'L_') or 'R_';
+            if m then
+                DrawJobSegmentFooterOverrideAndPet(
+                    storageKey,
+                    m,
+                    cross,
+                    named,
+                    segmentOverrideJobId,
+                    drawPetFooters and segmentOverrideJobId and idFix ~= 'pri',
+                    tag .. idFix,
+                    math.max(160, rowWidth - 16)
+                );
+            end
+        end
+
+        imgui.Dummy({ 0, 10 });
+        imgui.PopID();
+    end
+end
+
+-- Single 8-slot group (shared chord bar): one double-diamond wide
+local function DrawFullPaletteSingleCrossbarGroup(storageKey, comboMode, idFix, cs, parentClipX1, parentClipY1, parentClipX2, parentClipY2, drawPetFooters, cross, named, segmentOverrideJobId)
+    local w, h, gw, ghgt = crossbar.GetEditorCrossbarRowDimensions(cs);
+    local rowPadTop = 14;
+    local rowPadBottom = 14;
+    local rowPadH = (cs.labelFontSize or 10) + 22;
+    local rowPadLeft = rowPadH;
+    local rowPadRight = rowPadH + 16;
+    local rowHeight = ghgt + rowPadTop + rowPadBottom;
+    local rowWidth = gw + rowPadLeft + rowPadRight;
+    local flags = 0;
+    if ImGuiWindowFlags_NoScrollbar ~= nil then
+        flags = ImGuiWindowFlags_NoScrollbar;
+    end
+    imgui.PushStyleColor(ImGuiCol_ChildBg, { 0.176, 0.161, 0.137, 0.95 });
+    imgui.BeginChild('##xbone_' .. idFix, { rowWidth, rowHeight }, true, flags);
+    do
+        local dlBg = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+        local wx, wy = imgui.GetWindowPos();
+        local ww, wh = imgui.GetWindowSize();
+        if dlBg and wx and ww then
+            dlBg:AddRectFilled({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32({ 0.176, 0.161, 0.137, 0.95 }), 4);
+            dlBg:AddRect({ wx, wy }, { wx + ww, wy + wh }, imgui.GetColorU32(components.TAB_STYLE.gold), 4, 0, 1.5);
+        end
+    end
+    local rowX1, rowY1, rowX2, rowY2 = GetCurrentWindowContentScreenRect();
+    local dl = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+    local pushedClip = false;
+    local cx1, cy1, cx2, cy2 = rowX1, rowY1, rowX2, rowY2;
+    if parentClipX1 then
+        cx1, cy1, cx2, cy2 = IntersectRect(rowX1, rowY1, rowX2, rowY2, parentClipX1, parentClipY1, parentClipX2, parentClipY2);
+    end
+    if cx1 and dl and dl.PushClipRect then
+        dl:PushClipRect({ cx1, cy1 }, { cx2, cy2 }, true);
+        pushedClip = true;
+    end
+    local slotGridLeftScreenX = nil;
+    if cx1 then
+        local px, py = imgui.GetCursorScreenPos();
+        local drawOriginX = px + rowPadLeft;
+        slotGridLeftScreenX = drawOriginX;
+        local drawOriginY = py + rowPadTop;
+        crossbar.DrawPaletteEditorSharedChordTriggerGlyphs(drawOriginX, drawOriginY, cs);
+        crossbar.DrawPaletteEditorSingleRow(drawOriginX, drawOriginY, cs, comboMode, cx1, cy1, cx2, cy2);
+    end
+    if pushedClip and dl and dl.PopClipRect then
+        dl:PopClipRect();
+    end
+    imgui.EndChild();
+    imgui.PopStyleColor(1);
+    if drawPetFooters and cross and named and slotGridLeftScreenX then
+        imgui.Dummy({ 0, 6 });
+        imgui.PushID('petfoot_' .. idFix);
+        DrawJobSegmentFooterOverrideAndPet(
+            storageKey,
+            comboMode,
+            cross,
+            named,
+            segmentOverrideJobId,
+            drawPetFooters and segmentOverrideJobId,
+            'S_' .. idFix,
+            math.max(160, rowWidth - 16)
+        );
+        imgui.Dummy({ 0, 10 });
+        imgui.PopID();
+    end
+end
+
+-- "Not in use" warning in Edit Full Palette: larger, bright red, draw-list shadow/glow (when available).
+local function drawPaletteNotInUseWarning()
+    local text = 'This palette is not currently in use.';
+    local dl = imgui.GetWindowDrawList and imgui.GetWindowDrawList();
+    local canDl = (dl and dl.AddText and imgui.GetCursorScreenPos and imgui.GetColorU32);
+    if not canDl then
+        if imgui.SetWindowFontScale then
+            imgui.SetWindowFontScale(1.18);
+        end
+        imgui.TextColored({ 1, 0.2, 0.14, 1.0 }, text);
+        if imgui.SetWindowFontScale then
+            imgui.SetWindowFontScale(1.0);
+        end
+        return;
+    end
+    local scale = 1.2;
+    if imgui.SetWindowFontScale then
+        imgui.SetWindowFontScale(scale);
+    end
+    local tw, th;
+    if imgui.CalcTextSize then
+        local ts, t2 = imgui.CalcTextSize(text);
+        if type(ts) == 'table' then
+            tw, th = (ts[1] or ts.x or 0), (ts[2] or ts.y or 0);
+        elseif type(t2) == 'number' then
+            tw, th = ts, t2;
+        else
+            tw, th = ts, (imgui.GetTextLineHeight and imgui.GetTextLineHeight()) or 20;
+        end
+    else
+        tw, th = 300, 24;
+    end
+    if not tw or tw < 1 then
+        tw = 280;
+    end
+    if not th or th < 1 then
+        th = 22;
+    end
+    local x, y = imgui.GetCursorScreenPos();
+    local function c32(r, g, b, a)
+        return imgui.GetColorU32({ r, g, b, a or 1.0 });
+    end
+    -- Outer soft halo
+    for _, o in ipairs({ {2,0},{-2,0},{0,2},{0,-2}, {1,0},{-1,0},{0,1},{0,-1} }) do
+        dl:AddText({ x + o[1] * 2, y + o[2] * 2 }, c32(0.7, 0, 0, 0.35), text);
+    end
+    for _, o in ipairs({ {2,0},{-2,0},{0,2},{0,-2}, {2,2},{-2,2},{2,-2},{-2,-2} }) do
+        dl:AddText({ x + o[1], y + o[2] }, c32(0.85, 0.1, 0.08, 0.4), text);
+    end
+    for _, o in ipairs({ {1,0},{-1,0},{0,1},{0,-1}, {1,1},{-1,1},{1,-1},{-1,-1} }) do
+        dl:AddText({ x + o[1], y + o[2] }, c32(0.08, 0, 0, 0.92), text);
+    end
+    dl:AddText({ x, y }, c32(1, 0.2, 0.12, 1.0), text);
+    if imgui.SetWindowFontScale then
+        imgui.SetWindowFontScale(1.0);
+    end
+    imgui.Dummy({ tw, th });
+end
+
+local function DrawEmbeddedCrossbarComboModesPopup()
+    if not embedCrossbarComboCtx then
+        embedCrossbarComboWinOpen[1] = false;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+        editFullPaletteScrollHCached = nil;
+        return;
+    end
+
+    local ctx = embedCrossbarComboCtx;
+    local cross = gConfig and gConfig.hotbarCrossbar;
+    if not cross then
+        embedCrossbarComboCtx = nil;
+        embedCrossbarComboWinOpen[1] = false;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+        editFullPaletteScrollHCached = nil;
+        return;
+    end
+
+    embedCrossbarComboWinGraceFrames = embedCrossbarComboWinGraceFrames + 1;
+
+    -- Min/max every frame. Position + size only on the *first draw* of an open window (grace == 1).
+    -- Re-applying SetNextWindowSize/Pos every frame with Appearing fights layout and resets the inner scroll.
+    local wMin = EDIT_FULL_PALETTE_WIN_W_MIN;
+    local wMax = EDIT_FULL_PALETTE_WIN_W_MAX;
+    if EDIT_FULL_PALETTE_WIN_LOCK_WIDTH then
+        wMin = EDIT_FULL_PALETTE_WIN_W;
+        wMax = EDIT_FULL_PALETTE_WIN_W;
+    end
+    local hMin = EDIT_FULL_PALETTE_WIN_H_MIN;
+    local hMax = EDIT_FULL_PALETTE_WIN_H_MAX;
+    if EDIT_FULL_PALETTE_WIN_LOCK_HEIGHT then
+        hMin = EDIT_FULL_PALETTE_WIN_H_DEFAULT;
+        hMax = EDIT_FULL_PALETTE_WIN_H_DEFAULT;
+    end
+    imgui.SetNextWindowSizeConstraints({ wMin, hMin }, { wMax, hMax });
+
+    do
+        local applySavedGeom = (embedCrossbarComboWinGraceFrames == 1);
+        if applySavedGeom then
+            local saved = gConfig and gConfig.windowPositions and gConfig.windowPositions[EDIT_FULL_PALETTE_WINDOW_KEY];
+            local geomOnce = ImGuiCond_Always;
+            if saved and saved.x and saved.y then
+                imgui.SetNextWindowPos({ saved.x, saved.y }, geomOnce);
+            else
+                local g = rawget(_G, '_XIUI_CONFIG_LAST_GEOM');
+                if type(g) == 'table' and g[1] and g[2] then
+                    imgui.SetNextWindowPos({ g[1] + 36, g[2] + 36 }, geomOnce);
+                end
+            end
+
+            local sw = EDIT_FULL_PALETTE_WIN_W;
+            local sh = EDIT_FULL_PALETTE_WIN_H_DEFAULT;
+            if saved and type(saved.w) == 'number' and saved.w > 0 then
+                sw = math.max(wMin, math.min(wMax, saved.w));
+            end
+            if saved and type(saved.h) == 'number' and saved.h > 0 then
+                sh = math.max(hMin, math.min(hMax, saved.h));
+            end
+            imgui.SetNextWindowSize({ sw, sh }, geomOnce);
+        end
+    end
+    local winFlags = ImGuiWindowFlags_None;
+    if ImGuiWindowFlags_NoSavedSettings ~= nil and bit and bit.bor then
+        winFlags = bit.bor(winFlags, ImGuiWindowFlags_NoSavedSettings);
+    end
+    if ImGuiWindowFlags_NoDocking ~= nil and bit and bit.bor then
+        winFlags = bit.bor(winFlags, ImGuiWindowFlags_NoDocking);
+    end
+    -- Only the inner ##xbFullPalScroll should scroll; outer window scrollbar fights it and feels like â€œjumpingâ€.
+    if ImGuiWindowFlags_NoScrollbar ~= nil and bit and bit.bor then
+        winFlags = bit.bor(winFlags, ImGuiWindowFlags_NoScrollbar);
+    end
+
+    local kind = ctx.kind or 'job';
+    local scopeLine = BuildEmbedFullPaletteScopeLine(ctx, kind);
+    local winTitle = 'Edit Full Palette - ' .. scopeLine .. '###xbEmbCombWin';
+
+    if imgui.Begin(winTitle, embedCrossbarComboWinOpen, winFlags) then
+    embedCrossbarComboHasDrawn = true;
+    if embedCrossbarComboWinGraceFrames == 1 and (ctx.kind or 'job') == 'job' then
+        petEfpModeWork = nil;
+    end
+    if embedCrossbarComboWinGraceFrames == 1 then
+        embedEfpSubTab = 0;
+    end
+    do
+        local wx, wy = imgui.GetWindowPos();
+        local ww, wh = imgui.GetWindowSize();
+        if wx and wy and ww and wh then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[EDIT_FULL_PALETTE_WINDOW_KEY] = { x = wx, y = wy, w = ww, h = wh };
+        end
+    end
+    if not cross.namedPaletteComboModeSettings then
+        cross.namedPaletteComboModeSettings = {};
+    end
+    local named = cross.namedPaletteComboModeSettings;
+    local editJobId = (kind == 'job') and (ctx.jobId or data.jobId) or nil;
+    local segmentOverrideJobId = (kind == 'job') and (ctx.jobId or 1) or nil;
+    local editCross = BuildEditFullPaletteViewSettings(cross);
+
+    -- Header row 1: Macro Manager button + description
+    components.PushMacroManagerButtonStyle();
+    if imgui.Button('Macro Manager##xbEmbCombMacro') then
+        macropalette.OpenPalette();
+    end
+    components.PopMacroManagerButtonStyle();
+    imgui.SameLine();
+    imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Right-click a slot to clear; drag macros or slots to rearrange. Double-click to edit.');
+
+    -- Header row 2: Job/scope label + "not in use" warning
+    do
+        local jobLabel;
+        if kind == 'universal' then
+            jobLabel = 'Global [G]';
+        else
+            local jid = ctx.jobId or 1;
+            jobLabel = jobs[jid] or ('Job ' .. tostring(jid));
+        end
+        imgui.TextColored(components.TAB_STYLE.gold, jobLabel);
+        imgui.SameLine(0, 12);
+        imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Palette:');
+        imgui.SameLine(0, 4);
+        imgui.TextColored({ 0.85, 0.82, 0.72, 1.0 }, '"' .. (ctx.name or '?') .. '"');
+
+        local activeScope = palette.GetCrossbarPaletteScope and palette.GetCrossbarPaletteScope() or 'job';
+        local activeName = palette.GetActivePaletteForCombo and palette.GetActivePaletteForCombo('L2') or nil;
+        local isActive = false;
+        if kind == 'universal' and activeScope == 'universal' then
+            isActive = (activeName == ctx.name);
+        elseif kind == 'job' and activeScope == 'job' then
+            isActive = (activeName == ctx.name);
+        end
+        if not isActive then
+            imgui.SameLine(0, 16);
+            drawPaletteNotInUseWarning();
+        end
+    end
+
+    -- Job [J]: Slots = named palette storage; Pets = petpalette:* for the selected pet (see config/efp_pets_tab.lua).
+    if kind == 'job' then
+        imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'View:');
+        imgui.SameLine(0, 8);
+        local jTab = tostring(ctx.jobId or 1);
+        local function tryEfpTab(which)
+            if embedEfpSubTab == which then
+                return;
+            end
+            if data.IsDraftDirty() then
+                pendingEfpSubTab = which;
+                openUnsavedChangesPopup = true;
+            else
+                embedEfpSubTab = which;
+                editFullPaletteScrollHCached = nil;
+            end
+        end
+        if components.DrawStyledTab('Slots', 'efpViewSlot' .. jTab, embedEfpSubTab == 0, nil, nil, nil, 'palette') then
+            tryEfpTab(0);
+        end
+        imgui.SameLine(0, 4);
+        if components.DrawStyledTab('Pets', 'efpViewPet' .. jTab, embedEfpSubTab == 1, nil, nil, nil, 'palette') then
+            tryEfpTab(1);
+        end
+        if embedEfpSubTab == 1 then
+            imgui.Spacing();
+            do
+                local _wrapPop = false;
+                if imgui.GetContentRegionAvail and imgui.GetCursorPosX and imgui.PushTextWrapPos then
+                    local aw, _h = imgui.GetContentRegionAvail();
+                    local wrapW = 420;
+                    if type(aw) == 'table' then
+                        wrapW = math.max(200, (aw[1] or aw.x or wrapW) - 4);
+                    elseif type(aw) == 'number' then
+                        wrapW = math.max(200, aw - 4);
+                    end
+                    local cx = imgui.GetCursorPosX and imgui.GetCursorPosX() or 0;
+                    imgui.PushTextWrapPos(cx + wrapW);
+                    _wrapPop = true;
+                end
+                efpPets.draw(cross, data.IsDraftDirty());
+                if _wrapPop and imgui.PopTextWrapPos then
+                    imgui.PopTextWrapPos();
+                end
+            end
+        end
+    end
+
+    -- Header row 3: Quick palette switcher (selection only)
+    do
+        if kind == 'job' and embedEfpSubTab ~= 0 then
+            -- Pets view edits a different storage root; avoid switching named palette here.
+        else
+        local paletteNames;
+        if kind == 'universal' then
+            paletteNames = palette.GetUniversalCrossbarPaletteNamesOrdered and palette.GetUniversalCrossbarPaletteNamesOrdered() or {};
+        else
+            paletteNames = palette.GetCrossbarPaletteNamesForOrderTier and palette.GetCrossbarPaletteNamesForOrderTier(ctx.jobId or 1, tonumber(ctx.st) or 0) or {};
+        end
+        if #paletteNames > 1 then
+            imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Switch Palette:');
+            imgui.SameLine(0, 6);
+            imgui.PushStyleColor(ImGuiCol_FrameBg, { 0.10, 0.09, 0.07, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, { 0.14, 0.13, 0.11, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_FrameBgActive, { 0.14, 0.13, 0.11, 1.0 });
+            imgui.SetNextItemWidth(200);
+            if imgui.BeginCombo('##xbEditPalSwitch', ctx.name or '?') then
+                for _, pName in ipairs(paletteNames) do
+                    local isSel = (pName == ctx.name);
+                    if isSel then
+                        imgui.PushStyleColor(ImGuiCol_Text, components.TAB_STYLE.gold);
+                    end
+                    if imgui.Selectable(pName, isSel) then
+                        if pName ~= ctx.name then
+                            if data.IsDraftDirty() then
+                                pendingPaletteSwitchName = pName;
+                                openUnsavedChangesPopup = true;
+                            else
+                                data.FullyClosePaletteEditSession();
+                                crossbar.HidePaletteEditorPrimitives();
+                                ctx.name = pName;
+                                editFullPaletteScrollHCached = nil;
+                                embedCrossbarComboWinGraceFrames = 0;
+                            end
+                        end
+                    end
+                    if isSel then
+                        imgui.PopStyleColor();
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopStyleColor(3);
+        end
+        end
+    end
+    imgui.Spacing();
+
+    local storageKey;
+    if kind == 'job' and embedEfpSubTab == 1 then
+        storageKey = 'petpalette:' .. efpPets.getPetKeyString();
+    else
+        storageKey = GetEmbedFullPaletteStorageKey(ctx);
+    end
+    data.BeginCrossbarPaletteEditSession(storageKey, editJobId);
+    if not embedCrossbarComboWinOpen[1] and data.IsDraftDirty() then
+        embedCrossbarComboWinOpen[1] = true;
+        openUnsavedChangesPopup = true;
+    end
+
+    -- Scroll region height: cache + quantized avail (see GetContentRegionAvailHeight). Refresh when the user
+    -- resizes the outer window enough; avoids 1px jitter resetting scroll.
+    do
+        local regionBelowHeaderH = GetContentRegionAvailHeight();
+        local computed = math.max(120, math.floor(regionBelowHeaderH - EDIT_FULL_PALETTE_FOOTER_BLOCK_H + 0.5));
+        if embedCrossbarComboWinGraceFrames == 1 or editFullPaletteScrollHCached == nil then
+            editFullPaletteScrollHCached = computed;
+        elseif math.abs(computed - editFullPaletteScrollHCached) >= 8 then
+            editFullPaletteScrollHCached = computed;
+        end
+    end
+    -- Always reserve the scrollbar gutter: when optional override rows appear/disappear, content height crosses
+    -- the "needs scroll" threshold and the bar popping in/out reflows text width and bounces scroll to top.
+    local xbScrollFlags = 0;
+    if ImGuiWindowFlags_AlwaysVerticalScrollbar ~= nil then
+        xbScrollFlags = ImGuiWindowFlags_AlwaysVerticalScrollbar;
+    end
+    local isPetsEfp = (kind == 'job' and embedEfpSubTab == 1);
+    local petKeyEfp = isPetsEfp and efpPets.getPetKeyString() or nil;
+    local function efpPetsModeOrNil(mode)
+        if not isPetsEfp or not petKeyEfp then
+            return mode;
+        end
+        if not petEfpSegmentRowVisible(cross, mode, petKeyEfp) then
+            return nil;
+        end
+        return mode;
+    end
+    local drawEfpJobFoot = (kind == 'job' and not isPetsEfp);
+    local function drawEfpScrollBody()
+        local scrollX1, scrollY1, scrollX2, scrollY2 = GetCurrentWindowScreenRect();
+        -- TextColored does not wrap; these info lines are long in Pets view
+        local function efpPetsInfoWrapped(c, s)
+            if not s or s == '' then
+                return;
+            end
+            if not c then
+                c = { 0.75, 0.55, 0.4, 1.0 };
+            end
+            if imgui.PushStyleColor and ImGuiCol_Text then
+                imgui.PushStyleColor(ImGuiCol_Text, c);
+            end
+            local didWrap = false;
+            if imgui.GetCursorPosX and imgui.GetContentRegionAvail and imgui.PushTextWrapPos then
+                local aw, _h = imgui.GetContentRegionAvail();
+                local wavail = 400;
+                if type(aw) == 'table' then
+                    wavail = (aw[1] or aw.x or wavail) - 12;
+                elseif type(aw) == 'number' then
+                    wavail = aw - 12;
+                end
+                wavail = math.max(100, wavail);
+                local cx = imgui.GetCursorPosX();
+                imgui.PushTextWrapPos(cx + wavail);
+                didWrap = true;
+            end
+            if imgui.TextWrapped then
+                imgui.TextWrapped(s);
+            else
+                imgui.Text(s);
+            end
+            if didWrap and imgui.PopTextWrapPos then
+                imgui.PopTextWrapPos();
+            end
+            if imgui.PopStyleColor and ImGuiCol_Text then
+                imgui.PopStyleColor(1);
+            end
+        end
+        local function sectionHeader(text)
+            imgui.Spacing();
+            imgui.Spacing();
+            imgui.Separator();
+            imgui.Spacing();
+            imgui.TextColored(components.TAB_STYLE.gold, text);
+        end
+        sectionHeader('Primary (hold L2 / R2)');
+        do
+            local pL, pR = efpPetsModeOrNil('L2'), efpPetsModeOrNil('R2');
+            if isPetsEfp and (not pL) and (not pR) then
+                efpPetsInfoWrapped(
+                    { 0.75, 0.55, 0.4, 1.0 },
+                    'No L2/R2 pet bar for the selected pet. On the Slots view, turn on "Pet Palette" and include this pet for L2 and/or R2, or select another family/pet above.'
+                );
+            else
+                DrawFullPaletteCrossbarPair(storageKey, pL, pR, 'pri', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+            end
+        end
+        sectionHeader('Double-tap (L2x2 / R2x2)');
+        if not cross.enableDoubleTap then
+            imgui.BeginDisabled();
+            imgui.TextColored({ 0.55, 0.55, 0.55, 1.0 }, 'Enable Double-Tap in Controller Settings to use these bars.');
+            imgui.EndDisabled();
+        else
+            do
+                local pL, pR = efpPetsModeOrNil('L2x2'), efpPetsModeOrNil('R2x2');
+                if isPetsEfp and (not pL) and (not pR) then
+                    efpPetsInfoWrapped(
+                        { 0.75, 0.55, 0.4, 1.0 },
+                        'No double-tap pet bars for this pet. Use the Slots view to set Pet Palette for L2x2 and/or R2x2, or select another pet above.'
+                    );
+                else
+                    DrawFullPaletteCrossbarPair(storageKey, pL, pR, 'dbl', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+                end
+            end
+        end
+        sectionHeader('Chord (L2+R2 / R2+L2)');
+        if not cross.enableExpandedCrossbar then
+            imgui.BeginDisabled();
+            imgui.TextColored({ 0.55, 0.55, 0.55, 1.0 }, 'Enable L2+R2 / R2+L2 in Controller Settings to use these bars.');
+            imgui.EndDisabled();
+        elseif cross.useSharedExpandedBar then
+            efpPetsInfoWrapped(
+                { 0.7, 0.68, 0.6, 1.0 },
+                'Shared expanded bar: L2+R2 and R2+L2 use the same 8 slots.'
+            );
+            do
+                local pM = efpPetsModeOrNil('L2R2');
+                if isPetsEfp and (not pM) then
+                    efpPetsInfoWrapped(
+                        { 0.75, 0.55, 0.4, 1.0 },
+                        'No shared chord bar for this pet. On the Slots view, enable "Pet Palette" for L2+R2 / R2+L2 (shared) or change pet above.'
+                    );
+                else
+                    DrawFullPaletteSingleCrossbarGroup(storageKey, pM, 'chsh', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+                end
+            end
+        else
+            do
+                local pL, pR = efpPetsModeOrNil('L2R2'), efpPetsModeOrNil('R2L2');
+                if isPetsEfp and (not pL) and (not pR) then
+                    efpPetsInfoWrapped(
+                        { 0.75, 0.55, 0.4, 1.0 },
+                        'No chord pet bars for this pet. On the Slots view, enable Pet Palette for the chord row(s) or change pet above.'
+                    );
+                else
+                    DrawFullPaletteCrossbarPair(storageKey, pL, pR, 'chord', editCross, scrollX1, scrollY1, scrollX2, scrollY2, drawEfpJobFoot, cross, named, segmentOverrideJobId);
+                end
+            end
+        end
+        imgui.Dummy({ 0, 10 });
+    end
+
+    imgui.BeginChild('##xbFullPalScroll', { 0, editFullPaletteScrollHCached or 200 }, true, xbScrollFlags);
+    drawEfpScrollBody();
+    imgui.EndChild();
+
+    -- After slots draw: open macro editor from double-click (same frame as SetPending).
+    -- When the source slot was empty (slotData nil → "creating new" mode), forward the
+    -- (comboMode, slotIndex) as a bindTargetSlot so SaveMacro will auto-bind the new macro
+    -- to the slot the user actually double-clicked. Double-clicking a filled slot just
+    -- edits the existing macro in place, no bind target needed.
+    local pendingEdit = data.ConsumePendingPaletteSlotEdit();
+    if pendingEdit then
+        local editorOpts;
+        if pendingEdit.slotData == nil and pendingEdit.comboMode and pendingEdit.slotIndex then
+            editorOpts = {
+                bindTargetSlot = {
+                    comboMode = pendingEdit.comboMode,
+                    slotIndex = pendingEdit.slotIndex,
+                },
+            };
+        end
+        macropalette.OpenEditorForSlotData(pendingEdit.slotData, editorOpts);
+        -- hotbar.DrawPalette runs before paletteManager; draw editor here so it appears same frame.
+        if macropalette.DrawMacroEditor then
+            macropalette.DrawMacroEditor();
+        end
+    end
+
+    -- Footer: Undo + Apply + Close
+    local isDirty = data.IsDraftDirty();
+    local canUndo = data.CanUndoDraft();
+    if not canUndo then
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.20, 0.20, 0.20, 1.0 });
+    else
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.35, 0.30, 0.18, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.45, 0.38, 0.22, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.28, 0.24, 0.14, 1.0 });
+    end
+    if imgui.Button('Undo##xbEmbUndo', { 70, 0 }) and canUndo then
+        data.UndoDraft();
+    end
+    imgui.PopStyleColor(3);
+    imgui.SameLine();
+    if isDirty then
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.22, 0.55, 0.22, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.28, 0.65, 0.28, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.16, 0.44, 0.16, 1.0 });
+    else
+        imgui.PushStyleColor(ImGuiCol_Button, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.20, 0.20, 0.20, 1.0 });
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.20, 0.20, 0.20, 1.0 });
+    end
+    if imgui.Button('Apply Changes##xbEmbApply', { 140, 0 }) then
+        if isDirty then
+            data.ApplyDraft();
+        end
+    end
+    imgui.PopStyleColor(3);
+    imgui.SameLine();
+    if imgui.Button('Close##xbEmbCombClose', { 80, 0 }) then
+        if isDirty then
+            openUnsavedChangesPopup = true;
+        else
+            embedCrossbarComboWinOpen[1] = false;
+        end
+    end
+    if isDirty then
+        imgui.SameLine();
+        imgui.TextColored({ 0.9, 0.75, 0.3, 1.0 }, 'Unsaved changes');
+    end
+
+    -- Unsaved changes modal
+    if openUnsavedChangesPopup then
+        imgui.OpenPopup('Unsaved Changes##xbUnsavedModal');
+        openUnsavedChangesPopup = false;
+    end
+    if imgui.BeginPopup('Unsaved Changes##xbUnsavedModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        local isSwitching = (pendingPaletteSwitchName ~= nil);
+        local isEfpTab = (pendingEfpSubTab ~= nil);
+        if isSwitching then
+            imgui.TextWrapped('You have unsaved changes. Apply before switching palettes?');
+        elseif isEfpTab then
+            imgui.TextWrapped('You have unsaved changes. Apply before switching between Slots and Pets?');
+        else
+            imgui.TextWrapped('You have unsaved changes. Apply changes before closing?');
+        end
+        imgui.Spacing();
+        local applyLabel = 'Apply & Close';
+        if isSwitching then
+            applyLabel = 'Apply & Switch';
+        elseif isEfpTab then
+            applyLabel = 'Apply & Continue';
+        end
+        if imgui.Button(applyLabel .. '##xbUnsavedApply', { 130, 0 }) then
+            data.ApplyDraft();
+            if isSwitching then
+                data.FullyClosePaletteEditSession();
+                crossbar.HidePaletteEditorPrimitives();
+                ctx.name = pendingPaletteSwitchName;
+                editFullPaletteScrollHCached = nil;
+                embedCrossbarComboWinGraceFrames = 0;
+                pendingPaletteSwitchName = nil;
+            elseif isEfpTab then
+                embedEfpSubTab = pendingEfpSubTab;
+                pendingEfpSubTab = nil;
+                editFullPaletteScrollHCached = nil;
+            else
+                embedCrossbarComboWinOpen[1] = false;
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Discard##xbUnsavedDiscard', { 100, 0 }) then
+            data.DiscardDraft();
+            if isSwitching then
+                data.FullyClosePaletteEditSession();
+                crossbar.HidePaletteEditorPrimitives();
+                ctx.name = pendingPaletteSwitchName;
+                editFullPaletteScrollHCached = nil;
+                embedCrossbarComboWinGraceFrames = 0;
+                pendingPaletteSwitchName = nil;
+            elseif isEfpTab then
+                embedEfpSubTab = pendingEfpSubTab;
+                pendingEfpSubTab = nil;
+                editFullPaletteScrollHCached = nil;
+            else
+                embedCrossbarComboWinOpen[1] = false;
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Cancel##xbUnsavedCancel', { 100, 0 }) then
+            pendingPaletteSwitchName = nil;
+            pendingEfpSubTab = nil;
+            imgui.CloseCurrentPopup();
+        end
+        imgui.EndPopup();
+    end
+
+    data.EndCrossbarPaletteEditSession();
+    imgui.End();
+    else
+        data.EndCrossbarPaletteEditSession();
+        crossbar.HidePaletteEditorPrimitives();
+    end
+
+    if not embedCrossbarComboWinOpen[1] then
+        if embedCrossbarComboHasDrawn or embedCrossbarComboWinGraceFrames > 8 then
+            embedCrossbarComboCtx = nil;
+            embedCrossbarComboWinGraceFrames = 0;
+            embedCrossbarComboHasDrawn = false;
+            editFullPaletteScrollHCached = nil;
+            data.FullyClosePaletteEditSession();
+            crossbar.HidePaletteEditorPrimitives();
+        end
+    end
+end
+
+local function GetCrossbarModalStorageSubjob()
+    if windowState.selectedPaletteType == 'crossbar' and modalState.crossbarOperationSubjob ~= nil then
+        return modalState.crossbarOperationSubjob;
+    end
+    return windowState.selectedSubjobId;
+end
+
+local function ClearCrossbarEmbedModalFields()
+    modalState.crossbarOperationSubjob = nil;
+    modalState.crossbarCopyFromSubjob = nil;
+    modalState.embedCrossbarUniversal = false;
+    modalState.embedCrossbarUniversalCopy = false;
+    modalState.copyDestScope = 'job';
+end
+
+-- ImGui Selectable uses Header colors; push muted gold for unselected rows so hover is visible (font lacks em dash glyph; use ASCII in UI strings).
+local function PushPaletteRowStyle(isSelected)
+    local gold = components.TAB_STYLE.gold;
+    if isSelected then
+        imgui.PushStyleColor(ImGuiCol_Header, { gold[1], gold[2], gold[3], 0.4 });
+        imgui.PushStyleColor(ImGuiCol_HeaderHovered, { gold[1], gold[2], gold[3], 0.5 });
+        imgui.PushStyleColor(ImGuiCol_HeaderActive, { gold[1], gold[2], gold[3], 0.6 });
+    else
+        imgui.PushStyleColor(ImGuiCol_Header, { gold[1], gold[2], gold[3], 0.08 });
+        imgui.PushStyleColor(ImGuiCol_HeaderHovered, { gold[1], gold[2], gold[3], 0.22 });
+        imgui.PushStyleColor(ImGuiCol_HeaderActive, { gold[1], gold[2], gold[3], 0.32 });
+    end
+end
+
+local function PopPaletteRowStyle()
+    imgui.PopStyleColor(3);
+end
+
+-- Same palette as config.lua DrawWindow so the floating manager matches XIUI when drawn from d3d_present
+local function PushXiuiFloatingWindowTheme()
+    local gold = components.TAB_STYLE.gold;
+    local goldDark = {0.765, 0.684, 0.474, 1.0};
+    local goldDarker = {0.573, 0.512, 0.355, 1.0};
+    local bgDark = {0.051, 0.051, 0.051, 0.95};
+    local bgMedium = components.TAB_STYLE.bgMedium;
+    local bgLight = components.TAB_STYLE.bgLight;
+    local bgLighter = components.TAB_STYLE.bgLighter;
+    local textLight = {0.878, 0.855, 0.812, 1.0};
+    local borderDark = {0.3, 0.275, 0.235, 1.0};
+    local bgColor = bgDark;
+    local buttonColor = bgMedium;
+    local buttonHoverColor = bgLight;
+    local buttonActiveColor = bgLighter;
+    local tabColor = bgMedium;
+    local tabHoverColor = bgLight;
+    local tabActiveColor = {gold[1], gold[2], gold[3], 0.3};
+    local borderColor = borderDark;
+    local textColor = textLight;
+
+    imgui.PushStyleColor(ImGuiCol_WindowBg, bgColor);
+    imgui.PushStyleColor(ImGuiCol_ChildBg, {0, 0, 0, 0});
+    imgui.PushStyleColor(ImGuiCol_TitleBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_TitleBgActive, bgLight);
+    imgui.PushStyleColor(ImGuiCol_TitleBgCollapsed, bgDark);
+    imgui.PushStyleColor(ImGuiCol_FrameBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_FrameBgHovered, bgLight);
+    imgui.PushStyleColor(ImGuiCol_FrameBgActive, bgLighter);
+    imgui.PushStyleColor(ImGuiCol_Header, bgLight);
+    imgui.PushStyleColor(ImGuiCol_HeaderHovered, bgLighter);
+    imgui.PushStyleColor(ImGuiCol_HeaderActive, {gold[1], gold[2], gold[3], 0.3});
+    imgui.PushStyleColor(ImGuiCol_Border, borderColor);
+    imgui.PushStyleColor(ImGuiCol_Text, textColor);
+    imgui.PushStyleColor(ImGuiCol_TextDisabled, goldDark);
+    imgui.PushStyleColor(ImGuiCol_Button, buttonColor);
+    imgui.PushStyleColor(ImGuiCol_ButtonHovered, buttonHoverColor);
+    imgui.PushStyleColor(ImGuiCol_ButtonActive, buttonActiveColor);
+    imgui.PushStyleColor(ImGuiCol_CheckMark, gold);
+    imgui.PushStyleColor(ImGuiCol_SliderGrab, goldDark);
+    imgui.PushStyleColor(ImGuiCol_SliderGrabActive, gold);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarGrab, bgLighter);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarGrabHovered, borderDark);
+    imgui.PushStyleColor(ImGuiCol_ScrollbarGrabActive, goldDark);
+    imgui.PushStyleColor(ImGuiCol_Separator, borderDark);
+    imgui.PushStyleColor(ImGuiCol_PopupBg, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_Tab, tabColor);
+    imgui.PushStyleColor(ImGuiCol_TabHovered, tabHoverColor);
+    imgui.PushStyleColor(ImGuiCol_TabActive, tabActiveColor);
+    imgui.PushStyleColor(ImGuiCol_TabUnfocused, bgDark);
+    imgui.PushStyleColor(ImGuiCol_TabUnfocusedActive, bgMedium);
+    imgui.PushStyleColor(ImGuiCol_ResizeGrip, goldDarker);
+    imgui.PushStyleColor(ImGuiCol_ResizeGripHovered, goldDark);
+    imgui.PushStyleColor(ImGuiCol_ResizeGripActive, gold);
+
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {12, 12});
+    imgui.PushStyleVar(ImGuiStyleVar_FramePadding, {6, 4});
+    imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {8, 6});
+    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0);
+    imgui.PushStyleVar(ImGuiStyleVar_ChildRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_PopupRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_ScrollbarRounding, 4.0);
+    imgui.PushStyleVar(ImGuiStyleVar_GrabRounding, 4.0);
+end
+
+local function PopXiuiFloatingWindowTheme()
+    imgui.PopStyleVar(9);
+    imgui.PopStyleColor(34);
+end
+
+local function GetCopyDestinationNamesForModal()
+    local j = modalState.copyTargetJobId or 1;
+    local s = modalState.copyTargetSubjobId or 0;
+    if windowState.selectedPaletteType == 'hotbar' then
+        return palette.GetAvailablePalettes(1, j, s);
+    end
+    if modalState.copyDestScope == 'universal' then
+        return palette.GetUniversalCrossbarPaletteNamesOrdered();
+    end
+    return palette.GetCrossbarPaletteNamesForOrderTier(j, s);
+end
 
 -- Get job name from ID (uses libs/jobs.lua)
 local function GetJobName(jobId)
     if jobId == 0 then return 'Shared'; end
     return jobs[jobId] or ('Job ' .. jobId);
+end
+
+local function GetCrossbarPaletteJobIconTheme()
+    local c = gConfig and gConfig.hotbarCrossbar;
+    local t = c and c.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
 end
 
 -- Check if using fallback (shared) palettes for the selected type
@@ -55,9 +1843,21 @@ local function SetStatusMessage(message)
     windowState.statusMessageTime = os.clock();
 end
 
--- Open the palette manager window
+local function DrawStatusMessage()
+    if not windowState.statusMessage then return; end
+    if os.clock() - windowState.statusMessageTime < 3 then
+        imgui.Spacing();
+        imgui.TextColored({ 1.0, 0.6, 0.3, 1.0 }, windowState.statusMessage);
+    else
+        windowState.statusMessage = nil;
+    end
+end
+
+-- Open the floating Palette Manager (keyboard hotbar palettes only; crossbar uses config /xiui cpalette)
 function M.Open()
     windowState.isOpen = true;
+    windowState.selectedPaletteType = 'hotbar';
+    windowState.selectedPaletteName = nil;
     -- Initialize with current job if not set
     if not windowState.selectedJobId then
         windowState.selectedJobId = data.jobId or 1;
@@ -77,19 +1877,14 @@ function M.IsOpen()
     return windowState.isOpen;
 end
 
--- Helper: Draw palette type selector (hotbar vs crossbar)
-local function DrawPaletteTypeSelector()
-    imgui.Text('Type:');
-    imgui.SameLine();
-    if imgui.RadioButton('Hotbar##paletteType', windowState.selectedPaletteType == 'hotbar') then
-        windowState.selectedPaletteType = 'hotbar';
-        windowState.selectedPaletteName = nil;
+-- Toggle floating Palette Manager (/xiui pal)
+function M.ToggleHotbarPaletteManager()
+    if windowState.isOpen then
+        M.Close();
+        return false;
     end
-    imgui.SameLine();
-    if imgui.RadioButton('Crossbar##paletteType', windowState.selectedPaletteType == 'crossbar') then
-        windowState.selectedPaletteType = 'crossbar';
-        windowState.selectedPaletteName = nil;
-    end
+    M.Open();
+    return true;
 end
 
 -- Helper: Draw job selector dropdown
@@ -165,24 +1960,11 @@ local function DrawSubjobSelector()
     return changed;
 end
 
--- Helper: Draw palette list
+-- Helper: Draw palette list (floating window: keyboard hotbar only)
 local function DrawPaletteList()
-    local palettes;
+    palette.EnsureDefaultPaletteExists(windowState.selectedJobId, 0);
+    local palettes = palette.GetAvailablePalettes(1, windowState.selectedJobId, windowState.selectedSubjobId);
 
-    -- Always ensure default shared palette exists for this job
-    -- This handles both direct shared view and fallback scenarios
-    if windowState.selectedPaletteType == 'hotbar' then
-        palette.EnsureDefaultPaletteExists(windowState.selectedJobId, 0);
-        palettes = palette.GetAvailablePalettes(1, windowState.selectedJobId, windowState.selectedSubjobId);
-    else
-        palette.EnsureCrossbarDefaultPaletteExists(windowState.selectedJobId, 0);
-        palettes = palette.GetCrossbarAvailablePalettes(windowState.selectedJobId, windowState.selectedSubjobId);
-    end
-
-    -- Check fallback status using centralized function
-    local usingFallback = IsUsingFallback(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteType);
-
-    -- Palette list header with clearer source indication
     local headerText;
     if windowState.selectedSubjobId == 0 then
         headerText = string.format('Shared Library (%s)', GetJobName(windowState.selectedJobId));
@@ -190,40 +1972,39 @@ local function DrawPaletteList()
         headerText = string.format('%s/%s', GetJobName(windowState.selectedJobId), GetJobName(windowState.selectedSubjobId));
     end
     imgui.Text(headerText);
-    if usingFallback then
-        imgui.SameLine();
-        imgui.TextColored({0.4, 0.8, 1.0, 1.0}, '(Shared Library)');
-    end
     imgui.Separator();
 
-    -- List of palettes
     local listHeight = 150;
     imgui.BeginChild('##paletteList', { 0, listHeight }, true);
 
     if #palettes == 0 then
         imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'No palettes defined');
     else
+        local hbW = imgui.GetWindowWidth();
+        imgui.Columns(3, '##hbPalCols', true);
+        imgui.SetColumnWidth(0, STATUS_COL_W);
+        imgui.SetColumnWidth(1, math.max(60, hbW - STATUS_COL_W - COPY_COL_W - 40));
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Text('Palette');
+        imgui.NextColumn();
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Separator();
         for i, paletteName in ipairs(palettes) do
             local isSelected = windowState.selectedPaletteName == paletteName;
+            local inRb = palette.IsHotbarPaletteInRbCycle(windowState.selectedJobId, windowState.selectedSubjobId, paletteName);
 
-            -- Custom selected state styling using XIUI colors
-            if isSelected then
-                local gold = components.TAB_STYLE.gold;
-                imgui.PushStyleColor(ImGuiCol_Header, {gold[1], gold[2], gold[3], 0.4});
-                imgui.PushStyleColor(ImGuiCol_HeaderHovered, {gold[1], gold[2], gold[3], 0.5});
-                imgui.PushStyleColor(ImGuiCol_HeaderActive, {gold[1], gold[2], gold[3], 0.6});
-            end
-
-            if imgui.Selectable(paletteName .. '##palette' .. i, isSelected) then
+            imgui.PushID('hbp' .. i);
+            DrawStatusIcon(inRb);
+            imgui.NextColumn();
+            PushPaletteRowStyle(isSelected);
+            if imgui.Selectable(paletteName .. '##palette', isSelected) then
                 windowState.selectedPaletteName = paletteName;
             end
+            PopPaletteRowStyle();
 
-            if isSelected then
-                imgui.PopStyleColor(3);
-            end
-
-            -- Context menu for right-click
-            if imgui.BeginPopupContextItem('##paletteContext' .. i) then
+            if imgui.BeginPopupContextItem('##paletteContext') then
                 if imgui.MenuItem('Rename') then
                     modalState.mode = 'rename';
                     modalState.inputBuffer[1] = paletteName;
@@ -235,8 +2016,12 @@ local function DrawPaletteList()
                     modalState.mode = 'copy';
                     modalState.inputBuffer[1] = paletteName;
                     modalState.errorMessage = nil;
+                    modalState.copyOverwriteExisting = false;
+                    modalState.copyDestExistingIndex = 1;
+                    modalState.crossbarCopyFromSubjob = nil;
                     modalState.copyTargetJobId = windowState.selectedJobId;
                     modalState.copyTargetSubjobId = windowState.selectedSubjobId;
+                    modalState.copyDestScope = 'job';
                     modalState.isOpen = true;
                     windowState.selectedPaletteName = paletteName;
                 end
@@ -252,7 +2037,13 @@ local function DrawPaletteList()
                 end
                 imgui.EndPopup();
             end
+
+            imgui.NextColumn();
+            DrawCreateMacroButton('/xiui palette ' .. paletteName, paletteName, 'hbp' .. i);
+            imgui.NextColumn();
+            imgui.PopID();
         end
+        imgui.Columns(1);
     end
 
     imgui.EndChild();
@@ -260,19 +2051,25 @@ local function DrawPaletteList()
     return palettes;
 end
 
--- Helper: Draw action buttons
+-- Helper: Draw action buttons (floating window: keyboard hotbar only)
 local function DrawActionButtons(palettes)
-    -- New palette button
     if imgui.Button('+ New') then
         modalState.mode = 'create';
         modalState.inputBuffer[1] = '';
         modalState.errorMessage = nil;
+        if windowState.selectedPaletteType == 'crossbar' then
+            local j, s = GetOrResetXbCreateDefaults();
+            modalState.crossbarCreateJobId = j;
+            modalState.crossbarCreateStorageSubjob = s;
+        else
+            modalState.crossbarCreateJobId = nil;
+            modalState.crossbarCreateStorageSubjob = nil;
+        end
         modalState.isOpen = true;
     end
 
     imgui.SameLine();
 
-    -- Rename button (enabled if palette selected)
     local hasSelection = windowState.selectedPaletteName ~= nil;
     if not hasSelection then imgui.BeginDisabled(); end
     if imgui.Button('Rename') then
@@ -285,7 +2082,6 @@ local function DrawActionButtons(palettes)
 
     imgui.SameLine();
 
-    -- Delete button (enabled if palette selected and more than 1 palette)
     local canDelete = hasSelection and #palettes > 1;
     if not canDelete then imgui.BeginDisabled(); end
     if imgui.Button('Delete') then
@@ -298,85 +2094,222 @@ local function DrawActionButtons(palettes)
 
     imgui.SameLine();
 
-    -- Copy To button
     if not hasSelection then imgui.BeginDisabled(); end
     if imgui.Button('Copy To...') then
         modalState.mode = 'copy';
         modalState.inputBuffer[1] = windowState.selectedPaletteName;
         modalState.errorMessage = nil;
+        modalState.copyOverwriteExisting = false;
+        modalState.copyDestExistingIndex = 1;
         modalState.copyTargetJobId = windowState.selectedJobId;
         modalState.copyTargetSubjobId = windowState.selectedSubjobId;
+        modalState.crossbarCopyFromSubjob = nil;
+        modalState.copyDestScope = 'job';
         modalState.isOpen = true;
     end
     if not hasSelection then imgui.EndDisabled(); end
 
-    -- Reorder buttons on next line
     imgui.Spacing();
 
-    if not hasSelection then imgui.BeginDisabled(); end
-    if imgui.Button('Move Up') then
-        local success, err;
-        if windowState.selectedPaletteType == 'hotbar' then
-            success, err = palette.MovePalette(1, windowState.selectedPaletteName, -1, windowState.selectedJobId, windowState.selectedSubjobId);
-        else
-            success, err = palette.MoveCrossbarPalette(windowState.selectedPaletteName, -1, windowState.selectedJobId, windowState.selectedSubjobId);
+    local canMoveUp = false;
+    local canMoveDown = false;
+    if hasSelection and palettes and #palettes > 0 then
+        local ix;
+        for i, n in ipairs(palettes) do
+            if n == windowState.selectedPaletteName then
+                ix = i;
+                break;
+            end
         end
+        canMoveUp = ix ~= nil and ix > 1;
+        canMoveDown = ix ~= nil and ix < #palettes;
+    end
+
+    if not canMoveUp then imgui.BeginDisabled(); end
+    if imgui.Button('Move Up') then
+        local success, err = palette.MovePalette(1, windowState.selectedPaletteName, -1, windowState.selectedJobId, windowState.selectedSubjobId);
         if not success and err then
             SetStatusMessage(err);
         end
     end
+    if not canMoveUp then imgui.EndDisabled(); end
     imgui.SameLine();
+    if not canMoveDown then imgui.BeginDisabled(); end
     if imgui.Button('Move Down') then
-        local success, err;
-        if windowState.selectedPaletteType == 'hotbar' then
-            success, err = palette.MovePalette(1, windowState.selectedPaletteName, 1, windowState.selectedJobId, windowState.selectedSubjobId);
-        else
-            success, err = palette.MoveCrossbarPalette(windowState.selectedPaletteName, 1, windowState.selectedJobId, windowState.selectedSubjobId);
-        end
+        local success, err = palette.MovePalette(1, windowState.selectedPaletteName, 1, windowState.selectedJobId, windowState.selectedSubjobId);
         if not success and err then
             SetStatusMessage(err);
         end
+    end
+    if not canMoveDown then imgui.EndDisabled(); end
+    imgui.SameLine();
+    if not hasSelection then imgui.BeginDisabled(); end
+    local inRbCycle = hasSelection and palette.IsHotbarPaletteInRbCycle(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteName);
+    if imgui.Button((inRbCycle and 'Disable' or 'Enable') .. '##palRbTgl') then
+        palette.SetHotbarPaletteInRbCycle(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteName, not inRbCycle);
     end
     if not hasSelection then imgui.EndDisabled(); end
 
-    -- Show status message (auto-clears after 3 seconds)
-    if windowState.statusMessage then
-        if os.clock() - windowState.statusMessageTime < 3 then
-            imgui.TextColored({1.0, 0.6, 0.3, 1.0}, windowState.statusMessage);
-        else
-            windowState.statusMessage = nil;
-        end
-    end
-
-    -- "Use Shared Library" button (only when viewing subjob-specific palettes)
-    local usingFallback = IsUsingFallback(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteType);
-    if windowState.selectedSubjobId ~= 0 and not usingFallback then
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-        imgui.TextColored({0.6, 0.6, 0.6, 1.0}, 'Subjob-specific palettes override Shared Library.');
-        if imgui.Button('Use Shared Library') then
-            modalState.mode = 'use_shared';
-            modalState.isOpen = true;
-        end
-        if imgui.IsItemHovered() then
-            imgui.SetTooltip('Delete all subjob-specific palettes and use the Shared Library instead.');
-        end
-    end
+    DrawStatusMessage();
 end
 
 -- Helper: Draw create/rename modal
 local function DrawCreateRenameModal()
     if not modalState.isOpen or (modalState.mode ~= 'create' and modalState.mode ~= 'rename') then
+        xbJobCreatePopupPending  = false;
+        createRenamePopupPendingId = nil;
+        return;
+    end
+
+    -- Job crossbar palette create: non-modal (BeginPopup) â€” name + job + Shared/SJ storage; defaults to live job/subjob.
+    if modalState.mode == 'create' and windowState.selectedPaletteType == 'crossbar' and not modalState.embedCrossbarUniversal then
+        if modalState.crossbarCreateJobId == nil or modalState.crossbarCreateStorageSubjob == nil then
+            local j, s = GetOrResetXbCreateDefaults();
+            modalState.crossbarCreateJobId = j;
+            modalState.crossbarCreateStorageSubjob = s;
+        end
+        local cj = modalState.crossbarCreateJobId;
+        if cj < 1 then cj = 1; end
+        if cj > 22 then cj = 22; end
+        modalState.crossbarCreateJobId = cj;
+        local storSj = modalState.crossbarCreateStorageSubjob or 0;
+
+        if not xbJobCreatePopupPending then
+            imgui.SetNextWindowSize({ 560, 0 }, ImGuiCond_Always);
+            imgui.OpenPopup('Create Crossbar Palette##palMgrXbJobNm');
+            xbJobCreatePopupPending = true;
+        end
+        if imgui.BeginPopup('Create Crossbar Palette##palMgrXbJobNm', ImGuiWindowFlags_AlwaysAutoResize) then
+            components.PushPaletteManagerButtonStyle();
+            imgui.TextWrapped('Create a new palette for Job [J] / Subjob [SJ] crossbar storage.');
+            imgui.Spacing();
+
+            if storSj ~= 0 then
+                local usingFallback = IsUsingFallback(cj, storSj, 'crossbar');
+                if usingFallback then
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'Warning: Creating this palette will stop');
+                    imgui.TextColored({ 1.0, 0.7, 0.3, 1.0 }, 'using shared palettes for ' .. GetJobName(cj) .. '/' .. GetJobName(storSj) .. '.');
+                    imgui.Spacing();
+                end
+            end
+
+            imgui.Text('Job:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            if imgui.BeginCombo('##palMgrXbCreateJob', GetJobName(cj)) then
+                for jobId = 1, 22 do
+                    local isSelected = (jobId == cj);
+                    if imgui.Selectable(GetJobName(jobId) .. '##palMgrXbCj' .. jobId, isSelected) then
+                        modalState.crossbarCreateJobId = jobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.SameLine();
+            imgui.Text('Subjob storage:');
+            imgui.SameLine();
+            imgui.PushItemWidth(120);
+            local subLabel = storSj == 0 and 'Shared' or GetJobName(storSj);
+            if imgui.BeginCombo('##palMgrXbCreateSub', subLabel) then
+                local sharedSel = (storSj == 0);
+                if imgui.Selectable('Shared##palMgrXbCs0', sharedSel) then
+                    modalState.crossbarCreateStorageSubjob = 0;
+                end
+                if sharedSel then
+                    imgui.SetItemDefaultFocus();
+                end
+                for subjobId = 1, 22 do
+                    local isSelected = (subjobId == storSj);
+                    if imgui.Selectable(GetJobName(subjobId) .. '##palMgrXbCs' .. subjobId, isSelected) then
+                        modalState.crossbarCreateStorageSubjob = subjobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.Spacing();
+            imgui.Text('Palette name:');
+            imgui.PushItemWidth(220);
+            local enterPressed = imgui.InputText('##palMgrXbCreateName', modalState.inputBuffer, 32, ImGuiInputTextFlags_EnterReturnsTrue);
+            imgui.PopItemWidth();
+
+            if modalState.errorMessage then
+                imgui.TextColored({ 1.0, 0.3, 0.3, 1.0 }, modalState.errorMessage);
+            end
+
+            imgui.Spacing();
+
+            local newName = modalState.inputBuffer[1];
+            local canSubmit = newName and newName ~= '';
+
+            if not canSubmit then
+                imgui.BeginDisabled();
+            end
+            if imgui.Button('Create##palMgrXbCreateOk', { 88, 0 }) or (enterPressed and canSubmit) then
+                if canSubmit then
+                    storSj = modalState.crossbarCreateStorageSubjob or 0;
+                    local createJob = modalState.crossbarCreateJobId;
+                    local success, err = palette.CreateCrossbarPalette(newName, createJob, storSj);
+                    if success then
+                        xbCreatePersisted.jobId         = createJob;
+                        xbCreatePersisted.storageSubjob = storSj;
+                        ClearCrossbarEmbedModalFields();
+                        modalState.isOpen = false;
+                        modalState.crossbarCreateJobId = nil;
+                        modalState.crossbarCreateStorageSubjob = nil;
+                        imgui.CloseCurrentPopup();
+                    else
+                        modalState.errorMessage = err or 'Operation failed';
+                    end
+                end
+            end
+            if not canSubmit then
+                imgui.EndDisabled();
+            end
+
+            imgui.SameLine();
+            if imgui.Button('Cancel##palMgrXbCreateCancel', { 88, 0 }) then
+                modalState.isOpen = false;
+                modalState.crossbarCreateJobId = nil;
+                modalState.crossbarCreateStorageSubjob = nil;
+                ClearCrossbarEmbedModalFields();
+                imgui.CloseCurrentPopup();
+            end
+
+            components.PopPaletteManagerButtonStyle();
+            imgui.EndPopup();
+        else
+            -- Dismissed by clicking outside
+            xbJobCreatePopupPending = false;
+            modalState.isOpen = false;
+            modalState.crossbarCreateJobId = nil;
+            modalState.crossbarCreateStorageSubjob = nil;
+            ClearCrossbarEmbedModalFields();
+        end
         return;
     end
 
     local title = modalState.mode == 'create' and 'Create New Palette' or 'Rename Palette';
-    imgui.OpenPopup(title .. '##paletteModal');
+    local popupId = title .. '##paletteModal';
+    if createRenamePopupPendingId ~= popupId then
+        imgui.SetNextWindowSize({ 320, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup(popupId);
+        createRenamePopupPendingId = popupId;
+    end
 
-    if imgui.BeginPopupModal(title .. '##paletteModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
-        -- Warning when creating will break away from shared palettes
-        if modalState.mode == 'create' and windowState.selectedSubjobId ~= 0 then
+    if imgui.BeginPopup(popupId, ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
+        local embedU = modalState.embedCrossbarUniversal == true;
+        if modalState.mode == 'create' and not embedU and windowState.selectedSubjobId ~= 0 and windowState.selectedPaletteType == 'hotbar' then
             local usingFallback = IsUsingFallback(windowState.selectedJobId, windowState.selectedSubjobId, windowState.selectedPaletteType);
             if usingFallback then
                 imgui.TextColored({1.0, 0.7, 0.3, 1.0}, 'Warning: Creating this palette will stop');
@@ -385,6 +2318,24 @@ local function DrawCreateRenameModal()
             end
         end
 
+        -- Main job profile for this palette (Shared vs SJ tier does not change the icon)
+        if not embedU then
+            do
+                local jid = windowState.selectedJobId or 1;
+                local jtex = TextureManager.getJobIcon(jid, GetCrossbarPaletteJobIconTheme());
+                if jtex and jtex.image then
+                    local p = tonumber(ffi.cast('uint32_t', jtex.image));
+                    if p then
+                        imgui.AlignTextToFramePadding();
+                        imgui.Image(p, { 18, 18 });
+                        imgui.SameLine(0, 6);
+                    end
+                end
+            end
+        else
+            imgui.TextColored({ 0.85, 0.85, 0.5, 1.0 }, 'Global [G]');
+            imgui.SameLine(0, 8);
+        end
         imgui.Text('Palette Name:');
         imgui.PushItemWidth(200);
         local enterPressed = imgui.InputText('##paletteName', modalState.inputBuffer, 32, ImGuiInputTextFlags_EnterReturnsTrue);
@@ -404,40 +2355,32 @@ local function DrawCreateRenameModal()
         if imgui.Button('OK', { 80, 0 }) or enterPressed then
             if canSubmit then
                 local success, err;
-                if modalState.mode == 'create' then
-                    if windowState.selectedPaletteType == 'hotbar' then
-                        success, err = palette.CreatePalette(1, newName, windowState.selectedJobId, windowState.selectedSubjobId);
+                if embedU then
+                    if modalState.mode == 'create' then
+                        success, err = palette.CreateUniversalCrossbarPalette(newName);
                     else
-                        success, err = palette.CreateCrossbarPalette(newName, windowState.selectedJobId, windowState.selectedSubjobId);
+                        success, err = palette.RenameUniversalCrossbarPalette(windowState.selectedPaletteName, newName);
                     end
+                elseif modalState.mode == 'create' then
+                    -- Job crossbar create uses non-modal BeginPopup (see early exit above).
+                    success, err = palette.CreatePalette(1, newName, windowState.selectedJobId, windowState.selectedSubjobId);
                 else  -- rename
                     if windowState.selectedPaletteType == 'hotbar' then
                         success, err = palette.RenamePalette(1, windowState.selectedPaletteName, newName, windowState.selectedJobId, windowState.selectedSubjobId);
                     else
-                        success, err = palette.RenameCrossbarPalette(windowState.selectedPaletteName, newName, windowState.selectedJobId, windowState.selectedSubjobId);
+                        local opSub = GetCrossbarModalStorageSubjob();
+                        success, err = palette.RenameCrossbarPalette(windowState.selectedPaletteName, newName, windowState.selectedJobId, opSub);
                     end
                 end
 
                 if success then
                     windowState.selectedPaletteName = newName;
-
-                    -- Activate the newly created palette if viewing current job's palettes
-                    if modalState.mode == 'create' then
-                        local currentJobId = data.jobId;
-                        local currentSubjobId = data.subjobId or 0;
-                        local viewingShared = (windowState.selectedSubjobId == 0);
-                        local viewingCurrentJob = (windowState.selectedJobId == currentJobId);
-                        local viewingCurrentSubjob = (windowState.selectedSubjobId == currentSubjobId);
-
-                        -- Activate if: viewing this job's shared library OR viewing exact job/subjob match
-                        if viewingCurrentJob and (viewingShared or viewingCurrentSubjob) then
-                            if windowState.selectedPaletteType == 'hotbar' then
-                                palette.SetActivePalette(1, newName, currentJobId, currentSubjobId);
-                            else
-                                palette.SetActivePaletteForCombo('L2', newName);
-                            end
-                        end
+                    if embedU then
+                        embedCrossbarUniversalContext.selectedPaletteName = newName;
+                    elseif modalState.mode == 'rename' and windowState.selectedPaletteType == 'crossbar' then
+                        embedCrossbarJobContext.selectedPaletteName = newName;
                     end
+                    ClearCrossbarEmbedModalFields();
 
                     modalState.isOpen = false;
                     imgui.CloseCurrentPopup();
@@ -451,89 +2394,165 @@ local function DrawCreateRenameModal()
 
         if imgui.Button('Cancel', { 80, 0 }) then
             modalState.isOpen = false;
+            ClearCrossbarEmbedModalFields();
             imgui.CloseCurrentPopup();
         end
 
+        components.PopPaletteManagerButtonStyle();
         imgui.EndPopup();
+    else
+        -- Dismissed by clicking outside
+        createRenamePopupPendingId = nil;
+        modalState.isOpen = false;
+        ClearCrossbarEmbedModalFields();
     end
 end
 
 -- Helper: Draw copy modal
 local function DrawCopyModal()
     if not modalState.isOpen or modalState.mode ~= 'copy' then
+        copyPopupPending = false;
         return;
     end
 
-    imgui.OpenPopup('Copy Palette##copyModal');
+    if not copyPopupPending then
+        imgui.SetNextWindowSize({ 420, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup('Copy Palette##copyModal');
+        copyPopupPending = true;
+    end
+    if imgui.BeginPopup('Copy Palette##copyModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
+        local embedUcopy = modalState.embedCrossbarUniversalCopy == true;
+        local copySourceName = windowState.selectedPaletteName;
+        local isCrossbar = windowState.selectedPaletteType == 'crossbar';
 
-    if imgui.BeginPopupModal('Copy Palette##copyModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
-        imgui.Text('Copy "' .. windowState.selectedPaletteName .. '" to:');
+        if embedUcopy and modalState.copyDestScope == 'universal' then
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to another Global [G] palette:');
+        elseif embedUcopy and modalState.copyDestScope == 'job' then
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to a Job [J] palette:');
+        elseif not embedUcopy and isCrossbar and modalState.copyDestScope == 'universal' then
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to a Global [G] palette:');
+        else
+            imgui.Text('Copy "' .. (copySourceName or '') .. '" to:');
+        end
         imgui.Spacing();
 
-        -- Job selector
-        imgui.Text('Job:');
-        imgui.SameLine();
-        imgui.PushItemWidth(100);
-        if imgui.BeginCombo('##copyJobSelector', GetJobName(modalState.copyTargetJobId)) then
-            for jobId = 1, 22 do
-                local isSelected = (jobId == modalState.copyTargetJobId);
-                if imgui.Selectable(GetJobName(jobId), isSelected) then
-                    modalState.copyTargetJobId = jobId;
+        if isCrossbar then
+            imgui.Text('Destination storage:');
+            local scopeJob = modalState.copyDestScope == 'job';
+            if imgui.RadioButton('Job / Subjob [J]##palCopyDestJob', scopeJob) then
+                modalState.copyDestScope = 'job';
+            end
+            imgui.SameLine();
+            if imgui.RadioButton('Global [G]##palCopyDestG', not scopeJob) then
+                modalState.copyDestScope = 'universal';
+            end
+            imgui.ShowHelp('Job [J] copies into per-job crossbar storage (shared tier or subjob tier). Global [G] copies into all-jobs universal crossbar palettes.');
+            imgui.Spacing();
+        end
+
+        local showJobDestControls = (windowState.selectedPaletteType == 'hotbar')
+            or (isCrossbar and modalState.copyDestScope == 'job');
+
+        if showJobDestControls then
+            -- Job selector
+            imgui.Text('Job:');
+            imgui.SameLine();
+            imgui.PushItemWidth(100);
+            if imgui.BeginCombo('##copyJobSelector', GetJobName(modalState.copyTargetJobId)) then
+                for jobId = 1, 22 do
+                    local isSelected = (jobId == modalState.copyTargetJobId);
+                    if imgui.Selectable(GetJobName(jobId), isSelected) then
+                        modalState.copyTargetJobId = jobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
                 end
-                if isSelected then
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            -- Subjob selector
+            imgui.SameLine();
+            imgui.Text('Subjob:');
+            imgui.SameLine();
+            imgui.PushItemWidth(100);
+            local currentSubjobLabel = modalState.copyTargetSubjobId == 0 and 'Shared' or GetJobName(modalState.copyTargetSubjobId);
+            if imgui.BeginCombo('##copySubjobSelector', currentSubjobLabel) then
+                local sharedSelected = (modalState.copyTargetSubjobId == 0);
+                if imgui.Selectable('Shared', sharedSelected) then
+                    modalState.copyTargetSubjobId = 0;
+                end
+                if sharedSelected then
                     imgui.SetItemDefaultFocus();
                 end
-            end
-            imgui.EndCombo();
-        end
-        imgui.PopItemWidth();
-
-        -- Subjob selector
-        imgui.SameLine();
-        imgui.Text('Subjob:');
-        imgui.SameLine();
-        imgui.PushItemWidth(100);
-        local currentSubjobLabel = modalState.copyTargetSubjobId == 0 and 'Shared' or GetJobName(modalState.copyTargetSubjobId);
-        if imgui.BeginCombo('##copySubjobSelector', currentSubjobLabel) then
-            -- Shared option
-            local sharedSelected = (modalState.copyTargetSubjobId == 0);
-            if imgui.Selectable('Shared', sharedSelected) then
-                modalState.copyTargetSubjobId = 0;
-            end
-            if sharedSelected then
-                imgui.SetItemDefaultFocus();
-            end
-            -- Job options
-            for subjobId = 1, 22 do
-                local isSelected = (subjobId == modalState.copyTargetSubjobId);
-                if imgui.Selectable(GetJobName(subjobId), isSelected) then
-                    modalState.copyTargetSubjobId = subjobId;
+                for subjobId = 1, 22 do
+                    local isSelected = (subjobId == modalState.copyTargetSubjobId);
+                    if imgui.Selectable(GetJobName(subjobId), isSelected) then
+                        modalState.copyTargetSubjobId = subjobId;
+                    end
+                    if isSelected then
+                        imgui.SetItemDefaultFocus();
+                    end
                 end
-                if isSelected then
-                    imgui.SetItemDefaultFocus();
+                imgui.EndCombo();
+            end
+            imgui.PopItemWidth();
+
+            imgui.Spacing();
+
+            if modalState.copyTargetSubjobId ~= 0 then
+                local targetUsingFallback = IsUsingFallback(modalState.copyTargetJobId, modalState.copyTargetSubjobId, windowState.selectedPaletteType);
+                if targetUsingFallback then
+                    imgui.TextColored({1.0, 0.7, 0.3, 1.0}, 'Warning: This will stop using shared palettes for');
+                    imgui.TextColored({1.0, 0.7, 0.3, 1.0}, GetJobName(modalState.copyTargetJobId) .. '/' .. GetJobName(modalState.copyTargetSubjobId) .. '.');
+                    imgui.Spacing();
                 end
             end
-            imgui.EndCombo();
         end
-        imgui.PopItemWidth();
 
-        imgui.Spacing();
+        local destNames = GetCopyDestinationNamesForModal();
+        if #destNames == 0 then
+            modalState.copyDestExistingIndex = 1;
+        elseif modalState.copyDestExistingIndex > #destNames then
+            modalState.copyDestExistingIndex = #destNames;
+        elseif modalState.copyDestExistingIndex < 1 then
+            modalState.copyDestExistingIndex = 1;
+        end
 
-        -- Warning when copying to a subjob-specific location that currently uses shared palettes
-        if modalState.copyTargetSubjobId ~= 0 then
-            local targetUsingFallback = IsUsingFallback(modalState.copyTargetJobId, modalState.copyTargetSubjobId, windowState.selectedPaletteType);
-            if targetUsingFallback then
-                imgui.TextColored({1.0, 0.7, 0.3, 1.0}, 'Warning: This will stop using shared palettes for');
-                imgui.TextColored({1.0, 0.7, 0.3, 1.0}, GetJobName(modalState.copyTargetJobId) .. '/' .. GetJobName(modalState.copyTargetSubjobId) .. '.');
-                imgui.Spacing();
+        local copyOwBuf = { modalState.copyOverwriteExisting == true };
+        imgui.Checkbox('Overwrite an existing palette##copyPalOw', copyOwBuf);
+        modalState.copyOverwriteExisting = copyOwBuf[1];
+
+        if modalState.copyOverwriteExisting then
+            imgui.TextColored({1.0, 0.65, 0.35, 1.0}, 'Warning: All slot actions on the destination palette will be replaced.');
+            imgui.Spacing();
+            if #destNames == 0 then
+                imgui.TextColored({0.75, 0.75, 0.75, 1.0}, 'No palettes exist at this destination yet.');
+            else
+                imgui.Text('Destination palette:');
+                imgui.PushItemWidth(220);
+                local comboLabel = destNames[modalState.copyDestExistingIndex] or destNames[1];
+                if imgui.BeginCombo('##copyDestExisting', comboLabel) then
+                    for di, pname in ipairs(destNames) do
+                        if imgui.Selectable(pname .. '##copyDest' .. di, di == modalState.copyDestExistingIndex) then
+                            modalState.copyDestExistingIndex = di;
+                        end
+                        if di == modalState.copyDestExistingIndex then
+                            imgui.SetItemDefaultFocus();
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                imgui.PopItemWidth();
             end
+        else
+            imgui.Text('New name (leave blank to keep the same):');
+            imgui.PushItemWidth(200);
+            imgui.InputText('##copyNewName', modalState.inputBuffer, 32);
+            imgui.PopItemWidth();
         end
-
-        -- New name input
-        imgui.Text('New Name (leave blank to keep same):');
-        imgui.PushItemWidth(200);
-        imgui.InputText('##copyNewName', modalState.inputBuffer, 32);
-        imgui.PopItemWidth();
 
         -- Show error if any
         if modalState.errorMessage then
@@ -542,16 +2561,65 @@ local function DrawCopyModal()
 
         imgui.Spacing();
 
-        -- Check if copying to same location with same name
         local newName = modalState.inputBuffer[1];
         if newName == '' then newName = nil; end
-        local effectiveName = newName or windowState.selectedPaletteName;
-        local isSameLocation = modalState.copyTargetJobId == windowState.selectedJobId and
-                               modalState.copyTargetSubjobId == windowState.selectedSubjobId and
-                               effectiveName == windowState.selectedPaletteName;
+
+        local overwrite = modalState.copyOverwriteExisting == true;
+        local destArg;
+        if overwrite then
+            destArg = destNames[modalState.copyDestExistingIndex];
+        else
+            destArg = newName;
+        end
+
+        local effectiveName;
+        if overwrite then
+            effectiveName = destArg;
+        else
+            effectiveName = newName or windowState.selectedPaletteName;
+        end
+
+        local copyFromSubjob = windowState.selectedSubjobId;
+        if windowState.selectedPaletteType == 'crossbar' and modalState.crossbarCopyFromSubjob ~= nil then
+            copyFromSubjob = modalState.crossbarCopyFromSubjob;
+        end
+
+        local isCopyNoOp;
+        if embedUcopy then
+            if modalState.copyDestScope == 'universal' then
+                if overwrite then
+                    isCopyNoOp = not destArg or destArg == '' or destArg == copySourceName;
+                else
+                    isCopyNoOp = (not newName or newName == '') or (newName == copySourceName);
+                end
+            else
+                isCopyNoOp = false;
+            end
+        elseif isCrossbar and modalState.copyDestScope == 'universal' then
+            isCopyNoOp = false;
+        else
+            isCopyNoOp = modalState.copyTargetJobId == windowState.selectedJobId and
+                modalState.copyTargetSubjobId == copyFromSubjob and
+                effectiveName == windowState.selectedPaletteName;
+        end
+
+        local canCopy;
+        if embedUcopy then
+            if modalState.copyDestScope == 'universal' then
+                if overwrite then
+                    canCopy = not isCopyNoOp and destArg ~= nil and destArg ~= '' and #destNames > 0;
+                else
+                    canCopy = not isCopyNoOp and newName and newName ~= '';
+                end
+            else
+                canCopy = not isCopyNoOp and (not overwrite or (destArg ~= nil and destArg ~= '' and #destNames > 0));
+            end
+        else
+            canCopy = not isCopyNoOp and (not overwrite or (destArg ~= nil and destArg ~= '' and #destNames > 0));
+        end
 
         -- Buttons
-        if isSameLocation then imgui.BeginDisabled(); end
+        if not canCopy then imgui.BeginDisabled(); end
         if imgui.Button('Copy', { 80, 0 }) then
             local success, err;
             if windowState.selectedPaletteType == 'hotbar' then
@@ -561,48 +2629,85 @@ local function DrawCopyModal()
                     windowState.selectedSubjobId,
                     modalState.copyTargetJobId,
                     modalState.copyTargetSubjobId,
-                    newName
+                    destArg,
+                    overwrite
+                );
+            elseif embedUcopy then
+                if modalState.copyDestScope == 'universal' then
+                    local destFinal = overwrite and destArg or newName;
+                    success, err = palette.CopyUniversalCrossbarPalette(copySourceName, destFinal, overwrite);
+                else
+                    local destFinal = overwrite and destArg or (newName or copySourceName);
+                    success, err = palette.CopyUniversalCrossbarPaletteToJob(
+                        copySourceName,
+                        destFinal,
+                        modalState.copyTargetJobId,
+                        modalState.copyTargetSubjobId,
+                        overwrite
+                    );
+                end
+            elseif isCrossbar and modalState.copyDestScope == 'universal' then
+                local destFinal = overwrite and destArg or (newName or windowState.selectedPaletteName);
+                success, err = palette.CopyCrossbarPaletteToUniversal(
+                    windowState.selectedPaletteName,
+                    windowState.selectedJobId,
+                    copyFromSubjob,
+                    destFinal,
+                    overwrite
                 );
             else
                 success, err = palette.CopyCrossbarPalette(
                     windowState.selectedPaletteName,
                     windowState.selectedJobId,
-                    windowState.selectedSubjobId,
+                    copyFromSubjob,
                     modalState.copyTargetJobId,
                     modalState.copyTargetSubjobId,
-                    newName
+                    destArg,
+                    overwrite
                 );
             end
 
             if success then
                 modalState.isOpen = false;
+                ClearCrossbarEmbedModalFields();
                 imgui.CloseCurrentPopup();
             else
                 modalState.errorMessage = err or 'Copy failed';
             end
         end
-        if isSameLocation then imgui.EndDisabled(); end
+        if not canCopy then imgui.EndDisabled(); end
 
         imgui.SameLine();
 
         if imgui.Button('Cancel', { 80, 0 }) then
             modalState.isOpen = false;
+            ClearCrossbarEmbedModalFields();
             imgui.CloseCurrentPopup();
         end
 
+        components.PopPaletteManagerButtonStyle();
         imgui.EndPopup();
+    else
+        copyPopupPending = false;
+        modalState.isOpen = false;
+        ClearCrossbarEmbedModalFields();
     end
 end
 
 -- Helper: Draw delete confirmation modal
 local function DrawDeleteConfirmModal()
     if not modalState.isOpen or modalState.mode ~= 'delete' then
+        deletePopupPending = false;
         return;
     end
 
-    imgui.OpenPopup('Delete Palette##deleteModal');
-
-    if imgui.BeginPopupModal('Delete Palette##deleteModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if not deletePopupPending then
+        imgui.SetNextWindowSize({ 300, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup('Delete Palette##deleteModal');
+        deletePopupPending = true;
+    end
+    if imgui.BeginPopup('Delete Palette##deleteModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
         imgui.Text('Are you sure you want to delete');
         imgui.Text('"' .. (modalState.deletePaletteName or '') .. '"?');
         imgui.Spacing();
@@ -619,14 +2724,21 @@ local function DrawDeleteConfirmModal()
         -- Buttons
         if imgui.Button('Delete', { 80, 0 }) then
             local success, err;
-            if windowState.selectedPaletteType == 'hotbar' then
+            if modalState.embedCrossbarUniversal == true then
+                success, err = palette.DeleteUniversalCrossbarPalette(modalState.deletePaletteName);
+            elseif windowState.selectedPaletteType == 'hotbar' then
                 success, err = palette.DeletePalette(1, modalState.deletePaletteName, windowState.selectedJobId, windowState.selectedSubjobId);
             else
-                success, err = palette.DeleteCrossbarPalette(modalState.deletePaletteName, windowState.selectedJobId, windowState.selectedSubjobId);
+                local opSub = GetCrossbarModalStorageSubjob();
+                success, err = palette.DeleteCrossbarPalette(modalState.deletePaletteName, windowState.selectedJobId, opSub);
             end
             if success then
                 windowState.selectedPaletteName = nil;
+                embedCrossbarJobContext.selectedPaletteName = nil;
+                embedCrossbarJobContext.selectedStorageSubjob = nil;
+                embedCrossbarUniversalContext.selectedPaletteName = nil;
                 modalState.isOpen = false;
+                ClearCrossbarEmbedModalFields();
                 imgui.CloseCurrentPopup();
             else
                 modalState.errorMessage = err or 'Delete failed';
@@ -637,22 +2749,33 @@ local function DrawDeleteConfirmModal()
 
         if imgui.Button('Cancel', { 80, 0 }) then
             modalState.isOpen = false;
+            ClearCrossbarEmbedModalFields();
             imgui.CloseCurrentPopup();
         end
 
+        components.PopPaletteManagerButtonStyle();
         imgui.EndPopup();
+    else
+        deletePopupPending = false;
+        modalState.isOpen = false;
+        ClearCrossbarEmbedModalFields();
     end
 end
 
 -- Helper: Draw "Use Shared Library" confirmation modal
 local function DrawUseSharedModal()
     if not modalState.isOpen or modalState.mode ~= 'use_shared' then
+        useSharedPopupPending = false;
         return;
     end
 
-    imgui.OpenPopup('Use Shared Library##useSharedModal');
-
-    if imgui.BeginPopupModal('Use Shared Library##useSharedModal', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+    if not useSharedPopupPending then
+        imgui.SetNextWindowSize({ 380, 0 }, ImGuiCond_Always);
+        imgui.OpenPopup('Use Shared Library##useSharedModal');
+        useSharedPopupPending = true;
+    end
+    if imgui.BeginPopup('Use Shared Library##useSharedModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        components.PushPaletteManagerButtonStyle();
         local jobName = GetJobName(windowState.selectedJobId);
         local subjobName = GetJobName(windowState.selectedSubjobId);
 
@@ -690,48 +2813,685 @@ local function DrawUseSharedModal()
             modalState.isOpen = false;
             imgui.CloseCurrentPopup();
         end
+        components.PopPaletteManagerButtonStyle();
+        imgui.EndPopup();
+    else
+        useSharedPopupPending = false;
+        modalState.isOpen = false;
+    end
+end
+
+-- Embedded Global [G] crossbar palette manager (same interaction model as Job/J+SJ embed, no job binding)
+function M.DrawEmbeddedCrossbarManageUniversal()
+    windowState.selectedPaletteType = 'crossbar';
+
+    palette.EnsureUniversalCrossbarDefaultExists();
+    local names = palette.GetUniversalCrossbarPaletteNamesOrdered();
+
+    if #names > 0 then
+        local sn = embedCrossbarUniversalContext.selectedPaletteName;
+        local needPick = sn == nil;
+        if not needPick then
+            local found = false;
+            for _, n in ipairs(names) do
+                if n == sn then
+                    found = true;
+                    break;
+                end
+            end
+            if not found then
+                needPick = true;
+            end
+        end
+        if needPick then
+            embedCrossbarUniversalContext.selectedPaletteName = names[1];
+            windowState.selectedPaletteName = names[1];
+        end
+    end
+
+    local avail = imgui.GetContentRegionAvail();
+    local availW = type(avail) == 'table' and avail[1] or avail or 400;
+    -- Wider than 50%: config tab has room; avoids cramped Palette / Status columns
+    local shellW = math.max(300, math.min(availW * 0.62, 720));
+
+    -- List: column headers + separator + fixed visible rows; extra palettes scroll inside the child.
+    local lineH = imgui.GetTextLineHeightWithSpacing();
+    local nNames = #names;
+    local headerChromeH = math.floor(lineH * 2 + 6);
+    local listH;
+    if nNames == 0 then
+        listH = math.floor(lineH * 3 + 12);
+    else
+        listH = headerChromeH + EMBED_CROSSBAR_PAL_LIST_VISIBLE_ROWS * lineH + 2;
+    end
+    local headerBlockH = math.floor(lineH * 3 + 8);
+    local listToButtonsPad = 4;
+    local actionBlockH = GetEmbedCrossbarPalMgrActionBlockH();
+    local shellH = headerBlockH + listH + listToButtonsPad + actionBlockH;
+
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 12, 6 });
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgMedium);
+    imgui.PushStyleColor(ImGuiCol_Border, { 0.42, 0.36, 0.26, 0.85 });
+    imgui.BeginChild('##xbEmbedUniversalPalMgrShell', { shellW, shellH }, true, 0);
+
+    imgui.TextColored(components.MANAGER_BUTTON_STYLE.palette.headerText, 'Palette Manager');
+    imgui.Spacing();
+    imgui.TextColored({ 0.85, 0.82, 0.7, 1.0 }, 'Palettes - Global [G]');
+    imgui.Separator();
+
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgLighter);
+    -- Scrollbar only when content exceeds listH (not AlwaysVerticalScrollbar â€” avoids permanent gutter + squeeze)
+    imgui.BeginChild('##xbEmbedUniversalPalList', { 0, listH }, true, 0);
+
+    if #names == 0 then
+        imgui.TextColored({ 0.5, 0.5, 0.5, 1.0 }, 'No palettes');
+    else
+        local xbUW = imgui.GetWindowWidth();
+        imgui.Columns(3, '##xbEmbUCols', true);
+        imgui.SetColumnWidth(0, STATUS_COL_W);
+        imgui.SetColumnWidth(1, math.max(60, xbUW - STATUS_COL_W - COPY_COL_W - 40));
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Text('Palette');
+        imgui.NextColumn();
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Separator();
+        for i, name in ipairs(names) do
+            local isSel = embedCrossbarUniversalContext.selectedPaletteName == name;
+            local inCyc = palette.GetUniversalPaletteIncludeInCycle(name);
+            imgui.PushID('xbemu' .. i .. '_' .. name);
+            DrawStatusIcon(inCyc);
+            imgui.NextColumn();
+            local label = name .. ' (G)';
+            PushPaletteRowStyle(isSel);
+            if imgui.Selectable(label .. '##sel', isSel) then
+                embedCrossbarUniversalContext.selectedPaletteName = name;
+                windowState.selectedPaletteName = name;
+            end
+            PopPaletteRowStyle();
+            if imgui.BeginPopupContextItem('##ctxu') then
+                if imgui.MenuItem('Rename##xbemu') then
+                    modalState.mode = 'rename';
+                    modalState.inputBuffer[1] = name;
+                    modalState.errorMessage = nil;
+                    modalState.isOpen = true;
+                    modalState.embedCrossbarUniversal = true;
+                    embedCrossbarUniversalContext.selectedPaletteName = name;
+                    windowState.selectedPaletteName = name;
+                end
+                if imgui.MenuItem('Copy To...##xbemu') then
+                    modalState.mode = 'copy';
+                    modalState.inputBuffer[1] = name;
+                    modalState.errorMessage = nil;
+                    modalState.copyOverwriteExisting = false;
+                    modalState.copyDestExistingIndex = 1;
+                    modalState.embedCrossbarUniversalCopy = true;
+                    modalState.copyDestScope = 'universal';
+                    modalState.copyTargetJobId = data.jobId or 1;
+                    modalState.copyTargetSubjobId = data.subjobId or 0;
+                    embedCrossbarUniversalContext.selectedPaletteName = name;
+                    windowState.selectedPaletteName = name;
+                    modalState.isOpen = true;
+                end
+                if #names > 1 then
+                    imgui.Separator();
+                    if imgui.MenuItem('Delete##xbemu') then
+                        modalState.mode = 'delete';
+                        modalState.deletePaletteName = name;
+                        modalState.errorMessage = nil;
+                        modalState.embedCrossbarUniversal = true;
+                        modalState.isOpen = true;
+                        windowState.selectedPaletteName = name;
+                    end
+                end
+                imgui.EndPopup();
+            end
+            imgui.NextColumn();
+            DrawCreateMacroButton('/xiui cpal g ' .. name, name, 'xbemu' .. i);
+            imgui.NextColumn();
+            imgui.PopID();
+        end
+        imgui.Columns(1);
+    end
+
+    imgui.EndChild();
+    imgui.PopStyleColor();
+    imgui.Dummy({ 0, listToButtonsPad });
+
+    local selName = embedCrossbarUniversalContext.selectedPaletteName;
+    local hasSel = selName ~= nil;
+
+    components.PushPaletteManagerButtonStyle();
+    if imgui.Button('+ New##xbemuNew') then
+        modalState.mode = 'create';
+        modalState.inputBuffer[1] = '';
+        modalState.errorMessage = nil;
+        modalState.isOpen = true;
+        modalState.embedCrossbarUniversal = true;
+    end
+
+    imgui.SameLine();
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Rename##xbemuRen') then
+        modalState.mode = 'rename';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.embedCrossbarUniversal = true;
+        modalState.isOpen = true;
+        windowState.selectedPaletteName = selName;
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    local canDel = hasSel and #names > 1;
+    if not canDel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Delete##xbemuDel') then
+        modalState.mode = 'delete';
+        modalState.deletePaletteName = selName;
+        modalState.errorMessage = nil;
+        modalState.embedCrossbarUniversal = true;
+        modalState.isOpen = true;
+        windowState.selectedPaletteName = selName;
+    end
+    if not canDel then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Copy To...##xbemuCp') then
+        modalState.mode = 'copy';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.copyOverwriteExisting = false;
+        modalState.copyDestExistingIndex = 1;
+        modalState.embedCrossbarUniversalCopy = true;
+        modalState.copyDestScope = 'universal';
+        modalState.copyTargetJobId = data.jobId or 1;
+        modalState.copyTargetSubjobId = data.subjobId or 0;
+        modalState.embedCrossbarUniversal = true;
+        windowState.selectedPaletteName = selName;
+        modalState.isOpen = true;
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+
+    imgui.Spacing();
+
+    local idxInList = nil;
+    if hasSel then
+        for ti, n in ipairs(names) do
+            if n == selName then
+                idxInList = ti;
+                break;
+            end
+        end
+    end
+    local canUp = hasSel and idxInList ~= nil and idxInList > 1;
+    local canDown = hasSel and idxInList ~= nil and idxInList < #names;
+
+    if not canUp then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Move Up##xbemuUp') and canUp then
+        local success, err = palette.MoveUniversalCrossbarPalette(selName, -1);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canUp then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    if not canDown then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Move Down##xbemuDn') and canDown then
+        local success, err = palette.MoveUniversalCrossbarPalette(selName, 1);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canDown then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    local inRbSel = hasSel and palette.GetUniversalPaletteIncludeInCycle(selName);
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button((inRbSel and 'Disable' or 'Enable') .. '##xbemuRbTgl') then
+        palette.SetUniversalPaletteIncludeInCycle(selName, not inRbSel);
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+
+    imgui.SameLine();
+    if not hasSel then
+        imgui.BeginDisabled();
+    end
+    if imgui.Button('Edit Full Palette##xbemuFullPal') and hasSel then
+        embedCrossbarComboCtx = {
+            kind = 'universal',
+            name = selName,
+        };
+        embedCrossbarComboWinOpen[1] = true;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+    end
+    if not hasSel then
+        imgui.EndDisabled();
+    end
+    imgui.SameLine();
+    imgui.ShowHelp(
+        'Tip: put /xiui cpaledit in a macro to toggle this editor for your currently active crossbar palette (same as this button).'
+    );
+
+    components.PopPaletteManagerButtonStyle();
+    DrawStatusMessage();
+
+    imgui.EndChild();
+    imgui.PopStyleColor(2);
+    imgui.PopStyleVar();
+end
+
+-- Embedded job/subjob crossbar palette manager (Manage Palettes & Crossbar â€” no separate window)
+function M.DrawEmbeddedCrossbarManage(jobId, subjobId)
+    windowState.selectedPaletteType = 'crossbar';
+    windowState.selectedJobId = jobId;
+    windowState.selectedSubjobId = subjobId;
+
+    palette.EnsureCrossbarDefaultPaletteExists(jobId, subjobId);
+
+    local rows = palette.GetCrossbarManagePaletteRows(jobId, subjobId);
+
+    local function tierKeyEq(a, b)
+        return (tonumber(a) or 0) == (tonumber(b) or 0);
+    end
+
+    -- Ensure a valid selection so Move Up/Down can resolve index (storage tier must match row data).
+    if #rows > 0 then
+        local sn = embedCrossbarJobContext.selectedPaletteName;
+        local ss = embedCrossbarJobContext.selectedStorageSubjob;
+        local needPick = sn == nil or ss == nil;
+        if not needPick then
+            local found = false;
+            for _, r in ipairs(rows) do
+                if r.name == sn and tierKeyEq(r.storageSubjob, ss) then
+                    found = true;
+                    break;
+                end
+            end
+            if not found then
+                needPick = true;
+            end
+        end
+        if needPick then
+            local r0 = rows[1];
+            embedCrossbarJobContext.selectedPaletteName = r0.name;
+            embedCrossbarJobContext.selectedStorageSubjob = r0.storageSubjob;
+            windowState.selectedPaletteName = r0.name;
+            windowState.selectedCrossbarStorageSubjob = r0.storageSubjob;
+        end
+    end
+
+    local avail = imgui.GetContentRegionAvail();
+    local availW = type(avail) == 'table' and avail[1] or avail or 400;
+    local shellW = math.max(300, math.min(availW * 0.62, 720));
+
+    local lineH = imgui.GetTextLineHeightWithSpacing();
+    local nRows = #rows;
+    local headerChromeH = math.floor(lineH * 2 + 6);
+    local listH;
+    if nRows == 0 then
+        listH = math.floor(lineH * 3 + 12);
+    else
+        listH = headerChromeH + EMBED_CROSSBAR_PAL_LIST_VISIBLE_ROWS * lineH + 2;
+    end
+    local headerBlockH = math.floor(lineH * 3 + 8);
+    local listToButtonsPad = 4;
+    local actionBlockH = GetEmbedCrossbarPalMgrActionBlockH();
+    local shellH = headerBlockH + listH + listToButtonsPad + actionBlockH;
+
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 12, 6 });
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgMedium);
+    imgui.PushStyleColor(ImGuiCol_Border, { 0.42, 0.36, 0.26, 0.85 });
+    imgui.BeginChild('##xbEmbedPalMgrShell', { shellW, shellH }, true, 0);
+
+    imgui.TextColored(components.MANAGER_BUTTON_STYLE.palette.headerText, 'Palette Manager');
+    imgui.Spacing();
+    if subjobId == 0 then
+        imgui.TextColored({0.85, 0.82, 0.7, 1.0}, string.format('Palettes - Job (J) %s + Shared', GetJobName(jobId)));
+    else
+        imgui.TextColored({0.85, 0.82, 0.7, 1.0}, string.format('Palettes - Job (J) %s + Subjob (SJ) %s', GetJobName(jobId), GetJobName(subjobId)));
+    end
+    imgui.Separator();
+
+    imgui.PushStyleColor(ImGuiCol_ChildBg, components.TAB_STYLE.bgLighter);
+    imgui.BeginChild('##xbEmbedPalList', { 0, listH }, true, 0);
+
+    if #rows == 0 then
+        imgui.TextColored({0.5, 0.5, 0.5, 1.0}, 'No palettes');
+    else
+        local xbW = imgui.GetWindowWidth();
+        imgui.Columns(3, '##xbEmbCols', true);
+        imgui.SetColumnWidth(0, STATUS_COL_W);
+        imgui.SetColumnWidth(1, math.max(60, xbW - STATUS_COL_W - COPY_COL_W - 40));
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Text('Palette');
+        imgui.NextColumn();
+        imgui.Text('');
+        imgui.NextColumn();
+        imgui.Separator();
+        for i, row in ipairs(rows) do
+            local label = row.name .. palette.FormatCrossbarTierSuffixLabel(row.storageSubjob, subjobId);
+            local isSel = embedCrossbarJobContext.selectedPaletteName == row.name
+                and tierKeyEq(embedCrossbarJobContext.selectedStorageSubjob, row.storageSubjob);
+            local inRbEmb = palette.IsCrossbarPaletteInRbCycle(jobId, row.storageSubjob, row.name);
+            -- Build the CLI command for this palette row.
+            -- J tier (storageSubjob == 0): /xiui cpal BLM Name
+            -- SJ tier: /xiui cpal BLMNIN Name
+            local jobPrefix = GetJobName(jobId);
+            if row.storageSubjob ~= 0 then
+                jobPrefix = jobPrefix .. GetJobName(row.storageSubjob);
+            end
+            local rowCmd = '/xiui cpal ' .. jobPrefix .. ' ' .. row.name;
+            imgui.PushID('xbem' .. i .. '_' .. row.storageSubjob .. '_' .. row.name);
+            DrawStatusIcon(inRbEmb);
+            imgui.NextColumn();
+            PushPaletteRowStyle(isSel);
+            if imgui.Selectable(label .. '##sel', isSel) then
+                embedCrossbarJobContext.selectedPaletteName = row.name;
+                embedCrossbarJobContext.selectedStorageSubjob = row.storageSubjob;
+                windowState.selectedPaletteName = row.name;
+                windowState.selectedCrossbarStorageSubjob = row.storageSubjob;
+            end
+            PopPaletteRowStyle();
+            if imgui.BeginPopupContextItem('##ctx') then
+                if imgui.MenuItem('Rename##xbem') then
+                    modalState.mode = 'rename';
+                    modalState.inputBuffer[1] = row.name;
+                    modalState.errorMessage = nil;
+                    modalState.isOpen = true;
+                    modalState.crossbarOperationSubjob = row.storageSubjob;
+                    embedCrossbarJobContext.selectedPaletteName = row.name;
+                    embedCrossbarJobContext.selectedStorageSubjob = row.storageSubjob;
+                    windowState.selectedPaletteName = row.name;
+                end
+                if imgui.MenuItem('Copy To...##xbem') then
+                    modalState.mode = 'copy';
+                    modalState.inputBuffer[1] = row.name;
+                    modalState.errorMessage = nil;
+                    modalState.copyOverwriteExisting = false;
+                    modalState.copyDestExistingIndex = 1;
+                    modalState.copyDestScope = 'job';
+                    modalState.copyTargetJobId = jobId;
+                    modalState.copyTargetSubjobId = subjobId;
+                    modalState.crossbarCopyFromSubjob = row.storageSubjob;
+                    embedCrossbarJobContext.selectedPaletteName = row.name;
+                    embedCrossbarJobContext.selectedStorageSubjob = row.storageSubjob;
+                    windowState.selectedPaletteName = row.name;
+                    windowState.selectedCrossbarStorageSubjob = row.storageSubjob;
+                    modalState.isOpen = true;
+                end
+                if #rows > 1 then
+                    imgui.Separator();
+                    if imgui.MenuItem('Delete##xbem') then
+                        modalState.mode = 'delete';
+                        modalState.deletePaletteName = row.name;
+                        modalState.errorMessage = nil;
+                        modalState.crossbarOperationSubjob = row.storageSubjob;
+                        modalState.isOpen = true;
+                        windowState.selectedPaletteName = row.name;
+                    end
+                end
+                imgui.EndPopup();
+            end
+            imgui.NextColumn();
+            DrawCreateMacroButton(rowCmd, row.name, 'xbem' .. i);
+            imgui.NextColumn();
+            imgui.PopID();
+        end
+        imgui.Columns(1);
+    end
+
+    imgui.EndChild();
+    imgui.PopStyleColor();
+    imgui.Dummy({ 0, listToButtonsPad });
+
+    local selName = embedCrossbarJobContext.selectedPaletteName;
+    local selSt = embedCrossbarJobContext.selectedStorageSubjob;
+    local hasSel = selName ~= nil and selSt ~= nil;
+
+    components.PushPaletteManagerButtonStyle();
+    if imgui.Button('+ New##xbemNew') then
+        local j, s = GetOrResetXbCreateDefaults();
+        modalState.mode = 'create';
+        modalState.inputBuffer[1] = '';
+        modalState.errorMessage = nil;
+        modalState.crossbarCreateJobId = j;
+        modalState.crossbarCreateStorageSubjob = s;
+        modalState.isOpen = true;
+        ClearCrossbarEmbedModalFields();
+    end
+
+    imgui.SameLine();
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button('Rename##xbemRen') then
+        modalState.mode = 'rename';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.isOpen = true;
+        modalState.crossbarOperationSubjob = selSt;
+        windowState.selectedPaletteName = selName;
+    end
+    if not hasSel then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    local canDel = hasSel and #rows > 1;
+    if not canDel then imgui.BeginDisabled(); end
+    if imgui.Button('Delete##xbemDel') then
+        modalState.mode = 'delete';
+        modalState.deletePaletteName = selName;
+        modalState.errorMessage = nil;
+        modalState.isOpen = true;
+        modalState.crossbarOperationSubjob = selSt;
+        windowState.selectedPaletteName = selName;
+    end
+    if not canDel then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button('Copy To...##xbemCp') then
+        modalState.mode = 'copy';
+        modalState.inputBuffer[1] = selName;
+        modalState.errorMessage = nil;
+        modalState.copyOverwriteExisting = false;
+        modalState.copyDestExistingIndex = 1;
+        modalState.copyDestScope = 'job';
+        modalState.copyTargetJobId = jobId;
+        modalState.copyTargetSubjobId = subjobId;
+        modalState.crossbarCopyFromSubjob = selSt;
+        windowState.selectedPaletteName = selName;
+        windowState.selectedCrossbarStorageSubjob = selSt;
+        modalState.isOpen = true;
+    end
+    if not hasSel then imgui.EndDisabled(); end
+
+    imgui.Spacing();
+
+    -- Same ordered name list as MoveCrossbarPalette (per storage tier), so index matches swap logic
+    local tierNames = {};
+    local idxInTier = nil;
+    if hasSel then
+        tierNames = palette.GetCrossbarPaletteNamesForOrderTier(jobId, tonumber(selSt) or 0);
+        for ti, n in ipairs(tierNames) do
+            if n == selName then
+                idxInTier = ti;
+                break;
+            end
+        end
+    end
+    local canUp = hasSel and idxInTier ~= nil and idxInTier > 1;
+    local canDown = hasSel and idxInTier ~= nil and idxInTier < #tierNames;
+
+    if not canUp then imgui.BeginDisabled(); end
+    if imgui.Button('Move Up##xbemUp') and canUp then
+        local success, err = palette.MoveCrossbarPalette(selName, -1, jobId, selSt);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canUp then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    if not canDown then imgui.BeginDisabled(); end
+    if imgui.Button('Move Down##xbemDn') and canDown then
+        local success, err = palette.MoveCrossbarPalette(selName, 1, jobId, selSt);
+        if not success and err then
+            SetStatusMessage(err);
+        end
+    end
+    if not canDown then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    local inRbEmbSel = false;
+    if hasSel then
+        inRbEmbSel = palette.IsCrossbarPaletteInRbCycle(jobId, selSt or 0, selName);
+    end
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button((inRbEmbSel and 'Disable' or 'Enable') .. '##xbemRbTgl') then
+        palette.SetCrossbarPaletteInRbCycle(jobId, selSt or 0, selName, not inRbEmbSel);
+    end
+    if not hasSel then imgui.EndDisabled(); end
+
+    imgui.SameLine();
+    if not hasSel then imgui.BeginDisabled(); end
+    if imgui.Button('Edit Full Palette##xbemMpal') and hasSel then
+        embedCrossbarComboCtx = {
+            kind = 'job',
+            jobId = jobId,
+            subjobId = subjobId,
+            name = selName,
+            st = selSt,
+        };
+        embedCrossbarComboWinOpen[1] = true;
+        embedCrossbarComboWinGraceFrames = 0;
+        embedCrossbarComboHasDrawn = false;
+    end
+    if not hasSel then imgui.EndDisabled(); end
+    imgui.SameLine();
+    imgui.ShowHelp(
+        'Tip: put /xiui cpaledit in a macro to toggle this editor for your currently active crossbar palette (same as this button).'
+    );
+
+    components.PopPaletteManagerButtonStyle();
+    DrawStatusMessage();
+
+    imgui.EndChild();
+    imgui.PopStyleColor(2);
+    imgui.PopStyleVar();
+end
+
+-- Confirm closing XIUI Config while Edit Full Palette has unsaved draft changes (see DeferConfigCloseIfEditFullPaletteOpen).
+local function DrawCloseConfigWhileEditPaletteModal()
+    if openCloseConfigConfirmPopup then
+        imgui.OpenPopup('Unsaved Edit Full Palette##xiuiCloseCfgEditPalModal');
+        openCloseConfigConfirmPopup = false;
+    end
+    if imgui.BeginPopup('Unsaved Edit Full Palette##xiuiCloseCfgEditPalModal', ImGuiWindowFlags_AlwaysAutoResize) then
+        imgui.TextWrapped('You have unsaved changes in Edit Full Palette. What would you like to do?');
+        imgui.Spacing();
+        local cfg = require('config');
+        if imgui.Button('Save and Close##xiuiCfgClosePalSave', { 140, 0 }) then
+            data.ApplyDraft();
+            if SaveSettingsToDisk then
+                SaveSettingsToDisk();
+            end
+            ForceCloseEditFullPaletteWindow();
+            if cfg.SetWindowOpen then
+                cfg.SetWindowOpen(false);
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Revert and Close##xiuiCfgClosePalRevert', { 140, 0 }) then
+            data.DiscardDraft();
+            ForceCloseEditFullPaletteWindow();
+            if cfg.SetWindowOpen then
+                cfg.SetWindowOpen(false);
+            end
+            imgui.CloseCurrentPopup();
+        end
+        imgui.SameLine();
+        if imgui.Button('Cancel##xiuiCfgClosePalCancel', { 100, 0 }) then
+            imgui.CloseCurrentPopup();
+        end
         imgui.EndPopup();
     end
 end
 
+-- Modals + embedded Crossbar "Edit Full Palette" window run even when the floating Palette Manager is closed.
+local function DrawPaletteManagerModals()
+    DrawCloseConfigWhileEditPaletteModal();
+    DrawCreateRenameModal();
+    DrawCopyModal();
+    DrawDeleteConfirmModal();
+    DrawUseSharedModal();
+    DrawEmbeddedCrossbarComboModesPopup();
+end
+
 -- Draw the main palette manager window
 function M.Draw()
-    if not windowState.isOpen then
-        return;
+    -- Theme applies to the floating window, modals, and the large Crossbar "Edit Full Palette" window
+    local applyTheme = windowState.isOpen or modalState.isOpen or (embedCrossbarComboCtx ~= nil);
+    if applyTheme then
+        PushXiuiFloatingWindowTheme();
     end
 
-    -- Window size
-    imgui.SetNextWindowSize({ 350, 400 }, ImGuiCond_FirstUseEver);
+    if windowState.isOpen then
+        imgui.SetNextWindowSize({ 350, 400 }, ImGuiCond_FirstUseEver);
 
-    local windowFlags = ImGuiWindowFlags_None;
-    local isOpen = { windowState.isOpen };
+        local windowFlags = ImGuiWindowFlags_None;
+        local isOpen = { windowState.isOpen };
 
-    if imgui.Begin('Palette Manager##paletteManager', isOpen, windowFlags) then
-        -- Type selector
-        DrawPaletteTypeSelector();
-        imgui.Spacing();
+        if imgui.Begin('Palette Manager##paletteManager', isOpen, windowFlags) then
+            components.PushPaletteManagerButtonStyle();
+            DrawJobSelector();
+            DrawSubjobSelector();
+            imgui.Spacing();
 
-        -- Job/Subjob selectors
-        DrawJobSelector();
-        DrawSubjobSelector();
-        imgui.Spacing();
+            local palettes = DrawPaletteList();
+            imgui.Spacing();
 
-        -- Palette list
-        local palettes = DrawPaletteList();
-        imgui.Spacing();
+            DrawActionButtons(palettes);
+            components.PopPaletteManagerButtonStyle();
+        end
+        imgui.End();
 
-        -- Action buttons
-        DrawActionButtons(palettes);
-
-        -- Draw modals
-        DrawCreateRenameModal();
-        DrawCopyModal();
-        DrawDeleteConfirmModal();
-        DrawUseSharedModal();
+        windowState.isOpen = isOpen[1];
     end
-    imgui.End();
 
-    windowState.isOpen = isOpen[1];
+    DrawPaletteManagerModals();
+
+    if applyTheme then
+        PopXiuiFloatingWindowTheme();
+    end
 end
 
 return M;
+

--- a/XIUI/modules/hotbar/crossbar.lua
+++ b/XIUI/modules/hotbar/crossbar.lua
@@ -17,13 +17,35 @@ local dragdrop = require('libs.dragdrop');
 local data = require('modules.hotbar.data');
 local actions = require('modules.hotbar.actions');
 local textures = require('modules.hotbar.textures');
+-- TextureManager is used for the palette scope icon overlay (job icon / infinity for universal palettes).
+local TextureManager = require('libs.texturemanager');
 local controller = require('modules.hotbar.controller');
 local recast = require('modules.hotbar.recast');
 local slotrenderer = require('modules.hotbar.slotrenderer');
+-- playerdata caches the player's known abilities + weaponskills; `IsActionAvailable` falls
+-- back to "unavailable" when the caches are empty. Keyboard hotbars warm these from their
+-- own DrawWindow, but crossbar-only setups (`hotbarEnabled=false, crossbarEnabled=true`)
+-- never touched playerdata before — every JA/WS slot then read as unavailable (grayed +
+-- "X") even on jobs that knew the abilities. We now refresh once per frame from crossbar
+-- DrawWindow as well; the refresh is signature-gated internally (job/level/equip diff) so
+-- the steady-state cost is a few cache reads, not a full re-scan.
+local playerdata = require('modules.hotbar.playerdata');
 local animation = require('libs.animation');
 local skillchain = require('modules.hotbar.skillchain');
+-- macroparse extracts the primary line + JA badge type from a /ws or /pet macro body, so we can
+-- predict skillchain icons on macro slots whose first line is a weapon skill or blood pact.
+-- Display.lua does the same thing for keyboard hotbars; without it, crossbar macro slots whose
+-- primary line is /ws or /pet would never light up even though firing the macro IS the WS/pact.
+local macroparse = require('modules.hotbar.macroparse');
 local targetLib = require('libs.target');
 local palette = require('modules.hotbar.palette');
+-- Used to dim the crossbar when a blocking game menu is open AND `crossbarDisableInMenu`
+-- is enabled, so the player can see at a glance that controller input is paused.
+local gamestate = require('core.gamestate');
+-- macropalette is required only for the palette-editor drop handlers (effective palette key
+-- + macro source store). Required at module scope here (mirrors Ferris); if a future
+-- circular dependency creeps in this can be flipped to a lazy `require` inside the closures.
+local macropalette = require('modules.hotbar.macropalette');
 
 local M = {};
 
@@ -75,6 +97,13 @@ end
 
 local SLOTS_PER_SIDE = 8;
 local COMBO_MODES = controller.COMBO_MODES;
+-- Full enumeration of combo-mode storage keys (used by the Edit Full Palette editor and the
+-- pet-tab filter). 'Shared' is the chord-fallback for sharedExpanded layouts where both
+-- L2+R2 and R2+L2 collapse to one set.
+local ALL_COMBO_MODES = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2', 'Shared' };
+-- Naming prefix on resource maps + IDs used by the Edit Full Palette draft layer so its
+-- ImGui drop zones / animation keys never collide with the live HUD's 'crossbar_*' set.
+local PAL_ED_PREFIX = 'PalEd_';
 
 -- ============================================
 -- Layout Calculation Functions
@@ -277,7 +306,14 @@ local function GetCachedCrossbarIcon(comboMode, slotIndex, slotData)
 end
 
 -- Clear crossbar icon cache
+-- iconCache rows hold the only Lua ref to D3D textures returned by actions.GetBindIcon
+-- (LoadTextureFromPath wires a gc_safe_release finalizer). Wiping mid-frame — e.g. palette
+-- deletion fires InvalidateAllVisualCachesAfterPaletteListMutation while the crossbar
+-- DrawWindow is still building this frame's ImGui draw list — lets Lua GC finalize the COM
+-- texture while AddImage still references it (CTD on Ashita 4.16). DeferRelease holds the
+-- old table alive until FlushPendingReleases runs at the top of the next d3d_present.
 local function ClearCrossbarIconCache()
+    TextureManager.DeferRelease(iconCache);
     iconCache = {};
 end
 
@@ -286,6 +322,10 @@ local function ClearCrossbarIconCacheForSlot(comboMode, slotIndex)
     -- Use effective combo mode for cache key (Shared when shared expanded bar is enabled)
     comboMode = data.GetEffectiveComboModeForStorage and data.GetEffectiveComboModeForStorage(comboMode) or comboMode;
     if iconCache[comboMode] then
+        local oldRow = iconCache[comboMode][slotIndex];
+        if oldRow ~= nil then
+            TextureManager.DeferRelease(oldRow);
+        end
         iconCache[comboMode][slotIndex] = nil;
     end
 end
@@ -328,6 +368,16 @@ local state = {
         progress = 1.0,
         wasHidden = false,
     },
+
+    -- useSharedExpandedBar bookkeeping. The shared-center layout collapses the bar to one
+    -- diamond width and forces the X anchor to screen-center every frame; without these the
+    -- normal X anchor would either get persisted as the centered narrow value (chord persists
+    -- across a save) or snap back to the leftmost saved position on chord exit. The two-step
+    -- handoff is: while in chord we stash the last "wide" window X here, then on the first
+    -- frame that exits chord we re-anchor to that stashed X so the bar returns where the
+    -- user actually placed it (rather than wherever the centered narrow bar happened to land).
+    lastWideCrossbarWindowX = nil,
+    wasSharedCenterChordLayout = false,
 };
 
 -- ============================================
@@ -376,12 +426,24 @@ end
 -- ============================================
 
 -- Determine which combo modes to display on left/right based on active combo
--- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'both', or nil)
-local function GetDisplayModes(activeCombo)
+-- Returns: leftMode, rightMode, isExpanded, expandedSide ('left', 'right', 'center', 'both', or nil)
+-- When useSharedExpandedBar is enabled and the user holds a chord (L2+R2 / R2+L2), expandedSide
+-- becomes 'center': only the left column is drawn (using the 'Shared' storage key), the window
+-- shrinks to one diamond width, and DrawWindow re-centers it to screen X (a single 8-slot strip
+-- centered like the FFXIV controller bar) rather than the two-diamond wide layout.
+local function GetDisplayModes(activeCombo, settings)
+    settings = settings or (gConfig and gConfig.hotbarCrossbar);
+    local useSharedExp = settings and settings.useSharedExpandedBar == true;
     if activeCombo == COMBO_MODES.L2_THEN_R2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: L2 first, then R2 -> show L2R2 on left side only, right side dimmed (shows R2)
         return 'L2R2', 'R2', true, 'left';
     elseif activeCombo == COMBO_MODES.R2_THEN_L2 then
+        if useSharedExp then
+            return 'Shared', 'R2', true, 'center';
+        end
         -- Expanded: R2 first, then L2 -> show R2L2 on right side only, left side dimmed (shows L2)
         return 'L2', 'R2L2', true, 'right';
     elseif activeCombo == 'Shared' then
@@ -585,6 +647,69 @@ local function GetSlotPositionInWindow(side, slotIndex, windowX, windowY, settin
 end
 
 -- ============================================
+-- Window-decor padding (slot-top vs window-top accounting)
+-- ============================================
+-- ImGui clips anything we draw OUTSIDE the window's content rect. The crossbar paints a
+-- lot of decoration above the slot grid (L2/R2 trigger icons, combo text, R1 cpal-anchor
+-- pulse, palette-modifier refresh glyph) and below it (palette name, action labels). To
+-- keep all of that inside the window's draw region we open the ImGui window taller than
+-- the slot grid by CROSSBAR_WINDOW_TOP_DECOR_PAD on top and `GetCrossbarWindowBottomPad`
+-- on the bottom, then offset the window-top so the SLOT GRID still lands at the user's
+-- saved (or default) Y. `state.windowY` continues to mean "slot grid top" everywhere
+-- else in this module, which lets the rest of the layout code stay unchanged.
+local CROSSBAR_WINDOW_TOP_DECOR_PAD = 80;
+
+local function GetCrossbarWindowBottomPad(settings)
+    settings = settings or {};
+    local pad = 10;
+    if settings.showActionLabels then
+        pad = pad + (settings.labelFontSize or 10) + 6 + math.max(0, tonumber(settings.actionLabelOffsetY) or 0);
+    end
+    pad = pad + math.floor(((settings.mpCostFontSize or 10) + (settings.quantityFontSize or 10)) * 0.15 + 0.5);
+    return math.min(72, math.max(10, pad));
+end
+
+-- Profile stores SLOT TOP Y (`gConfig.windowPositions.Crossbar.y`), not window-top. When
+-- we apply a saved position we subtract the decor pad so the slot grid lands where the
+-- user originally placed it. The `appliedPositions` flag keeps ImGui's drag from being
+-- overridden every frame (ImGuiCond_Always otherwise).
+local function ApplyCrossbarWindowPositionOnce()
+    if not gConfig or not gConfig.windowPositions or not gConfig.windowPositions['Crossbar'] then
+        return false;
+    end
+    if not gConfig.appliedPositions then
+        gConfig.appliedPositions = {};
+    end
+    if gConfig.appliedPositions['Crossbar'] then
+        return false;
+    end
+    local pos = gConfig.windowPositions['Crossbar'];
+    imgui.SetNextWindowPos({ pos.x, pos.y - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    gConfig.appliedPositions['Crossbar'] = true;
+    return true;
+end
+
+-- Save SLOT TOP Y, not window-top, so the saved coordinate stays meaningful even if the
+-- decor pad changes between releases (or a future patch adds more decoration above the
+-- slot grid). Skips writes when nothing changed to avoid table churn / unnecessary disk
+-- saves on every frame.
+local function SaveCrossbarWindowSlotTopPosition()
+    if not gConfig then return; end
+    local wx, wy = imgui.GetWindowPos();
+    if not gConfig.windowPositions then
+        gConfig.windowPositions = {};
+    end
+    local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+    local saved = gConfig.windowPositions['Crossbar'];
+    if not saved then
+        gConfig.windowPositions['Crossbar'] = { x = wx, y = slotTopY };
+    elseif saved.x ~= wx or saved.y ~= slotTopY then
+        saved.x = wx;
+        saved.y = slotTopY;
+    end
+end
+
+-- ============================================
 -- Initialization
 -- ============================================
 
@@ -671,12 +796,147 @@ end
 -- animOpacity: 0-1 for animation fade (default 1.0)
 -- yOffset: Y offset in pixels for animation (default 0)
 -- skillchainName: (optional) Skillchain name for WS slots
-local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName)
+-- Reusable cbInteraction sub-tables built lazily for palette-editor slots so the editor and
+-- the live crossbar each get their own slotInteraction set (different idPrefix/buttonId/
+-- dropZoneId — palette editor uses 'paled_*'; live crossbar uses 'crossbar_*'). Keeping
+-- them separate also lets the slotrenderer drop-zone-lock semantics treat them differently
+-- (paled_* are never locked; crossbar_* respect crossbarLockMovement).
+local cbInteractionPalEd = {};
+
+local function GetCbInteractionPaletteEditor(comboMode, slotIndex)
+    if not cbInteractionPalEd[comboMode] then cbInteractionPalEd[comboMode] = {}; end
+    local cached = cbInteractionPalEd[comboMode][slotIndex];
+    if cached then return cached; end
+
+    local entry = {
+        buttonId = string.format('##paled_%s_%d', comboMode, slotIndex),
+        dropZoneId = string.format('paled_%s_%d', comboMode, slotIndex),
+        pressKey = 'paled_' .. comboMode .. '_' .. slotIndex,
+        onDrop = function(payload)
+            -- Palette-editor drops go through the draft layer; Apply Draft promotes them to live.
+            -- All branches normalize through the overlay (draft falls back to live) and finalize
+            -- before writing so dual-arm macros swap correctly and empty results clear properly.
+            if payload.type == 'macro' then
+                if payload.data and payload.data.macroPaletteKey == nil then
+                    if macropalette.GetEffectivePaletteType then
+                        payload.data.macroPaletteKey = macropalette.GetEffectivePaletteType();
+                    else
+                        payload.data.macroPaletteKey = data.jobId or 1;
+                    end
+                end
+                if payload.data and macropalette.GetMacroSourceTagForDrops
+                    and payload.data.macroSourceStore == nil then
+                    payload.data.macroSourceStore = macropalette.GetMacroSourceTagForDrops();
+                end
+                local arm = {};
+                for k, v in pairs(payload.data) do arm[k] = v; end
+                if arm.macroRef == nil and payload.data.id then
+                    arm.macroRef = payload.data.id;
+                end
+                local existingRaw = data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex);
+                local existing = data.NormalizeCrossbarSlotRawForSwap(existingRaw);
+                local store = arm.macroSourceStore
+                    or (macropalette.GetMacroSourceTagForDrops and macropalette.GetMacroSourceTagForDrops())
+                    or 'profile';
+                local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                data.SetDraftSlotData(comboMode, slotIndex, built);
+            elseif payload.type == 'crossbar_slot' then
+                -- Always read source/target from overlay at drop time; payload.data was captured
+                -- at drag start and can alias stale tables after earlier moves in the same session.
+                local srcCombo = payload.comboMode;
+                local srcSlot = payload.slotIndex;
+                if srcCombo == comboMode and srcSlot == slotIndex then return; end
+                if data.BeginDraftUndoGroup then data.BeginDraftUndoGroup(); end
+                local srcRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(srcCombo, srcSlot));
+                local tgtRaw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+                local newTgt, newSrc = data.SwapActiveMacroArmsInPlace(srcRaw, tgtRaw);
+                local fT = data.FinalizeCrossbarRawSlotForStorage(newTgt);
+                local fS = data.FinalizeCrossbarRawSlotForStorage(newSrc);
+                if fT == nil then
+                    data.ClearDraftSlotData(comboMode, slotIndex);
+                else
+                    data.SetDraftSlotData(comboMode, slotIndex, fT);
+                end
+                if fS == nil then
+                    data.ClearDraftSlotData(srcCombo, srcSlot);
+                else
+                    data.SetDraftSlotData(srcCombo, srcSlot, fS);
+                end
+                if data.EndDraftUndoGroup then data.EndDraftUndoGroup(); end
+                -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+                -- the icon cache clear above is the only refresh needed for the source slot.
+                ClearCrossbarIconCacheForSlot(srcCombo, srcSlot);
+            elseif payload.type == 'slot' then
+                if payload.data then
+                    local c = data.FinalizeCrossbarRawSlotForStorage(data.CopyTable(payload.data));
+                    if c == nil then
+                        data.ClearDraftSlotData(comboMode, slotIndex);
+                    else
+                        data.SetDraftSlotData(comboMode, slotIndex, c);
+                    end
+                end
+            end
+            -- Visual refresh for the target slot (matches live-HUD drop behaviour).
+            -- 1.8.0 immediate-mode renderer has no persistent slot prim cache to invalidate;
+            -- the icon cache clear is the only refresh needed (the bind hash on next frame
+            -- naturally re-derives slot draw state — see ClearSlotIconCache notes in macropalette).
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        getDragData = function()
+            -- Use overlay (draft falling back to live) so dragging a slot that hasn't been
+            -- touched in this edit session still carries its persisted data. Reading draft-only
+            -- here would drag nil and the drop handler would clear the target slot.
+            local raw = data.NormalizeCrossbarSlotRawForSwap(data.GetCrossbarSlotRawForSwapOverlay(comboMode, slotIndex));
+            return {
+                type = 'crossbar_slot',
+                comboMode = comboMode,
+                slotIndex = slotIndex,
+                data = raw,
+            };
+        end,
+        onRightClick = function()
+            data.ClearDraftSlotData(comboMode, slotIndex);
+            ClearCrossbarIconCacheForSlot(comboMode, slotIndex);
+        end,
+        -- Double-click in Edit Full Palette opens the macro editor for the slot's draft
+        -- content. For empty slots that resolves to nil and macropalette.OpenEditorForSlotData
+        -- starts a fresh "creating new" session seeded with the active palette type's defaults.
+        -- The (comboMode, slotIndex) carried in the pending edit lets palettemanager auto-bind
+        -- the new macro to this slot after Save (see config/palettemanager.lua consume site).
+        -- We funnel through data.SetPendingPaletteSlotEdit so the editor opens on the NEXT
+        -- frame (consumed by config/palettemanager.lua after slots draw); opening it directly
+        -- inside this click handler would put a modal inside the hotbar's draw pass and skip
+        -- the macropalette draw-order assumptions.
+        onDoubleClick = function()
+            local slotData = data.GetDraftSlotData
+                and data.GetDraftSlotData(comboMode, slotIndex)
+                or nil;
+            data.SetPendingPaletteSlotEdit(slotData, comboMode, slotIndex);
+        end,
+    };
+    cbInteractionPalEd[comboMode][slotIndex] = entry;
+    return entry;
+end
+
+-- Palette-editor empty-slot panel tint (matches the Edit Full Palette row fill in palettemanager.lua).
+-- Lighter than the live crossbar's 0x55000000 so slot outlines read clearly against the editor row.
+local PAL_ED_EMPTY_SLOT_BG = 0xFF8E96AC;
+
+local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive, isPressed, animOpacity, yOffset, skillchainName, activeCombo, editorClipRect, magicBurstName)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
-    -- Get pre-created interaction closures and IDs
-    local interaction = GetCbInteraction(comboMode, slotIndex);
+    -- Edit Full Palette state: when active, this slot belongs to the editor's draft layer
+    -- rather than the live crossbar. palSk is the storage-key the editor is targeting; the
+    -- draft layer is separate per-key (so editing one palette doesn't touch the live binding).
+    local palSk = data.GetCrossbarPaletteEditSessionKey and data.GetCrossbarPaletteEditSessionKey();
+    local isEditor = palSk ~= nil;
+
+    -- Get pre-created interaction closures and IDs. Editor and live get different prefixes so
+    -- the slotrenderer drop-zone-lock policy can distinguish them (paled_* are never locked).
+    local interaction = isEditor
+        and GetCbInteractionPaletteEditor(comboMode, slotIndex)
+        or GetCbInteraction(comboMode, slotIndex);
 
     -- Apply Y offset for animation
     local drawY = y + yOffset;
@@ -687,8 +947,14 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
         iconPressScale = animation.getPressScale(interaction.pressKey, isPressed and isActive);
     end
 
-    -- Get slot data
-    local slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    -- Slot data source: editor reads from the draft layer (synced from live at session start
+    -- via data.SyncDraftSlotFromLive); live crossbar always reads the persisted binding.
+    local slotData;
+    if isEditor then
+        slotData = data.GetDraftSlotData and data.GetDraftSlotData(comboMode, slotIndex) or nil;
+    else
+        slotData = data.GetCrossbarSlotData(comboMode, slotIndex);
+    end
 
     -- Get icon + cached abbreviation for this action (cached - only rebuilds when bind changes)
     local icon, cachedAbbr, cachedAbbrW = GetCachedCrossbarIcon(comboMode, slotIndex, slotData);
@@ -696,6 +962,33 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     -- Global UI scale (slotSize/x/y come in already scaled; we apply gs here to
     -- font sizes and pixel offsets that come straight from settings).
     local gs = (gConfig and gConfig.globalScale) or 1.0;
+
+    -- Diamond position: 1=Top, 2=Right, 3=Bottom, 4=Left (slots 5-8 map via -4 for face buttons).
+    -- Top-slot labels placed below would overlap the bottom slot's MP/quantity text, so the
+    -- editor (and any caller that asks for labels) flips them above for the top position.
+    local posIndex = (slotIndex <= 4) and slotIndex or (slotIndex - 4);
+    local labelAboveSlot = (posIndex == 1);
+
+    -- Dim policy. Live crossbar: inactive sides get a softer dim; when a trigger is held the
+    -- non-active half dims much harder so the active set pops. Editor: nothing is "inactive".
+    local dimFactor = 1.0;
+    if not isEditor and not isActive then
+        if activeCombo and activeCombo ~= COMBO_MODES.NONE then
+            dimFactor = settings.inactiveSideWhileTriggerDim;
+            if dimFactor == nil then dimFactor = 0.15; end
+        else
+            dimFactor = settings.inactiveSlotDim or 0.5;
+        end
+    end
+
+    -- Editor background: lighter tint behind empty editor slots so slot borders pop on the
+    -- panel row; filled editor slots use the user's normal background.
+    local slotBgColor = settings.slotBackgroundColor or 0x55000000;
+    local slotOpacity = settings.slotOpacity or 1.0;
+    if isEditor and not slotData then
+        slotBgColor = PAL_ED_EMPTY_SLOT_BG;
+        slotOpacity = 1.0;
+    end
 
     -- Update reusable params table in-place
     local p = cbParams;
@@ -707,28 +1000,30 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.cachedAbbrW = cachedAbbrW;
     p.bind = slotData;
     p.icon = icon;
-    p.slotBgColor = settings.slotBackgroundColor or 0x55000000;
-    p.slotOpacity = settings.slotOpacity or 1.0;
-    p.dimFactor = isActive and 1.0 or (settings.inactiveSlotDim or 0.5);
+    p.slotBgColor = slotBgColor;
+    p.slotOpacity = slotOpacity;
+    p.dimFactor = dimFactor;
     p.animOpacity = animOpacity;
     p.isPressed = isPressed and isActive;
     p.iconPressScale = iconPressScale;
-    p.showMpCost = settings.showMpCost ~= false;
+    p.showMpCost = isEditor and false or (settings.showMpCost ~= false);
     p.mpCostFontSize = (settings.mpCostFontSize or 10) * gs;
     p.mpCostFontColor = settings.mpCostFontColor or 0xFFD4FF97;
     p.mpCostNoMpColor = settings.mpCostNoMpColor or 0xFFFF4444;
     p.mpCostOffsetX = (settings.mpCostOffsetX or 0) * gs;
     p.mpCostOffsetY = (settings.mpCostOffsetY or 0) * gs;
-    p.showQuantity = settings.showQuantity ~= false;
+    p.showQuantity = isEditor and false or (settings.showQuantity ~= false);
     p.showStackQuantity = settings.showStackQuantity == true;
     p.quantityFontSize = (settings.quantityFontSize or 10) * gs;
     p.quantityFontColor = settings.quantityFontColor or 0xFFFFFFFF;
     p.quantityOffsetX = (settings.quantityOffsetX or 0) * gs;
     p.quantityOffsetY = (settings.quantityOffsetY or 0) * gs;
-    p.showLabel = settings.showActionLabels or false;
+    -- Editor: always show labels (on-slot abbrev with hover popup); live crossbar respects the user setting.
+    p.showLabel = isEditor and true or (settings.showActionLabels or false);
     p.labelText = slotData and (slotData.displayName or slotData.action or '') or '';
-    p.labelOffsetX = (settings.actionLabelOffsetX or 0) * gs;
-    p.labelOffsetY = ((settings.actionLabelOffsetY or 0) + 2) * gs;
+    p.labelOffsetX = isEditor and 0 or ((settings.actionLabelOffsetX or 0) * gs);
+    p.labelOffsetY = isEditor and 0 or (((settings.actionLabelOffsetY or 0) + 2) * gs);
+    p.labelAboveSlot = labelAboveSlot;
     p.labelFontSize = (settings.labelFontSize or 10) * gs;
     p.recastTimerFontSize = (settings.recastTimerFontSize or 11) * gs;
     p.recastTimerFontColor = settings.recastTimerFontColor or 0xFFFFFFFF;
@@ -744,10 +1039,29 @@ local function DrawSlot(comboMode, slotIndex, x, y, slotSize, settings, isActive
     p.dragType = 'crossbar_slot';
     p.getDragData = interaction.getDragData;
     p.onRightClick = interaction.onRightClick;
+    -- Editor slots: double-click opens the macro editor (empty slot = new macro seeded
+    -- with palette defaults, filled slot = edit existing). Live crossbar slots leave
+    -- onDoubleClick nil so single-click executes the action immediately.
+    p.onDoubleClick = isEditor and interaction.onDoubleClick or nil;
+    -- Editor slots don't have a "live" action to execute; suppressing the single-click
+    -- action is what enables the click-tracking pipeline in slotrenderer to detect a
+    -- second click and dispatch onDoubleClick. Live HUD keeps the default behavior.
+    p.suppressActionOnClick = isEditor and true or false;
     p.showTooltip = true;
-    -- Skillchain highlight
-    p.skillchainName = skillchainName;
+    -- Editor-only params consumed by slotrenderer Pass 2 (clip culling + on-slot multi-line label).
+    p.editorClipRect = editorClipRect;
+    p.editorMinimalView = isEditor;
+    p.labelForeground = isEditor;
+    -- Editor drops should win against the live crossbar zone underneath when the editor preview
+    -- overlaps the HUD (FlushDeferredDrops resolves overlaps by highest priority).
+    p.dropPriority = isEditor and 10 or nil;
+    -- Skillchain highlight (only on live crossbar; editor preview suppresses it).
+    p.skillchainName = (not isEditor) and skillchainName or nil;
     p.skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44;
+    -- Magic Burst highlight — same suppression rules as skillchain (editor preview has no
+    -- live target so the prediction would be meaningless / misleading there).
+    p.magicBurstName = (not isEditor) and magicBurstName or nil;
+    p.magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF;
 
     -- Render slot using shared renderer (handles ALL rendering and interactions)
     slotrenderer.DrawSlot(p);
@@ -879,8 +1193,125 @@ local function DrawTriggerIcons(activeCombo, l2GroupX, r2GroupX, groupY, groupWi
                 {0, 0}, {1, 1},
                 tintColor
             );
+
+            -- R1 return indicator: rendered above R2 when the user has set a "cpal" anchor
+            -- (via `/xiui cpal <Job>`). Pulses to draw the eye toward the return-to-anchor
+            -- shortcut. Per-scope so anchors don't leak across universal vs job-scoped views.
+            local scope = palette.GetCrossbarPaletteScope();
+            local anchor = palette.GetCpalAnchor and palette.GetCpalAnchor(scope);
+            if anchor then
+                local r1Texture = textures:GetControllerIcon('R1');
+                if r1Texture and r1Texture.image then
+                    local r1Ptr = tonumber(ffi.cast('uint32_t', r1Texture.image));
+                    if r1Ptr then
+                        local r1Width = baseIconWidth;
+                        local r1Height = baseIconHeight;
+                        local r1IconX = r2GroupX + (groupWidth / 2) - (r1Width / 2);
+                        local r1IconY = r2IconY - r1Height - 4;
+
+                        -- ~2.5 Hz size pulse (peak +30%) keeps the indicator visible without
+                        -- being distracting. Sin → abs so the icon "breathes" symmetrically.
+                        local pulse = math.abs(math.sin(os.clock() * 2.5));
+                        local sizeScale = 1.0 + 0.30 * pulse;
+                        local sw = r1Width * sizeScale;
+                        local sh = r1Height * sizeScale;
+                        local sx = r1IconX + r1Width * 0.5 - sw * 0.5;
+                        local sy = r1IconY + r1Height * 0.5 - sh * 0.5;
+
+                        -- Pill-shaped dark backdrop spans the icon + "x2" text so they read
+                        -- as a single legend regardless of the underlying scene.
+                        local textGap, textEstW, pad = 3, 14, 4;
+                        drawList:AddRectFilled(
+                            { r1IconX - pad, r1IconY - pad },
+                            { r1IconX + r1Width + textGap + textEstW + pad, r1IconY + r1Height + pad },
+                            0x99000000, 5
+                        );
+
+                        drawList:AddImage(r1Ptr, { sx, sy }, { sx + sw, sy + sh }, { 0, 0 }, { 1, 1 }, 0xFFFFFFFF);
+                        -- Gold ARGB: A=FF R=FF G=C8 B=32 → ImGui's GetColorU32 byte order is 0xAABBGGRR
+                        drawList:AddText(
+                            { r1IconX + r1Width + textGap, r1IconY + r1Height * 0.5 - 6 },
+                            0xFF32C8FF,
+                            'x2'
+                        );
+                    end
+                end
+            end
         end
     end
+end
+
+-- Shared expanded bar (useSharedExpandedBar): the L2+R2 / R2+L2 chord collapses both diamonds
+-- into a single centered 8-slot strip, so DrawTriggerIcons can't position L2 over the left group
+-- and R2 over the (now-absent) right group. This variant renders an "L2 + R2" chord glyph centred
+-- on the single visible diamond: both icons inline with a small "+" between them, tinted brighter
+-- when their trigger is part of the active combo. Same draw list as DrawTriggerIcons so the chord
+-- glyph layers with the same z-order as the regular trigger labels.
+local function DrawTriggerIconsSharedExpandedCenter(activeCombo, groupLeftX, groupY, groupWidth, settings, drawList)
+    if not settings.showTriggerLabels then return; end
+    if not drawList then return; end
+
+    local baseScale = settings.triggerIconScale or 1.0;
+    local iw = 49 * baseScale;
+    local ih = 28 * baseScale;
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    -- chordTight: pull the +/glyphs closer together as the icons shrink so the legend stays compact
+    -- (matches the spacing the editor's shared-chord glyph uses in DrawPaletteEditorL2R2TriggerGlyphs).
+    local chordTight = math.max(0.5, 0.65 * baseScale);
+    local cx = groupLeftX + groupWidth * 0.5;
+    local cy = groupY - ih * 0.5;
+
+    -- Both triggers participate in any chord / double-tap involving them, so animate accordingly.
+    local l2Active = activeCombo == COMBO_MODES.L2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.L2_DOUBLE;
+    local r2Active = activeCombo == COMBO_MODES.R2 or activeCombo == COMBO_MODES.L2_THEN_R2 or activeCombo == COMBO_MODES.R2_THEN_L2 or activeCombo == COMBO_MODES.R2_DOUBLE;
+    if activeCombo == COMBO_MODES.NONE then
+        l2Active = false;
+        r2Active = false;
+    end
+
+    local l2PressScale = 1.0;
+    local r2PressScale = 1.0;
+    if settings.enablePressScale ~= false then
+        l2PressScale = animation.getPressScale('trigger_L2', l2Active);
+        r2PressScale = animation.getPressScale('trigger_R2', r2Active);
+    end
+
+    -- Measure the "+" once so the chord can be centered as a single unit (icon + plus + icon).
+    -- Fallback dims 10x14 keep layout sensible on builds where imgui.CalcTextSize isn't bound.
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImageScaled(texName, ix, iy, w, h, tintColor)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        drawList:AddImage(p, { ix, iy }, { ix + w, iy + h }, { 0, 0 }, { 1, 1 }, tintColor);
+    end
+
+    local ptw, pth = plusSize();
+    local lw = iw * l2PressScale;
+    local lh = ih * l2PressScale;
+    local rw = iw * r2PressScale;
+    local rh = ih * r2PressScale;
+    local total = lw + chordTight + ptw + chordTight + rw;
+    local leftX = cx - total * 0.5;
+    local l2Tint = l2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    local r2Tint = r2Active and 0xFFFFFFFF or 0x88FFFFFF;
+    drawImageScaled('L2', leftX, cy - lh * 0.5, lw, lh, l2Tint);
+    drawList:AddText({ leftX + lw + chordTight, cy - pth * 0.5 }, textCol, '+');
+    drawImageScaled('R2', leftX + lw + chordTight + ptw + chordTight, cy - rh * 0.5, rw, rh, r2Tint);
 end
 
 -- Draw combo text in center for complex combos (L2R2, R2L2, L2x2, R2x2) or edit mode
@@ -934,7 +1365,13 @@ local function DrawComboText(activeCombo, centerX, topY, settings)
     end
 end
 
--- Draw palette name below crossbar (e.g., "Stuns (2/5)")
+-- Draw palette name below crossbar (e.g., "Stuns (2/5)"). The index/total count is
+-- restricted to ENABLED palettes (RB-cycle filtered) and is hidden entirely when there
+-- is only one cycleable palette (a 1/1 badge is just noise). For universal [G] scope,
+-- routes through GetCrossbarPaletteLabelIndexAndTotal which uses the universal cycle list
+-- instead of the per-job rows. (Lookup is microseconds at typical 1-10 palette counts; a
+-- per-frame label cache was tried and reverted because it could go stale on PaletteManager
+-- CRUD without a roster-version invalidation hook.)
 local function DrawPaletteName(centerX, bottomY, settings)
     if not settings.showPaletteName then return; end
 
@@ -943,10 +1380,14 @@ local function DrawPaletteName(centerX, bottomY, settings)
 
     local jobId = data.jobId or 1;
     local subjobId = data.subjobId or 0;
-    local index = palette.GetCrossbarPaletteIndex(paletteName, jobId, subjobId) or 1;
-    local total = palette.GetCrossbarPaletteCount(jobId, subjobId) or 1;
+    local index, total = palette.GetCrossbarPaletteLabelIndexAndTotal(paletteName, jobId, subjobId);
 
-    local displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    local displayText;
+    if index and total and total > 1 then
+        displayText = string.format('%s (%d/%d)', paletteName, index, total);
+    else
+        displayText = paletteName;
+    end
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local fontSize = (settings.paletteNameFontSize or 10) * gs;
     local offsetX = (settings.paletteNameOffsetX or 0) * gs;
@@ -961,8 +1402,97 @@ local function DrawPaletteName(centerX, bottomY, settings)
     end
 end
 
--- Helper to draw just the left side
-local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- ============================================
+-- Palette scope icon (above the center divider)
+-- Shows the infinity glyph for Global/universal palettes, or the job icon for job-scoped.
+-- Lazily caches the infinity texture; the job-icon TextureManager has its own cache.
+-- ============================================
+local cachedInfinityPaletteTex = nil;
+
+local function GetInfinityPaletteIconTexture()
+    if cachedInfinityPaletteTex and cachedInfinityPaletteTex.image then
+        return cachedInfinityPaletteTex;
+    end
+    cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/FFXIV-1/infinite');
+    if not cachedInfinityPaletteTex or not cachedInfinityPaletteTex.image then
+        cachedInfinityPaletteTex = TextureManager.getFileTexture('jobs/Classic/infinite');
+    end
+    return cachedInfinityPaletteTex;
+end
+
+local function GetPaletteJobIconThemeFromSettings(settings)
+    local t = settings and settings.paletteJobIconTheme;
+    if t == 'Classic' or t == 'FFXI' or t == 'FFXIV-1' then
+        return t;
+    end
+    return 'Classic';
+end
+
+-- When showPaletteScopeIcon is nil (legacy profiles), the scope icon follows showPaletteName;
+-- explicit true/false overrides. Keeps the icon visible by default for existing users without
+-- forcing them through the settings menu after the upgrade.
+local function ShouldShowPaletteScopeIcon(settings)
+    if not settings then return false; end
+    if settings.showPaletteScopeIcon == false then return false; end
+    if settings.showPaletteScopeIcon == true then return true; end
+    return settings.showPaletteName == true;
+end
+
+-- Draws the scope marker (infinity for Global / universal, job icon otherwise) centred just
+-- above the divider. Only fires when a palette is actually active for the L2 group.
+local function DrawPaletteScopeIconAboveDivider(dividerX, dividerTopY, settings, drawList)
+    if not ShouldShowPaletteScopeIcon(settings) or not drawList then return; end
+
+    local paletteName = palette.GetActivePaletteForCombo('L2');
+    if not paletteName then return; end
+
+    local jobId = data.jobId or 1;
+    local iconTex;
+    if palette.GetCrossbarPaletteScope() == 'universal' then
+        iconTex = GetInfinityPaletteIconTexture();
+    else
+        iconTex = TextureManager.getJobIcon(jobId, GetPaletteJobIconThemeFromSettings(settings));
+    end
+
+    if not iconTex or not iconTex.image then return; end
+
+    local iconPtr = tonumber(ffi.cast('uint32_t', iconTex.image));
+    if not iconPtr then return; end
+
+    -- Size: explicit slider override (8..64 px) or auto-derive from palette-name font size.
+    local iconSize;
+    local explicitSize = tonumber(settings.paletteScopeIconSize);
+    if explicitSize and explicitSize > 0 then
+        iconSize = math.floor(math.max(8, math.min(64, explicitSize)) + 0.5);
+    else
+        local fontSize = settings.paletteNameFontSize or 10;
+        iconSize = math.max(12, math.min(22, math.floor(fontSize * 1.45)));
+        iconSize = math.floor(iconSize * 1.50 + 0.5);
+    end
+    local gapAboveLine = 3;
+    local scopeLiftY = tonumber(settings.paletteScopeIconOffsetY) or 6;
+    -- Clearance above the L2 / R2 combo-text strip at the top of the window.
+    local clearanceAboveComboText = 6;
+    -- Horizontally align with palette-name X offset so the icon stacks with the name.
+    local iconCenterX = dividerX + (settings.paletteNameOffsetX or 0);
+    local iconTopY = dividerTopY - gapAboveLine - iconSize - scopeLiftY - clearanceAboveComboText;
+    local leftX = iconCenterX - iconSize / 2;
+
+    drawList:AddImage(
+        iconPtr,
+        { leftX, iconTopY },
+        { leftX + iconSize, iconTopY + iconSize },
+        { 0, 0 },
+        { 1, 1 },
+        imgui.GetColorU32({ 1, 1, 1, 1 })
+    );
+end
+
+-- Helper to draw just the left side. `activeCombo` is threaded through so DrawSlot's dim
+-- policy can apply Ferris's "stronger dim on the inactive half while a trigger is held"
+-- behavior (settings.inactiveSideWhileTriggerDim, default 0.15) — without it the inactive
+-- half just gets settings.inactiveSlotDim (default 0.5) like 1.7.5/early-1.8.0.
+local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -970,15 +1500,40 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('L2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- Resolve slotData ONCE per slot so both prediction paths (skillchain + magic burst)
+        -- share the same fetch; previously the SC path re-fetched per branch. Cheap either
+        -- way, but cleaner now that two features need the same row.
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
+        -- Skillchain prediction: matches display.lua's coverage so the crossbar lights up the
+        -- same WS / Blood Pact / macro slots the keyboard hotbar does. Bloodpact slots use the
+        -- separate name->attributes map in skillchain.lua (bloodPactResonationMap); macro slots
+        -- run through macroparse to extract the primary /ws or /pet line and then route to the
+        -- matching predictor. Without the pet/macro branches, SMN ability slots and any /pet or
+        -- /ws macro would never get a skillchain icon overlay on the crossbar.
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        -- Magic Burst prediction: spells / magical pact rages / /ma|/pet-primary macros. The
+        -- single GetMagicBurstForSlot call internally routes by actionType + (for macros) the
+        -- macroparse primary line — mirrors the dispatch pattern used by display.lua.
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -989,8 +1544,9 @@ local function DrawLeftSide(mode, groupX, groupY, slotSize, settings, isActive, 
     end
 end
 
--- Helper to draw just the right side
-local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
+-- Helper to draw just the right side. See DrawLeftSide above for the rationale on the
+-- trailing activeCombo / magicBurstEnabled parameters.
+local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive, pressedSlot, showPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
     animOpacity = animOpacity or 1.0;
     yOffset = yOffset or 0;
 
@@ -998,15 +1554,29 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     for slotIndex = 1, SLOTS_PER_SIDE do
         local slotX, slotY = GetSlotPositionInWindow('R2', slotIndex, state.windowX, state.windowY, settings);
         local isPressed = showPressed and pressedSlot == slotIndex;
-        -- Check for skillchain prediction on weapon skill slots
+        -- See DrawLeftSide for slotData / SC / MB routing rationale (identical logic).
+        local slotData = (skillchainEnabled or magicBurstEnabled) and data.GetCrossbarSlotData(mode, slotIndex) or nil;
+
         local slotSkillchainName = nil;
-        if skillchainEnabled then
-            local slotData = data.GetCrossbarSlotData(mode, slotIndex);
-            if slotData and slotData.actionType == 'ws' and slotData.action then
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
                 slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
             end
         end
-        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName);
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+        DrawSlot(mode, slotIndex, slotX, slotY, slotSize, settings, isActive, isPressed, animOpacity, yOffset, slotSkillchainName, activeCombo, nil, slotMagicBurstName);
     end
 
     -- Draw center button icons via ImGui (if visible enough)
@@ -1017,17 +1587,260 @@ local function DrawRightSide(mode, groupX, groupY, slotSize, settings, isActive,
     end
 end
 
--- Helper to draw a complete bar set (both sides) - used for non-animated drawing
+-- Helper to draw a complete bar set (both sides) - used for non-animated drawing.
+-- activeCombo flows from M.DrawWindow down to DrawSlot for the trigger-held dim policy.
 local function DrawBarSet(leftMode, rightMode, leftGroupX, leftGroupY, rightGroupX, rightGroupY,
                           slotSize, settings, leftActive, rightActive, pressedSlot,
-                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled)
-    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
-    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled);
+                          leftShowPressed, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled)
+    DrawLeftSide(leftMode, leftGroupX, leftGroupY, slotSize, settings, leftActive, pressedSlot, leftShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+    DrawRightSide(rightMode, rightGroupX, rightGroupY, slotSize, settings, rightActive, pressedSlot, rightShowPressed, animOpacity, drawList, yOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
+end
+
+-- ============================================
+-- Double-Tap Preview Windows
+-- ============================================
+-- Reference floating windows that mirror the L2x2 / R2x2 bars at user-configurable scale
+-- and opacity. Rendered as independent ImGui windows AFTER the main crossbar so they have
+-- their own position/draw list (no shared primitives, no z-fighting). Drawn non-interactive
+-- (suppressActionOnClick) — the previews are visual reference only; actual slot activation
+-- still routes through the main bar's controller path.
+
+-- Return a shallow copy of settings with all layout-affecting fields scaled. Preserves the
+-- caller's settings unchanged so the main bar keeps its own layout numbers.
+--
+-- Result is cached on a (settings ref, scale, layout-key signature) tuple — the full
+-- shallow-copy is the dominant cost when the preview is on (8 slots × 2 windows × scaled
+-- settings every frame). Invalidates only when the caller passes a new settings table OR
+-- changes one of the geometry/scale inputs. This avoids the per-frame table-copy churn
+-- without going stale on slider drags (signature changes immediately).
+local previewSettingsCache = {
+    settingsRef = nil,
+    scale       = nil,
+    signature   = nil,
+    result      = nil,
+};
+
+local function MakePreviewSettings(settings, scale)
+    -- Cheap signature: only the fields MakePreviewSettings actually reads. Keep this in
+    -- sync with the scaled fields below — additions need a sig entry or the cache goes stale.
+    local sig = string.format('%s|%s|%s|%s|%s|%s|%s|%s|%s',
+        tostring(settings.slotSize), tostring(settings.slotGapV), tostring(settings.slotGapH),
+        tostring(settings.diamondSpacing), tostring(settings.groupSpacing),
+        tostring(settings.buttonIconSize), tostring(settings.buttonIconGapH), tostring(settings.buttonIconGapV),
+        tostring(settings.triggerIconScale));
+
+    if previewSettingsCache.settingsRef == settings
+        and previewSettingsCache.scale == scale
+        and previewSettingsCache.signature == sig then
+        return previewSettingsCache.result;
+    end
+
+    local s = {};
+    for k, v in pairs(settings) do s[k] = v; end
+    s.slotSize       = math.max(8, math.floor((settings.slotSize       or 40) * scale));
+    s.slotGapV       = math.max(1, math.floor((settings.slotGapV       or 2)  * scale));
+    s.slotGapH       = math.max(1, math.floor((settings.slotGapH       or 2)  * scale));
+    s.diamondSpacing = math.max(2, math.floor((settings.diamondSpacing or 16) * scale));
+    s.groupSpacing   = math.max(4, math.floor((settings.groupSpacing   or 24) * scale));
+    s.buttonIconSize = math.max(4, math.floor((settings.buttonIconSize or 24) * scale));
+    s.buttonIconGapH = math.max(1, math.floor((settings.buttonIconGapH or 2)  * scale));
+    s.buttonIconGapV = math.max(1, math.floor((settings.buttonIconGapV or 2)  * scale));
+    s.triggerIconScale = (settings.triggerIconScale or 1.0) * scale;
+
+    previewSettingsCache.settingsRef = settings;
+    previewSettingsCache.scale       = scale;
+    previewSettingsCache.signature   = sig;
+    previewSettingsCache.result      = s;
+    return s;
+end
+
+-- Draw one side of a double-tap preview using ImGui-only rendering (non-interactive).
+-- winX/winY    : top-left of the preview ImGui window (slot grid origin).
+-- side         : always 'L2' for single-group preview windows (slots start at window left).
+-- mode         : crossbar storage mode string ('L2x2', 'R2x2', 'L2', 'R2', etc.) whose slots to render.
+-- baseOp       : base opacity for the slot backgrounds (NOT dimmed) so frames stay visible.
+-- dimFactor    : 0-1 multiplier applied to icon/text rendering (mirrors main bar dim policy).
+-- targetServerId / skillchainEnabled / magicBurstEnabled: same per-slot SC/MB resolution
+--                inputs used by the main DrawLeftSide/DrawRightSide path. Letting the preview
+--                share them keeps the highlight calculus identical between live and preview
+--                (a slot that lights up on the live bar lights up on its preview).
+local function DrawPreviewSide(winX, winY, windowKey, side, mode, ps, baseOp, dimFactor, drawList, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize  = ps.slotSize or 40;
+    local contentOp = baseOp * dimFactor;
+
+    -- Slot background (flat rounded rect). slotrenderer's built-in bg path requires a D3D
+    -- slot primitive (we have none in preview), so paint it manually with baseOp so the
+    -- frame stays visible while icons dim with contentOp.
+    local bgArgb = ps.slotBackgroundColor or 0x55000000;
+    local bgA_raw = bit.rshift(bit.band(bgArgb, 0xFF000000), 24) / 255;
+    local bgA = math.max(bgA_raw, 0.55) * baseOp;
+    local bgR = bit.rshift(bit.band(bgArgb, 0x00FF0000), 16) / 255;
+    local bgG = bit.rshift(bit.band(bgArgb, 0x0000FF00), 8) / 255;
+    local bgB = bit.band(bgArgb, 0x000000FF) / 255;
+    local cornerR = math.max(4, math.min(10, math.floor(slotSize * 0.125 + 0.5)));
+    local bgU32 = imgui.GetColorU32({ bgR, bgG, bgB, bgA });
+
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        local slotX, slotY = GetSlotPositionInWindow(side, slotIndex, winX, winY, ps);
+
+        if drawList then
+            drawList:AddRectFilled({ slotX, slotY }, { slotX + slotSize, slotY + slotSize }, bgU32, cornerR);
+        end
+
+        local slotData = data.GetCrossbarSlotData(mode, slotIndex);
+        local icon = GetCachedCrossbarIcon(mode, slotIndex, slotData);
+
+        -- Per-slot skillchain + magic burst resolution — identical dispatch to DrawLeftSide
+        -- so a slot that highlights on the live crossbar highlights on its preview window
+        -- too. Without this the preview would silently omit both borders, hiding useful
+        -- "you could chain/MB from the other bar" cues exactly when the player is deciding
+        -- whether to commit to a double-tap.
+        local slotSkillchainName = nil;
+        if skillchainEnabled and slotData and slotData.action then
+            if slotData.actionType == 'ws' then
+                slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, slotData.action);
+            elseif slotData.actionType == 'pet' then
+                slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, slotData.action);
+            elseif slotData.actionType == 'macro' and slotData.macroText then
+                local primaryType, primaryName = macroparse.GetMacroPrimaryAndJaBadge(slotData.macroText);
+                if primaryType == 'ws' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, primaryName);
+                elseif primaryType == 'pet' and primaryName then
+                    slotSkillchainName = skillchain.GetSkillchainForBloodPact(targetServerId, primaryName);
+                end
+            end
+        end
+        local slotMagicBurstName = nil;
+        if magicBurstEnabled and slotData then
+            slotMagicBurstName = skillchain.GetMagicBurstForSlot(targetServerId, slotData);
+        end
+
+        slotrenderer.DrawSlot({
+            x    = slotX,
+            y    = slotY,
+            size = slotSize,
+            windowName = windowKey,
+            bind = slotData,
+            icon = icon,
+            slotBgColor = 0x00000000,
+            slotOpacity = 1.0,
+            dimFactor   = 1.0,
+            animOpacity = contentOp,
+            isPressed   = false,
+            iconPressScale = 1.0,
+            -- MP cost + quantity are intentionally OFF on the double-tap preview regardless of
+            -- the user's main-bar settings: the preview is a transient "what's on the other
+            -- bar" overlay, not an action-resolution surface, so a player glancing at it just
+            -- wants the icon + cooldown to decide if the next press is worth it. Showing MP /
+            -- charges duplicates the info on the live bar and crowds an already-small preview.
+            -- Cooldowns are kept (recastTimer* + flashCooldownUnder5) — they ARE useful here
+            -- because the preview's whole purpose is "should I commit to this bar".
+            showMpCost = false,
+            showQuantity = false,
+            showLabel = false,
+            recastTimerFontSize   = ps.recastTimerFontSize or 11,
+            recastTimerFontColor  = ps.recastTimerFontColor or 0xFFFFFFFF,
+            flashCooldownUnder5   = ps.flashCooldownUnder5 or false,
+            useHHMMCooldownFormat = ps.useHHMMCooldownFormat or false,
+            -- Skillchain + Magic Burst highlights. Colors fall back to the live-bar defaults
+            -- so the preview matches the main bar without requiring its own settings keys.
+            skillchainName  = slotSkillchainName,
+            skillchainColor = gConfig.hotbarGlobal.skillchainHighlightColor or 0xFFD4AA44,
+            magicBurstName  = slotMagicBurstName,
+            magicBurstColor = gConfig.hotbarGlobal.magicBurstHighlightColor or 0xFF44D4FF,
+            buttonId              = string.format('##dtprev_%s_%s_%d', windowKey, mode, slotIndex),
+            suppressActionOnClick = true,
+            forceImGuiIcon        = true,
+            drawCornerTextForeground = true,
+        });
+    end
+
+    if drawList and ps.showButtonIcons and contentOp > 0.05 then
+        DrawDiamondCenterIconsImGui('dpad', winX, winY, ps, true, drawList, contentOp);
+        DrawDiamondCenterIconsImGui('face', winX, winY, ps, true, drawList, contentOp);
+    end
+end
+
+-- Draw one double-tap preview window (L2x2 or R2x2 reference).
+-- windowKey : unique ImGui window name and persisted-position key.
+-- mode      : crossbar storage mode for the 8 slots displayed (e.g. 'L2x2', 'R2x2', 'L2', 'R2').
+-- ps        : scaled settings table (from MakePreviewSettings).
+-- baseOp    : base opacity (user slider * visibilityOpacity).
+-- dimFactor : 0-1 content dim (1.0 = at rest, inactiveSideWhileTriggerDim while any trigger held).
+-- settings  : raw crossbar settings (used for doubleTapPreviewLocked move-anchor gating).
+local function DrawDoubleTapPreviewWindow(windowKey, mode, ps, baseOp, dimFactor, activeCombo, settings, targetServerId, skillchainEnabled, magicBurstEnabled)
+    local slotSize = ps.slotSize or 40;
+    local gw, gh = CalculateGroupDimensions(slotSize, ps.slotGapV or 2, ps.slotGapH or 2, ps.diamondSpacing or 16);
+    local totalW = gw;
+    local totalH = gh;
+
+    local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+    if savedPos then
+        imgui.SetNextWindowPos({savedPos.x, savedPos.y}, ImGuiCond_Always);
+    else
+        imgui.SetNextWindowPos({200, 200}, ImGuiCond_FirstUseEver);
+    end
+    imgui.SetNextWindowSize({totalW, totalH}, ImGuiCond_Always);
+
+    -- Preview windows intentionally omit NoBringToFrontOnFocus so they stay layered above the
+    -- main crossbar (which has that flag set). NoMove + the move anchor below gives us
+    -- explicit positioning control without ImGui drifting the window on focus.
+    local flags = bit.bor(
+        ImGuiWindowFlags_NoDecoration,
+        ImGuiWindowFlags_NoResize,
+        ImGuiWindowFlags_NoFocusOnAppearing,
+        ImGuiWindowFlags_NoNav,
+        ImGuiWindowFlags_NoBackground,
+        ImGuiWindowFlags_NoDocking,
+        ImGuiWindowFlags_NoMove
+    );
+
+    -- Zero window padding so the draw list clip rect matches the window bounds exactly.
+    -- Without this the default 8 px padding clips slots at the left/right edges (same fix
+    -- that landed for the main crossbar window in the previous smoke-test pass).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+    local didBegin = imgui.Begin(windowKey, true, flags);
+    imgui.PopStyleVar();
+
+    if didBegin then
+        local wX, wY = imgui.GetWindowPos();
+        if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+        if savedPos == nil then
+            gConfig.windowPositions[windowKey] = {x = wX, y = wY};
+        end
+
+        local dl = imgui.GetWindowDrawList();
+        DrawPreviewSide(wX, wY, windowKey, 'L2', mode, ps, baseOp, dimFactor, dl, activeCombo, targetServerId, skillchainEnabled, magicBurstEnabled);
+    end
+    imgui.End();
+
+    -- Move anchor: independent lock so previews can be repositioned without unlocking the
+    -- main crossbar (and vice versa).
+    local previewLocked = settings and settings.doubleTapPreviewLocked;
+    if not previewLocked then
+        local pos = gConfig.windowPositions and gConfig.windowPositions[windowKey];
+        local anchorX = pos and pos.x or 200;
+        local anchorY = pos and pos.y or 200;
+        local newX, newY = drawing.DrawMoveAnchor(windowKey, anchorX, anchorY, {
+            anchorSide  = 'top',
+            windowWidth = totalW,
+        });
+        if newX ~= nil then
+            if not gConfig.windowPositions then gConfig.windowPositions = {}; end
+            gConfig.windowPositions[windowKey] = {x = newX, y = newY};
+        end
+    end
 end
 
 -- Main draw function
 function M.DrawWindow(settings, moduleSettings)
     if not state.initialized then return; end
+
+    -- Warm playerdata caches even when keyboard hotbars are disabled. Cheap on cache hit
+    -- (signature compare against job/level/equip ids), only does the heavy ability/WS scan
+    -- when the signature changes. See the require-site comment for the user-visible bug
+    -- this prevents (all JA/WS slots reading as unavailable on crossbar-only setups).
+    playerdata.RefreshCachedLists(data);
 
     local gs = (gConfig and gConfig.globalScale) or 1.0;
     local slotSize = (settings.slotSize or 48) * gs;
@@ -1037,34 +1850,12 @@ function M.DrawWindow(settings, moduleSettings)
     local groupSpacing = (settings.groupSpacing or 40) * gs;
 
     -- Calculate dimensions using layout functions
-    local width, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local fullWidth, height, groupWidth, groupHeight = GetCrossbarDimensions(settings);
+    local width = fullWidth;
 
-    -- Window flags (dummy window for positioning, like hotbar display.lua)
-    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
-
-    local windowName = 'Crossbar';
-    local defaultX, defaultY = GetDefaultPosition(settings);
-
-    -- Check if anchor is currently being dragged - if so, force position
-    local anchorDragging = drawing.IsAnchorDragging(windowName);
-    
-    if anchorDragging then
-        -- Use state position directly during drag for immediate response
-        imgui.SetNextWindowPos({state.windowX, state.windowY}, ImGuiCond_Always);
-    else
-        -- Apply saved position (once) or default
-        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-
-        if hasSaved then
-            ApplyWindowPosition(windowName);
-        else
-            imgui.SetNextWindowPos({defaultX, defaultY}, ImGuiCond_FirstUseEver);
-        end
-    end
-    
-    imgui.SetNextWindowSize({width, height}, ImGuiCond_Always);
-
-    -- Get current combo mode and pressed slot from controller
+    -- Get current combo mode and pressed slot from controller. Resolved BEFORE the window
+    -- size/position calls so the useSharedExpandedBar branch can shrink the window to a single
+    -- diamond and re-center it (a chord with useSharedExp on collapses to one 8-slot strip).
     local activeCombo = controller.GetActiveCombo();
     local pressedSlot = controller.GetPressedSlot();
 
@@ -1075,6 +1866,75 @@ function M.DrawWindow(settings, moduleSettings)
         activeCombo = editBar;
         pressedSlot = nil;  -- Don't show pressed state in edit mode
     end
+
+    -- Determine which bar set to display based on active combo. expandedSide == 'center' is
+    -- the useSharedExpandedBar branch (chord collapses both diamonds into one centered strip).
+    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo, settings);
+
+    -- useSharedExpandedBar special layout: shrink window to one diamond, re-center on screen X,
+    -- skip the right group draw + center divider/scope icon (they have no meaning when there's
+    -- only one diamond visible). Outside of chord, behaves identically to the standard 2-diamond
+    -- layout. exitingChordCenter catches the FIRST frame after the user releases the chord: we
+    -- restore the stashed wide-bar X so SaveCrossbarWindowSlotTopPosition doesn't persist the
+    -- narrow centered value.
+    local hideRightForSharedCenter = (isExpanded and expandedSide == 'center');
+    if hideRightForSharedCenter then
+        width = groupWidth;
+    end
+    local exitingChordCenter = state.wasSharedCenterChordLayout and (not hideRightForSharedCenter);
+
+    -- Window flags (dummy window for positioning, like hotbar display.lua)
+    local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
+
+    local windowName = 'Crossbar';
+    local defaultX, defaultY = GetDefaultPosition(settings);
+
+    local function storedCrossbarPosY()
+        local posY = defaultY;
+        local savedPos = gConfig.windowPositions and gConfig.windowPositions[windowName];
+        if savedPos and savedPos.y ~= nil then
+            posY = savedPos.y;
+        elseif state.windowY ~= nil then
+            posY = state.windowY;
+        end
+        return posY;
+    end
+
+    -- Check if anchor is currently being dragged - if so, force position
+    local anchorDragging = drawing.IsAnchorDragging(windowName);
+
+    -- state.windowX / state.windowY track the SLOT GRID origin. ImGui's window must open
+    -- CROSSBAR_WINDOW_TOP_DECOR_PAD pixels higher so the decoration above the slots
+    -- (L2/R2 triggers, combo text, R1 cpal-anchor pulse) stays inside the window's
+    -- content rect and doesn't get clipped.
+    if anchorDragging then
+        -- Use state position directly during drag for immediate response
+        imgui.SetNextWindowPos({ state.windowX, state.windowY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif hideRightForSharedCenter then
+        -- Shared-center chord: force X to screen-center each frame so the narrow window reads as
+        -- the FFXIV-style single 8-slot strip (Y persists from the last wide-bar position).
+        local io = imgui.GetIO();
+        local screenW = (io and io.DisplaySize and io.DisplaySize.x) or 1920;
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ (screenW - width) * 0.5, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    elseif exitingChordCenter and state.lastWideCrossbarWindowX ~= nil then
+        -- First frame after chord release: re-anchor to the wide-bar X we stashed before the
+        -- chord, otherwise the user-visible position would briefly snap to the centered narrow X.
+        local slotY = storedCrossbarPosY();
+        imgui.SetNextWindowPos({ state.lastWideCrossbarWindowX, slotY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_Always);
+    else
+        -- Apply saved position (once, slot-top -> window-top offset handled inside) or default
+        local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+
+        if hasSaved then
+            ApplyCrossbarWindowPositionOnce();
+        else
+            imgui.SetNextWindowPos({ defaultX, defaultY - CROSSBAR_WINDOW_TOP_DECOR_PAD }, ImGuiCond_FirstUseEver);
+        end
+    end
+
+    local bottomPad = GetCrossbarWindowBottomPad(settings);
+    imgui.SetNextWindowSize({ width, height + CROSSBAR_WINDOW_TOP_DECOR_PAD + bottomPad }, ImGuiCond_Always);
 
     -- Determine visibility for activeOnly display mode
     local leftVisible, rightVisible, crossbarVisible = GetVisibilityState(activeCombo, settings, isEditMode);
@@ -1100,8 +1960,14 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
-    -- Determine which bar set to display based on active combo
-    local targetLeftMode, targetRightMode, isExpanded, expandedSide = GetDisplayModes(activeCombo);
+    -- Menu-open dim: when a blocking game menu is open and the user has "Disable Crossbar
+    -- While In Menu" enabled, controller.lua already stops routing input — we additionally
+    -- dim everything the crossbar draws so it visually reads as "paused" rather than just
+    -- silently unresponsive. visibilityOpacity propagates into every slot via the per-slot
+    -- animOpacity param plus the background / border / trigger / divider alpha scales below.
+    if gamestate.IsMenuOpen() and settings.crossbarDisableInMenu ~= false then
+        visibilityOpacity = visibilityOpacity * 0.35;
+    end
 
     -- Check if animations are disabled - if so, force complete any in-progress animation
     if settings.enableTransitionAnimations == false and state.animation.active then
@@ -1143,7 +2009,11 @@ function M.DrawWindow(settings, moduleSettings)
     local leftActive, rightActive;
     if isExpanded then
         -- In expanded mode, only the expanded side is active, other side is dimmed
-        if expandedSide == 'left' then
+        if expandedSide == 'center' then
+            -- useSharedExpandedBar: only the left column is drawn (no right group exists this frame)
+            leftActive = true;
+            rightActive = false;
+        elseif expandedSide == 'left' then
             leftActive = true;
             rightActive = false;
         elseif expandedSide == 'right' then
@@ -1171,10 +2041,13 @@ function M.DrawWindow(settings, moduleSettings)
     -- Get draw list for ImGui-based rendering (behind config when open)
     local drawList = GetUIDrawList();
 
-    -- Get target server ID for skillchain prediction (cached for all slots)
+    -- Get target server ID for skillchain / magic burst prediction (cached for all slots).
+    -- Both features key off the same target so a single resolve+cache covers everything; the
+    -- per-slot SC and MB calls are no-ops when their respective enable flags are off.
     local targetServerId = nil;
     local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
-    if skillchainEnabled then
+    local magicBurstEnabled = gConfig.hotbarGlobal.magicBurstHighlightEnabled ~= false;
+    if skillchainEnabled or magicBurstEnabled then
         local mainTargetIdx = targetLib.GetTargets();
         if mainTargetIdx and mainTargetIdx ~= 0 then
             local targetEntity = GetEntity(mainTargetIdx);
@@ -1184,15 +2057,48 @@ function M.DrawWindow(settings, moduleSettings)
         end
     end
 
+    -- Zero out WindowPadding so the leftmost and rightmost diamond slots (which sit flush
+    -- against the window's content rect) aren't clipped by ImGui's default 8px padding.
+    -- Without this the left/right slots of each diamond render partially off-window and
+    -- their button hitboxes get pushed inward (slot interactions become unreliable).
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
     -- Begin ImGui window - ALL slot rendering happens inside to enable interactions
     if imgui.Begin('Crossbar', true, windowFlags) then
-        -- Save position if moved (profile support)
-        SaveWindowPosition('Crossbar');
+        -- Save SLOT-TOP position if moved (decor-pad-aware; profile coordinate stays the
+        -- slot grid top so the saved value is meaningful even if decor pad changes later).
+        -- During the shared-center chord the X is force-centered each frame, so we MUST NOT
+        -- let SaveCrossbarWindowSlotTopPosition persist that narrow centered X — only sync Y.
+        if hideRightForSharedCenter then
+            if gConfig.windowPositions and gConfig.windowPositions[windowName] then
+                local wx, wy = imgui.GetWindowPos();
+                local s = gConfig.windowPositions[windowName];
+                local slotTopY = wy + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+                if s.y ~= slotTopY then
+                    s.y = slotTopY;
+                end
+                -- Track the centered window X for free (used by lastWideCrossbarWindowX restore)
+                if s.x ~= wx then
+                    s.x = wx;
+                end
+            end
+        else
+            SaveCrossbarWindowSlotTopPosition();
+        end
         windowPosX, windowPosY = imgui.GetWindowPos();
 
-        -- Update stored position
+        -- Update stored position. state.windowY = slot grid top (window top + decor pad);
+        -- the rest of the layout code references state.windowY as the slot origin.
         state.windowX = windowPosX;
-        state.windowY = windowPosY;
+        state.windowY = windowPosY + CROSSBAR_WINDOW_TOP_DECOR_PAD;
+
+        -- Stash the wide-bar X so that when the user releases the chord we can restore it
+        -- (otherwise the narrow centered X from this frame would be the "last" saved X).
+        if not hideRightForSharedCenter then
+            state.lastWideCrossbarWindowX = windowPosX;
+        end
+        -- Remember the layout for the NEXT frame so exitingChordCenter (above) can detect
+        -- the chord-release transition and re-anchor X.
+        state.wasSharedCenterChordLayout = hideRightForSharedCenter;
 
         -- Recalculate group positions with updated window position
         leftGroupX = state.windowX;
@@ -1244,35 +2150,36 @@ function M.DrawWindow(settings, moduleSettings)
                     -- Left side changed - animate it
                     if outOpacity > 0.01 then
                         DrawLeftSide(state.animation.fromLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromLeftActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            leftActive, pressedSlot, leftShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Left side didn't change - draw at full opacity (with visibility fade)
                     DrawLeftSide(state.animation.toLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
 
-            -- Draw RIGHT side (skip in activeOnly mode if not visible)
-            if not isActiveOnlyMode or rightVisible then
+            -- Draw RIGHT side (skip in activeOnly mode if not visible, or whenever the chord
+            -- collapsed both groups into a single centered strip — there is no right group).
+            if (not hideRightForSharedCenter) and (not isActiveOnlyMode or rightVisible) then
                 if state.animation.rightChanged then
                     -- Right side changed - animate it
                     if outOpacity > 0.01 then
                         DrawRightSide(state.animation.fromRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled);
+                            fromRightActive, pressedSlot, false, outOpacity, drawList, outYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                     if inOpacity > 0.01 then
                         DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled);
+                            rightActive, pressedSlot, rightShowPressed, inOpacity, drawList, inYOffset, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                     end
                 else
                     -- Right side didn't change - draw at full opacity (with visibility fade)
                     DrawRightSide(state.animation.toRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
             end
         else
@@ -1281,12 +2188,16 @@ function M.DrawWindow(settings, moduleSettings)
                 -- ActiveOnly mode: draw only visible sides with visibility fade
                 if leftVisible then
                     DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
-                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
-                if rightVisible then
+                if (not hideRightForSharedCenter) and rightVisible then
                     DrawRightSide(state.currentRightMode, rightGroupX, rightGroupY, slotSize, settings,
-                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled);
+                        rightActive, pressedSlot, rightShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
                 end
+            elseif hideRightForSharedCenter then
+                -- Shared-center chord: render only the (now-Shared) left column as one centered strip.
+                DrawLeftSide(state.currentLeftMode, leftGroupX, leftGroupY, slotSize, settings,
+                    leftActive, pressedSlot, leftShowPressed, visibilityOpacity, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled);
             else
                 -- Normal mode: draw both sides at full opacity
                 DrawBarSet(
@@ -1295,17 +2206,21 @@ function M.DrawWindow(settings, moduleSettings)
                     slotSize, settings,
                     leftActive, rightActive,
                     pressedSlot, leftShowPressed, rightShowPressed,
-                    1.0, drawList, 0, targetServerId, skillchainEnabled
+                    1.0, drawList, 0, targetServerId, skillchainEnabled, activeCombo, magicBurstEnabled
                 );
             end
         end
 
         imgui.End();
     end
+    -- Pop the WindowPadding style we pushed before Begin. Has to be unconditional (must match
+    -- the push even when Begin returns false / window is collapsed).
+    imgui.PopStyleVar();
 
-    -- Draw move anchor (only visible when config is open)
-    -- Only show when crossbar movement is NOT locked (uses global lock setting)
-    local crossbarLocked = gConfig and gConfig.hotbarLockMovement;
+    -- Draw move anchor (only visible when config is open).
+    -- Uses the crossbar-specific lock so Hotbar's lock toggle doesn't accidentally freeze
+    -- the crossbar (fixes the issue where Lock Crossbar was tied to Hotbar's setting).
+    local crossbarLocked = gConfig and gConfig.crossbarLockMovement;
     if not crossbarLocked then
         -- Use same window name as ImGui window so positions are shared
         local anchorNewX, anchorNewY = drawing.DrawMoveAnchor('Crossbar', state.windowX, state.windowY);
@@ -1323,22 +2238,36 @@ function M.DrawWindow(settings, moduleSettings)
     local isActiveOnlyMode = settings.displayMode == 'activeOnly' and not isEditMode;
     local showCenterElements = not isActiveOnlyMode;
 
-    -- Draw center divider (optional, hidden in activeOnly mode)
-    if settings.showDivider and drawList and showCenterElements then
-        local dividerX = state.windowX + groupWidth + (groupSpacing / 2);
-        local dividerY1 = state.windowY + 10;
-        local dividerY2 = state.windowY + height - 10;
+    -- Center decor (divider line, scope icon, combo text, palette name): all hidden in
+    -- activeOnly mode since that layout collapses to a single side and the divider has no meaning.
+    -- Shared-center chord layout: centerX is the middle of the (now single-diamond) window so the
+    -- scope icon / combo text / palette name still sit over the visible bar. The DIVIDER itself
+    -- is suppressed in chord since there's no longer a left/right split to divide.
+    local centerX;
+    if hideRightForSharedCenter then
+        centerX = state.windowX + width * 0.5;
+    else
+        centerX = state.windowX + groupWidth + (groupSpacing / 2);
+    end
+    local dividerTopY = state.windowY + 10;
 
+    if settings.showDivider and drawList and showCenterElements and (not hideRightForSharedCenter) then
+        local dividerY2 = state.windowY + height - 10;
         drawList:AddLine(
-            { dividerX, dividerY1 },
-            { dividerX, dividerY2 },
+            { centerX, dividerTopY },
+            { centerX, dividerY2 },
             imgui.GetColorU32({ 1, 1, 1, 0.3 }),
             2
         );
     end
 
+    -- Palette scope icon (infinity for Global / job icon for job-scoped) — drawn above the
+    -- divider's top endpoint. Same drawList as the divider so z-order is consistent.
+    if showCenterElements and drawList then
+        DrawPaletteScopeIconAboveDivider(centerX, dividerTopY, settings, drawList);
+    end
+
     -- Draw combo text in center for complex combos (hidden in activeOnly mode)
-    local centerX = state.windowX + groupWidth + (groupSpacing / 2);
     local topY = state.windowY - 4;  -- Above the window
     if showCenterElements then
         DrawComboText(activeCombo, centerX, topY, settings);
@@ -1350,9 +2279,15 @@ function M.DrawWindow(settings, moduleSettings)
         DrawPaletteName(centerX, bottomY, settings);
     end
 
-    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode)
+    -- Draw L2/R2 trigger icons above the groups (hidden in activeOnly mode). The shared-center
+    -- chord uses a different glyph (L2 + R2 chord centred on the single visible diamond) since
+    -- there's no left-vs-right group to position labels against.
     if drawList and showCenterElements then
-        DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        if hideRightForSharedCenter then
+            DrawTriggerIconsSharedExpandedCenter(activeCombo, leftGroupX, leftGroupY, groupWidth, settings, drawList);
+        else
+            DrawTriggerIcons(activeCombo, leftGroupX, rightGroupX, leftGroupY, groupWidth, settings, drawList);
+        end
     end
 
     -- Draw palette modifier indicator (refresh icon when modifier key is held)
@@ -1380,6 +2315,41 @@ function M.DrawWindow(settings, moduleSettings)
                 );
             end
         end
+    end
+
+    -- Double-tap preview windows. Drawn AFTER the main crossbar so they end up in
+    -- separate ImGui windows with their own draw list / position, layered above the main
+    -- bar. Gated on both `enableDoubleTap` (the L2x2/R2x2 modes have to be enabled at all)
+    -- and `showDoubleTapPreview` (the per-feature visibility toggle). When the active combo
+    -- IS the matching double-tap, the preview swaps to the BASE L2/R2 slots as a reference
+    -- — the main bar is already showing the double-tap content.
+    if settings.enableDoubleTap and settings.showDoubleTapPreview then
+        local scale  = settings.doubleTapPreviewScale  or 0.60;
+        local baseOp = (settings.doubleTapPreviewOpacity or 1.0) * visibilityOpacity;
+        -- Skip the preview render path entirely when nothing would be visible (menu dim or
+        -- activeOnly hide). Saves the 16-slot DrawSlot + ImGui begin/end overhead per frame.
+        if baseOp <= 0.02 then return; end
+        local dimFact = settings.inactiveSideWhileTriggerDim;
+        if dimFact == nil then dimFact = 0.15; end
+        local ps = MakePreviewSettings(settings, scale);
+
+        local isL2xActive = (activeCombo == COMBO_MODES.L2_DOUBLE);
+        local isR2xActive = (activeCombo == COMBO_MODES.R2_DOUBLE);
+        local anyTriggerHeld = (activeCombo ~= COMBO_MODES.NONE);
+        local previewDim = anyTriggerHeld and dimFact or 1.0;
+
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewL2x2',
+            isL2xActive and 'L2' or 'L2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
+        DrawDoubleTapPreviewWindow(
+            'CrossbarPreviewR2x2',
+            isR2xActive and 'R2' or 'R2x2',
+            ps, baseOp, previewDim, activeCombo, settings,
+            targetServerId, skillchainEnabled, magicBurstEnabled
+        );
     end
 end
 
@@ -1467,6 +2437,11 @@ end
 -- Clear icon cache (call when job changes)
 function M.ClearIconCache()
     ClearCrossbarIconCache();
+    -- Mirror the wipe to actions.lua's negative-result cache so "no icon" decisions
+    -- pinned from a previous state don't survive into the new job/palette context.
+    if actions and actions.ClearNoIconCache then
+        actions.ClearNoIconCache();
+    end
 end
 
 -- Clear icon cache for a specific slot (call on targeted slot updates)
@@ -1487,6 +2462,187 @@ function M.ResetPositions()
     if gConfig.appliedPositions then
         gConfig.appliedPositions['Crossbar'] = nil;
     end
+end
+
+-- ============================================
+-- Edit Full Palette (called from config/palettemanager.lua's ImGui window)
+-- ============================================
+-- The editor draws a static representation of a crossbar row using the SAME DrawSlot path
+-- as the live HUD, so layout (diamond geometry, slot size, label position, MP/quantity)
+-- always matches what the user actually plays with. The editor differs from the HUD in:
+--   * Slot data is read from the draft layer (data.GetDraftSlotData) not the live binding.
+--   * MP / quantity / cooldown text are suppressed (showMpCost=false, showQuantity=false).
+--   * The action name renders ON the slot (labelForeground + editorMinimalView).
+--   * Drop zones use 'paled_*' IDs with dropPriority=10 so they win against the HUD zones
+--     underneath when the editor window overlaps the live crossbar.
+--   * Optional editorClipRect culls slots scrolled off the editor panel.
+-- These are all set by the local DrawSlot wrapper above; the public functions here just
+-- iterate the 8 slots of each diamond and call DrawSlot once per slot.
+
+-- Shared palette-editor slot row. Either or both of modeLeft (L2 group) and modeRight
+-- (R2 group) may be set; pass nil on a side to omit it (Pets tab filter renders single-sided rows).
+local function DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    if not state.initialized then return; end
+    if not modeLeft and not modeRight then return; end
+    local editorClipRect;
+    if clipMinX and clipMinY and clipMaxX and clipMaxY then
+        editorClipRect = { clipMinX, clipMinY, clipMaxX, clipMaxY };
+    end
+    local slotSize = settings.slotSize or 48;
+    for slotIndex = 1, SLOTS_PER_SIDE do
+        if modeLeft then
+            local sx, sy = GetSlotPositionInWindow('L2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeLeft, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+        if modeRight then
+            local sx, sy = GetSlotPositionInWindow('R2', slotIndex, screenOriginX, screenOriginY, settings);
+            DrawSlot(modeRight, slotIndex, sx, sy, slotSize, settings, true, false, 1.0, 0, nil, COMBO_MODES.NONE, editorClipRect);
+        end
+    end
+end
+
+function M.DrawPaletteEditorL2R2Row(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeLeft, modeRight, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+function M.DrawPaletteEditorSingleRow(screenOriginX, screenOriginY, settings, modeOnly, clipMinX, clipMinY, clipMaxX, clipMaxY)
+    DrawPaletteEditorRow(screenOriginX, screenOriginY, settings, modeOnly, nil, clipMinX, clipMinY, clipMaxX, clipMaxY);
+end
+
+-- Trigger glyphs raised above the editor's slot cluster. glyphMode:
+--   'primary'     — L2 | R2 (one glyph per side, gap between d-pad and face).
+--   'doubleTap'   — L2 + "x2", R2 + "x2".
+--   'chordCombo'  — Left: L2+R2, Right: R2+L2 (with text "+" between).
+--   'sharedChord' — Single L2+R2 glyph centred over the shared diamond.
+-- Optional sides = { l=bool, r=bool } (default both true) — used by Pets-tab single-sided rows.
+function M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, glyphMode, sides)
+    local dl = imgui.GetWindowDrawList();
+    if not dl then return; end
+    glyphMode = glyphMode or 'primary';
+    local sl = (not sides or sides.l ~= false);
+    local sr = (not sides or sides.r ~= false);
+    local totalW, _, groupW, ghgt = GetCrossbarDimensions(settings);
+    local gs = totalW - 2 * groupW;
+    local slotSize = settings.slotSize or 48;
+    local scale = (settings.triggerIconScale or 1.0) * math.max(0.42, math.min(1.1, slotSize / 48));
+    local iw = 49 * scale;
+    local ih = 28 * scale;
+    local yLift = 35;
+    local cy = screenOriginY + ghgt * 0.5 - yLift;
+    local tint = imgui.GetColorU32({ 1, 1, 1, 0.88 });
+    local textCol = imgui.GetColorU32({ 0.92, 0.86, 0.65, 0.95 });
+    local chordTight = math.max(0.5, 0.65 * scale);
+    local doubleTapImgGap = math.max(1, 2 * scale);
+
+    local function plusSize()
+        local ptw, pth = 10, 14;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize('+');
+            if type(ts) == 'table' then
+                ptw = ts[1] or ts.x or ptw;
+                pth = ts[2] or ts.y or pth;
+            elseif type(ts) == 'number' then
+                ptw = ts;
+            end
+        end
+        return ptw, pth;
+    end
+
+    local function drawImage(texName, ix, iy)
+        local tex = textures:GetControllerIcon(texName);
+        if not tex or not tex.image then return; end
+        local p = tonumber(ffi.cast('uint32_t', tex.image));
+        if not p or p == 0 then return; end
+        dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+    end
+
+    local function drawComboAtCenter(cx, firstTex, secondTex)
+        local ptw, pth = plusSize();
+        local gL, gR = chordTight, chordTight;
+        local total = iw + gL + ptw + gR + iw;
+        local leftX = cx - total * 0.5;
+        drawImage(firstTex, leftX, cy - ih * 0.5);
+        dl:AddText({ leftX + iw + gL, cy - pth * 0.5 }, textCol, '+');
+        drawImage(secondTex, leftX + iw + gL + ptw + gR, cy - ih * 0.5);
+    end
+
+    if glyphMode == 'sharedChord' then
+        drawComboAtCenter(screenOriginX + groupW * 0.5, 'L2', 'R2');
+        return;
+    end
+
+    if glyphMode == 'chordCombo' then
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then drawComboAtCenter(l2cx, 'L2', 'R2'); end
+        if sr then drawComboAtCenter(r2cx, 'R2', 'L2'); end
+        return;
+    end
+
+    if glyphMode == 'doubleTap' then
+        local x2Str = 'x2';
+        local tw, th = 18, 16;
+        if imgui.CalcTextSize then
+            local ts = imgui.CalcTextSize(x2Str);
+            if type(ts) == 'table' then
+                tw = ts[1] or ts.x or tw;
+                th = ts[2] or ts.y or th;
+            end
+        end
+        local l2cx = screenOriginX + groupW * 0.5;
+        local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+        if sl then
+            local l2Tex = textures:GetControllerIcon('L2');
+            if l2Tex and l2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', l2Tex.image));
+                if p and p ~= 0 then
+                    local ix = l2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        if sr then
+            local r2Tex = textures:GetControllerIcon('R2');
+            if r2Tex and r2Tex.image then
+                local p = tonumber(ffi.cast('uint32_t', r2Tex.image));
+                if p and p ~= 0 then
+                    local ix = r2cx - iw * 0.5;
+                    local iy = cy - ih * 0.5;
+                    dl:AddImage(p, { ix, iy }, { ix + iw, iy + ih }, { 0, 0 }, { 1, 1 }, tint);
+                    dl:AddText({ ix + iw + doubleTapImgGap, cy - th * 0.5 }, textCol, x2Str);
+                end
+            end
+        end
+        return;
+    end
+
+    -- primary
+    local l2cx = screenOriginX + groupW * 0.5;
+    local r2cx = screenOriginX + groupW + gs + groupW * 0.5;
+    if sl then drawImage('L2', l2cx - iw * 0.5, cy - ih * 0.5); end
+    if sr then drawImage('R2', r2cx - iw * 0.5, cy - ih * 0.5); end
+end
+
+-- Convenience wrapper used by the Shared (chord-fallback) row.
+function M.DrawPaletteEditorSharedChordTriggerGlyphs(screenOriginX, screenOriginY, settings)
+    M.DrawPaletteEditorL2R2TriggerGlyphs(screenOriginX, screenOriginY, settings, 'sharedChord');
+end
+
+-- Exposed so palettemanager.lua can size the editor row to match the live HUD dimensions
+-- without duplicating the math (slot size, gaps, diamond spacing, etc. all flow through here).
+function M.GetEditorCrossbarRowDimensions(settings)
+    return GetCrossbarDimensions(settings);
+end
+
+-- Legacy GDI hook (kept as a no-op for API compatibility with `palettemanager.lua`).
+-- Pre-1.8.0 this hid the persistent D3D/GDI primitives backing the editor's slot row when
+-- the editor window was not currently drawing. Under 1.8.0's imtext architecture there are
+-- no persistent objects to hide — un-emitted draw calls simply don't render. The function
+-- is retained so callers don't break and so the contract is documented; consider removing
+-- once palettemanager.lua's six call sites are updated.
+function M.HidePaletteEditorPrimitives()
 end
 
 return M;


### PR DESCRIPTION
…gration

What changed
- config/palettemanager.lua: Override and Pet rows in Edit Full Palette for segment override management. Scroll-safe layout for segment rows. Job-shared copy flow. Warning when editing a palette that is not the currently active segment palette. Quick palette switcher for segments. Crossbar edit appearance controls decoupled from in-game crossbar visuals.
- modules/hotbar/crossbar.lua: Palette editor row APIs for segment integration. Trigger glyphs for segment editing context. editorClipRect passed into DrawSlot for clipped preview of segment override palettes.

Why
- Provides a UI for managing which palette a crossbar segment points to, with contextual warnings and copy operations. Depends on pr/18 (EFP draft infrastructure) and pr/20 (segment override data storage).