### PR TITLE
Pet palette: Avatars and Elementals split, EFP pet tabs, BST jug Read…

### DIFF
--- a/XIUI/config/efp_pets_tab.lua
+++ b/XIUI/config/efp_pets_tab.lua
@@ -1,0 +1,222 @@
+--[[
+* Edit Full Palette: Pets tab - pick a pet family, then a concrete pet key, for editing petpalette:* crossbar data.
+* Lists are profile-wide (not tied to current main job): each family uses the class-appropriate key set.
+* ASCII labels only (game font).
+]]--
+
+local imgui = require('imgui');
+local components = require('config.components');
+local petreg = require('modules.hotbar.petregistry');
+
+local M = {};
+
+local T_AVATARS = 1;
+local T_ELEMENTALS = 2;
+local T_BEASTS = 3;
+local T_WYVERN = 4;
+local T_PUPPET = 5;
+
+M.state = {
+    typeTab = T_AVATARS,
+    subIdx = 1,
+};
+
+M._curList = {};
+
+function M.resetState()
+    M.state.typeTab = T_AVATARS;
+    M.state.subIdx = 1;
+    M._curList = {};
+end
+
+local excl = petreg.PETBAR_EXCLUDED_STORAGE_KEYS;
+
+local function jobIdForFamilyTab(typeTab)
+    if typeTab == T_AVATARS or typeTab == T_ELEMENTALS then
+        return petreg.JOB_SMN;
+    end
+    if typeTab == T_BEASTS then
+        return petreg.JOB_BST;
+    end
+    if typeTab == T_WYVERN then
+        return petreg.JOB_DRG;
+    end
+    if typeTab == T_PUPPET then
+        return petreg.JOB_PUP;
+    end
+    return petreg.JOB_SMN;
+end
+
+local function buildListForType(typeTab)
+    local j = jobIdForFamilyTab(typeTab);
+    local all = petreg.GetAvailablePetKeys(j) or {};
+    local out = {};
+    local function addKey(k, label)
+        if not k then
+            return;
+        end
+        if excl and excl[k] then
+            return;
+        end
+        table.insert(out, { key = k, label = label or petreg.GetDisplayNameForKey(k) });
+    end
+    for _, k in ipairs(all) do
+        if typeTab == T_AVATARS then
+            if k:find('^avatar:') then
+                addKey(k);
+            end
+        elseif typeTab == T_ELEMENTALS then
+            if k:find('^spirit:') then
+                addKey(k);
+            end
+        elseif typeTab == T_BEASTS then
+            if k == 'jug' or k == 'charm' or k:find('^jug:') then
+                addKey(k);
+            end
+        elseif typeTab == T_WYVERN then
+            if k == 'wyvern' then
+                addKey(k, 'Wyvern');
+            end
+        elseif typeTab == T_PUPPET then
+            if k == 'automaton' then
+                addKey(k, 'Automaton');
+            end
+        end
+    end
+    if typeTab == T_AVATARS or typeTab == T_ELEMENTALS then
+        table.sort(out, function(a, b)
+            return petreg.GetSmnPetKeyOrderWeight(a.key) < petreg.GetSmnPetKeyOrderWeight(b.key);
+        end);
+    else
+        table.sort(out, function(a, b)
+            return (a.label or '') < (b.label or '');
+        end);
+    end
+    return out;
+end
+
+function M.rebuildListAndClamp()
+    M._curList = buildListForType(M.state.typeTab);
+    if #M._curList == 0 then
+        M.state.subIdx = 1;
+        return;
+    end
+    if M.state.subIdx > #M._curList then
+        M.state.subIdx = #M._curList;
+    end
+    if M.state.subIdx < 1 then
+        M.state.subIdx = 1;
+    end
+end
+
+-- Full pet key suffix, e.g. "avatar:carbuncle" or "wyvern" (no "petpalette:" prefix).
+function M.getPetKeyString()
+    M.rebuildListAndClamp();
+    if #M._curList == 0 then
+        return 'wyvern';
+    end
+    return M._curList[M.state.subIdx].key;
+end
+
+local function efpTextWrapped(s, col)
+    if not s then
+        return;
+    end
+    if col and imgui.PushStyleColor and ImGuiCol_Text then
+        imgui.PushStyleColor(ImGuiCol_Text, col);
+    end
+    if imgui.TextWrapped then
+        imgui.TextWrapped(s);
+    else
+        imgui.Text(s);
+    end
+    if col and imgui.PopStyleColor then
+        imgui.PopStyleColor(1);
+    end
+end
+
+function M.draw(cross, disablePetTargetChange)
+    M.rebuildListAndClamp();
+    local jn = 'p';
+
+    efpTextWrapped(
+        'These layouts are stored per pet on this profile. When you have that pet out and a trigger row uses Pet Palette, your job crossbar uses these slots.',
+        { 0.55, 0.53, 0.5, 1.0 }
+    );
+    imgui.Spacing();
+
+    if disablePetTargetChange and imgui.BeginDisabled then
+        imgui.BeginDisabled();
+    end
+    local tnames = { 'Avatars', 'Elementals', 'Beasts', 'Wyvern', 'Puppet' };
+    imgui.TextColored({ 0.62, 0.6, 0.55, 1.0 }, 'Pet family:');
+    imgui.SameLine(0, 8);
+    for ti = 1, 5 do
+        if ti > 1 then
+            imgui.SameLine(0, 4);
+        end
+        local sel = (M.state.typeTab == ti);
+        if components.DrawStyledTab(tnames[ti], 'efppty_' .. ti .. '_' .. jn, sel, nil, components.TAB_STYLE.smallHeight, components.TAB_STYLE.smallPadding, 'palette') then
+            local prev = M.state.typeTab;
+            M.state.typeTab = ti;
+            if prev ~= ti then
+                M.state.subIdx = 1;
+            end
+        end
+    end
+    M.rebuildListAndClamp();
+
+    if #M._curList == 0 then
+        efpTextWrapped('No pets in this family to edit (unexpected). Try another family tab.', { 0.85, 0.5, 0.45, 1.0 });
+    else
+        if M.state.subIdx < 1 or M.state.subIdx > #M._curList then
+            M.state.subIdx = 1;
+        end
+        local cur = M._curList[M.state.subIdx];
+        local preview = cur.label;
+        do
+            local aw, _ah = imgui.GetContentRegionAvail and imgui.GetContentRegionAvail() or 400, 0;
+            local w = 280;
+            if type(aw) == 'table' then
+                w = math.max(200, (aw[1] or aw.x or w));
+            elseif type(aw) == 'number' then
+                w = math.max(200, aw);
+            end
+            imgui.SetNextItemWidth(math.min(w, 520));
+        end
+        if imgui.BeginCombo('Pet##efppcombo' .. jn, preview) then
+            for i, row in ipairs(M._curList) do
+                if imgui.Selectable(row.label, i == M.state.subIdx) then
+                    M.state.subIdx = i;
+                end
+            end
+            imgui.EndCombo();
+        end
+        efpTextWrapped(
+            'Choose pet, then edit slots below. A few avatars are omitted where there is no pet bar to bind. Elementals (spirits) are separate from avatars in Pet Palette settings.',
+            { 0.5, 0.5, 0.48, 1.0 }
+        );
+    end
+
+    if cross then
+        local n = 0;
+        for _, m in ipairs({ 'L2', 'R2', 'L2x2', 'R2x2', 'L2R2', 'R2L2' }) do
+            local s = cross.comboModeSettings and cross.comboModeSettings[m];
+            if s and s.petAware == true then
+                n = n + 1;
+            end
+        end
+        efpTextWrapped(
+            string.format('Pet Palette segments on in Slots: %d (turn on more there to see more rows in this list).', n),
+            { 0.55, 0.53, 0.48, 1.0 }
+        );
+    end
+    if disablePetTargetChange and imgui.EndDisabled then
+        imgui.EndDisabled();
+    end
+    if disablePetTargetChange then
+        efpTextWrapped('Apply or Undo to change which pet you are editing.', { 0.7, 0.55, 0.3, 1.0 });
+    end
+end
+
+return M;

--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -274,7 +274,7 @@ end
 function M.createHotbarGlobalDefaults()
     return T{
         -- Game UI patches
-        disableMacroBars = false,  -- Disable native XI macros (macro bar display + controller macro blocking)
+        disableMacroBars = false,  -- Keyboard: hide native macro bar UI + block Ctrl/Alt+number macro keys (controller blocking is Crossbar → Disable XI Macros)
         controllerHoldToShow = true,  -- Controller triggers use hold-to-show (like macrofix addon) instead of tap-to-toggle
 
         -- Blocked game keys - array of key definitions that should be blocked from reaching the game
@@ -292,6 +292,10 @@ function M.createHotbarGlobalDefaults()
         -- Palette cycling controller (RB + Dpad)
         paletteCycleControllerEnabled = true,  -- Enable controller palette cycling
         hotbarPaletteCycleButton = 'R1',       -- 'R1' or 'L1' for hotbar cycling
+
+        logPaletteName = true,                 -- Log palette name when cycling keyboard hotbars
+        logPaletteNameCrossbar = true,         -- Log palette name when cycling via controller (crossbar)
+        logPaletteNameCrossbarCycleHint = true, -- Second CLI line: RB+D-pad return hint after job preview
 
         -- Visual settings
         slotSize = 48,          -- Slot size in pixels
@@ -333,7 +337,7 @@ function M.createHotbarGlobalDefaults()
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -350,7 +354,16 @@ function M.createHotbarGlobalDefaults()
         skillchainIconScale = 1.0,              -- Scale multiplier for icon (0.5-2.0)
         skillchainIconOffsetX = 0,              -- X offset in pixels
         skillchainIconOffsetY = 0,              -- Y offset in pixels
-    
+
+        -- Magic Burst highlight settings. Window opens IMMEDIATELY when a SC closes and runs
+        -- for 7.0s (matches retail's MB cutoff at the back end while front-loading the visual
+        -- cue). Highlights spell / magical pact rage / /ma-or-/pet macro slots whose element
+        -- matches one of the SC's burstable elements. Uses the same corner icon as the
+        -- skillchain highlight (the SC's name asset) but in the bottom-left corner with a
+        -- cyan-blue border to keep the two highlights visually distinct.
+        magicBurstHighlightEnabled = true,      -- Show MB highlight on element-matching spell slots
+        magicBurstHighlightColor = 0xFF44D4FF,  -- Cyan-blue (ARGB) — distinct from gold SC border
+
         -- Cooldown timer settings
         recastTimerFontSize = 11,               -- Font size for cooldown timer display
         recastTimerFontColor = 0xFFFFFFFF,      -- Color for cooldown timer text
@@ -372,6 +385,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Pet-aware toggle (when true, hotbar can have different palettes per pet for SMN/BST/DRG/PUP)
         petAware = false,
         showPetIndicator = true,  -- Show indicator dot when petAware is enabled
+        -- When set: array of type tokens 'avatars'|'elementals'|'beasts'|'wyvern'|'puppet' (legacy 'summons' = avatars+elementals). nil = all.
+        petPalettePetKeys = nil,
 
         -- Layout settings (always per-bar)
         enabled = true,
@@ -420,7 +435,7 @@ function M.createHotbarBarDefaults(overrides)
         keybindOffsetX = 0,
         keybindOffsetY = 0,
         showMpCost = true,
-        mpCostAnchor = 'topRight',
+        mpCostAnchor = 'topLeft',
         mpCostOffsetX = 0,
         mpCostOffsetY = 0,
         showQuantity = true,
@@ -443,6 +458,8 @@ function M.createHotbarBarDefaults(overrides)
         -- Structure: paletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Palettes are displayed in this order; missing palettes are appended alphabetically
         paletteOrder = {},
+        -- paletteExcludeFromCycle[orderKey][paletteName] = true skips palette for RB / keyboard cycling only
+        paletteExcludeFromCycle = {},
     };
     if overrides then
         for k, v in pairs(overrides) do
@@ -460,22 +477,51 @@ end
 -- The crossbar provides 4 combo modes: L2, R2, L2+R2, R2+L2 (32 total slots)
 function M.createCrossbarDefaults()
     return T{
-        -- Layout mode: 'hotbar', 'crossbar', or 'both'
-        mode = 'hotbar',
+        -- Show controller crossbar UI (mirrors gConfig.crossbarEnabled; kept for migration)
+        showCrossbar = true,
+
+        -- Hide crossbar when game menu open (independent from Hotbar → Hide When Menu Open)
+        crossbarHideOnMenuFocus = false,
+
+        -- Disable crossbar input while a game menu is open (keeps it visible but blocks trigger macros)
+        crossbarDisableInMenu = true,
+
+        -- Config UI: which main section is active (1=Controller, 2=Manage palettes, 3=Global visuals)
+        configUiTab = 1,
+        -- 'universal' = editing [G] all-jobs sets; 'job' = editing palettes for configEditJobId
+        configFocus = 'job',
+        configEditJobId = nil,   -- nil = use live main job from data when in job focus
+        configEditSubjobId = nil,
 
         -- Job-specific toggle (when true, actions are stored per-job; when false, actions are shared across all jobs)
         jobSpecific = true,
 
-        -- Per-combo-mode settings (pet-aware is per-combo, palettes are GLOBAL)
-        -- NOTE: activePalette was removed - crossbar palettes are now global (see palette.lua state.crossbarActivePalette)
+        -- All-jobs universal crossbar palettes (storage: global:palette:{name} in slotActions)
+        enableUniversalCrossbarPalettes = false,
+        -- 'job' = job/subjob named palettes; 'universal' = all-jobs sets (toggle L1+R1 when enabled)
+        defaultCrossbarPaletteScope = 'job',
+        -- Per-palette: includeInCycle = false hides palette from RB+D-pad when scope is universal
+        crossbarUniversalPaletteMeta = {},
+        universalCrossbarPaletteOrder = {},
+
+        -- Per-segment: petAware, optional per-segment petPalettePetKeys, universalOverridePalette = all-jobs palette name. Default pet types: petPalettePetKeys on parent.
         comboModeSettings = {
-            L2 = { petAware = false },
-            R2 = { petAware = false },
-            L2R2 = { petAware = false },
-            R2L2 = { petAware = false },
-            L2x2 = { petAware = false },
-            R2x2 = { petAware = false },
+            L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2R2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2L2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            L2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
+            R2x2 = { petAware = false, universalOverridePalette = nil, petPalettePetKeys = nil },
         },
+        -- Optional per named [J] palette: comboMode -> { petAware?, universalOverridePalette? } (nil field = inherit Crossbar defaults)
+        namedPaletteComboModeSettings = {},
+
+        -- Crossbar [J] only: which pet families (avatars/elementals/beasts/wyvern/puppet) use pet hotbar storage; nil = all. Not per named palette.
+        petPalettePetKeys = nil,
+
+        -- Per main job id (string key): effective combo mode -> { scope = 'jobShared' | 'global', globalPalette = name? }
+        -- Primary L2/R2 are not used. Resolves slot data to jobsegment:{jobId}:{mode} or global:palette:{name}.
+        segmentOverrides = {},
 
         -- Layout
         slotSize = 40,              -- Slot size in pixels
@@ -495,7 +541,8 @@ function M.createCrossbarDefaults()
         slotBackgroundColor = 0x55000000,
         slotOpacity = 1.0,                  -- Opacity multiplier for slot.png (0.0-1.0)
         activeSlotHighlight = 0x44FFFFFF,   -- Highlight color when trigger held
-        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side
+        inactiveSlotDim = 0.5,              -- Dim multiplier for inactive side (expanded / non-trigger dim)
+        inactiveSideWhileTriggerDim = 0.15, -- Dim for the non-active half while L2 or R2 is held
 
         -- Display mode
         displayMode = 'normal',             -- 'normal' or 'activeOnly'
@@ -511,6 +558,8 @@ function M.createCrossbarDefaults()
         buttonIconGapH = 8,                 -- Horizontal spacing between center icons
         buttonIconGapV = 2,                 -- Vertical spacing between center icons
         buttonIconPosition = 'corner',      -- 'corner' or 'replace_keybind'
+        -- Job icon set for palette UI (Manage Palettes strip + in-game palette scope icon when Job [J])
+        paletteJobIconTheme = 'Classic',     -- 'Classic', 'FFXI', 'FFXIV-1' (under assets/jobs/)
         controllerTheme = 'Xbox',           -- 'PlayStation', 'Xbox', or 'Nintendo' button icons
         controllerScheme = 'xbox',          -- Controller profile: 'xbox', 'dualsense', 'switchpro', 'dinput'
         triggerIconScale = 0.8,             -- Scale for L2/R2 trigger icons (base 49x28)
@@ -545,10 +594,14 @@ function M.createCrossbarDefaults()
         comboTextOffsetY = 0,               -- Y offset for combo text position
 
         -- Palette name display (shows current palette and index, e.g., "Stuns (2/5)")
-        showPaletteName = false,            -- Toggle to show palette name
+        showPaletteName = false,            -- Toggle to show palette name text below crossbar
+        showPaletteScopeIcon = true,        -- Job / Global scope icon above divider; nil in saved config = legacy (follow showPaletteName)
         paletteNameFontSize = 10,           -- Font size for palette name
         paletteNameOffsetX = 0,             -- X offset for position
         paletteNameOffsetY = 0,             -- Y offset for position
+        -- Job / Global palette scope icon above center divider
+        paletteScopeIconOffsetY = 12,       -- Vertical lift (px); higher = icon moves up
+        paletteScopeIconSize = 22,          -- Icon width/height (px); legacy profiles fall back to font-based size if unset
 
         -- Expanded crossbar (L2+R2 combos)
         enableExpandedCrossbar = true,      -- Enable L2+R2 and R2+L2 combos
@@ -557,6 +610,12 @@ function M.createCrossbarDefaults()
         -- Double-tap crossbar (tap trigger twice quickly)
         enableDoubleTap = false,            -- Enable L2x2 and R2x2 double-tap modes
         doubleTapWindow = 0.3,              -- Time window for double-tap detection (seconds)
+
+        -- Double-tap preview windows (always-visible overlays showing L2x2 / R2x2 bars)
+        showDoubleTapPreview    = false,     -- Show floating preview windows for double-tap bars
+        doubleTapPreviewScale   = 0.60,     -- Preview scale relative to main crossbar (0.3–1.0)
+        doubleTapPreviewOpacity = 1.0,      -- Preview opacity multiplier (0.2–1.0; dims with trigger)
+        doubleTapPreviewLocked  = false,    -- Lock preview positions independently of the main crossbar
 
         -- Analog trigger thresholds (0-255 normalized range)
         -- Used by Xbox (XInput) and PlayStation (DirectInput with signed->unsigned conversion)
@@ -587,6 +646,8 @@ function M.createCrossbarDefaults()
         -- Structure: crossbarPaletteOrder['{jobId}:{subjobId}'] = { 'paletteName1', 'paletteName2', ... }
         -- Note: Crossbar palettes are independent from hotbar palettes
         crossbarPaletteOrder = {},
+        -- Same shape as paletteExcludeFromCycle on hotbar; per job:storage-tier key
+        crossbarPaletteExcludeFromCycle = {},
     };
 end
 

--- a/XIUI/modules/castcost/display.lua
+++ b/XIUI/modules/castcost/display.lua
@@ -120,6 +120,7 @@ function M.Render(itemInfo, itemType, settings, colors)
     local timeText = '';
     local hasEnoughMp = true; -- Track if player has enough MP for spells
     local hasEnoughTp = true; -- Track if player has enough TP for weapon skills
+    local isBstJugReadySpellCost = false; -- BST jug Ready: ManaCost field holds pet charge cost
 
     -- Get player's current MP and TP for cost comparison
     local playerMp = 0;
@@ -145,11 +146,22 @@ function M.Render(itemInfo, itemType, settings, colors)
 
     if itemType == 'spell' then
         -- Spell: Show MP cost, recast
+        -- BST jug Ready moves: MP field actually stores the pet charge cost (display as "Cost:").
+        local petregistry = require('modules.hotbar.petregistry');
+        local player = GetPlayerSafe();
+        if player and player:GetMainJob() == petregistry.JOB_BST
+            and itemInfo.name and petregistry.IsBstJugReadyMoveName(itemInfo.name) then
+            isBstJugReadySpellCost = true;
+        end
         -- Always check if player has enough MP (even if not displaying cost)
         if itemInfo.mpCost and itemInfo.mpCost > 0 then
             hasEnoughMp = playerMp >= itemInfo.mpCost;
             if settings.showMpCost then
-                costText = string.format('MP: %d', itemInfo.mpCost);
+                if isBstJugReadySpellCost then
+                    costText = string.format('Cost: %d', itemInfo.mpCost);
+                else
+                    costText = string.format('MP: %d', itemInfo.mpCost);
+                end
             end
         end
         if settings.showRecast and itemInfo.recastDelay and itemInfo.recastDelay > 0 then
@@ -329,6 +341,8 @@ function M.Render(itemInfo, itemType, settings, colors)
                 costColor = colors.tpNotEnoughColor or 0xFFFF6666;
             elseif isWeaponSkill then
                 costColor = colors.tpCostTextColor or 0xFFFFCC00;  -- Gold/yellow for TP
+            elseif isBstJugReadySpellCost then
+                costColor = colors.tpCostTextColor or 0xFFFFCC00;  -- Same gold as TP for pet Ready charge
             else
                 costColor = colors.mpCostTextColor or 0xFFD4FF97;
             end

--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 * XIUI Hotbar - Macro Palette Module
 * Provides a visual grid of user-created macros that can be dragged to hotbar slots
 ]]--
@@ -18,11 +18,142 @@ local petpalette = require('modules.hotbar.petpalette');
 local petregistry = require('modules.hotbar.petregistry');
 local playerdata = require('modules.hotbar.playerdata');
 local actiondb = require('modules.hotbar.actiondb');
+local iconmatch = require('modules.hotbar.iconmatch');
+local macroBuckets = require('modules.hotbar.macro_palette_buckets');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
+local profileManager = require('core.profile_manager');
+local sharedMacroStore = require('core.shared_macro_store');
 -- display and crossbar are loaded lazily to avoid circular dependencies
 local display = nil;
 local crossbar = nil;
 
 local M = {};
+
+-- Bundle for macropalette_macroeditor.lua (Lua 5.1: max 60 upvalues per function).
+local MP = {};
+
+MP.editingMacro = nil;
+MP.isCreatingNew = false;
+MP.currentPalettePage = 1;
+MP.editorPaletteKey = nil;
+MP.editorAutoLabel = nil;
+MP.editorAutoIconKey = nil;
+MP.editorDidInitialIconPick = false;
+MP.editorIconAutoSource = 'all';
+MP.editorCustomIconCategory = 'all';
+MP.selectedPaletteType = nil;
+MP.selectedAvatarPalette = nil;
+-- SMN only: when true, macro grid lists Base SMN + every avatar bucket together.
+MP.smnShowAllAvatarSubsets = false;
+-- BST: jug-family subset (movesKey from petregistry), nil = Base BST bucket.
+MP.selectedBstJugMovesKey = nil;
+-- BST: when true, macro grid lists Base BST + every jug:* macro bucket together.
+MP.bstShowAllJugSubsets = false;
+MP.cachedPetCommands = nil;
+MP.petAvatarFilter = 1;
+MP.searchFilter = { '' };
+-- Macro Palette window: filter tiles by display/action name (not icon-picker search).
+MP.macroPaletteSearchName = { '' };
+MP.macroNewCategoryBuf = { '' };
+MP.macroCustomRenameBuf = { '' };
+MP.macroCustomRenameTargetKey = nil; -- 'custom:N' for MacroCustomRename modal
+MP.macroCustomDeleteKey = nil; -- pending delete: confirm modal
+MP.macroCustomDeleteLabel = nil;
+MP.macroCustomDeleteN = 0;
+MP.macroMoveSourceKey = nil;
+MP.macroMoveMacroId = nil;
+MP.macroMoveDestKey = nil;
+MP._macroSearchPaletteKey = nil;
+MP._lastMacroPaletteSearch = nil;
+-- Which scope switch confirmation is open (single non-modal BeginPopup, no full-screen dim).
+MP.macroScopeConfirmKind = nil; -- 'toShared' | 'toProfile' while 'MacroScopeSwitch##xiui' is open
+MP.showAllMode = false;
+MP.showAllPetMode = false;
+MP.wsWeaponFilter = 'All';
+MP.spellTypeFilter = 'All';
+MP.abilityJobFilter = 0;
+MP.petTypeOverride = 0;
+MP.iconPickerTargetIsJaBadge = false;
+MP.iconPickerOpen = false;
+MP.iconPickerFilter = { '' };
+MP.iconPickerTab = 1;
+MP.iconPickerPage = { 1, 1, 1 };
+MP.iconPickerLastFilter = { '', '', '' };
+MP.iconPickerSpellType = 'All';
+MP.iconPickerItemType = 0;
+MP.editorImplicitActionIconDone = false;
+MP.editorIconManuallySet = false;
+-- When true, JA badge icon is not replaced by implicit /ja resolution; use "Sync JA badge" to refresh.
+MP.editorJaBadgeManuallySet = false;
+MP.editorIconPrefsHydrated = false;
+
+
+
+-- Palette / editor: GetBindIcon + ResolveMacroJaBadgeIcon do real work (macroparse, DB, texture lookup).
+-- The macro grid calls them once per tile per frame â€” cache by stable keys; clear when palette type changes.
+local PALETTE_ICON_NONE = {};
+local PALETTE_JA_NONE = {};
+
+local paletteMainIconCache = {};
+local paletteJaBadgeIconCache = {};
+local paletteIconCacheDbKey = nil;
+
+local editorPreviewIconKey = nil;
+local editorPreviewCachedIcon = nil;
+
+local function ClearEditorPreviewIconCache()
+    editorPreviewIconKey = nil;
+    editorPreviewCachedIcon = nil;
+end
+
+local function ClearPaletteJaBadgeIconCache()
+    for k in pairs(paletteJaBadgeIconCache) do
+        paletteJaBadgeIconCache[k] = nil;
+    end
+end
+
+local function BuildMacroMainIconCacheKey(macro)
+    if not macro then
+        return 'nil';
+    end
+    return table.concat({
+        tostring(macro.id or 0),
+        macro.actionType or '',
+        macro.action or '',
+        macro.target or '',
+        macro.macroText or '',
+        macro.customIconType or '',
+        tostring(macro.customIconId or ''),
+        macro.customIconPath or '',
+        macro.itemId and tostring(macro.itemId) or '',
+        tostring(macro.macroRef or ''),
+    }, '|');
+end
+
+local function BuildMacroJaBadgeCacheKey(macro)
+    if not macro then
+        return '';
+    end
+    return table.concat({
+        tostring(macro.id or 0),
+        macro.macroText or '',
+        tostring(macro.jaBadgeCustomIconType or ''),
+        tostring(macro.jaBadgeCustomIconId or ''),
+        macro.jaBadgeCustomIconPath or '',
+        tostring(macro.showJaBadgeOnMacro ~= false),
+    }, '|');
+end
+
+local function GetCachedPaletteMainIcon(macro)
+    local k = BuildMacroMainIconCacheKey(macro);
+    local hit = paletteMainIconCache[k];
+    if hit ~= nil then
+        return hit == PALETTE_ICON_NONE and nil or hit;
+    end
+    local icon = actions.GetBindIcon(macro);
+    paletteMainIconCache[k] = icon or PALETTE_ICON_NONE;
+    return icon;
+end
 
 -- ============================================
 -- Constants
@@ -30,11 +161,13 @@ local M = {};
 
 local INPUT_BUFFER_SIZE = 64;
 local MACRO_BUFFER_SIZE = 512;  -- 8 lines * ~60 chars each
-local PALETTE_COLUMNS = 6;
+local PALETTE_COLUMNS = 7;
 local PALETTE_ROWS = 6;
-local PALETTE_MACROS_PER_PAGE = PALETTE_COLUMNS * PALETTE_ROWS;  -- 36 macros per page
+local PALETTE_MACROS_PER_PAGE = PALETTE_COLUMNS * PALETTE_ROWS;  -- 42 macros per page
 local PALETTE_TILE_SIZE = 48;
 local PALETTE_TILE_GAP = 4;
+-- Slightly rounded macro grid tiles (ImGui button shape; icons draw square on top).
+local PALETTE_TILE_ROUNDING = 6;
 local PALETTE_PADDING = 8;
 
 -- XIUI Color Scheme (from components.TAB_STYLE)
@@ -70,10 +203,20 @@ end
 -- If preferAction is true, prioritize action name over displayName (for previews)
 local function GetActionAbbreviation(macro, preferAction)
     local name;
+    -- Macros: never abbreviate from raw `action` (it may be the full multiline buffer â€” yields garbage like /"S<).
+    if macro and macro.actionType == 'macro' and macro.macroText and macro.macroText ~= '' then
+        local mp = require('modules.hotbar.macroparse');
+        local _, pName = mp.GetMacroPrimaryAndJaBadge(macro.macroText);
+        if pName and pName ~= '' then
+            name = pName;
+        end
+    end
+    if not name or name == '' then
     if preferAction then
         name = macro.action or macro.displayName or '';
     else
         name = macro.displayName or macro.action or '';
+        end
     end
     if name == '' then return '?'; end
 
@@ -131,17 +274,17 @@ local function ClearAllIconCaches()
     if slotrenderer and slotrenderer.ClearSlotRenderingCache then
         slotrenderer.ClearSlotRenderingCache();
     end
-    -- Edits that change a macro's action leave the old actionType:action entry
-    -- orphaned in mpCostCache / availabilityCache. Functionally fine (the new key
-    -- naturally misses), but bounds memory across many edits.
+    -- 1.8.0 additions: edits that change a macro's action leave the old actionType:action
+    -- entry orphaned in the MP cost / availability caches. Functionally fine (the new key
+    -- naturally misses) but unbounded across many edits, so flush both during full clears.
     if slotrenderer and slotrenderer.ClearMPCostCache then
         slotrenderer.ClearMPCostCache();
     end
     if slotrenderer and slotrenderer.ClearAvailabilityCache then
         slotrenderer.ClearAvailabilityCache();
     end
-    -- Clear the icon-resolution negative cache so newly-added custom icons
-    -- on edited macros are picked up next frame.
+    -- Drop the icon-resolution negative cache so newly-added custom icons on edited
+    -- macros are picked up on the next frame instead of remaining "no icon".
     if actions and actions.ClearNoIconCache then
         actions.ClearNoIconCache();
     end
@@ -162,6 +305,8 @@ local function ClearSlotIconCache(barIndex, slotIndex)
     if display and display.ClearIconCacheForSlot then
         display.ClearIconCacheForSlot(barIndex, slotIndex);
     end
+    -- Note: per-slot slotrenderer.InvalidateSlotByKey was removed in 1.8.0. Slot rendering is
+    -- immediate-mode (no persistent prim cache); the per-frame bind hash naturally re-derives.
 end
 
 -- Helper to clear icon cache for a single crossbar slot (targeted - fast)
@@ -179,6 +324,7 @@ local function ClearCrossbarSlotIconCache(comboMode, slotIndex)
     if crossbar and crossbar.ClearIconCacheForSlot then
         crossbar.ClearIconCacheForSlot(comboMode, slotIndex);
     end
+    -- Note: per-slot slotrenderer.InvalidateSlotByKey was removed in 1.8.0. See ClearSlotIconCache above.
 end
 
 -- Action type constants (needed by DrawMacroTile and DrawMacroEditor)
@@ -187,11 +333,14 @@ local ACTION_TYPE_LABELS = {
     ma = 'Spell (ma)',
     ja = 'Ability (ja)',
     ws = 'Weaponskill (ws)',
-    item = 'Item',
+    item = 'Items',
     equip = 'Equip',
     macro = 'Macro',
     pet = 'Pet Command',
 };
+
+-- Items palette bucket: Action Type combo offers only these (order: Item, Macro, Equip).
+local ACTION_TYPES_ITEMS_BUCKET = { 'item', 'macro', 'equip' };
 
 -- Recast source types for macros (allows displaying cooldown from a different action)
 local RECAST_SOURCE_TYPES = { 'none', 'ma', 'ja', 'item', 'pet' };
@@ -240,8 +389,39 @@ local EQUIP_SLOT_MASKS = {
 -- Special key for global (non-job-specific) slot storage
 local GLOBAL_SLOT_KEY = 'global';
 
--- Special key for global macros (shared across all jobs)
-local GLOBAL_MACRO_KEY = 'global';
+-- Macro palette bucket keys (see macro_palette_buckets.lua)
+local GLOBAL_MACRO_KEY = macroBuckets.GLOBAL;
+local ITEMS_MACRO_KEY = macroBuckets.ITEMS;
+local EQUIPMENT_MACRO_KEY = macroBuckets.EQUIPMENT;
+local XIUI_MACRO_KEY = macroBuckets.XIUI;
+
+local function DefaultNewMacroBodyForPaletteKey(paletteKey)
+    if data.MacroPaletteKeysEqual(paletteKey, ITEMS_MACRO_KEY) then
+        return {
+            actionType = 'item',
+            action = '',
+            target = 't',
+            displayName = '',
+            customIconType = 'xiui_default',
+            customIconPath = 'item',
+        }, 'xiui_default::item';
+    end
+    return {
+        actionType = 'ma',
+        action = '',
+        target = 't',
+        displayName = '',
+        customIconType = 'xiui_default',
+        customIconPath = 'ma',
+    }, 'xiui_default::ma';
+end
+
+local function IsSharedJobAgnosticMacroSelection(sel)
+    if sel == GLOBAL_MACRO_KEY or sel == ITEMS_MACRO_KEY or sel == EQUIPMENT_MACRO_KEY or sel == XIUI_MACRO_KEY then
+        return true;
+    end
+    return macroBuckets.isCustomCategoryKey(sel);
+end
 
 -- Helper to deep copy a table (for migrating slot data)
 local function deepCopyTable(tbl)
@@ -293,30 +473,15 @@ end
 -- State
 -- ============================================
 
-local paletteOpen = false;
-local selectedMacroIndex = nil;
-local editingMacro = nil;
-local isCreatingNew = false;
-local currentPalettePage = 1;  -- Current page in macro palette (1-indexed)
-
--- Selected job for viewing/editing macros (nil = use current player job)
-local selectedPaletteType = nil;  -- Can be GLOBAL_MACRO_KEY or a job ID
-local selectedAvatarPalette = nil;  -- For SMN: nil = base, or avatar name like 'Ifrit'
-
--- Cached pet commands (managed locally, not in shared module)
-local cachedPetCommands = nil;
-local petAvatarFilter = 1;  -- 1 = All, 2+ = specific avatar index
-
--- Search filter for dropdowns
-local searchFilter = { '' };
-
--- Icon picker state
-local iconPickerOpen = false;
-local iconPickerFilter = { '' };
-local iconPickerTab = 1;  -- 1 = Spells, 2 = Items, 3 = Custom
-local iconPickerPage = { 1, 1, 1 };  -- Current page for each tab [spells, items, custom]
-local iconPickerLastFilter = { '', '', '' };  -- Track filter changes to reset page
-local iconPickerSpellType = 'All';  -- Current spell type filter
+-- Palette open state (table: avoids extra upvalues when palette draw uses MacroPaletteDrawEnv).
+local paletteUi = { open = false, selectedMacroIndex = nil };
+local ICON_AUTO_SOURCES = { 'all', 'spells', 'items', 'custom' };
+local ICON_AUTO_SOURCE_LABELS = {
+    ['all'] = 'All',
+    ['spells'] = 'Spells',
+    ['items'] = 'Items',
+    ['custom'] = 'Custom',
+};
 
 -- Spell type display names and order
 local SPELL_TYPE_ORDER = {
@@ -404,7 +569,6 @@ local ITEM_TYPE_ICONS = {
     [8] = 4096,   -- Fire Crystal
     [10] = 6232,  -- Furnishing item
 };
-local iconPickerItemType = 0;  -- 0 = All
 
 -- Custom icon categories (subdirectories in assets/hotbar/custom/)
 local CUSTOM_ICON_CATEGORIES = {};  -- Populated by scanning directory
@@ -432,6 +596,8 @@ local filteredSpellsCache = nil;
 local filteredSpellsCacheKey = nil;  -- "filter:type" key for cache invalidation
 local filteredItemsCache = nil;
 local filteredItemsCacheKey = nil;  -- "filter" key for cache invalidation
+local filteredCustomIconsCache = nil;
+local filteredCustomIconsCacheKey = nil;  -- filter + category for custom tab
 
 -- Icon picker grid constants
 local ICON_GRID_COLUMNS_DEFAULT = 12;  -- Default columns, recalculated based on window width
@@ -486,7 +652,7 @@ local function RefreshCachedLists()
     playerdata.RefreshCachedLists(data);
     -- Clear local pet commands cache when job changes
     if playerdata.GetCacheJobId() ~= data.jobId then
-        cachedPetCommands = nil;
+        MP.cachedPetCommands = nil;
     end
 end
 
@@ -734,8 +900,262 @@ local function LoadCustomIcons()
         if b == 'all' then return false; end
         return a:lower() < b:lower();
     end);
+
+    -- LoadCustomIcons replaces CUSTOM_ICON_CATEGORIES with a new table; keep MP.* in sync for the macro editor sub-module.
+    MP.CUSTOM_ICON_CATEGORIES = CUSTOM_ICON_CATEGORIES;
+    MP.CUSTOM_ICON_LABELS = CUSTOM_ICON_LABELS;
     
     return customIconsCache;
+end
+
+local function HydrateMacroEditorIconPrefs()
+    if not gConfig or not gConfig.macroEditorIconPrefs then
+        return;
+    end
+    local p = gConfig.macroEditorIconPrefs;
+    local src = p.iconAutoSource;
+    if src == 'all' or src == 'spells' or src == 'items' or src == 'custom' then
+        MP.editorIconAutoSource = src;
+    end
+    if type(p.customIconFolder) == 'string' and p.customIconFolder ~= '' then
+        MP.editorCustomIconCategory = p.customIconFolder;
+    end
+end
+
+local function ValidateEditorCustomIconCategoryAgainstScan()
+    LoadCustomIcons();
+    local cat = MP.editorCustomIconCategory or 'all';
+    if cat == 'all' then
+        return;
+    end
+    local found = false;
+    for _, c in ipairs(CUSTOM_ICON_CATEGORIES or {}) do
+        if c == cat then
+            found = true;
+            break;
+        end
+    end
+    if not found then
+        MP.editorCustomIconCategory = 'all';
+    end
+end
+
+local function PersistMacroEditorIconPrefs()
+    if not gConfig then
+        return;
+    end
+    if not gConfig.macroEditorIconPrefs then
+        gConfig.macroEditorIconPrefs = {};
+    end
+    gConfig.macroEditorIconPrefs.iconAutoSource = MP.editorIconAutoSource;
+    gConfig.macroEditorIconPrefs.customIconFolder = MP.editorCustomIconCategory;
+    if SaveSettingsToDisk then
+        SaveSettingsToDisk();
+    end
+end
+
+-- Rescan custom/ PNG lists (new files, addon reload) without restarting the game client.
+local function InvalidateCustomIconScanCaches()
+    customIconsCache = nil;
+    customIconsByCategoryCache = nil;
+    customCategoryIconCache = {};
+    filteredCustomIconsCache = nil;
+    filteredCustomIconsCacheKey = nil;
+    local ok, cir = pcall(require, 'modules.hotbar.customiconresolve');
+    if ok and cir and cir.InvalidateScanCache then
+        cir.InvalidateScanCache();
+    end
+end
+
+-- Normalized relative path compare for saved custom icon paths (mixed slashes).
+local function NormalizeCustomIconRelPath(p)
+    if not p then
+        return '';
+    end
+    return tostring(p):gsub('/', '\\'):gsub('^%s+', ''):gsub('%s+$', '');
+end
+
+--- Find scanned custom icon entry by path saved on a macro (path relative to assets/hotbar/custom/).
+local function FindCustomIconEntryBySavedPath(savedPath)
+    savedPath = NormalizeCustomIconRelPath(savedPath);
+    if savedPath == '' then
+        return nil;
+    end
+    LoadCustomIcons();
+    local sle = savedPath:lower();
+    for _, icon in ipairs(customIconsCache or {}) do
+        if icon.path and NormalizeCustomIconRelPath(icon.path):lower() == sle then
+            return icon;
+        end
+    end
+    local leaf = savedPath:match('[^\\/]+$') or savedPath;
+    leaf = leaf:gsub('%.png$', ''):lower();
+    for _, icon in ipairs(customIconsCache or {}) do
+        if icon.path then
+            local il = (icon.path:match('[^\\/]+$') or icon.path):gsub('%.png$', ''):lower();
+            if il == leaf then
+                return icon;
+            end
+        end
+    end
+    return nil;
+end
+
+-- Same normalization as macro editor auto-pick (matches TryAutoPickCustomIcon).
+local function PaletteNormalizeIconMatchText(s)
+    if not s then
+        return '';
+    end
+    s = tostring(s):lower();
+    s = s:gsub('^%s+', ''):gsub('%s+$', '');
+    s = s:gsub('[\r\n\t]', ' ');
+    s = s:gsub('[%p%c%s]', '');
+    return s;
+end
+
+local function PaletteBuildIconMatchNeedles(actionName)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return {};
+    end
+
+    local needles = {};
+    local function add(n)
+        n = PaletteNormalizeIconMatchText(n);
+        if n ~= '' then
+            needles[n] = true;
+        end
+    end
+
+    local fullNorm = PaletteNormalizeIconMatchText(actionName);
+    add(actionName);
+    local rhs = actionName:match(':%s*(.+)$');
+    if rhs then
+        add(rhs);
+    end
+    local paren = actionName:match('%(([^)]+)%)');
+    if paren then
+        add(paren);
+    end
+    local lastWord = actionName:match('([^%s]+)%s*$');
+    if lastWord then
+        local lwNorm = PaletteNormalizeIconMatchText(lastWord);
+        -- Do not add a last-word needle when it is only a tail of the full normalized name
+        -- (e.g. "Attack" for "Sneak Attack" â†’ sneakattack) â€” exact match would pick generic Attack.png
+        -- before fuzzy matching can prefer Sneak_Attack_*.
+        if lwNorm ~= '' and lwNorm ~= fullNorm then
+            local weakTail = (#lwNorm < 9 and #fullNorm > #lwNorm + 4 and fullNorm:sub(-#lwNorm) == lwNorm);
+            if not weakTail then
+                add(lastWord);
+            end
+        end
+    end
+
+    local arr = {};
+    for n, _ in pairs(needles) do
+        table.insert(arr, n);
+    end
+    table.sort(arr, function(a, b)
+        return #a > #b;
+    end);
+    return arr;
+end
+
+--- Best custom icon match for an action name (same rules as TryAutoPickCustomIcon). Returns icon entry or nil.
+local function ResolveBestCustomIconMatchForActionName(actionName, categoryFilter)
+    actionName = tostring(actionName or '');
+    if actionName == '' then
+        return nil;
+    end
+    LoadCustomIcons();
+    local category = categoryFilter or 'all';
+    local list = customIconsByCategoryCache and (customIconsByCategoryCache[category] or customIconsByCategoryCache['all']) or nil;
+    if not list or #list == 0 then
+        return nil;
+    end
+
+    local needles = PaletteBuildIconMatchNeedles(actionName);
+    if #needles == 0 then
+        return nil;
+    end
+
+    for _, icon in ipairs(list) do
+        if icon and icon.name and icon.path then
+            local iconNorm = PaletteNormalizeIconMatchText(icon.name);
+            for _, needle in ipairs(needles) do
+                if iconNorm == needle then
+                    return icon;
+                end
+            end
+        end
+    end
+
+    -- Fuzzy round: collect all decent matches, then prefer the most specific (longest normalized stem)
+    -- so short substrings don't steal the pick when several PNGs could match.
+    local fuzzy = {};
+    for _, icon in ipairs(list) do
+        if icon and icon.name and icon.path and iconmatch.IsDecentIconNameMatch(actionName, icon.name) then
+            table.insert(fuzzy, icon);
+        end
+    end
+    if #fuzzy == 1 then
+        return fuzzy[1];
+    end
+    if #fuzzy > 1 then
+        table.sort(fuzzy, function(x, y)
+            local sx = iconmatch.MatchQualityScore(actionName, x.name);
+            local sy = iconmatch.MatchQualityScore(actionName, y.name);
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return #iconmatch.NormalizeIconKey(x.name) > #iconmatch.NormalizeIconKey(y.name);
+        end);
+        return fuzzy[1];
+    end
+
+    return nil;
+end
+
+-- Icon picker search: collapse spaces, underscores, punctuation so "Sneak Attack", "sneak_attack",
+-- and "sneakattack" match the same assets (multi-word spell/ability/file names).
+local function normalizeIconPickerNameKey(s)
+    if not s then
+        return '';
+    end
+    return tostring(s):lower():gsub('[^a-z0-9]', '');
+end
+
+local function iconPickerNameMatchesFilter(name, filter)
+    if not filter or filter == '' then
+        return true;
+    end
+    if not name or name == '' then
+        return false;
+    end
+    local normName = normalizeIconPickerNameKey(name);
+    local normAll = normalizeIconPickerNameKey(filter);
+    if normAll == '' then
+        return true;
+    end
+    if normName:find(normAll, 1, true) then
+        return true;
+    end
+    local tokens = {};
+    for w in tostring(filter):gmatch('%S+') do
+        local t = normalizeIconPickerNameKey(w);
+        if t ~= '' then
+            table.insert(tokens, t);
+        end
+    end
+    if #tokens <= 1 then
+        return false;
+    end
+    for _, t in ipairs(tokens) do
+        if not normName:find(t, 1, true) then
+            return false;
+        end
+    end
+    return true;
 end
 
 -- Get custom icons filtered by category
@@ -749,24 +1169,31 @@ local function GetCustomIconsFiltered(category, filter)
         sourceList = customIconsByCategoryCache[category] or {};
     end
     
-    -- Apply text filter if any
+    -- Apply text filter if any (best matches first: full-name embed beats loose substring)
     if filter and filter ~= '' then
         local filtered = {};
-        filter = filter:lower();
         for _, icon in ipairs(sourceList) do
-            if icon.name:lower():find(filter, 1, true) then
+            if iconPickerNameMatchesFilter(icon.name or '', filter) then
                 table.insert(filtered, icon);
             end
         end
+        table.sort(filtered, function(x, y)
+            local sx = iconmatch.MatchQualityScore(filter, x.name or '');
+            local sy = iconmatch.MatchQualityScore(filter, y.name or '');
+            if sx ~= sy then
+                return sx > sy;
+            end
+            return (x.name or '') < (y.name or '');
+        end);
         return filtered;
     end
     
     return sourceList;
 end
 
--- Load a custom icon texture by relative path (uses TextureManager with LRU caching)
+-- Load a custom icon texture by relative path (same cache as hotbar; avoids duplicate VRAM + TextureManager LRU thrash)
 local function LoadCustomIconTexture(relativePath)
-    return TextureManager.getCustomIcon(relativePath);
+    return actions.GetCustomHotbarIconTexture(relativePath);
 end
 
 -- Create a new custom icon folder
@@ -903,10 +1330,51 @@ local function PopComboStyle()
     imgui.PopStyleColor(11);
 end
 
+-- Status tier colors for "Show All" mode
+local STATUS_COLORS = {
+    ['have']        = { 0.35, 0.85, 0.35, 1.0 },
+    ['learnable']   = { 0.95, 0.78, 0.25, 1.0 },
+    ['unavailable'] = { 0.75, 0.30, 0.30, 1.0 },
+};
+
+-- Base colors per magic type (full brightness = STATUS_HAVE)
+local SPELL_TYPE_COLORS = {
+    WhiteMagic   = { 0.96, 0.92, 0.78, 1.0 },  -- eggshell/holy white
+    BlackMagic   = { 0.75, 0.50, 0.90, 1.0 },  -- purple
+    BardSong     = { 0.50, 0.80, 1.00, 1.0 },  -- light blue
+    Ninjutsu     = { 0.78, 0.60, 0.38, 1.0 },  -- scroll brown
+    SummonerPact = { 0.50, 0.75, 0.38, 1.0 },  -- moss green
+    BlueMagic    = { 0.30, 0.70, 0.95, 1.0 },  -- steel blue
+    Geomancy     = { 0.60, 0.85, 0.45, 1.0 },  -- earthy green
+    Trust        = { 0.80, 0.80, 0.80, 1.0 },  -- silver
+};
+
+-- Human-readable headers for each spell type
+local SPELL_TYPE_HEADERS = {
+    WhiteMagic   = 'White Magic',
+    BlackMagic   = 'Black Magic',
+    BardSong     = 'Songs',
+    Ninjutsu     = 'Ninjutsu',
+    SummonerPact = 'Summoning',
+    BlueMagic    = 'Blue Magic',
+    Geomancy     = 'Geomancy',
+    Trust        = 'Trust',
+};
+
+-- Canonical type display order
+local SPELL_TYPE_ORDER = {
+    'WhiteMagic', 'BlackMagic', 'BardSong', 'Ninjutsu',
+    'SummonerPact', 'BlueMagic', 'Geomancy', 'Trust',
+};
+local SPELL_TYPE_RANK = {};
+for i, t in ipairs(SPELL_TYPE_ORDER) do SPELL_TYPE_RANK[t] = i; end
+
+
 -- Draw a searchable dropdown combo box with XIUI styling
 -- showIcons: if true, will attempt to load and display item icons
 -- equipSlotFilter: if provided, only show items that can be equipped in this slot (e.g., 'main', 'head')
-local function DrawSearchableCombo(label, items, currentValue, onSelect, showIcons, equipSlotFilter)
+-- useStatusColors: if true, color text by item.status (have/learnable/unavailable)
+local function DrawSearchableCombo(label, items, currentValue, onSelect, showIcons, equipSlotFilter, itemWidth, useStatusColors)
     local displayText = currentValue ~= '' and currentValue or 'Select...';
 
     -- Get the slot mask for filtering if provided
@@ -915,16 +1383,17 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
     -- Apply XIUI styling to combo popup
     PushComboStyle();
 
-    imgui.SetNextItemWidth(220);
+    local comboW = (type(itemWidth) == 'number' and itemWidth > 0) and itemWidth or 220;
+    imgui.SetNextItemWidth(comboW);
     -- Use HeightLargest so popup fits our child window without its own scrollbar
     if imgui.BeginCombo(label, displayText, ImGuiComboFlags_HeightLargest) then
         -- Search input at top (fixed, not scrollable)
-        imgui.SetNextItemWidth(200);
+        imgui.SetNextItemWidth(math.max(80, comboW - 20));
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
-        imgui.InputText('##search' .. label, searchFilter, INPUT_BUFFER_SIZE);
+        imgui.InputText('##search' .. label, MP.searchFilter, INPUT_BUFFER_SIZE);
         imgui.PopStyleColor();
 
-        if searchFilter[1] == '' then
+        if MP.searchFilter[1] == '' then
             -- Show placeholder hint
             local inputPos = {imgui.GetItemRectMin()};
             imgui.SetCursorScreenPos({inputPos[1] + 6, inputPos[2] + 3});
@@ -937,9 +1406,13 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
         local childHeight = 200;
         imgui.BeginChild('##comboScroll' .. label, {0, childHeight}, false);
 
-        local filter = searchFilter[1]:lower();
+        local filter = MP.searchFilter[1];
         local matchCount = 0;
         local iconSize = 16;
+        local GOLD_STAR_COLOR = {1.0, 0.88, 0.12, 1.0};
+        local PINK_STAR_COLOR = {1.0, 0.45, 0.72, 1.0};
+        local lastType = nil;
+        local isSearching = filter ~= '';
 
         for _, item in ipairs(items) do
             local itemName = item.name or '';
@@ -950,48 +1423,195 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
                 passesSlotFilter = bit.band(item.slots, slotMask) ~= 0;
             end
 
-            if passesSlotFilter and (filter == '' or itemName:lower():find(filter, 1, true)) then
+            if passesSlotFilter and iconPickerNameMatchesFilter(itemName, filter) then
                 matchCount = matchCount + 1;
+
+                -- Insert type group header when type changes (only when not searching)
+                if not isSearching and item.type and item.type ~= lastType then
+                    if lastType ~= nil then
+                        imgui.Separator();
+                    end
+                    local headerLabel = SPELL_TYPE_HEADERS[item.type] or item.type;
+                    local headerColor = SPELL_TYPE_COLORS[item.type] or COLORS.textDim;
+                    imgui.TextColored(headerColor, headerLabel);
+                    lastType = item.type;
+                end
+
                 local isSelected = currentValue == itemName;
+                local uid = item.id or matchCount;
+                local isSpellWithType = item.type and SPELL_TYPE_COLORS[item.type] ~= nil;
 
-                -- Determine text color: gold if selected, blue if usable, default otherwise
-                local textColor = nil;
-                if isSelected then
-                    textColor = COLORS.gold;
-                elseif item.usable then
-                    textColor = COLORS.usable;
-                end
+                if isSpellWithType and not isSelected then
+                    -- â”€â”€ Two-color spell rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+                    -- [level] â†’ magic type color; name â†’ status color.
+                    -- Use one hit target (InvisibleButton): overlapping Selectable + Text ate clicks.
+                    local levelColor = SPELL_TYPE_COLORS[item.type];
+                    local nameColor = (item.status and STATUS_COLORS[item.status]) or COLORS.text;
+                    local rowW = math.max(60, comboW - 24);
+                    local padY = 2;
+                    local lineH = imgui.GetTextLineHeight();
+                    local rowH = lineH + padY * 2;
 
-                if textColor then
-                    imgui.PushStyleColor(ImGuiCol_Text, textColor);
-                end
+                    imgui.InvisibleButton('##item' .. uid, {rowW, rowH});
+                    local clicked = imgui.IsItemClicked();
+                    local hovered = imgui.IsItemHovered();
 
-                -- Show icon if enabled and item has an id
-                if showIcons and item.id then
-                    -- Use memory-only loading (no PNG creation) for browsing
-                    local icon = actions.GetItemIconForBrowsing(item.id);
-                    if icon and icon.image then
-                        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
-                        if iconPtr then
-                            imgui.Image(iconPtr, {iconSize, iconSize});
-                            imgui.SameLine();
+                    local dl = imgui.GetWindowDrawList();
+                    local rmin = {imgui.GetItemRectMin()};
+                    local tx = rmin[1] + 6;
+                    local ty = rmin[2] + padY;
+                    local curX = tx;
+                    if item.level then
+                        local lvlStr = '[' .. tostring(item.level) .. '] ';
+                        dl:AddText({curX, ty}, imgui.GetColorU32(levelColor), lvlStr);
+                        local lw = imgui.CalcTextSize(lvlStr);
+                        curX = curX + ((type(lw) == 'table' and (lw[1] or lw.x)) or lw);
+                    end
+                    dl:AddText({curX, ty}, imgui.GetColorU32(nameColor), itemName);
+                    local nw = imgui.CalcTextSize(itemName);
+                    curX = curX + ((type(nw) == 'table' and (nw[1] or nw.x)) or nw);
+
+                    local starCol, starTip = nil, nil;
+                    if item.pinkStarTooltip then
+                        starCol = PINK_STAR_COLOR;
+                        starTip = item.pinkStarTooltip;
+                    elseif item.familyVarianceReason then
+                        starCol = GOLD_STAR_COLOR;
+                        starTip = item.familyVarianceReason;
+                    end
+                    if starCol then
+                        dl:AddText({curX + 4, ty}, imgui.GetColorU32(starCol), '*');
+                    end
+
+                    if hovered then
+                        if starTip then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(starTip);
+                            imgui.EndTooltip();
+                        elseif item.reason then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(item.reason);
+                            imgui.EndTooltip();
                         end
                     end
-                end
 
-                local itemLabel = item.level and string.format('[%d] %s', item.level, itemName) or itemName;
-                -- Add quantity for items with count > 1
-                if item.count and item.count > 1 then
-                    itemLabel = itemLabel .. ' x' .. item.count;
-                end
-                if imgui.Selectable(itemLabel .. '##item' .. (item.id or matchCount), isSelected) then
-                    onSelect(item);
-                    searchFilter[1] = '';
-                    imgui.CloseCurrentPopup();
-                end
+                    if clicked then
+                        onSelect(item);
+                        MP.searchFilter[1] = '';
+                        imgui.CloseCurrentPopup();
+                    end
+                else
+                    -- â”€â”€ Standard single-color rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+                    local textColor = nil;
+                    if isSelected then
+                        textColor = COLORS.gold;
+                    elseif useStatusColors and item.status and STATUS_COLORS[item.status] then
+                        textColor = STATUS_COLORS[item.status];
+                    elseif item.usable then
+                        textColor = COLORS.usable;
+                    end
 
-                if textColor then
-                    imgui.PopStyleColor();
+                    local starCol, starTip = nil, nil;
+                    if item.familyVarianceReason then
+                        starCol = GOLD_STAR_COLOR;
+                        starTip = item.familyVarianceReason;
+                    elseif item.pinkStarTooltip then
+                        starCol = PINK_STAR_COLOR;
+                        starTip = item.pinkStarTooltip;
+                    end
+
+                    if starCol and starTip then
+                        local baseCol = isSelected and COLORS.gold or (textColor or COLORS.text);
+                        local rowW = math.max(60, comboW - 24);
+                        local rowH = math.max(iconSize + 4, imgui.GetTextLineHeight() + 6);
+
+                        imgui.InvisibleButton('##item' .. uid, {rowW, rowH});
+                        local clicked = imgui.IsItemClicked();
+                        local hovered = imgui.IsItemHovered();
+
+                        local dl = imgui.GetWindowDrawList();
+                        local rmin = {imgui.GetItemRectMin()};
+                        local curX = rmin[1] + 4;
+                        local curY = rmin[2] + 2;
+
+                        if showIcons and item.id then
+                            local icon = actions.GetItemIconForBrowsing(item.id);
+                            if icon and icon.image then
+                                local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+                                if iconPtr then
+                                    dl:AddImage(iconPtr, {curX, curY}, {curX + iconSize, curY + iconSize});
+                                    curX = curX + iconSize + 6;
+                                end
+                            end
+                        end
+
+                        local labelMain = itemName;
+                        if item.level then
+                            labelMain = string.format('[%d] %s', item.level, itemName);
+                        elseif item.reqStr then
+                            labelMain = string.format('%s  (%s)', itemName, item.reqStr);
+                        end
+                        if item.count and item.count > 1 then
+                            labelMain = labelMain .. ' x' .. item.count;
+                        end
+
+                        local ty = curY + math.max(0, (rowH - imgui.GetTextLineHeight()) / 2 - 2);
+                        dl:AddText({curX, ty}, imgui.GetColorU32(baseCol), labelMain);
+                        local lw = imgui.CalcTextSize(labelMain);
+                        curX = curX + ((type(lw) == 'table' and (lw[1] or lw.x)) or lw);
+                        dl:AddText({curX + 4, ty}, imgui.GetColorU32(starCol), '*');
+
+                        if hovered then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(starTip);
+                            imgui.EndTooltip();
+                        end
+
+                        if clicked then
+                            onSelect(item);
+                            MP.searchFilter[1] = '';
+                            imgui.CloseCurrentPopup();
+                        end
+                    else
+                        if textColor then imgui.PushStyleColor(ImGuiCol_Text, textColor); end
+
+                        -- Show icon if enabled and item has an id
+                        if showIcons and item.id then
+                            local icon = actions.GetItemIconForBrowsing(item.id);
+                            if icon and icon.image then
+                                local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+                                if iconPtr then
+                                    imgui.Image(iconPtr, {iconSize, iconSize});
+                                    imgui.SameLine();
+                                end
+                            end
+                        end
+
+                        local itemLabel;
+                        if item.level then
+                            itemLabel = string.format('[%d] %s', item.level, itemName);
+                        elseif item.reqStr then
+                            itemLabel = string.format('%s  (%s)', itemName, item.reqStr);
+                        else
+                            itemLabel = itemName;
+                        end
+                        if item.count and item.count > 1 then
+                            itemLabel = itemLabel .. ' x' .. item.count;
+                        end
+                        if imgui.Selectable(itemLabel .. '##item' .. uid, isSelected) then
+                            onSelect(item);
+                            MP.searchFilter[1] = '';
+                            imgui.CloseCurrentPopup();
+                        end
+
+                        if item.reason and imgui.IsItemHovered() then
+                            imgui.BeginTooltip();
+                            imgui.TextUnformatted(item.reason);
+                            imgui.EndTooltip();
+                        end
+
+                        if textColor then imgui.PopStyleColor(); end
+                    end
                 end
             end
         end
@@ -1013,34 +1633,127 @@ end
 -- Macro Database Functions
 -- ============================================
 
+-- Clear SMN avatar / BST jug subset palette UI state (when switching macro type or job bucket).
+local function ClearSmnMacroSubsetUi()
+    MP.selectedAvatarPalette = nil;
+    MP.smnShowAllAvatarSubsets = false;
+end
+
+local function ClearBstJugMacroSubsetUi()
+    MP.selectedBstJugMovesKey = nil;
+    MP.bstShowAllJugSubsets = false;
+end
+
+local function ResetPetJobMacroPaletteSubsets()
+    ClearSmnMacroSubsetUi();
+    ClearBstJugMacroSubsetUi();
+end
+
 -- Get current effective type for the palette (selected type or player's current job)
--- Returns GLOBAL_MACRO_KEY for global macros, a job ID, or a composite key like "15:avatar:ifrit"
+-- Returns GLOBAL_MACRO_KEY, ITEMS_MACRO_KEY, a job ID, or a composite key like "15:avatar:ifrit"
 local function GetEffectivePaletteType()
-    if selectedPaletteType then
+    if MP.selectedPaletteType then
         -- If Global is selected, return the global key
-        if selectedPaletteType == GLOBAL_MACRO_KEY then
+        if MP.selectedPaletteType == GLOBAL_MACRO_KEY then
             return GLOBAL_MACRO_KEY;
         end
+        if MP.selectedPaletteType == ITEMS_MACRO_KEY then
+            return ITEMS_MACRO_KEY;
+        end
+        if MP.selectedPaletteType == EQUIPMENT_MACRO_KEY then
+            return EQUIPMENT_MACRO_KEY;
+        end
+        if MP.selectedPaletteType == XIUI_MACRO_KEY then
+            return XIUI_MACRO_KEY;
+        end
+        if type(MP.selectedPaletteType) == 'string' and macroBuckets.isCustomCategoryKey(MP.selectedPaletteType) then
+            return MP.selectedPaletteType;
+        end
         -- If a valid job ID is selected
-        if type(selectedPaletteType) == 'number' and selectedPaletteType > 0 then
+        if type(MP.selectedPaletteType) == 'number' and MP.selectedPaletteType > 0 then
             -- Check for SMN avatar-specific palette
-            if selectedPaletteType == petregistry.JOB_SMN and selectedAvatarPalette then
-                local avatarKey = petregistry.avatars[selectedAvatarPalette];
+            if MP.selectedPaletteType == petregistry.JOB_SMN and MP.selectedAvatarPalette then
+                local avatarKey = petregistry.avatars[MP.selectedAvatarPalette];
                 if avatarKey then
-                    return string.format('%d:avatar:%s', selectedPaletteType, avatarKey);
+                    return string.format('%d:avatar:%s', MP.selectedPaletteType, avatarKey);
                 end
             end
-            return selectedPaletteType;
+            if MP.selectedPaletteType == petregistry.JOB_BST and MP.selectedBstJugMovesKey then
+                return petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(MP.selectedBstJugMovesKey);
+            end
+            return MP.selectedPaletteType;
         end
     end
     -- Default to current player job
     return data.jobId or 1;
+end
+-- Exposed for crossbar drop: must match fallbacks in HandleDropOnSlot (not raw job id for Global/items/etc.)
+M.GetEffectivePaletteType = GetEffectivePaletteType;
+
+--- True when macros are being saved under the Items palette bucket (`macroDB.items`).
+function M.EditorMacroPaletteKeyIsItems(saveKey)
+    local k = saveKey;
+    if k == nil then
+        k = MP.editorPaletteKey;
+    end
+    if k == nil then
+        k = GetEffectivePaletteType();
+    end
+    return data.MacroPaletteKeysEqual(k, ITEMS_MACRO_KEY);
+end
+
+--- Restrict editor to item/macro/equip types when Saving To (or editing) Items palette; coerce illegal types to Item.
+function M.ClampMacroEditorForItemsPalette()
+    if not MP.editingMacro then
+        return;
+    end
+    if not M.EditorMacroPaletteKeyIsItems(MP.editorPaletteKey) then
+        return;
+    end
+    local allowed = { item = true, macro = true, equip = true };
+    local at = MP.editingMacro.actionType or 'item';
+    if not allowed[at] then
+        MP.editingMacro.actionType = 'item';
+        MP.editingMacro.action = '';
+        MP.editorFields.action[1] = '';
+        MP.searchFilter[1] = '';
+        MP.editingMacro.recastSourceType = nil;
+        MP.editingMacro.recastSourceAction = nil;
+        MP.editingMacro.recastSourceItemId = nil;
+        MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES, 'none');
+        MP.editorFields.recastSourceAction[1] = '';
+        MP.editingMacro.showJaBadgeOnMacro = nil;
+        MP.editingMacro.customIconType = 'xiui_default';
+        MP.editingMacro.customIconPath = 'item';
+        MP.editorAutoIconKey = 'xiui_default::item';
+        MP.editorImplicitActionIconDone = false;
+    end
+    MP.editorFields.actionType[1] = MP.FindIndex(ACTION_TYPES, MP.editingMacro.actionType or 'item');
 end
 
 -- Get display name for a palette type key
 local function GetPaletteDisplayName(typeKey)
     if typeKey == GLOBAL_MACRO_KEY then
         return 'Global';
+    end
+    if typeKey == ITEMS_MACRO_KEY then
+        return 'Items';
+    end
+    if typeKey == EQUIPMENT_MACRO_KEY then
+        return 'Equipment';
+    end
+    if typeKey == XIUI_MACRO_KEY then
+        return 'XIUI Commands';
+    end
+    if type(typeKey) == 'string' and macroBuckets.isCustomCategoryKey(typeKey) then
+        if gConfig and gConfig.macroCustomCategories then
+            for _, entry in ipairs(gConfig.macroCustomCategories) do
+                if entry.key == typeKey then
+                    return entry.label or typeKey;
+                end
+            end
+        end
+        return typeKey;
     end
     if type(typeKey) == 'number' then
         return jobs[typeKey] or 'Unknown';
@@ -1055,45 +1768,355 @@ local function GetPaletteDisplayName(typeKey)
                     return string.format('%s (%s)', jobs[tonumber(jobId)] or 'SMN', name);
                 end
             end
+        elseif jobId and petType == petregistry.PET_TYPE_JUG and petId then
+            local petLabel = petregistry.GetDisplayNameForKey(petregistry.PET_TYPE_JUG .. ':' .. petId);
+            return string.format('%s (%s)', jobs[tonumber(jobId)] or 'BST', petLabel);
         end
     end
     return tostring(typeKey);
 end
 
+local function CountMacrosInPalette(paletteKey)
+    if gConfig and gConfig.macroDB and gConfig.macroDB[paletteKey] then
+        return #gConfig.macroDB[paletteKey];
+    end
+    return 0;
+end
+
+-- Cache key so search/icon caches reset when toggling SMN "all subsets" view.
+local SMN_ALL_SUBSETS_VIEW_TAG = '__all_subsets__';
+local BST_ALL_SUBSETS_VIEW_TAG = '__bst_all_jug_subsets__';
+
+local function IsSmnAllSubsetsPaletteView()
+    return MP.selectedPaletteType == petregistry.JOB_SMN and MP.smnShowAllAvatarSubsets;
+end
+
+local function IsBstAllSubsetsPaletteView()
+    return MP.selectedPaletteType == petregistry.JOB_BST and MP.bstShowAllJugSubsets;
+end
+
+--- Stable jug subset rows: picker families (deduped by slug) then extra jug:* keys (e.g. Lynx, Arctic).
+local function BstJugSubsetEntriesOrdered()
+    local rows = {};
+    local seen = {};
+    local jid = petregistry.JOB_BST;
+    for _, row in ipairs(petregistry.GetBstJugReadyFamilyPickerList()) do
+        local slug = row.movesKey:lower();
+        if not seen[slug] then
+            seen[slug] = true;
+            table.insert(rows, {
+                movesKey = row.movesKey,
+                label = row.name,
+                fullKey = petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(row.movesKey),
+            });
+        end
+    end
+    local extras = {};
+    for _, pk in ipairs(petregistry.GetAvailablePetKeys(jid)) do
+        local slug = pk:match('^jug:(.+)$');
+        if slug and not seen[slug] then
+            local mk = petregistry.MovesKeyFromBstMacroPaletteSlug(slug);
+            if mk then
+                seen[slug] = true;
+                table.insert(extras, {
+                    movesKey = mk,
+                    label = petregistry.GetDisplayNameForKey(pk),
+                    fullKey = string.format('%d:%s:%s', jid, petregistry.PET_TYPE_JUG, slug),
+                });
+            end
+        end
+    end
+    table.sort(extras, function(a, b)
+        return (a.label or '') < (b.label or '');
+    end);
+    for _, e in ipairs(extras) do
+        table.insert(rows, e);
+    end
+    return rows;
+end
+
+local function CountBstAllJugSubsetsMacros()
+    local n = CountMacrosInPalette(petregistry.JOB_BST);
+    for _, ent in ipairs(BstJugSubsetEntriesOrdered()) do
+        n = n + CountMacrosInPalette(ent.fullKey);
+    end
+    return n;
+end
+
+local function BuildBstAllJugSubsetsRows()
+    local out = {};
+    local jid = petregistry.JOB_BST;
+    if not gConfig or not gConfig.macroDB then
+        return out;
+    end
+    local baseDb = gConfig.macroDB[jid];
+    if baseDb then
+        for _, m in ipairs(baseDb) do
+            table.insert(out, { macro = m, paletteKey = jid, subsetLabel = 'Base BST' });
+        end
+    end
+    for _, ent in ipairs(BstJugSubsetEntriesOrdered()) do
+        local adb = gConfig.macroDB[ent.fullKey];
+        if adb then
+            for _, m in ipairs(adb) do
+                table.insert(out, { macro = m, paletteKey = ent.fullKey, subsetLabel = ent.label });
+            end
+        end
+    end
+    return out;
+end
+
+local function CountSmnAllSubsetsMacros()
+    local n = 0;
+    local jid = petregistry.JOB_SMN;
+    if not gConfig or not gConfig.macroDB then
+        return 0;
+    end
+    local base = gConfig.macroDB[jid];
+    if base then
+        n = n + #base;
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local ak = petregistry.avatars[avatar];
+        if ak then
+            local fk = string.format('%d:avatar:%s', jid, ak);
+            local adb = gConfig.macroDB[fk];
+            if adb then
+                n = n + #adb;
+            end
+        end
+    end
+    return n;
+end
+
+--- Flatten Base SMN + each avatar macro bucket (order: base, then avatars list order).
+local function BuildSmnAllSubsetsRows()
+    local rows = {};
+    local jid = petregistry.JOB_SMN;
+    if not gConfig or not gConfig.macroDB then
+        return rows;
+    end
+    local baseDb = gConfig.macroDB[jid];
+    if baseDb then
+        for _, m in ipairs(baseDb) do
+            table.insert(rows, { macro = m, paletteKey = jid, subsetLabel = 'Base SMN' });
+        end
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local ak = petregistry.avatars[avatar];
+        if ak then
+            local fk = string.format('%d:avatar:%s', jid, ak);
+            local adb = gConfig.macroDB[fk];
+            if adb then
+                for _, m in ipairs(adb) do
+                    table.insert(rows, { macro = m, paletteKey = fk, subsetLabel = avatar });
+                end
+            end
+        end
+    end
+    return rows;
+end
+
+local function EnsureMacroCustomCategoriesList()
+    if not gConfig.macroCustomCategories then
+        gConfig.macroCustomCategories = {};
+    end
+    if not gConfig.macroCustomNextSeq or gConfig.macroCustomNextSeq < 1 then
+        gConfig.macroCustomNextSeq = 1;
+    end
+end
+
+local function AddMacroCustomCategory(displayLabel)
+    EnsureMacroCustomCategoriesList();
+    local label = tostring(displayLabel or ''):match('^%s*(.-)%s*$') or '';
+    if label == '' then
+        return nil;
+    end
+    local key = macroBuckets.CUSTOM_PREFIX .. tostring(gConfig.macroCustomNextSeq);
+    gConfig.macroCustomNextSeq = gConfig.macroCustomNextSeq + 1;
+    table.insert(gConfig.macroCustomCategories, { key = key, label = label });
+    if not gConfig.macroDB then
+        gConfig.macroDB = {};
+    end
+    if not gConfig.macroDB[key] then
+        gConfig.macroDB[key] = {};
+    end
+    return key;
+end
+
+local function RemoveMacroCustomCategory(remKey)
+    if not gConfig.macroCustomCategories then
+        return;
+    end
+    for i, e in ipairs(gConfig.macroCustomCategories) do
+        if e.key == remKey then
+            table.remove(gConfig.macroCustomCategories, i);
+            break;
+        end
+    end
+    if gConfig.macroDB and gConfig.macroDB[remKey] then
+        gConfig.macroDB[remKey] = nil;
+    end
+end
+
+--- Numeric job id from a save key (Global â†’ nil; composite SMN avatar keys â†’ job id).
+local function EditorSaveKeyToJobId(saveKey)
+    if saveKey == GLOBAL_MACRO_KEY or saveKey == ITEMS_MACRO_KEY or saveKey == EQUIPMENT_MACRO_KEY or saveKey == XIUI_MACRO_KEY then
+        return nil;
+    end
+    if type(saveKey) == 'string' and macroBuckets.isCustomCategoryKey(saveKey) then
+        return nil;
+    end
+    if type(saveKey) == 'number' then
+        return saveKey;
+    end
+    if type(saveKey) == 'string' then
+        local jid = saveKey:match('^(%d+):');
+        if jid then
+            return tonumber(jid);
+        end
+    end
+    return nil;
+end
+
+-- While creating an SMN macro, set Save Sub Type to match Avatar Filter when filter is a specific avatar (not "All").
+local function SyncSaveSubTypeFromPetAvatarFilter()
+    if not MP.isCreatingNew then
+        return;
+    end
+    local saveJid = EditorSaveKeyToJobId(MP.editorPaletteKey);
+    if saveJid ~= petregistry.JOB_SMN then
+        return;
+    end
+    if MP.petAvatarFilter <= 1 then
+        return;
+    end
+    local avatarList = petregistry.GetAvatarList();
+    local avatar = avatarList[MP.petAvatarFilter - 1];
+    if not avatar then
+        return;
+    end
+    local avatarKey = petregistry.avatars[avatar];
+    if not avatarKey then
+        return;
+    end
+    MP.editorPaletteKey = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
+end
+
+-- Align create-macro Avatar Filter with "Saving To" / "Save Sub Type" for SMN (independent of Macro Palette window avatar).
+local function SyncPetAvatarFilterFromSaveSubType()
+    local key = MP.editorPaletteKey;
+    if not key then
+        return;
+    end
+    local jid = EditorSaveKeyToJobId(key);
+    if jid ~= petregistry.JOB_SMN then
+        return;
+    end
+    if type(key) == 'number' and key == petregistry.JOB_SMN then
+        MP.petAvatarFilter = 1;
+        MP.cachedPetCommands = nil;
+        return;
+    end
+    if type(key) == 'string' then
+        local jobId, petType, petId = key:match('^(%d+):([^:]+):(.+)$');
+        if jobId and tonumber(jobId) == petregistry.JOB_SMN and petType == 'avatar' and petId then
+            local avatarList = petregistry.GetAvatarList();
+            for i, name in ipairs(avatarList) do
+                if petregistry.avatars[name] == petId then
+                    MP.petAvatarFilter = i + 1;
+                    MP.cachedPetCommands = nil;
+                    return;
+                end
+            end
+        end
+    end
+end
+
+local function SyncBstJugFamilyFromSaveSubType()
+    local key = MP.editorPaletteKey;
+    if not MP.editingMacro then
+        return;
+    end
+    if not key or type(key) ~= 'string' then
+        return;
+    end
+    local jobId, petType, petId = key:match('^(%d+):([^:]+):(.+)$');
+    if not jobId or tonumber(jobId) ~= petregistry.JOB_BST then
+        return;
+    end
+    if petType ~= petregistry.PET_TYPE_JUG then
+        return;
+    end
+    local mk = petregistry.MovesKeyFromBstMacroPaletteSlug(petId);
+    if not mk then
+        return;
+    end
+    MP.editingMacro.bstJugReadyMovesKey = mk;
+    MP.editingMacro.bstJugReadyFamilyLabel = nil;
+    for _, row in ipairs(petregistry.GetBstJugReadyFamilyPickerList()) do
+        if row.movesKey == mk then
+            MP.editingMacro.bstJugReadyFamilyLabel = row.name;
+            break;
+        end
+    end
+end
+
+-- While creating a BST Ready (Use) macro, align Save Sub Type with the picked jug family (SMN avatar parity).
+local function SyncSaveSubTypeFromBstJugFamily()
+    if not MP.isCreatingNew then
+        return;
+    end
+    if EditorSaveKeyToJobId(MP.editorPaletteKey) ~= petregistry.JOB_BST then
+        return;
+    end
+    local mk = MP.editingMacro and MP.editingMacro.bstJugReadyMovesKey;
+    if not mk or mk == '' then
+        return;
+    end
+    MP.editorPaletteKey = petregistry.FormatBstMacroPaletteSaveKeyFromMovesKey(mk);
+end
+
+local function SyncMacroEditorSubtypeFieldsFromSaveKey()
+    SyncPetAvatarFilterFromSaveSubType();
+    SyncBstJugFamilyFromSaveSubType();
+end
+
 -- Sync palette to current player job (call on job change)
 function M.SyncToCurrentJob()
-    -- Only sync if not viewing Global - preserve Global selection across job changes
-    if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+    -- Only sync when viewing a job bucket â€” preserve shared/custom macro categories across job changes
+    if not IsSharedJobAgnosticMacroSelection(MP.selectedPaletteType) then
+        MP.selectedPaletteType = data.jobId or 1;
     end
     -- Clear spell/ability/item caches so they rebuild for new job
     playerdata.ClearCache();
-    cachedPetCommands = nil;
-    petAvatarFilter = 1;
-    selectedAvatarPalette = nil;
+    MP.cachedPetCommands = nil;
+    MP.petAvatarFilter = 1;
+    ResetPetJobMacroPaletteSubsets();
     -- Close editor window if open (spells/abilities are job-specific)
-    if editingMacro then
-        editingMacro = nil;
-        isCreatingNew = false;
-        searchFilter[1] = '';
-        iconPickerOpen = false;
+    if MP.editingMacro then
+        MP.editingMacro = nil;
+        MP.isCreatingNew = false;
+        MP.searchFilter[1] = '';
+        MP.iconPickerOpen = false;
+        ClearEditorPreviewIconCache();
     end
     -- Clear macro selection (macros are per-type)
-    selectedMacroIndex = nil;
+    paletteUi.selectedMacroIndex = nil;
     -- If palette is open, immediately refresh the caches
-    if paletteOpen then
+    if paletteUi.open then
         RefreshCachedLists();
     end
 end
 
 -- Clear pet commands cache (call on pet change for BST)
 function M.ClearPetCommandsCache()
-    cachedPetCommands = nil;
+    MP.cachedPetCommands = nil;
 end
 
 -- Get the macro database for selected type (Global or job-specific)
-function M.GetMacroDatabase()
-    local typeKey = GetEffectivePaletteType();
+function M.GetMacroDatabase(typeKeyOverride)
+    local typeKey = typeKeyOverride or GetEffectivePaletteType();
 
     if not gConfig.macroDB then
         gConfig.macroDB = {};
@@ -1106,20 +2129,42 @@ function M.GetMacroDatabase()
     return gConfig.macroDB[typeKey], typeKey;
 end
 
--- Add a new macro to the database
-function M.AddMacro(macroData)
-    local db, _ = M.GetMacroDatabase();
+local function markSharedMacroLibraryDirtyIfNeeded()
+    if gConfig and sharedMacroStore.IsSharedScope(gConfig) then
+        sharedMacroStore.MarkSharedLibraryDirty();
+    end
+end
 
-    -- Generate unique ID
+-- Add a new macro to the database
+function M.AddMacro(macroData, typeKeyOverride)
+    local db, typeKey = M.GetMacroDatabase(typeKeyOverride);
+
+    if typeKey == macroBuckets.GLOBAL and macroGlobalDefaults.IsUniversalTwoHourMacro(macroData) then
+        for _, ex in ipairs(db) do
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(ex) then
+                return nil;
+            end
+        end
+    end
+
+    -- Generate unique ID (per palette bucket). In Shared scope, also consider the frozen profile
+    -- library so new ids never collide with profile hotbar macroRef values in the same bucket.
     local maxId = 0;
     for _, macro in ipairs(db) do
         if macro.id and macro.id > maxId then
             maxId = macro.id;
         end
     end
+    if gConfig and sharedMacroStore.IsSharedScope(gConfig) then
+        local fmax = sharedMacroStore.GetMaxMacroIdInFrozenProfileBucket(typeKey);
+        if fmax > maxId then
+            maxId = fmax;
+        end
+    end
 
     macroData.id = maxId + 1;
     table.insert(db, macroData);
+    markSharedMacroLibraryDirtyIfNeeded();
     SaveSettingsToDisk();
     data.MarkMacroLookupDirty();
 
@@ -1127,13 +2172,17 @@ function M.AddMacro(macroData)
 end
 
 -- Update an existing macro
-function M.UpdateMacro(macroId, macroData)
-    local db = M.GetMacroDatabase();
+function M.UpdateMacro(macroId, macroData, typeKeyOverride)
+    local db = M.GetMacroDatabase(typeKeyOverride);
 
     for i, macro in ipairs(db) do
         if macro.id == macroId then
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                return false;
+            end
             macroData.id = macroId;  -- Preserve ID
             db[i] = macroData;
+            markSharedMacroLibraryDirtyIfNeeded();
             SaveSettingsToDisk();
             -- Clear icon cache so hotbar slots referencing this macro update
             ClearAllIconCaches();
@@ -1145,43 +2194,64 @@ function M.UpdateMacro(macroId, macroData)
     return false;
 end
 
--- Clear all hotbar/crossbar slots that reference a specific macro ID
--- For Global macros, clears from ALL jobs' slot actions
-local function ClearSlotsReferencingMacro(macroId, typeKey)
-    local isGlobalMacro = (typeKey == GLOBAL_MACRO_KEY);
+-- Macro IDs are unique only within one macroDB[typeKey] table; the same numeric id can exist
+-- in Global and in each job palette. Clearing by macroRef alone removed unrelated slots.
+local function CountPaletteBucketsWithMacroId(macroId)
+    if not gConfig or not gConfig.macroDB then
+        return 0;
+    end
+    local n = 0;
+    for _, macros in pairs(gConfig.macroDB) do
+        if type(macros) == 'table' then
+            for _, m in ipairs(macros) do
+                if m.id == macroId then
+                    n = n + 1;
+                    break;
+                end
+            end
+        end
+    end
+    return n;
+end
 
-    -- Clear from all hotbars (1-6)
+-- deletedTypeKey / onlyBucketForThisId / deleteKind: see data.ApplyMacroDeleteToSlotAction
+local function ClearMacroSlotsInConfigTable(cfg, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    if not cfg then
+        return false;
+    end
+    local changed = false;
     for barIndex = 1, 6 do
         local configKey = 'hotbarBar' .. barIndex;
-        if gConfig[configKey] and gConfig[configKey].slotActions then
-            local barSettings = gConfig[configKey];
-
-            -- Clear from ALL storage keys (macro could be on any job:subjob combination)
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
             for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
                 if jobSlotActions then
                     for slotIndex, slotAction in pairs(jobSlotActions) do
-                        if slotAction and slotAction.macroRef == macroId then
-                            jobSlotActions[slotIndex] = { cleared = true };
+                        local newSlot, chg = data.ApplyMacroDeleteToSlotAction(
+                            slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, { cleared = true });
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
                         end
                     end
                 end
             end
         end
     end
-
-    -- Clear from crossbar (all combo modes, all storage keys)
-    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
-        local crossbarSettings = gConfig.hotbarCrossbar;
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
         local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
-
         for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
             if jobSlotActions then
                 for _, comboMode in ipairs(comboModes) do
                     local comboSlots = jobSlotActions[comboMode];
                     if comboSlots then
                         for slotIndex, slotAction in pairs(comboSlots) do
-                            if slotAction and slotAction.macroRef == macroId then
-                                comboSlots[slotIndex] = nil;
+                            local newSlot, chg = data.ApplyMacroDeleteToSlotAction(
+                                slotAction, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind, nil);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
                             end
                         end
                     end
@@ -1189,18 +2259,207 @@ local function ClearSlotsReferencingMacro(macroId, typeKey)
             end
         end
     end
+    return changed;
 end
 
--- Delete a macro from the database
-function M.DeleteMacro(macroId)
-    local db, typeKey = M.GetMacroDatabase();
+-- Clear every slot that references a removed macroDB bucket (entire key deleted).
+local function ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, removedBucketKey, deleteKind)
+    if not cfg or removedBucketKey == nil then
+        return false;
+    end
+    local changed = false;
+    for barIndex = 1, 6 do
+        local configKey = 'hotbarBar' .. barIndex;
+        if cfg[configKey] and cfg[configKey].slotActions then
+            local barSettings = cfg[configKey];
+            for storageKey, jobSlotActions in pairs(barSettings.slotActions) do
+                if jobSlotActions then
+                    for slotIndex, slotAction in pairs(jobSlotActions) do
+                        local newSlot, chg = data.ApplyMacroPaletteBucketRemovedToSlotAction(
+                            slotAction, removedBucketKey, deleteKind, { cleared = true });
+                        if chg then
+                            jobSlotActions[slotIndex] = newSlot;
+                            changed = true;
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if cfg.hotbarCrossbar and cfg.hotbarCrossbar.slotActions then
+        local crossbarSettings = cfg.hotbarCrossbar;
+        local comboModes = { 'L2', 'R2', 'L2R2', 'R2L2', 'L2x2', 'R2x2' };
+        for storageKey, jobSlotActions in pairs(crossbarSettings.slotActions) do
+            if jobSlotActions then
+                for _, comboMode in ipairs(comboModes) do
+                    local comboSlots = jobSlotActions[comboMode];
+                    if comboSlots then
+                        for slotIndex, slotAction in pairs(comboSlots) do
+                            local newSlot, chg = data.ApplyMacroPaletteBucketRemovedToSlotAction(
+                                slotAction, removedBucketKey, deleteKind, nil);
+                            if chg then
+                                comboSlots[slotIndex] = newSlot;
+                                changed = true;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return changed;
+end
+
+local function RemoveCustomCategoryFromProfileMeta(cfg, remKey)
+    if not cfg or not cfg.macroCustomCategories or not remKey then
+        return false;
+    end
+    for i, e in ipairs(cfg.macroCustomCategories) do
+        if e.key == remKey then
+            table.remove(cfg.macroCustomCategories, i);
+            return true;
+        end
+    end
+    return false;
+end
+
+-- Shared library: the bucket is global; other profiles' layouts may still list it or have slots. Sync metadata and slots.
+local function SweepOtherProfilesForSharedCustomCategoryDelete(remKey, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg then
+                local chg = ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, remKey, 'profile');
+                if ClearMacroSlotsInConfigForRemovedPaletteBucket(cfg, remKey, 'shared') then
+                    chg = true;
+                end
+                if RemoveCustomCategoryFromProfileMeta(cfg, remKey) then
+                    chg = true;
+                end
+                if chg then
+                    profileManager.SaveProfileSettings(name, cfg);
+                end
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Display label only; storage key stays 'custom:N' (macro data and hotbar macroPaletteKey refs unchanged).
+local function ApplyRenameMacroCustomCategory(catKey, newLabel)
+    if not catKey or not macroBuckets.isCustomCategoryKey(catKey) then
+        return false;
+    end
+    local label = tostring(newLabel or ''):match('^%s*(.-)%s*$') or '';
+    if label == '' then
+        return false;
+    end
+    EnsureMacroCustomCategoriesList();
+    for _, e in ipairs(gConfig.macroCustomCategories) do
+        if e.key == catKey then
+            e.label = label;
+            return true;
+        end
+    end
+    return false;
+end
+
+-- Remove a custom bucket: clear all hotbar/crossbar slot refs, delete macro rows, and sync other profiles in shared mode.
+local function DeleteMacroCustomCategoryCompletely(remKey)
+    if not remKey or not macroBuckets.isCustomCategoryKey(remKey) then
+        return false;
+    end
+    local inShared = (gConfig.macroStorageScope or 'profile') == 'shared';
+    -- Custom buckets use one palette key, but a slot may have profile+shared library arms; clear both.
+    ClearMacroSlotsInConfigForRemovedPaletteBucket(gConfig, remKey, 'profile');
+    ClearMacroSlotsInConfigForRemovedPaletteBucket(gConfig, remKey, 'shared');
+    RemoveMacroCustomCategory(remKey);
+    if inShared and config and config.currentProfile then
+        SweepOtherProfilesForSharedCustomCategoryDelete(remKey, config.currentProfile);
+    end
+    markSharedMacroLibraryDirtyIfNeeded();
+    if MP.selectedPaletteType == remKey then
+        MP.selectedPaletteType = GLOBAL_MACRO_KEY;
+    end
+    ResetPetJobMacroPaletteSubsets();
+    paletteUi.selectedMacroIndex = nil;
+    MP.currentPalettePage = 1;
+    MP.macroCustomRenameTargetKey = nil;
+    playerdata.ClearCache();
+    MP.cachedPetCommands = nil;
+    MP.petAvatarFilter = 1;
+    SaveSettingsToDisk();
+    ClearAllIconCaches();
+    data.InvalidateConfigDerivedCaches();
+    data.MarkMacroLookupDirty();
+    return true;
+end
+
+-- After deleting a global shared macro: clear that ref on all other profile files (current gConfig was already cleared + saved)
+local function SweepOtherProfilesForSharedMacroDelete(macroId, typeKey, onlyBucket, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg and ClearMacroSlotsInConfigTable(cfg, macroId, typeKey, onlyBucket, 'shared') then
+                profileManager.SaveProfileSettings(name, cfg);
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Shared macro library: update bindings on other profiles after MoveMacro (same as delete sweep, but rewrite refs).
+local function SweepOtherProfilesForSharedMacroMove(oldId, oldKey, newId, newKey, onlyBucket, currentName)
+    currentName = currentName or (config and config.currentProfile) or 'Default';
+    local globalProfiles = profileManager.GetGlobalProfiles();
+    if not globalProfiles or not globalProfiles.names then
+        return;
+    end
+    for _, name in ipairs(globalProfiles.names) do
+        if name and name ~= currentName then
+            local cfg = profileManager.GetProfileSettings(name);
+            if cfg and data.RewriteMacroPaletteBindingsInConfig(cfg, oldId, oldKey, newId, newKey, onlyBucket, false) then
+                profileManager.SaveProfileSettings(name, cfg);
+            end
+        end
+    end
+    sharedMacroStore.InvalidateDiskSharedCache();
+end
+
+-- Clear hotbar/crossbar live config (gConfig). Edit Full Palette draft buffers are not scanned here;
+-- dead macroRef in an open draft fixes on Apply (resolve) or when the user edits the slot.
+local function ClearSlotsReferencingMacro(macroId, deletedTypeKey, onlyBucketForThisId, deleteKind)
+    ClearMacroSlotsInConfigTable(gConfig, macroId, deletedTypeKey, onlyBucketForThisId, deleteKind);
+end
+
+-- Delete a macro from the database (optional typeKeyOverride targets a specific macroDB bucket).
+function M.DeleteMacro(macroId, typeKeyOverride)
+    local db, typeKey = M.GetMacroDatabase(typeKeyOverride);
+    local deleteKind = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') and 'shared' or 'profile';
 
     for i, macro in ipairs(db) do
         if macro.id == macroId then
+            if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                return false;
+            end
+            local onlyBucketForThisId = (CountPaletteBucketsWithMacroId(macroId) == 1);
             table.remove(db, i);
-            -- Clear any hotbar/crossbar slots referencing this macro
-            ClearSlotsReferencingMacro(macroId, typeKey);
+            ClearSlotsReferencingMacro(macroId, typeKey, onlyBucketForThisId, deleteKind);
+            markSharedMacroLibraryDirtyIfNeeded();
             SaveSettingsToDisk();
+            if deleteKind == 'shared' and config and config.currentProfile then
+                SweepOtherProfilesForSharedMacroDelete(macroId, typeKey, onlyBucketForThisId, config.currentProfile);
+            end
             -- Clear icon cache so hotbar slots update immediately
             ClearAllIconCaches();
             data.MarkMacroLookupDirty();
@@ -1209,6 +2468,56 @@ function M.DeleteMacro(macroId)
     end
 
     return false;
+end
+
+--- Copy a macro row into destPaletteKey with a new id, rewrite bindings that pointed at (macroId, sourcePaletteKey), then remove the source row.
+--- Profile + shared arms are both updated on current layout; other profiles are swept when macro storage is shared.
+function M.MoveMacroToPalette(macroId, sourcePaletteKey, destPaletteKey)
+    if not gConfig or not gConfig.macroDB or not macroId or sourcePaletteKey == nil or destPaletteKey == nil then
+        return false;
+    end
+    if data.MacroPaletteKeysEqual(sourcePaletteKey, destPaletteKey) then
+        return false;
+    end
+    local dbSrc = gConfig.macroDB[sourcePaletteKey];
+    if type(dbSrc) ~= 'table' then
+        return false;
+    end
+    local macroRow = nil;
+    local macroIdx = nil;
+    for i, m in ipairs(dbSrc) do
+        if m.id == macroId then
+            macroRow = m;
+            macroIdx = i;
+            break;
+        end
+    end
+    if not macroRow then
+        return false;
+    end
+    if macroGlobalDefaults.IsUniversalTwoHourMacro(macroRow) then
+        return false;
+    end
+    local copy = deepCopyTable(macroRow);
+    copy.id = nil;
+    local newId = M.AddMacro(copy, destPaletteKey);
+    if not newId then
+        return false;
+    end
+    local onlyBucketForThisId = (CountPaletteBucketsWithMacroId(macroId) == 1);
+    data.RewriteMacroPaletteBindingsInConfig(gConfig, macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId, true);
+    data.RewriteMacroPaletteBindingsInDraft(macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId);
+    local deleteKind = (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') and 'shared' or 'profile';
+    if deleteKind == 'shared' and config and config.currentProfile then
+        SweepOtherProfilesForSharedMacroMove(macroId, sourcePaletteKey, newId, destPaletteKey, onlyBucketForThisId, config.currentProfile);
+    end
+    table.remove(dbSrc, macroIdx);
+    markSharedMacroLibraryDirtyIfNeeded();
+    SaveSettingsToDisk();
+    ClearAllIconCaches();
+    data.InvalidateConfigDerivedCaches();
+    data.MarkMacroLookupDirty();
+    return true;
 end
 
 -- Get a macro by ID
@@ -1224,19 +2533,103 @@ function M.GetMacroById(macroId)
     return nil;
 end
 
+-- opts.bindTargetSlot = { comboMode = string, slotIndex = number } — when present AND the
+-- editor enters "creating new" mode (slotData nil), the first successful Save will write the
+-- new macro's binding into that crossbar draft slot. Consumed exactly once on first Save;
+-- cleared on Cancel/close to prevent stale binds carrying over to unrelated sessions.
+function M.OpenEditorForSlotData(slotData, opts)
+    ClearEditorPreviewIconCache();
+    MP.editorDidInitialIconPick = false;
+    MP.editorImplicitActionIconDone = false;
+    MP.editorIconManuallySet = false;
+    MP.editorJaBadgeManuallySet = false;
+    MP.showAllMode = false;
+    MP.showAllPetMode = false;
+    MP.spellTypeFilter = 'All';
+    MP.abilityJobFilter = 0;
+    MP.petTypeOverride = 0;
+    MP.editorIconPrefsHydrated = false;
+    MP.pendingNewMacroBindTarget = nil;
+
+    if slotData and slotData.macroRef then
+        local paletteKey = slotData.macroPaletteKey or data.jobId or 1;
+        local macro = data.GetMacroById(slotData.macroRef, paletteKey);
+        if macro then
+            MP.editingMacro = deep_copy_table(macro);
+            MP.isCreatingNew = false;
+            MP.editorPaletteKey = paletteKey;
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            RefreshCachedLists();
+            return;
+        end
+    end
+
+    if slotData then
+        MP.editingMacro = deep_copy_table(slotData);
+        MP.isCreatingNew = false;
+        MP.editorPaletteKey = slotData.macroPaletteKey or GetEffectivePaletteType();
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+    else
+        MP.isCreatingNew = true;
+        MP.editorPaletteKey = GetEffectivePaletteType();
+        local body, autoKey = DefaultNewMacroBodyForPaletteKey(MP.editorPaletteKey);
+        MP.editingMacro = body;
+        MP.editorAutoIconKey = autoKey;
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+        if opts and opts.bindTargetSlot and opts.bindTargetSlot.comboMode and opts.bindTargetSlot.slotIndex then
+            MP.pendingNewMacroBindTarget = {
+                comboMode = opts.bindTargetSlot.comboMode,
+                slotIndex = opts.bindTargetSlot.slotIndex,
+            };
+        end
+    end
+    RefreshCachedLists();
+end
+
+-- Open the macro editor as a new macro pre-filled with a raw macro text command.
+-- The palette window is opened automatically; the user can choose where to save.
+function M.OpenNewMacroWithText(macroText, displayName)
+    M.OpenPalette();
+    ClearEditorPreviewIconCache();
+    MP.isCreatingNew              = true;
+    MP.editorDidInitialIconPick   = false;
+    MP.editorImplicitActionIconDone = false;
+    MP.editorIconManuallySet      = false;
+    MP.editorJaBadgeManuallySet   = false;
+    MP.editingMacro = {
+        actionType  = 'macro',
+        macroText   = macroText,
+        displayName = displayName or '',
+        action      = '',
+    };
+    if MP.editorFields and MP.FindIndex then
+        MP.editorFields.actionType[1]       = MP.FindIndex(MP.ACTION_TYPES or {}, 'macro');
+        MP.editorFields.action[1]           = '';
+        MP.editorFields.target[1]           = MP.FindIndex(MP.TARGET_OPTIONS or {}, 't');
+        MP.editorFields.displayName[1]      = displayName or '';
+        MP.editorFields.macroText[1]        = macroText;
+        MP.editorFields.recastSourceType[1] = MP.FindIndex(MP.RECAST_SOURCE_TYPES or {}, 'none');
+        MP.editorFields.recastSourceAction[1] = '';
+    end
+end
+
 -- ============================================
 -- Drag & Drop Functions (using dragdrop library)
 -- ============================================
 
 -- Start dragging a macro from the palette
-function M.StartDragMacro(macroIndex, macroData)
+function M.StartDragMacro(macroIndex, macroData, macroPaletteKeyOverride)
     -- Get icon for this macro
     local icon = actions.GetBindIcon(macroData);
 
     -- Include palette key in data so crossbar drops know which palette the macro came from
     local dragData = {};
     for k, v in pairs(macroData) do dragData[k] = v; end
-    dragData.macroPaletteKey = GetEffectivePaletteType();
+    dragData.macroPaletteKey = macroPaletteKeyOverride or GetEffectivePaletteType();
+    dragData.macroSourceStore = M.GetMacroSourceTagForDrops();
 
     dragdrop.StartDrag('macro', {
         data = dragData,
@@ -1248,22 +2641,32 @@ end
 
 -- Start dragging from a hotbar slot
 function M.StartDragSlot(barIndex, slotIndex, slotData)
-    -- Empty/orphaned slot - nothing to drag
+    -- 1.8.0 defensive guard: empty/orphaned slots have nothing to drag; dragdrop.StartDrag
+    -- with a nil payload bypassed the displayName fallback below and started a "ghost" drag
+    -- in 1.7.5 that confused the drop-zone logic. Bail early instead.
     if not slotData then return; end
-
     -- Get icon for this slot
     local icon = actions.GetBindIcon(slotData);
-
+    -- Raw slot preserves dual profile/shared macro arms (resolved slotData is flattened)
+    local raw = data.GetRawHotbarSlotAction(barIndex, slotIndex);
     dragdrop.StartDrag('slot', {
-        data = slotData,
+        data = raw,
         barIndex = barIndex,
         slotIndex = slotIndex,
-        label = slotData.displayName or slotData.action or 'Slot',
+        label = slotData and (slotData.displayName or slotData.action) or 'Slot',
         icon = icon,
     });
 end
 
 -- Clear drag state
+-- 'shared' | 'profile' â€” which library new hotbar/crossbar binds refer to (for delete + cross-scope resolution)
+function M.GetMacroSourceTagForDrops()
+    if gConfig and (gConfig.macroStorageScope or 'profile') == 'shared' then
+        return 'shared';
+    end
+    return 'profile';
+end
+
 function M.ClearDrag()
     dragdrop.CancelDrag();
 end
@@ -1313,53 +2716,58 @@ function M.HandleDropOnSlot(payload, targetBarIndex, targetSlotIndex)
     local jobSlotActions = ensureSlotActionsStructure(gConfig[configKey], storageKey);
 
     if payload.type == 'macro' then
-        -- Dragging from palette to slot - store only the macro reference.
-        -- macroDB is the single source of truth for action/macroText/displayName/etc.
+        -- Dragging from palette to slot
         local macroData = payload.data;
         if macroData then
-            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite({
-                macroRef = macroData.id,
-                macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType(),
-            });
+            local macroPaletteKey = macroData.macroPaletteKey or GetEffectivePaletteType();
+            local arm = {};
+            for k, v in pairs(macroData) do arm[k] = v; end
+            arm.macroPaletteKey = macroPaletteKey;
+            arm.macroRef = macroData.id;
+            local existing = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+            local store = arm.macroSourceStore or M.GetMacroSourceTagForDrops();
+            local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+            jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(built);
             MarkHotbarDirty();
         end
 
     elseif payload.type == 'slot' then
-        -- Dragging from slot to slot (swap or move)
+        -- Dragging from slot to slot (swap)
         local sourceBarIndex = payload.barIndex;
         local sourceSlotIndex = payload.slotIndex;
-        local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
-
-        local sourceData = data.BuildSlotDataForWrite(payload.data);
-
-        -- Get target slot data
-        local targetBind = data.GetKeybindForSlot(targetBarIndex, targetSlotIndex);
-        local targetData;
-        if targetBind then
-            targetData = data.BuildSlotDataForWrite(targetBind);
-        else
-            -- Target slot is empty - mark as cleared
-            targetData = { cleared = true };
+        if sourceBarIndex == targetBarIndex and sourceSlotIndex == targetSlotIndex then
+            return false;
         end
-
-        -- Ensure source config structure exists
+        local sourceConfigKey = 'hotbarBar' .. sourceBarIndex;
         if not gConfig[sourceConfigKey] then
             gConfig[sourceConfigKey] = {};
         end
-        -- Use pet-aware storage key for source bar
         local sourceStorageKey = data.GetStorageKeyForBar(sourceBarIndex);
         local sourceJobSlotActions = ensureSlotActionsStructure(gConfig[sourceConfigKey], sourceStorageKey);
-
-        -- Swap the slots
-        jobSlotActions[targetSlotIndex] = sourceData;
-        sourceJobSlotActions[sourceSlotIndex] = targetData;
-
+        local sourceRaw = data.GetRawHotbarSlotAction(sourceBarIndex, sourceSlotIndex);
+        local targetRaw = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+        local newTarget, newSource = data.SwapActiveMacroArmsInPlace(sourceRaw, targetRaw);
+        jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(newTarget);
+        sourceJobSlotActions[sourceSlotIndex] = data.FinalizeHotbarRawSlotForStorage(newSource);
         MarkHotbarDirty();
 
     elseif payload.type == 'crossbar_slot' then
         -- Dragging from crossbar to hotbar (one-way copy, doesn't clear source)
-        if payload.data then
-            jobSlotActions[targetSlotIndex] = data.BuildSlotDataForWrite(payload.data);
+        local crossRaw = payload.data;
+        if crossRaw and not crossRaw.cleared then
+            local existing = data.GetRawHotbarSlotAction(targetBarIndex, targetSlotIndex);
+            local isMacro = data.IsMacroSlotDualLayout(crossRaw)
+                or (crossRaw.macroRef and (not crossRaw.actionType or crossRaw.actionType == 'macro'));
+            if isMacro then
+                local arm = select(1, data._GetActiveMacroBindingFromSlot(crossRaw));
+                if arm and arm.macroRef then
+                    local store = arm.macroSourceStore or M.GetMacroSourceTagForDrops();
+                    local built = data.BuildMacroSlotAfterDrop(arm, store, existing);
+                    jobSlotActions[targetSlotIndex] = data.FinalizeHotbarRawSlotForStorage(built);
+                end
+            else
+                jobSlotActions[targetSlotIndex] = deepCopyTable(crossRaw);
+            end
             MarkHotbarDirty();
         end
     end
@@ -1386,14 +2794,15 @@ end
 -- ============================================
 
 function M.OpenPalette()
-    paletteOpen = true;
-    selectedMacroIndex = nil;
-    editingMacro = nil;
-    isCreatingNew = false;
+    paletteUi.open = true;
+    paletteUi.selectedMacroIndex = nil;
+    MP.editingMacro = nil;
+    MP.isCreatingNew = false;
+    ClearEditorPreviewIconCache();
 
-    -- Sync to current player job when opening (unless Global was selected)
-    if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+    -- Sync to current player job when opening (unless a shared or custom category was selected)
+    if not IsSharedJobAgnosticMacroSelection(MP.selectedPaletteType) then
+        MP.selectedPaletteType = data.jobId or 1;
     end
 
     -- Refresh spell/ability/weaponskill caches
@@ -1406,19 +2815,30 @@ function M.ClosePalette()
         SaveSettingsToDisk();
         hotbarDataDirty = false;
     end
-    paletteOpen = false;
-    selectedMacroIndex = nil;
-    editingMacro = nil;
-    isCreatingNew = false;
-    currentPalettePage = 1;  -- Reset to page 1
+    paletteUi.open = false;
+    paletteUi.selectedMacroIndex = nil;
+    MP.editingMacro = nil;
+    MP.isCreatingNew = false;
+    MP.currentPalettePage = 1;  -- Reset to page 1
+    if MP.macroPaletteSearchName then
+        MP.macroPaletteSearchName[1] = '';
+    end
+    MP._lastMacroPaletteSearch = nil;
+    MP.editorDidInitialIconPick = false;
+    MP.editorIconManuallySet = false;
+    MP.editorJaBadgeManuallySet = false;
+    ClearEditorPreviewIconCache();
+    paletteMainIconCache = {};
+    ClearPaletteJaBadgeIconCache();
+    paletteIconCacheDbKey = nil;
 end
 
 function M.IsPaletteOpen()
-    return paletteOpen;
+    return paletteUi.open;
 end
 
 function M.TogglePalette()
-    if paletteOpen then
+    if paletteUi.open then
         M.ClosePalette();
     else
         M.OpenPalette();
@@ -1427,7 +2847,7 @@ end
 
 -- Draw a single macro tile (used in palette)
 local function DrawMacroTile(macro, index, x, y, size)
-    local isSelected = selectedMacroIndex == index;
+    local isSelected = paletteUi.selectedMacroIndex == index;
     local isHovered = false;
 
     -- Set cursor position
@@ -1446,13 +2866,13 @@ local function DrawMacroTile(macro, index, x, y, size)
         imgui.PushStyleColor(ImGuiCol_ButtonActive, COLORS.bgLight);
     end
 
-    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4);
+    imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, PALETTE_TILE_ROUNDING);
     imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
     imgui.PushStyleColor(ImGuiCol_Border, isSelected and COLORS.gold or COLORS.border);
 
     local buttonId = string.format('##macrotile%d', index);
     if imgui.Button(buttonId, {size, size}) then
-        selectedMacroIndex = index;
+        paletteUi.selectedMacroIndex = index;
     end
 
     imgui.PopStyleColor(4);
@@ -1508,17 +2928,21 @@ local function DrawMacroTile(macro, index, x, y, size)
         imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {8, 6});
         imgui.BeginTooltip();
-        imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
-        imgui.Spacing();
-        imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
-        if macro.actionType ~= 'macro' and macro.target then
-            local formattedTarget = FormatTargetForDisplay(macro.target);
-            if formattedTarget then
-                imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+        if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+            imgui.TextColored(COLORS.gold, '2-Hour Ability');
+        else
+            imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
+            if macro.actionType ~= 'macro' and macro.target then
+                local formattedTarget = FormatTargetForDisplay(macro.target);
+                if formattedTarget then
+                    imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                end
             end
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
         end
-        imgui.Spacing();
-        imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
         imgui.EndTooltip();
         imgui.PopStyleVar();
         imgui.PopStyleColor(2);
@@ -1572,43 +2996,353 @@ for i, job in ipairs(JOB_LIST) do
     JOB_ID_MAP[job.id] = i;
 end
 
--- Draw the palette window
-function M.DrawPalette()
-    if not paletteOpen then
+local function PickDefaultMacroMoveDestination(sourceKey)
+    local order = { GLOBAL_MACRO_KEY, ITEMS_MACRO_KEY, EQUIPMENT_MACRO_KEY, XIUI_MACRO_KEY };
+    for _, k in ipairs(order) do
+        if not data.MacroPaletteKeysEqual(k, sourceKey) then
+            return k;
+        end
+    end
+    EnsureMacroCustomCategoriesList();
+    for _, cat in ipairs(gConfig and gConfig.macroCustomCategories or {}) do
+        local k = cat.key;
+        if not data.MacroPaletteKeysEqual(k, sourceKey) then
+            return k;
+        end
+    end
+    for _, job in ipairs(JOB_LIST) do
+        if not data.MacroPaletteKeysEqual(job.id, sourceKey) then
+            return job.id;
+        end
+    end
+    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+        local avatarKey = petregistry.avatars[avatar];
+        if avatarKey then
+            local fk = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
+            if not data.MacroPaletteKeysEqual(fk, sourceKey) then
+                return fk;
+            end
+        end
+    end
+    for _, pk in ipairs(petregistry.GetAvailablePetKeys(petregistry.JOB_BST)) do
+        local slug = pk:match('^jug:(.+)$');
+        if slug then
+            local fk = string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug);
+            if not data.MacroPaletteKeysEqual(fk, sourceKey) then
+                return fk;
+            end
+        end
+    end
+    return GLOBAL_MACRO_KEY;
+end
+
+-- Bottom-right /ja badge on macro tiles (same corner style as small status icons on slots).
+-- Declared before M.DrawPalette so palette grid can call it (Lua local scope).
+local function DrawMacroJaBadgeOverlay(drawList, macro, x, y, boxSize)
+    if not drawList or not macro or macro.actionType ~= 'macro' or not macro.macroText then
         return;
     end
+    if macro.showJaBadgeOnMacro == false then
+        return;
+    end
+    local jaName = actions.GetMacroJaBadgeAbilityName(macro.macroText);
+    if not jaName or jaName == '' then
+        return;
+    end
+    local jbKey = BuildMacroJaBadgeCacheKey(macro);
+    local jaIcon = paletteJaBadgeIconCache[jbKey];
+    if jaIcon == nil then
+        jaIcon = actions.ResolveMacroJaBadgeIcon(macro) or PALETTE_JA_NONE;
+        paletteJaBadgeIconCache[jbKey] = jaIcon;
+    end
+    if jaIcon == PALETTE_JA_NONE or not jaIcon.image then
+        return;
+    end
+    local iconPtr = tonumber(ffi.cast('uint32_t', jaIcon.image));
+    if not iconPtr or iconPtr == 0 then
+        return;
+    end
+    local iconSize = math.max(10, math.floor(boxSize * 0.35));
+    local padding = 2;
+    local iconX = x + boxSize - iconSize - padding;
+    local iconY = y + boxSize - iconSize - padding;
+    drawList:AddImage(iconPtr, {iconX, iconY}, {iconX + iconSize, iconY + iconSize});
+end
+
+-- Draw icon preview box with current icon (macro editor); must be above DrawIconButton users.
+local function DrawIconPreview(macro, x, y, size)
+    local drawList = imgui.GetWindowDrawList();
+    if not drawList then return; end
+
+    local bgColor = imgui.GetColorU32({0.1, 0.09, 0.08, 0.95});
+    local borderColor = imgui.GetColorU32(COLORS.border);
+    drawList:AddRectFilled({x, y}, {x + size, y + size}, bgColor, 4);
+    drawList:AddRect({x, y}, {x + size, y + size}, borderColor, 4, 0, 1);
+
+    local pvKey = BuildMacroMainIconCacheKey(macro);
+    if pvKey ~= editorPreviewIconKey then
+        editorPreviewIconKey = pvKey;
+        editorPreviewCachedIcon = actions.GetBindIcon(macro);
+    end
+    local icon = editorPreviewCachedIcon;
+    if icon and icon.image then
+        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
+        if iconPtr then
+            local padding = 4;
+            drawList:AddImage(
+                iconPtr,
+                {x + padding, y + padding},
+                {x + size - padding, y + size - padding}
+            );
+        end
+    else
+        local abbr = GetActionAbbreviation(macro, true);
+        local textSize = imgui.CalcTextSize(abbr);
+        local textX = x + (size - textSize) / 2;
+        local textY = y + (size - 14) / 2;
+        local textColor = imgui.GetColorU32(COLORS.gold);
+        drawList:AddText({textX, textY}, textColor, abbr);
+    end
+
+    DrawMacroJaBadgeOverlay(drawList, macro, x, y, size);
+end
+
+-- Draw the palette window (Lua 5.1: max 60 upvalues per function; heavy body uses MacroPaletteDrawEnv.)
+local MacroPaletteDrawEnv = {};
+
+local function InitMacroPaletteDrawEnv()
+    local E = MacroPaletteDrawEnv;
+    E.imgui = imgui;
+    E.ffi = ffi;
+    E.data = data;
+    E.actions = actions;
+    E.textures = textures;
+    E.dragdrop = dragdrop;
+    E.petregistry = petregistry;
+    E.playerdata = playerdata;
+    E.petpalette = petpalette;
+    E.sharedMacroStore = sharedMacroStore;
+    E.macroBuckets = macroBuckets;
+    E.COLORS = COLORS;
+    E.MP = MP;
+    E.M = M;
+    E.paletteUi = paletteUi;
+    E.JOB_LIST = JOB_LIST;
+    E.INPUT_BUFFER_SIZE = INPUT_BUFFER_SIZE;
+    E.GLOBAL_MACRO_KEY = GLOBAL_MACRO_KEY;
+    E.ITEMS_MACRO_KEY = ITEMS_MACRO_KEY;
+    E.EQUIPMENT_MACRO_KEY = EQUIPMENT_MACRO_KEY;
+    E.XIUI_MACRO_KEY = XIUI_MACRO_KEY;
+    E.PALETTE_COLUMNS = PALETTE_COLUMNS;
+    E.PALETTE_ROWS = PALETTE_ROWS;
+    E.PALETTE_MACROS_PER_PAGE = PALETTE_MACROS_PER_PAGE;
+    E.PALETTE_TILE_SIZE = PALETTE_TILE_SIZE;
+    E.PALETTE_TILE_GAP = PALETTE_TILE_GAP;
+    E.PALETTE_TILE_ROUNDING = PALETTE_TILE_ROUNDING;
+    E.SMN_ALL_SUBSETS_VIEW_TAG = SMN_ALL_SUBSETS_VIEW_TAG;
+    E.BST_ALL_SUBSETS_VIEW_TAG = BST_ALL_SUBSETS_VIEW_TAG;
+    E.ACTION_TYPE_LABELS = ACTION_TYPE_LABELS;
+    E.RefreshCachedLists = RefreshCachedLists;
+    E.BuildSmnAllSubsetsRows = BuildSmnAllSubsetsRows;
+    E.BuildBstAllJugSubsetsRows = BuildBstAllJugSubsetsRows;
+    E.IsSmnAllSubsetsPaletteView = IsSmnAllSubsetsPaletteView;
+    E.IsBstAllSubsetsPaletteView = IsBstAllSubsetsPaletteView;
+    E.GetPaletteDisplayName = GetPaletteDisplayName;
+    E.PushWindowStyle = PushWindowStyle;
+    E.PopWindowStyle = PopWindowStyle;
+    E.PushComboStyle = PushComboStyle;
+    E.PopComboStyle = PopComboStyle;
+    E.ClearAllIconCaches = ClearAllIconCaches;
+    E.ResetPetJobMacroPaletteSubsets = ResetPetJobMacroPaletteSubsets;
+    E.EnsureMacroCustomCategoriesList = EnsureMacroCustomCategoriesList;
+    E.AddMacroCustomCategory = AddMacroCustomCategory;
+    E.markSharedMacroLibraryDirtyIfNeeded = markSharedMacroLibraryDirtyIfNeeded;
+    E.ApplyRenameMacroCustomCategory = ApplyRenameMacroCustomCategory;
+    E.DeleteMacroCustomCategoryCompletely = DeleteMacroCustomCategoryCompletely;
+    E.CountMacrosInPalette = CountMacrosInPalette;
+    E.CountSmnAllSubsetsMacros = CountSmnAllSubsetsMacros;
+    E.CountBstAllJugSubsetsMacros = CountBstAllJugSubsetsMacros;
+    E.GetEffectivePaletteType = GetEffectivePaletteType;
+    E.ClearBstJugMacroSubsetUi = ClearBstJugMacroSubsetUi;
+    E.ClearSmnMacroSubsetUi = ClearSmnMacroSubsetUi;
+    E.BstJugSubsetEntriesOrdered = BstJugSubsetEntriesOrdered;
+    E.SyncMacroEditorSubtypeFieldsFromSaveKey = SyncMacroEditorSubtypeFieldsFromSaveKey;
+    E.GetCachedPaletteMainIcon = GetCachedPaletteMainIcon;
+    E.DrawMacroJaBadgeOverlay = DrawMacroJaBadgeOverlay;
+    E.FormatTargetForDisplay = FormatTargetForDisplay;
+    E.ClearEditorPreviewIconCache = ClearEditorPreviewIconCache;
+end
+
+InitMacroPaletteDrawEnv();
+
+local function DrawPaletteBody()
+    local E = MacroPaletteDrawEnv;
+    local imgui = E.imgui;
+    local ffi = E.ffi;
+    local data = E.data;
+    local actions = E.actions;
+    local textures = E.textures;
+    local dragdrop = E.dragdrop;
+    local petregistry = E.petregistry;
+    local playerdata = E.playerdata;
+    local petpalette = E.petpalette;
+    local sharedMacroStore = E.sharedMacroStore;
+    local macroBuckets = E.macroBuckets;
+    local COLORS = E.COLORS;
+    local MP = E.MP;
+    local M = E.M;
+    local paletteUi = E.paletteUi;
+    local JOB_LIST = E.JOB_LIST;
+    local INPUT_BUFFER_SIZE = E.INPUT_BUFFER_SIZE;
+    local GLOBAL_MACRO_KEY = E.GLOBAL_MACRO_KEY;
+    local ITEMS_MACRO_KEY = E.ITEMS_MACRO_KEY;
+    local EQUIPMENT_MACRO_KEY = E.EQUIPMENT_MACRO_KEY;
+    local XIUI_MACRO_KEY = E.XIUI_MACRO_KEY;
+    local PALETTE_COLUMNS = E.PALETTE_COLUMNS;
+    local PALETTE_ROWS = E.PALETTE_ROWS;
+    local PALETTE_MACROS_PER_PAGE = E.PALETTE_MACROS_PER_PAGE;
+    local PALETTE_TILE_SIZE = E.PALETTE_TILE_SIZE;
+    local PALETTE_TILE_GAP = E.PALETTE_TILE_GAP;
+    local PALETTE_TILE_ROUNDING = E.PALETTE_TILE_ROUNDING;
+    local SMN_ALL_SUBSETS_VIEW_TAG = E.SMN_ALL_SUBSETS_VIEW_TAG;
+    local BST_ALL_SUBSETS_VIEW_TAG = E.BST_ALL_SUBSETS_VIEW_TAG;
+    local ACTION_TYPE_LABELS = E.ACTION_TYPE_LABELS;
+    local RefreshCachedLists = E.RefreshCachedLists;
+    local BuildSmnAllSubsetsRows = E.BuildSmnAllSubsetsRows;
+    local BuildBstAllJugSubsetsRows = E.BuildBstAllJugSubsetsRows;
+    local IsSmnAllSubsetsPaletteView = E.IsSmnAllSubsetsPaletteView;
+    local IsBstAllSubsetsPaletteView = E.IsBstAllSubsetsPaletteView;
+    local GetPaletteDisplayName = E.GetPaletteDisplayName;
+    local PushWindowStyle = E.PushWindowStyle;
+    local PopWindowStyle = E.PopWindowStyle;
+    local PushComboStyle = E.PushComboStyle;
+    local PopComboStyle = E.PopComboStyle;
+    local ClearAllIconCaches = E.ClearAllIconCaches;
+    local ResetPetJobMacroPaletteSubsets = E.ResetPetJobMacroPaletteSubsets;
+    local EnsureMacroCustomCategoriesList = E.EnsureMacroCustomCategoriesList;
+    local AddMacroCustomCategory = E.AddMacroCustomCategory;
+    local markSharedMacroLibraryDirtyIfNeeded = E.markSharedMacroLibraryDirtyIfNeeded;
+    local ApplyRenameMacroCustomCategory = E.ApplyRenameMacroCustomCategory;
+    local DeleteMacroCustomCategoryCompletely = E.DeleteMacroCustomCategoryCompletely;
+    local CountMacrosInPalette = E.CountMacrosInPalette;
+    local CountSmnAllSubsetsMacros = E.CountSmnAllSubsetsMacros;
+    local CountBstAllJugSubsetsMacros = E.CountBstAllJugSubsetsMacros;
+    local GetEffectivePaletteType = E.GetEffectivePaletteType;
+    local ClearBstJugMacroSubsetUi = E.ClearBstJugMacroSubsetUi;
+    local ClearSmnMacroSubsetUi = E.ClearSmnMacroSubsetUi;
+    local BstJugSubsetEntriesOrdered = E.BstJugSubsetEntriesOrdered;
+    local SyncMacroEditorSubtypeFieldsFromSaveKey = E.SyncMacroEditorSubtypeFieldsFromSaveKey;
+    local GetCachedPaletteMainIcon = E.GetCachedPaletteMainIcon;
+    local DrawMacroJaBadgeOverlay = E.DrawMacroJaBadgeOverlay;
+    local FormatTargetForDisplay = E.FormatTargetForDisplay;
+    local ClearEditorPreviewIconCache = E.ClearEditorPreviewIconCache;
 
     -- Continuously check for job changes while palette is open
     -- This catches cases where job changed but cache wasn't refreshed properly
     RefreshCachedLists();
 
-    -- Initialize selectedPaletteType to current job if not set
-    if not selectedPaletteType then
-        selectedPaletteType = data.jobId or 1;
+    -- Initialize MP.selectedPaletteType to current job if not set
+    if not MP.selectedPaletteType then
+        MP.selectedPaletteType = data.jobId or 1;
     end
 
-    local db, typeKey = M.GetMacroDatabase();
+    local smnMergeMeta = nil;
+    local bstMergeMeta = nil;
+    local db;
+    local typeKey;
+    if IsSmnAllSubsetsPaletteView() then
+        smnMergeMeta = BuildSmnAllSubsetsRows();
+        db = {};
+        for i, row in ipairs(smnMergeMeta) do
+            db[i] = row.macro;
+        end
+        typeKey = petregistry.JOB_SMN;
+    elseif IsBstAllSubsetsPaletteView() then
+        bstMergeMeta = BuildBstAllJugSubsetsRows();
+        db = {};
+        for i, row in ipairs(bstMergeMeta) do
+            db[i] = row.macro;
+        end
+        typeKey = petregistry.JOB_BST;
+    else
+        db, typeKey = M.GetMacroDatabase();
+    end
+
+    local paletteViewCacheKey = smnMergeMeta and (tostring(petregistry.JOB_SMN) .. ':' .. SMN_ALL_SUBSETS_VIEW_TAG)
+        or (bstMergeMeta and (tostring(petregistry.JOB_BST) .. ':' .. BST_ALL_SUBSETS_VIEW_TAG))
+        or typeKey;
+    if MP._macroSearchPaletteKey ~= paletteViewCacheKey then
+        MP._macroSearchPaletteKey = paletteViewCacheKey;
+        MP.macroPaletteSearchName[1] = '';
+        MP._lastMacroPaletteSearch = nil;
+    end
+    if paletteIconCacheDbKey ~= paletteViewCacheKey then
+        paletteMainIconCache = {};
+        paletteJaBadgeIconCache = {};
+        paletteIconCacheDbKey = paletteViewCacheKey;
+    end
     local isGlobal = (typeKey == GLOBAL_MACRO_KEY);
+    local isItems = (typeKey == ITEMS_MACRO_KEY);
+    local isEquipment = (typeKey == EQUIPMENT_MACRO_KEY);
+    local isXiui = (typeKey == XIUI_MACRO_KEY);
+    local isCustomMacroBucket = macroBuckets.isCustomCategoryKey(typeKey);
+    local isSharedMacroPalette = isGlobal or isItems or isEquipment or isXiui or isCustomMacroBucket;
     local typeName = GetPaletteDisplayName(typeKey);
     local currentPlayerJob = data.jobId or 1;
-    -- For SMN with avatar selected, check base job ID
     local baseJobId = type(typeKey) == 'number' and typeKey or tonumber(tostring(typeKey):match('^(%d+)'));
-    local isViewingCurrentJob = (not isGlobal and baseJobId == currentPlayerJob);
+    local isViewingCurrentJob = (not isSharedMacroPalette and baseJobId == currentPlayerJob);
 
-    -- Calculate pagination
-    local totalMacros = #db;
+    -- Name filter (substring match on display name or action name; case-insensitive)
+    local needleRaw = (MP.macroPaletteSearchName[1] or ''):match('^%s*(.-)%s*$') or '';
+    if MP._lastMacroPaletteSearch ~= needleRaw then
+        MP._lastMacroPaletteSearch = needleRaw;
+        MP.currentPalettePage = 1;
+    end
+
+    local filteredIndices = {};
+    if needleRaw == '' then
+        for i = 1, #db do
+            filteredIndices[i] = i;
+        end
+    else
+        local needle = needleRaw:lower();
+        for i = 1, #db do
+            local m = db[i];
+            local disp = (m.displayName or ''):lower();
+            local act = (m.action or ''):lower();
+            if disp:find(needle, 1, true) or act:find(needle, 1, true) then
+                table.insert(filteredIndices, i);
+            end
+        end
+    end
+
+    if paletteUi.selectedMacroIndex then
+        local selOk = false;
+        for _, fi in ipairs(filteredIndices) do
+            if fi == paletteUi.selectedMacroIndex then
+                selOk = true;
+                break;
+            end
+        end
+        if not selOk then
+            paletteUi.selectedMacroIndex = nil;
+        end
+    end
+
+    -- Calculate pagination (filtered list)
+    local totalMacros = #filteredIndices;
     local totalPages = math.max(1, math.ceil(totalMacros / PALETTE_MACROS_PER_PAGE));
 
     -- Clamp current page to valid range
-    if currentPalettePage > totalPages then
-        currentPalettePage = totalPages;
+    if MP.currentPalettePage > totalPages then
+        MP.currentPalettePage = totalPages;
     end
-    if currentPalettePage < 1 then
-        currentPalettePage = 1;
+    if MP.currentPalettePage < 1 then
+        MP.currentPalettePage = 1;
     end
 
     -- Calculate how many macros/rows on this page
-    local startIdx = (currentPalettePage - 1) * PALETTE_MACROS_PER_PAGE + 1;
+    local startIdx = (MP.currentPalettePage - 1) * PALETTE_MACROS_PER_PAGE + 1;
     local endIdx = math.min(startIdx + PALETTE_MACROS_PER_PAGE - 1, totalMacros);
     local macrosOnPage = math.max(0, endIdx - startIdx + 1);
     local rowsOnPage = math.max(1, math.ceil(macrosOnPage / PALETTE_COLUMNS));
@@ -1629,9 +3363,161 @@ function M.DrawPalette()
     PushWindowStyle();
 
     if imgui.Begin('Macro Palette###MacroPalette', isOpen, windowFlags) then
-        -- Header with gold accent
-        imgui.TextColored(COLORS.gold, 'Drag macros to your hotbar slots');
-        imgui.Spacing();
+        -- Header: instruction (left) + macro source toggle (right, S = Shared, P = Profile)
+        do
+            local scopeShared = (gConfig.macroStorageScope or 'profile') == 'shared';
+            local scopeBtnSize = 22;
+            imgui.TextColored(COLORS.gold, 'Drag macros to your hotbar slots');
+            imgui.SameLine();
+            -- GetContentRegionAvail: use (w,h) or table [1]/[2]; do not use .x â€” sugar Vector can error (see palettemanager GetContentRegionAvailHeight).
+            local availW, availH = imgui.GetContentRegionAvail();
+            if type(availW) == 'table' then
+                availW = availW[1] or 0;
+            end
+            availW = tonumber(availW) or 0;
+            imgui.SetCursorPosX(imgui.GetCursorPosX() + availW - scopeBtnSize);
+            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, scopeBtnSize * 0.5);
+            imgui.PushStyleVar(ImGuiStyleVar_FramePadding, { 0, 0 });
+            if scopeShared then
+                imgui.PushStyleColor(ImGuiCol_Button, { 0.35, 0.30, 0.18, 0.95 });
+                imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.50, 0.44, 0.28, 1.0 });
+                imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.45, 0.40, 0.24, 1.0 });
+            else
+                imgui.PushStyleColor(ImGuiCol_Button, { 0.14, 0.13, 0.11, 0.95 });
+                imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.22, 0.20, 0.16, 1.0 });
+                imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.18, 0.16, 0.13, 1.0 });
+            end
+            local scopeLabel = scopeShared and 'S##MacroScopeToggle' or 'P##MacroScopeToggle';
+            if imgui.Button(scopeLabel, { scopeBtnSize, scopeBtnSize }) then
+                if scopeShared then
+                    MP.macroScopeConfirmKind = 'toProfile';
+                else
+                    MP.macroScopeConfirmKind = 'toShared';
+                end
+                imgui.OpenPopup('MacroScopeSwitch##xiui');
+            end
+            imgui.PopStyleColor(3);
+            imgui.PopStyleVar(2);
+            if imgui.IsItemHovered() then
+                imgui.BeginTooltip();
+                imgui.PushTextWrapPos(400);
+                local profName = (GetCurrentProfileName and GetCurrentProfileName()) or (config and config.currentProfile) or 'current';
+                if scopeShared then
+                    imgui.TextColored(COLORS.gold, 'Shared is active (S)');
+                    imgui.Spacing();
+                    imgui.TextWrapped('This macro set is available here and is shared with all XIUI profiles that use Shared (SharedMacros.lua). Click the button to edit this character\'s profile-only macros instead.');
+                else
+                    imgui.TextColored(COLORS.text, 'Profile is active (P)');
+                    imgui.Spacing();
+                    imgui.TextWrapped('This macro set is available on the "' .. tostring(profName) .. '" profile only. Click the button to use the shared macro list instead (all profiles on Shared).');
+                end
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'Your hotbar/crossbar layout is not removed when you switch. Icons and actions use the active library; a slot that pointed at the other library may look empty until you switch back or re-drag a macro. The palette and bars refresh when you change mode.');
+                imgui.PopTextWrapPos();
+                imgui.EndTooltip();
+            end
+        end
+
+        -- Macro scope confirm: non-modal BeginPopup (palettemanager copy flow) = no full-screen dim; anchor to this window.
+        do
+            imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+            imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+            imgui.PushStyleColor(ImGuiCol_TitleBg, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_TitleBgActive, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_FrameBg, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLORS.bgLight);
+            imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgMedium);
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+
+            local SCOPE_MODAL_W = 420;
+            local estPopupH = 200;
+            local aboveGap = 6;
+            imgui.SetNextWindowSize({ SCOPE_MODAL_W, 0 }, ImGuiCond_Appearing);
+            local wx, wy = imgui.GetWindowPos();
+            local wiw, wih = imgui.GetWindowSize();
+            if type(wx) == 'table' then
+                local t = wx;
+                wx, wy = tonumber(t[1]) or 0, tonumber(t[2] or 0) or 0;
+            else
+                wx, wy = tonumber(wx) or 0, tonumber(wy) or 0;
+            end
+            if type(wiw) == 'table' then
+                local t = wiw;
+                wiw, wih = tonumber(t[1]) or 0, tonumber(t[2] or 0) or 0;
+            else
+                wiw, wih = tonumber(wiw) or 0, tonumber(wih) or 0;
+            end
+            local posX = wx + (wiw - SCOPE_MODAL_W) * 0.5;
+            if posX < 2 then
+                posX = 2;
+            end
+            -- Prefer just above the palette; if that would be off-screen, sit on the top of the palette (overlaps header strip).
+            local posY = wy - aboveGap - estPopupH;
+            if posY < 2 then
+                posY = wy + 6;
+            end
+            imgui.SetNextWindowPos({ posX, posY }, ImGuiCond_Always);
+
+            if imgui.BeginPopup('MacroScopeSwitch##xiui') then
+                local function closeScopePopup()
+                    MP.macroScopeConfirmKind = nil;
+                    imgui.CloseCurrentPopup();
+                end
+
+                if MP.macroScopeConfirmKind == 'toShared' then
+                    imgui.TextColored(COLORS.gold, 'Switch to shared macros?');
+                    imgui.TextWrapped('You will use the global list (SharedMacros.lua) for every profile set to Shared. Your profile-only macros stay saved in this .lua if you switch back.');
+                    imgui.Spacing();
+                    imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
+                    if imgui.Button('Switch##ssok', { 100, 24 }) then
+                        sharedMacroStore.ApplySwitchToShared(gConfig);
+                        data.InvalidateConfigDerivedCaches();
+                        SaveSettingsToDisk();
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        RefreshCachedLists();
+                        ClearAllIconCaches();
+                        closeScopePopup();
+                    end
+                    imgui.PopStyleColor();
+                    imgui.SameLine();
+                    if imgui.Button('Cancel##sscancel', { 100, 24 }) then
+                        closeScopePopup();
+                    end
+                elseif MP.macroScopeConfirmKind == 'toProfile' then
+                    imgui.TextColored(COLORS.gold, 'Switch to profile-only macros?');
+                    imgui.TextWrapped('You will use only this profile file again. The shared file is not changed.');
+                    imgui.Spacing();
+                    imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
+                    if imgui.Button('Switch##spok', { 100, 24 }) then
+                        if (gConfig.macroStorageScope or 'profile') == 'shared' then
+                            SaveSettingsToDisk();
+                        end
+                        sharedMacroStore.ApplySwitchToProfile(gConfig);
+                        data.InvalidateConfigDerivedCaches();
+                        SaveSettingsToDisk();
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        RefreshCachedLists();
+                        ClearAllIconCaches();
+                        closeScopePopup();
+                    end
+                    imgui.PopStyleColor();
+                    imgui.SameLine();
+                    if imgui.Button('Cancel##spcancel', { 100, 24 }) then
+                        closeScopePopup();
+                    end
+                else
+                    closeScopePopup();
+                end
+                imgui.EndPopup();
+            end
+
+            imgui.PopStyleColor(9);
+        end
+
+        imgui.Dummy({ 0, 4 });
 
         -- Type selector row
         imgui.TextColored(COLORS.textDim, 'Type:');
@@ -1639,7 +3525,7 @@ function M.DrawPalette()
 
         -- Style the combo popup
         PushComboStyle();
-        imgui.PushItemWidth(100);
+        imgui.PushItemWidth(148);
 
         -- Helper to get macro count for a type (Global or job ID)
         local function getMacroCount(key)
@@ -1649,8 +3535,8 @@ function M.DrawPalette()
             return 0;
         end
 
-        -- Build display label with macro count
-        local macroCount = getMacroCount(typeKey);
+        -- Build display label with macro count (uses current grid, including SMN / BST "all subsets" merge)
+        local macroCount = #db;
         local displayLabel = macroCount > 0 and string.format('%s (%d)', typeName, macroCount) or typeName;
 
         if imgui.BeginCombo('##TypeSelect', displayLabel, ImGuiComboFlags_None) then
@@ -1671,15 +3557,15 @@ function M.DrawPalette()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
             end
 
-            if imgui.Selectable(globalLabel, globalSelected) then
-                selectedPaletteType = GLOBAL_MACRO_KEY;
-                selectedAvatarPalette = nil;
-                selectedMacroIndex = nil;
-                currentPalettePage = 1;
+                if imgui.Selectable(globalLabel, globalSelected) then
+                    MP.selectedPaletteType = GLOBAL_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
                 -- Clear caches to force refresh
                 playerdata.ClearCache();
-                cachedPetCommands = nil;
-                petAvatarFilter = 1;
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
             end
             imgui.PopStyleColor();
 
@@ -1687,12 +3573,140 @@ function M.DrawPalette()
                 imgui.SetItemDefaultFocus();
             end
 
-            -- Separator between Global and jobs
+            -- Items bucket (gear / consumables â€” not tied to a job)
+            local itemsSelected = isItems;
+            local itemsMacroCount = getMacroCount(ITEMS_MACRO_KEY);
+            local itemsLabel = 'Items';
+            if itemsMacroCount > 0 then
+                itemsLabel = string.format('Items (%d)', itemsMacroCount);
+            end
+
+            if itemsMacroCount > 0 and not itemsSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif itemsSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(itemsLabel, itemsSelected) then
+                    MP.selectedPaletteType = ITEMS_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if itemsSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- Equipment bucket (gear swap macros, all jobs)
+            local equipSelected = isEquipment;
+            local equipMacroCount = getMacroCount(EQUIPMENT_MACRO_KEY);
+            local equipLabel = 'Equipment';
+            if equipMacroCount > 0 then
+                equipLabel = string.format('Equipment (%d)', equipMacroCount);
+            end
+
+            if equipMacroCount > 0 and not equipSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif equipSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(equipLabel, equipSelected) then
+                    MP.selectedPaletteType = EQUIPMENT_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if equipSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- XIUI slash-command shortcuts (seeded defaults; editable like any macro bucket)
+            local xiuiSelected = isXiui;
+            local xiuiMacroCount = getMacroCount(XIUI_MACRO_KEY);
+            local xiuiLabel = 'XIUI Commands';
+            if xiuiMacroCount > 0 then
+                xiuiLabel = string.format('XIUI Commands (%d)', xiuiMacroCount);
+            end
+
+            if xiuiMacroCount > 0 and not xiuiSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            elseif xiuiSelected then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+
+                if imgui.Selectable(xiuiLabel, xiuiSelected) then
+                    MP.selectedPaletteType = XIUI_MACRO_KEY;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                MP.currentPalettePage = 1;
+                playerdata.ClearCache();
+                MP.cachedPetCommands = nil;
+                MP.petAvatarFilter = 1;
+            end
+            imgui.PopStyleColor();
+
+            if xiuiSelected then
+                imgui.SetItemDefaultFocus();
+            end
+
+            -- Player-defined categories (keys under macroDB["custom:N"])
+            EnsureMacroCustomCategoriesList();
+            for _, cat in ipairs(gConfig.macroCustomCategories) do
+                local cKey = cat.key;
+                local cSel = (MP.selectedPaletteType == cKey);
+                local cCount = getMacroCount(cKey);
+                local cLabel = cat.label or cKey;
+                if cCount > 0 then
+                    cLabel = string.format('%s (%d)', cLabel, cCount);
+                end
+
+                if cCount > 0 and not cSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                elseif cSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+
+                if imgui.Selectable(cLabel, cSel) then
+                    MP.selectedPaletteType = cKey;
+                    ResetPetJobMacroPaletteSubsets();
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    playerdata.ClearCache();
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
+                end
+                imgui.PopStyleColor();
+
+                if cSel then
+                    imgui.SetItemDefaultFocus();
+                end
+            end
+
+            -- Separator between non-job buckets and jobs
             imgui.Separator();
 
             -- Job options
             for i, job in ipairs(JOB_LIST) do
-                local isSelected = (not isGlobal and job.id == typeKey);
+                local isSelected = (not isSharedMacroPalette and MP.selectedPaletteType == job.id);
                 local jobMacroCount = getMacroCount(job.id);
 
                 -- Build label with indicators
@@ -1723,14 +3737,14 @@ function M.DrawPalette()
                 end
 
                 if imgui.Selectable(label, isSelected) then
-                    selectedPaletteType = job.id;
-                    selectedAvatarPalette = nil;  -- Clear avatar selection when switching jobs
-                    selectedMacroIndex = nil;  -- Clear selection when switching types
-                    currentPalettePage = 1;    -- Reset to page 1 when switching types
+                    MP.selectedPaletteType = job.id;
+                    ResetPetJobMacroPaletteSubsets(); -- Clear avatar / jug subset selection when switching jobs
+                    paletteUi.selectedMacroIndex = nil;  -- Clear selection when switching types
+                    MP.currentPalettePage = 1;    -- Reset to page 1 when switching types
                     -- Clear caches to force refresh
                     playerdata.ClearCache();
-                    cachedPetCommands = nil;
-                    petAvatarFilter = 1;
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
                 end
 
                 imgui.PopStyleColor();
@@ -1744,28 +3758,298 @@ function M.DrawPalette()
         imgui.PopItemWidth();
         PopComboStyle();
 
-        -- Avatar sub-palette dropdown (only for SMN)
-        -- Use selectedPaletteType (the job ID) not typeKey (which may be composite like "15:avatar:ifrit")
-        if not isGlobal and selectedPaletteType == petregistry.JOB_SMN then
+        local catAddBtnSize = (imgui.GetFrameHeight and imgui.GetFrameHeight()) or 24;
+        imgui.SameLine(0, 6);
+        if imgui.Button('+##macroCatAddBtn', { catAddBtnSize, catAddBtnSize }) then
+            imgui.OpenPopup('MacroAddCustomCategory##xiui');
+        end
+        if imgui.IsItemHovered() then
+            imgui.BeginTooltip();
+            imgui.Text('Add a custom type.');
+            imgui.EndTooltip();
+        end
+
+        if isCustomMacroBucket and typeKey then
+            imgui.SameLine(0, 8);
+            imgui.PushStyleColor(ImGuiCol_Button, { 0.62, 0.12, 0.1, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_ButtonHovered, { 0.78, 0.2, 0.16, 1.0 });
+            imgui.PushStyleColor(ImGuiCol_ButtonActive, { 0.7, 0.16, 0.12, 1.0 });
+            if imgui.Button('-##macroCatDelToolbar', { catAddBtnSize, catAddBtnSize }) then
+                MP.macroCustomDeleteKey = typeKey;
+                MP.macroCustomDeleteLabel = GetPaletteDisplayName(typeKey);
+                MP.macroCustomDeleteN = CountMacrosInPalette(typeKey);
+                imgui.OpenPopup('MacroCustomCatDelete##xiui');
+            end
+            imgui.PopStyleColor(3);
+            if imgui.IsItemHovered() then
+                imgui.BeginTooltip();
+                imgui.Text('Delete this custom type. Macros in the group are removed; any hotbar or crossbar slot that holds one of those macros reverts to an empty slot. Other slots are unchanged.');
+                imgui.EndTooltip();
+            end
+            imgui.SameLine(0, 8);
+            if imgui.SmallButton('Rename##macroCatRenToolbar') then
+                MP.macroCustomRenameTargetKey = typeKey;
+                MP.macroCustomRenameBuf[1] = GetPaletteDisplayName(typeKey);
+                imgui.OpenPopup('MacroCustomRename##xiui');
+            end
+        end
+
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroAddCustomCategory##xiui') then
+            imgui.TextColored(COLORS.textDim, 'New category name');
+            imgui.SetNextItemWidth(240);
+            imgui.InputText('##macroNewCatPopup', MP.macroNewCategoryBuf, INPUT_BUFFER_SIZE);
+            imgui.Spacing();
+            if imgui.Button('Add##macroCatAddPopup', { 100, 24 }) then
+                local nk = AddMacroCustomCategory(MP.macroNewCategoryBuf[1]);
+                if nk then
+                    MP.selectedPaletteType = nk;
+                    ResetPetJobMacroPaletteSubsets();
+                    MP.macroNewCategoryBuf[1] = '';
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    playerdata.ClearCache();
+                    MP.cachedPetCommands = nil;
+                    MP.petAvatarFilter = 1;
+                    markSharedMacroLibraryDirtyIfNeeded();
+                    SaveSettingsToDisk();
+                    data.MarkMacroLookupDirty();
+                    imgui.CloseCurrentPopup();
+                end
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Rename custom type (modal; opened from toolbar)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroCustomRename##xiui') then
+            local rk = MP.macroCustomRenameTargetKey;
+            if rk and macroBuckets.isCustomCategoryKey(rk) then
+                imgui.TextColored(COLORS.textDim, 'Display name (macros and slot data keep the same type key).');
+                imgui.SetNextItemWidth(300);
+                imgui.InputText('##mcrenfield', MP.macroCustomRenameBuf, INPUT_BUFFER_SIZE);
+                imgui.Spacing();
+                if imgui.Button('Apply##mcrenconf', { 100, 24 }) then
+                    if ApplyRenameMacroCustomCategory(rk, MP.macroCustomRenameBuf[1]) then
+                        markSharedMacroLibraryDirtyIfNeeded();
+                        SaveSettingsToDisk();
+                        MP.macroCustomRenameTargetKey = nil;
+                        imgui.CloseCurrentPopup();
+                    end
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##mcrencan', { 100, 24 }) then
+                    MP.macroCustomRenameTargetKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            else
+                MP.macroCustomRenameTargetKey = nil;
+                imgui.CloseCurrentPopup();
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Confirm delete for a custom type (modal; opened from red - button)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroCustomCatDelete##xiui') then
+            local dk = MP.macroCustomDeleteKey;
+            if dk and macroBuckets.isCustomCategoryKey(dk) then
+                local n = tonumber(MP.macroCustomDeleteN) or 0;
+                local lab = tostring(MP.macroCustomDeleteLabel or dk);
+                imgui.TextColored(COLORS.gold, 'Delete this custom type?');
+                imgui.PushTextWrapPos(440);
+                local macroW = n == 1 and '1 macro' or (string.format('%d macros', n));
+                imgui.TextWrapped(string.format('This permanently removes %s saved under "%s" (macro text, icons, and palette data for that type).', macroW, lab));
+                imgui.TextWrapped('On every hotbar and crossbar, any slot that contains a macro from this type reverts to an empty slot. All other slots are unchanged.');
+                if (gConfig and (gConfig.macroStorageScope or 'profile') == 'shared') then
+                    imgui.TextWrapped('Shared macro mode: the type is removed from the shared library, and other XIUI profiles get the same per-slot updates anywhere their bars referenced these macros.');
+                end
+                imgui.PopTextWrapPos();
+                imgui.Spacing();
+                if imgui.Button('Delete##mcdelconf', { 100, 24 }) then
+                    DeleteMacroCustomCategoryCompletely(dk);
+                    MP.macroCustomDeleteKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##mcdelcan', { 100, 24 }) then
+                    MP.macroCustomDeleteKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            else
+                MP.macroCustomDeleteKey = nil;
+                imgui.CloseCurrentPopup();
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- Move macro to another palette bucket (modal)
+        imgui.PushStyleColor(ImGuiCol_PopupBg, COLORS.bgDark);
+        imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
+        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        if imgui.BeginPopup('MacroMoveToPalette##xiui') then
+            local srcK = MP.macroMoveSourceKey;
+            local mid = MP.macroMoveMacroId;
+            if not srcK or not mid then
+                MP.macroMoveSourceKey = nil;
+                MP.macroMoveMacroId = nil;
+                MP.macroMoveDestKey = nil;
+                imgui.CloseCurrentPopup();
+            else
+                imgui.TextColored(COLORS.gold, 'Move macro');
+                imgui.PushTextWrapPos(440);
+                imgui.TextWrapped(
+                    'Creates a copy in the destination palette with a new internal id, removes it from the source palette, '
+                        .. 'and updates hotbar and crossbar bindings so slots that already use this macro keep working.');
+                imgui.PopTextWrapPos();
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'From');
+                imgui.SameLine(0, 8);
+                imgui.Text(GetPaletteDisplayName(srcK));
+                imgui.Spacing();
+                imgui.TextColored(COLORS.textDim, 'To');
+                imgui.SameLine(0, 8);
+                PushComboStyle();
+                imgui.SetNextItemWidth(360);
+                if imgui.BeginCombo('##macroMoveDest', GetPaletteDisplayName(MP.macroMoveDestKey), ImGuiComboFlags_None) then
+                    local function offerMoveDest(key)
+                        if data.MacroPaletteKeysEqual(key, srcK) then
+                            return;
+                        end
+                        local cnt = CountMacrosInPalette(key);
+                        local lab = GetPaletteDisplayName(key);
+                        if cnt > 0 then
+                            lab = string.format('%s (%d)', lab, cnt);
+                        end
+                        local sel = data.MacroPaletteKeysEqual(key, MP.macroMoveDestKey);
+                        if sel then
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                        elseif cnt > 0 then
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                        else
+                            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                        end
+                        if imgui.Selectable(lab, sel) then
+                            MP.macroMoveDestKey = key;
+                        end
+                        imgui.PopStyleColor();
+                    end
+                    offerMoveDest(GLOBAL_MACRO_KEY);
+                    offerMoveDest(ITEMS_MACRO_KEY);
+                    offerMoveDest(EQUIPMENT_MACRO_KEY);
+                    offerMoveDest(XIUI_MACRO_KEY);
+                    EnsureMacroCustomCategoriesList();
+                    for _, cat in ipairs(gConfig.macroCustomCategories or {}) do
+                        offerMoveDest(cat.key);
+                    end
+                    imgui.Separator();
+                    for _, job in ipairs(JOB_LIST) do
+                        offerMoveDest(job.id);
+                    end
+                    for _, avatar in ipairs(petregistry.GetAvatarList()) do
+                        local avatarKey = petregistry.avatars[avatar];
+                        if avatarKey then
+                            offerMoveDest(string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey));
+                        end
+                    end
+                    for _, pk in ipairs(petregistry.GetAvailablePetKeys(petregistry.JOB_BST)) do
+                        local slug = pk:match('^jug:(.+)$');
+                        if slug then
+                            offerMoveDest(string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug));
+                        end
+                    end
+                    imgui.EndCombo();
+                end
+                PopComboStyle();
+                imgui.Spacing();
+                local canApply = MP.macroMoveDestKey ~= nil and not data.MacroPaletteKeysEqual(MP.macroMoveDestKey, srcK);
+                if not canApply then
+                    imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.45);
+                end
+                if imgui.Button('Move##macroMoveApply', {100, 26}) and canApply then
+                    if M.MoveMacroToPalette(mid, srcK, MP.macroMoveDestKey) then
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.macroMoveSourceKey = nil;
+                        MP.macroMoveMacroId = nil;
+                        MP.macroMoveDestKey = nil;
+                        imgui.CloseCurrentPopup();
+                    end
+                end
+                if not canApply then
+                    imgui.PopStyleVar();
+                end
+                imgui.SameLine(0, 8);
+                if imgui.Button('Cancel##macroMoveCancel', {100, 26}) then
+                    MP.macroMoveSourceKey = nil;
+                    MP.macroMoveMacroId = nil;
+                    MP.macroMoveDestKey = nil;
+                    imgui.CloseCurrentPopup();
+                end
+            end
+            imgui.EndPopup();
+        end
+        imgui.PopStyleColor(3);
+
+        -- SMN: base / all avatars merged / single avatar (own row so the window stays narrow)
+        if not isSharedMacroPalette and MP.selectedPaletteType == petregistry.JOB_SMN then
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Sub-type:');
             imgui.SameLine();
             local avatarList = petregistry.GetAvatarList();
-            local avatarLabel = selectedAvatarPalette or 'Base SMN';
-
-            -- Count macros for current avatar selection
-            local avatarMacroCount = 0;
-            local currentAvatarKey = GetEffectivePaletteType();
-            if gConfig.macroDB and gConfig.macroDB[currentAvatarKey] then
-                avatarMacroCount = #gConfig.macroDB[currentAvatarKey];
-            end
-            if avatarMacroCount > 0 then
-                avatarLabel = string.format('%s (%d)', avatarLabel, avatarMacroCount);
+            local allSubCount = CountSmnAllSubsetsMacros();
+            local avatarLabel;
+            if MP.smnShowAllAvatarSubsets then
+                avatarLabel = allSubCount > 0 and string.format('All subsets (%d)', allSubCount) or 'All subsets';
+            else
+                avatarLabel = MP.selectedAvatarPalette or 'Base SMN';
+                local avatarMacroCount = 0;
+                local currentAvatarKey = GetEffectivePaletteType();
+                if gConfig.macroDB and gConfig.macroDB[currentAvatarKey] then
+                    avatarMacroCount = #gConfig.macroDB[currentAvatarKey];
+                end
+                if avatarMacroCount > 0 then
+                    avatarLabel = string.format('%s (%d)', avatarLabel, avatarMacroCount);
+                end
             end
 
             PushComboStyle();
-            imgui.SetNextItemWidth(140);
+            imgui.SetNextItemWidth(148);
             if imgui.BeginCombo('##AvatarPalette', avatarLabel, ImGuiComboFlags_None) then
-                -- Base SMN option
-                local isBaseSelected = selectedAvatarPalette == nil;
+                -- All subsets: one grid with Base SMN + every avatar bucket
+                local allSubLabel = allSubCount > 0 and string.format('All subsets (%d)', allSubCount) or 'All subsets';
+                local allSubSel = MP.smnShowAllAvatarSubsets;
+                if allSubSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif allSubCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+                if imgui.Selectable(allSubLabel, allSubSel) then
+                    ClearBstJugMacroSubsetUi();
+                    MP.smnShowAllAvatarSubsets = true;
+                    MP.selectedAvatarPalette = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+                if allSubSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                local isBaseSelected = (not MP.smnShowAllAvatarSubsets and MP.selectedAvatarPalette == nil);
                 local baseMacroCount = 0;
                 if gConfig.macroDB and gConfig.macroDB[petregistry.JOB_SMN] then
                     baseMacroCount = #gConfig.macroDB[petregistry.JOB_SMN];
@@ -1781,10 +4065,12 @@ function M.DrawPalette()
                 end
 
                 if imgui.Selectable(baseLabel, isBaseSelected) then
-                    selectedAvatarPalette = nil;
-                    selectedMacroIndex = nil;
-                    currentPalettePage = 1;
-                    cachedPetCommands = nil;  -- Refresh pet commands for new avatar
+                    ClearBstJugMacroSubsetUi();
+                    MP.smnShowAllAvatarSubsets = false;
+                    MP.selectedAvatarPalette = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
                 end
                 imgui.PopStyleColor();
 
@@ -1794,9 +4080,8 @@ function M.DrawPalette()
 
                 imgui.Separator();
 
-                -- Avatar options
                 for _, avatar in ipairs(avatarList) do
-                    local isSelected = selectedAvatarPalette == avatar;
+                    local isSelected = (not MP.smnShowAllAvatarSubsets and MP.selectedAvatarPalette == avatar);
                     local avatarKey = petregistry.avatars[avatar];
                     local fullKey = string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey);
                     local macroCount = 0;
@@ -1814,10 +4099,12 @@ function M.DrawPalette()
                     end
 
                     if imgui.Selectable(label, isSelected) then
-                        selectedAvatarPalette = avatar;
-                        selectedMacroIndex = nil;
-                        currentPalettePage = 1;
-                        cachedPetCommands = nil;  -- Refresh pet commands for new avatar
+                        ClearBstJugMacroSubsetUi();
+                        MP.smnShowAllAvatarSubsets = false;
+                        MP.selectedAvatarPalette = avatar;
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        MP.cachedPetCommands = nil;
                     end
                     imgui.PopStyleColor();
 
@@ -1830,10 +4117,134 @@ function M.DrawPalette()
             PopComboStyle();
         end
 
+        -- BST: Base / all jug families merged / single jug family (parity with SMN Sub-type)
+        if not isSharedMacroPalette and MP.selectedPaletteType == petregistry.JOB_BST then
+            imgui.Spacing();
+            imgui.TextColored(COLORS.textDim, 'Sub-type:');
+            imgui.SameLine();
+            local bstJugList = BstJugSubsetEntriesOrdered();
+            local allBstSubCount = CountBstAllJugSubsetsMacros();
+            local bstSubLabel;
+            if MP.bstShowAllJugSubsets then
+                bstSubLabel = allBstSubCount > 0 and string.format('All subsets (%d)', allBstSubCount) or 'All subsets';
+            else
+                bstSubLabel = 'Base BST';
+                if MP.selectedBstJugMovesKey ~= nil then
+                    bstSubLabel = MP.selectedBstJugMovesKey;
+                    for _, ent in ipairs(bstJugList) do
+                        if ent.movesKey == MP.selectedBstJugMovesKey then
+                            bstSubLabel = ent.label;
+                            break;
+                        end
+                    end
+                end
+                local curBstKey = GetEffectivePaletteType();
+                local bstFamMacroCount = 0;
+                if gConfig.macroDB and gConfig.macroDB[curBstKey] then
+                    bstFamMacroCount = #gConfig.macroDB[curBstKey];
+                end
+                if bstFamMacroCount > 0 then
+                    bstSubLabel = string.format('%s (%d)', bstSubLabel, bstFamMacroCount);
+                end
+            end
+
+            PushComboStyle();
+            imgui.SetNextItemWidth(148);
+            if imgui.BeginCombo('##BstJugPalette', bstSubLabel, ImGuiComboFlags_None) then
+                local allBstLabel = allBstSubCount > 0 and string.format('All subsets (%d)', allBstSubCount) or 'All subsets';
+                local allBstSel = MP.bstShowAllJugSubsets;
+                if allBstSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif allBstSubCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+                if imgui.Selectable(allBstLabel, allBstSel) then
+                    ClearSmnMacroSubsetUi();
+                    MP.bstShowAllJugSubsets = true;
+                    MP.selectedBstJugMovesKey = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+                if allBstSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                local bstBaseSel = (not MP.bstShowAllJugSubsets and MP.selectedBstJugMovesKey == nil);
+                local bstBaseMacroCount = 0;
+                if gConfig.macroDB and gConfig.macroDB[petregistry.JOB_BST] then
+                    bstBaseMacroCount = #gConfig.macroDB[petregistry.JOB_BST];
+                end
+                local bstBaseLabel = bstBaseMacroCount > 0 and string.format('Base BST (%d)', bstBaseMacroCount) or 'Base BST';
+
+                if bstBaseSel then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                elseif bstBaseMacroCount > 0 then
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                else
+                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                end
+
+                if imgui.Selectable(bstBaseLabel, bstBaseSel) then
+                    ClearSmnMacroSubsetUi();
+                    MP.bstShowAllJugSubsets = false;
+                    MP.selectedBstJugMovesKey = nil;
+                    paletteUi.selectedMacroIndex = nil;
+                    MP.currentPalettePage = 1;
+                    MP.cachedPetCommands = nil;
+                end
+                imgui.PopStyleColor();
+
+                if bstBaseSel then
+                    imgui.SetItemDefaultFocus();
+                end
+
+                imgui.Separator();
+
+                for _, ent in ipairs(bstJugList) do
+                    local jugSel = (not MP.bstShowAllJugSubsets and MP.selectedBstJugMovesKey == ent.movesKey);
+                    local jugMc = 0;
+                    if gConfig.macroDB and gConfig.macroDB[ent.fullKey] then
+                        jugMc = #gConfig.macroDB[ent.fullKey];
+                    end
+                    local jugLab = jugMc > 0 and string.format('%s (%d)', ent.label, jugMc) or ent.label;
+
+                    if jugSel then
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+                    elseif jugMc > 0 then
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+                    else
+                        imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+                    end
+
+                    if imgui.Selectable(jugLab, jugSel) then
+                        ClearSmnMacroSubsetUi();
+                        MP.bstShowAllJugSubsets = false;
+                        MP.selectedBstJugMovesKey = ent.movesKey;
+                        paletteUi.selectedMacroIndex = nil;
+                        MP.currentPalettePage = 1;
+                        MP.cachedPetCommands = nil;
+                    end
+                    imgui.PopStyleColor();
+
+                    if jugSel then
+                        imgui.SetItemDefaultFocus();
+                    end
+                end
+                imgui.EndCombo();
+            end
+            PopComboStyle();
+        end
+
         -- Pet Palette section (only show if selected palette type is a pet job AND any bar has petAware enabled)
         local isPetJob = false;
-        if selectedPaletteType and type(selectedPaletteType) == 'number' then
-            isPetJob = petregistry.IsPetJob(selectedPaletteType);
+        if MP.selectedPaletteType and type(MP.selectedPaletteType) == 'number' then
+            isPetJob = petregistry.IsPetJob(MP.selectedPaletteType);
         end
 
         local hasPetAwareBar = false;
@@ -1934,8 +4345,8 @@ function M.DrawPalette()
 
                         imgui.Separator();
 
-                        -- Spirits section
-                        imgui.TextColored(COLORS.textDim, 'Spirits');
+                        -- Elementals (SMN spirit pets)
+                        imgui.TextColored(COLORS.textDim, 'Elementals');
                         for _, summon in ipairs(allSummons) do
                             if summon.category == 'spirit' then
                                 local petKey = petregistry.GetPetKeyForSummon(summon.name);
@@ -1969,6 +4380,36 @@ function M.DrawPalette()
         end
 
         imgui.Spacing();
+        imgui.TextColored(COLORS.textDim, 'Search by name:');
+        imgui.SetNextItemWidth(math.min(180, gridWidth));
+        imgui.InputText('##MacroPaletteNameSearch', MP.macroPaletteSearchName, INPUT_BUFFER_SIZE);
+        imgui.ShowHelp('Filters the macro grid by display name or action name (case-insensitive).');
+
+        imgui.Spacing();
+
+        local function rowPaletteKeyForGridIdx(idx)
+            if smnMergeMeta and smnMergeMeta[idx] then
+                return smnMergeMeta[idx].paletteKey;
+            end
+            if bstMergeMeta and bstMergeMeta[idx] then
+                return bstMergeMeta[idx].paletteKey;
+            end
+            return typeKey;
+        end
+        local function rowSubsetLabelForGridIdx(idx)
+            if smnMergeMeta and smnMergeMeta[idx] then
+                return smnMergeMeta[idx].subsetLabel;
+            end
+            if bstMergeMeta and bstMergeMeta[idx] then
+                return bstMergeMeta[idx].subsetLabel;
+            end
+            return nil;
+        end
+
+        local hasSelection = paletteUi.selectedMacroIndex and db[paletteUi.selectedMacroIndex];
+        local universalLocked = hasSelection and macroGlobalDefaults.IsUniversalTwoHourMacro(db[paletteUi.selectedMacroIndex]);
+        local copyEnabled = hasSelection and not universalLocked;
+        local editDelEnabled = hasSelection and not universalLocked;
 
         -- Button row with XIUI button styling
         imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
@@ -1979,14 +4420,67 @@ function M.DrawPalette()
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
 
         if imgui.Button('+ New Macro', {115, 26}) then
-            isCreatingNew = true;
-            editingMacro = {
-                actionType = 'ma',
-                action = '',
-                target = 't',
-                displayName = '',
-            };
-            selectedMacroIndex = nil;
+            MP.isCreatingNew = true;
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
+            paletteUi.selectedMacroIndex = nil;
+            MP.editorPaletteKey = GetEffectivePaletteType();
+            local body, autoKey = DefaultNewMacroBodyForPaletteKey(MP.editorPaletteKey);
+            MP.editingMacro = body;
+            MP.editorAutoIconKey = autoKey;
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+        end
+
+        imgui.SameLine();
+
+        if not copyEnabled then
+            imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
+        end
+        if imgui.Button('Copy', {60, 26}) and copyEnabled then
+            MP.editingMacro = deep_copy_table(db[paletteUi.selectedMacroIndex]);
+            MP.editingMacro.id = nil;
+            MP.isCreatingNew = true;
+            MP.editorPaletteKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
+            ClearEditorPreviewIconCache();
+        end
+        if not copyEnabled then
+            imgui.PopStyleVar();
+        end
+
+        imgui.SameLine();
+
+        if not copyEnabled then
+            imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
+        end
+        if imgui.Button('Move', {52, 26}) and copyEnabled then
+            MP.macroMoveSourceKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            MP.macroMoveMacroId = db[paletteUi.selectedMacroIndex].id;
+            MP.macroMoveDestKey = PickDefaultMacroMoveDestination(MP.macroMoveSourceKey);
+            imgui.OpenPopup('MacroMoveToPalette##xiui');
+        end
+        if not copyEnabled then
+            imgui.PopStyleVar();
         end
 
         imgui.PopStyleColor(5);
@@ -1994,37 +4488,48 @@ function M.DrawPalette()
 
         imgui.SameLine();
 
-        -- Edit/Delete buttons (always visible, disabled when no selection)
-        local hasSelection = selectedMacroIndex and db[selectedMacroIndex];
-
-        if not hasSelection then
+        -- Edit/Delete buttons (always visible, disabled when no selection or Universal 2Hr locked)
+        if not editDelEnabled then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.4);
         end
 
-        if imgui.Button('Edit', {60, 26}) and hasSelection then
-            editingMacro = deep_copy_table(db[selectedMacroIndex]);
-            isCreatingNew = false;
+        if imgui.Button('Edit', {60, 26}) and editDelEnabled then
+            MP.editingMacro = deep_copy_table(db[paletteUi.selectedMacroIndex]);
+            MP.isCreatingNew = false;
+            MP.editorPaletteKey = rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex);
+            SyncMacroEditorSubtypeFieldsFromSaveKey();
+            M.ClampMacroEditorForItemsPalette();
+            MP.editorDidInitialIconPick = false;
+            MP.editorImplicitActionIconDone = false;
+            MP.editorIconManuallySet = false;
+            MP.editorJaBadgeManuallySet = false;
+            MP.showAllMode = false;
+            MP.showAllPetMode = false;
+            MP.spellTypeFilter = 'All';
+            MP.abilityJobFilter = 0;
+            MP.petTypeOverride = 0;
+            MP.editorIconPrefsHydrated = false;
         end
 
         imgui.SameLine();
 
         -- Delete button with danger styling (or dimmed when disabled)
-        if hasSelection then
+        if editDelEnabled then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.dangerDim);
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.danger);
             imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.9, 0.35, 0.35, 1.0});
         end
 
-        if imgui.Button('Delete', {60, 26}) and hasSelection then
-            M.DeleteMacro(db[selectedMacroIndex].id);
-            selectedMacroIndex = nil;
+        if imgui.Button('Delete', {60, 26}) and editDelEnabled then
+            M.DeleteMacro(db[paletteUi.selectedMacroIndex].id, rowPaletteKeyForGridIdx(paletteUi.selectedMacroIndex));
+            paletteUi.selectedMacroIndex = nil;
         end
 
-        if hasSelection then
+        if editDelEnabled then
             imgui.PopStyleColor(3);
         end
 
-        if not hasSelection then
+        if not editDelEnabled then
             imgui.PopStyleVar();
         end
 
@@ -2036,12 +4541,16 @@ function M.DrawPalette()
         if #db == 0 then
             imgui.TextColored(COLORS.textDim, 'No macros yet.');
             imgui.TextColored(COLORS.textMuted, 'Click "+ New Macro" to create one.');
+        elseif totalMacros == 0 then
+            imgui.TextColored(COLORS.textDim, 'No macros match your search.');
+            imgui.TextColored(COLORS.textMuted, 'Clear the search field or try different text.');
         else
             -- Draw grid row by row using standard ImGui layout
             for row = 0, rowsOnPage - 1 do
                 for col = 0, PALETTE_COLUMNS - 1 do
-                    local idx = startIdx + row * PALETTE_COLUMNS + col;
-                    if idx <= endIdx then
+                    local pos = startIdx + row * PALETTE_COLUMNS + col;
+                    if pos <= endIdx then
+                        local idx = filteredIndices[pos];
                         local macro = db[idx];
                         if macro then
                             if col > 0 then
@@ -2049,7 +4558,7 @@ function M.DrawPalette()
                             end
 
                             -- Draw the tile inline
-                            local isSelected = selectedMacroIndex == idx;
+                            local isSelected = paletteUi.selectedMacroIndex == idx;
 
                             if isSelected then
                                 imgui.PushStyleColor(ImGuiCol_Button, {0.15, 0.13, 0.08, 0.95});
@@ -2061,7 +4570,7 @@ function M.DrawPalette()
                                 imgui.PushStyleColor(ImGuiCol_ButtonActive, COLORS.bgLight);
                             end
 
-                            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, 4);
+                            imgui.PushStyleVar(ImGuiStyleVar_FrameRounding, PALETTE_TILE_ROUNDING);
                             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
                             imgui.PushStyleColor(ImGuiCol_Border, isSelected and COLORS.gold or COLORS.border);
 
@@ -2069,18 +4578,17 @@ function M.DrawPalette()
                             local buttonPos = {imgui.GetCursorScreenPos()};
 
                             if imgui.Button(buttonId, {PALETTE_TILE_SIZE, PALETTE_TILE_SIZE}) then
-                                selectedMacroIndex = idx;
+                                paletteUi.selectedMacroIndex = idx;
                             end
 
                             imgui.PopStyleColor(4);
                             imgui.PopStyleVar(2);
 
                             -- Draw icon on top of button, or abbreviation if no icon
-                            local icon = actions.GetBindIcon(macro);
-                            local iconRendered = false;
-                            if icon and icon.image then
                                 local drawList = imgui.GetWindowDrawList();
-                                if drawList then
+                            local icon = GetCachedPaletteMainIcon(macro);
+                            local iconRendered = false;
+                            if icon and icon.image and drawList then
                                     local iconSize = PALETTE_TILE_SIZE - 8;
                                     local iconX = buttonPos[1] + 4;
                                     local iconY = buttonPos[2] + 4;
@@ -2090,6 +4598,8 @@ function M.DrawPalette()
                                         iconRendered = true;
                                     end
                                 end
+                            if drawList then
+                                DrawMacroJaBadgeOverlay(drawList, macro, buttonPos[1], buttonPos[2], PALETTE_TILE_SIZE);
                             end
 
                             -- No icon - show abbreviated action name
@@ -2108,7 +4618,7 @@ function M.DrawPalette()
                             -- Handle drag
                             if imgui.IsItemActive() and imgui.IsMouseDragging(0, 3) then
                                 if not dragdrop.IsDragging() and not dragdrop.IsDragPending() then
-                                    M.StartDragMacro(idx, macro);
+                                    M.StartDragMacro(idx, macro, rowPaletteKeyForGridIdx(idx));
                                 end
                             end
 
@@ -2118,17 +4628,25 @@ function M.DrawPalette()
                                 imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
                                 imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, {8, 6});
                                 imgui.BeginTooltip();
-                                imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
-                                imgui.Spacing();
-                                imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
-                                if macro.actionType ~= 'macro' and macro.target then
-                                    local formattedTarget = FormatTargetForDisplay(macro.target);
-                                    if formattedTarget then
-                                        imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                                if macroGlobalDefaults.IsUniversalTwoHourMacro(macro) then
+                                    imgui.TextColored(COLORS.gold, '2-Hour Ability');
+                                else
+                                    imgui.TextColored(COLORS.gold, macro.displayName or macro.action or 'Unknown');
+                                    local subLbl = rowSubsetLabelForGridIdx(idx);
+                                    if subLbl then
+                                        imgui.TextColored(COLORS.textMuted, 'Subset: ' .. subLbl);
                                     end
+                                    imgui.Spacing();
+                                    imgui.TextColored(COLORS.textDim, 'Type: ' .. (ACTION_TYPE_LABELS[macro.actionType] or macro.actionType or '?'));
+                                    if macro.actionType ~= 'macro' and macro.target then
+                                        local formattedTarget = FormatTargetForDisplay(macro.target);
+                                        if formattedTarget then
+                                            imgui.TextColored(COLORS.textDim, 'Target: ' .. formattedTarget);
+                                        end
+                                    end
+                                    imgui.Spacing();
+                                    imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
                                 end
-                                imgui.Spacing();
-                                imgui.TextColored(COLORS.textMuted, 'Drag to hotbar slot');
                                 imgui.EndTooltip();
                                 imgui.PopStyleVar();
                                 imgui.PopStyleColor(2);
@@ -2156,13 +4674,13 @@ function M.DrawPalette()
         imgui.SetCursorPosX(paginationStartX);
 
         -- Previous button (disabled when on first page)
-        local canGoPrev = currentPalettePage > 1;
+        local canGoPrev = MP.currentPalettePage > 1;
         if not canGoPrev then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.3);
         end
         if imgui.Button('<##PrevPage', {30, 22}) and canGoPrev then
-            currentPalettePage = currentPalettePage - 1;
-            selectedMacroIndex = nil;
+            MP.currentPalettePage = MP.currentPalettePage - 1;
+            paletteUi.selectedMacroIndex = nil;
         end
         if not canGoPrev then
             imgui.PopStyleVar();
@@ -2171,7 +4689,7 @@ function M.DrawPalette()
         imgui.SameLine();
 
         -- Page indicator
-        local pageText = string.format('Page %d / %d', currentPalettePage, totalPages);
+        local pageText = string.format('Page %d / %d', MP.currentPalettePage, totalPages);
         local textWidth = imgui.CalcTextSize(pageText);
         imgui.SetCursorPosX(paginationStartX + (paginationWidth - textWidth) / 2);
         imgui.TextColored(COLORS.textDim, pageText);
@@ -2180,13 +4698,13 @@ function M.DrawPalette()
         imgui.SetCursorPosX(paginationStartX + paginationWidth - 30);
 
         -- Next button (disabled when on last page)
-        local canGoNext = currentPalettePage < totalPages;
+        local canGoNext = MP.currentPalettePage < totalPages;
         if not canGoNext then
             imgui.PushStyleVar(ImGuiStyleVar_Alpha, 0.3);
         end
         if imgui.Button('>##NextPage', {30, 22}) and canGoNext then
-            currentPalettePage = currentPalettePage + 1;
-            selectedMacroIndex = nil;
+            MP.currentPalettePage = MP.currentPalettePage + 1;
+            paletteUi.selectedMacroIndex = nil;
         end
         if not canGoNext then
             imgui.PopStyleVar();
@@ -2202,9 +4720,22 @@ function M.DrawPalette()
     end
 
     -- Draw macro editor popup if needed
-    if editingMacro then
+    if MP.editingMacro then
         M.DrawMacroEditor();
     end
+end
+
+function M.DrawPalette()
+    -- Macro editor must draw even when the palette list is closed (e.g. opened from Edit Full Palette
+    -- via double-click); otherwise MP.editingMacro is set but no window is ever drawn.
+    if not paletteUi.open then
+        if MP.editingMacro then
+            RefreshCachedLists();
+            M.DrawMacroEditor();
+        end
+        return;
+    end
+    DrawPaletteBody();
 end
 
 -- ============================================
@@ -2269,40 +4800,6 @@ local function FindIndex(array, value)
     return 1;
 end
 
--- Draw icon preview box with current icon
-local function DrawIconPreview(macro, x, y, size)
-    local drawList = imgui.GetWindowDrawList();
-    if not drawList then return; end
-
-    -- Draw background box
-    local bgColor = imgui.GetColorU32({0.1, 0.09, 0.08, 0.95});
-    local borderColor = imgui.GetColorU32(COLORS.border);
-    drawList:AddRectFilled({x, y}, {x + size, y + size}, bgColor, 4);
-    drawList:AddRect({x, y}, {x + size, y + size}, borderColor, 4, 0, 1);
-
-    -- Draw icon if available
-    local icon = actions.GetBindIcon(macro);
-    if icon and icon.image then
-        local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
-        if iconPtr then
-            local padding = 4;
-            drawList:AddImage(
-                iconPtr,
-                {x + padding, y + padding},
-                {x + size - padding, y + size - padding}
-            );
-        end
-    else
-        -- No icon - show abbreviated action name (prefer action for preview)
-        local abbr = GetActionAbbreviation(macro, true);
-        local textSize = imgui.CalcTextSize(abbr);
-        local textX = x + (size - textSize) / 2;
-        local textY = y + (size - 14) / 2;
-        local textColor = imgui.GetColorU32(COLORS.gold);
-        drawList:AddText({textX, textY}, textColor, abbr);
-    end
-end
-
 -- Helper to draw an icon button (works around ImageButton signature issues)
 local function DrawIconButton(id, icon, size, isSelected, tooltipText)
     local clicked = false;
@@ -2357,12 +4854,12 @@ end
 
 -- Draw the icon picker popup
 local function DrawIconPicker()
-    if not iconPickerOpen or not editingMacro then
+    if not MP.iconPickerOpen or not MP.editingMacro then
         return;
     end
 
     -- Start item loading when items tab is selected
-    if iconPickerTab == 2 then
+    if MP.iconPickerTab == 2 then
         StartItemIconLoading();
         LoadItemIconBatch();  -- Load a batch each frame
     end
@@ -2389,7 +4886,7 @@ local function DrawIconPicker()
         local tabWidth = 70;
 
         -- Spells tab
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2397,7 +4894,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Spells', {tabWidth, 24}) then
-            iconPickerTab = 1;
+            MP.iconPickerTab = 1;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2405,7 +4902,7 @@ local function DrawIconPicker()
         imgui.SameLine();
 
         -- Items tab
-        if iconPickerTab == 2 then
+        if MP.iconPickerTab == 2 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2413,7 +4910,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Items', {tabWidth, 24}) then
-            iconPickerTab = 2;
+            MP.iconPickerTab = 2;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2421,7 +4918,7 @@ local function DrawIconPicker()
         imgui.SameLine();
 
         -- Custom tab
-        if iconPickerTab == 3 then
+        if MP.iconPickerTab == 3 then
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
         else
@@ -2429,7 +4926,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Border, COLORS.border);
         end
         if imgui.Button('Custom', {tabWidth, 24}) then
-            iconPickerTab = 3;
+            MP.iconPickerTab = 3;
             -- Keep filter text, don't reset - reduces lag from cache rebuilds
         end
         imgui.PopStyleColor(2);
@@ -2441,10 +4938,18 @@ local function DrawIconPicker()
         imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.danger);
         imgui.PushStyleColor(ImGuiCol_Border, COLORS.danger);
         if imgui.Button('Clear', {50, 24}) then
-            editingMacro.customIconType = nil;
-            editingMacro.customIconId = nil;
-            editingMacro.customIconPath = nil;
-            iconPickerOpen = false;
+            if MP.iconPickerTargetIsJaBadge then
+                MP.editingMacro.jaBadgeCustomIconType = nil;
+                MP.editingMacro.jaBadgeCustomIconId = nil;
+                MP.editingMacro.jaBadgeCustomIconPath = nil;
+                MP.editorJaBadgeManuallySet = false;
+            else
+                MP.editingMacro.customIconType = nil;
+                MP.editingMacro.customIconId = nil;
+                MP.editingMacro.customIconPath = nil;
+            end
+            MP.editorAutoIconKey = nil;
+            MP.iconPickerOpen = false;
         end
         imgui.PopStyleColor(3);
 
@@ -2456,10 +4961,10 @@ local function DrawIconPicker()
         imgui.TextColored(COLORS.goldDim, 'Search:');
         imgui.SameLine();
         imgui.SetNextItemWidth(200);
-        imgui.InputText('##iconSearch', iconPickerFilter, INPUT_BUFFER_SIZE);
+        imgui.InputText('##iconSearch', MP.iconPickerFilter, INPUT_BUFFER_SIZE);
 
         -- Show loading status for items tab (count shown near page navigation)
-        if iconPickerTab == 2 and itemIconLoadState.loading then
+        if MP.iconPickerTab == 2 and itemIconLoadState.loading then
             imgui.SameLine();
             imgui.TextColored(COLORS.textMuted, string.format('Loading... %d%%', GetItemLoadProgress()));
         end
@@ -2467,7 +4972,7 @@ local function DrawIconPicker()
         imgui.Spacing();
 
         -- Spell type filter buttons with icons (only for spells tab)
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             local filterIconSize = 24;
             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
             imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {3, 3});
@@ -2475,7 +4980,7 @@ local function DrawIconPicker()
 
             for i, spellType in ipairs(SPELL_TYPE_ORDER) do
                 local tooltip = SPELL_TYPE_LABELS[spellType] or spellType;
-                local isSelected = iconPickerSpellType == spellType;
+                local isSelected = MP.iconPickerSpellType == spellType;
 
                 if isSelected then
                     imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgLight);
@@ -2492,8 +4997,8 @@ local function DrawIconPicker()
 
                 -- Use DrawIconButton which works on all Ashita versions
                 if DrawIconButton('##spellFilter' .. i, icon, filterIconSize, isSelected, tooltip) then
-                    iconPickerSpellType = spellType;
-                    iconPickerPage[1] = 1;
+                    MP.iconPickerSpellType = spellType;
+                    MP.iconPickerPage[1] = 1;
                 end
 
                 if i < #SPELL_TYPE_ORDER then
@@ -2506,7 +5011,7 @@ local function DrawIconPicker()
         end
 
         -- Item type filter buttons with icons (only for items tab)
-        if iconPickerTab == 2 then
+        if MP.iconPickerTab == 2 then
             local filterIconSize = 24;
             imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
             imgui.PushStyleVar(ImGuiStyleVar_ItemSpacing, {3, 3});
@@ -2514,7 +5019,7 @@ local function DrawIconPicker()
 
             for i, itemType in ipairs(ITEM_TYPE_ORDER) do
                 local tooltip = ITEM_TYPE_LABELS[itemType] or tostring(itemType);
-                local isSelected = iconPickerItemType == itemType;
+                local isSelected = MP.iconPickerItemType == itemType;
                 local itemId = ITEM_TYPE_ICONS[itemType];
 
                 -- Get item icon texture
@@ -2522,8 +5027,8 @@ local function DrawIconPicker()
 
                 -- Use DrawIconButton which works on all Ashita versions
                 if DrawIconButton('##itemFilter' .. i, icon, filterIconSize, isSelected, tooltip) then
-                    iconPickerItemType = itemType;
-                    iconPickerPage[2] = 1;
+                    MP.iconPickerItemType = itemType;
+                    MP.iconPickerPage[2] = 1;
                 end
 
                 if i < #ITEM_TYPE_ORDER then
@@ -2536,7 +5041,7 @@ local function DrawIconPicker()
         end
 
         -- Custom icon category filter buttons (only for custom tab)
-        if iconPickerTab == 3 then
+        if MP.iconPickerTab == 3 then
             -- Load categories if not loaded
             LoadCustomIcons();
             
@@ -2569,7 +5074,7 @@ local function DrawIconPicker()
                     imgui.PushStyleColor(ImGuiCol_Text, COLORS.goldDim);
                     if imgui.Button(letter .. '##customFilter' .. i, {filterIconSize, filterIconSize}) then
                         customIconCategory = category;
-                        iconPickerPage[3] = 1;
+                        MP.iconPickerPage[3] = 1;
                         customIconsCacheKey = nil;
                     end
                     imgui.PopStyleColor(3);
@@ -2582,7 +5087,7 @@ local function DrawIconPicker()
                     -- Use DrawIconButton for categories with icons
                     if DrawIconButton('##customFilter' .. i, categoryIcon, filterIconSize, isSelected, tooltip) then
                         customIconCategory = category;
-                        iconPickerPage[3] = 1;
+                        MP.iconPickerPage[3] = 1;
                         customIconsCacheKey = nil;  -- Invalidate cache
                     end
                 end
@@ -2629,7 +5134,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
             
-            if imgui.BeginPopupModal('Create Custom Folder##newFolderPopup', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+            if imgui.BeginPopup('Create Custom Folder##newFolderPopup') then
                 imgui.TextColored(COLORS.goldDim, 'Folder name:');
                 imgui.SetNextItemWidth(250);
                 imgui.InputText('##newFolderInput', newFolderName, 64);
@@ -2656,60 +5161,62 @@ local function DrawIconPicker()
             imgui.PopStyleColor(9);
         end
 
-        local filter = iconPickerFilter[1]:lower();
-        local currentPage = iconPickerPage[iconPickerTab];
+        local filter = MP.iconPickerFilter[1];
+        local currentPage = MP.iconPickerPage[MP.iconPickerTab];
 
         -- Build cache key for filtered results
         local cacheKey;
-        if iconPickerTab == 1 then
-            cacheKey = filter .. ':spell:' .. iconPickerSpellType;
-        elseif iconPickerTab == 2 then
-            cacheKey = filter .. ':item:' .. tostring(iconPickerItemType);
-        elseif iconPickerTab == 3 then
+        if MP.iconPickerTab == 1 then
+            cacheKey = filter .. ':spell:' .. MP.iconPickerSpellType;
+        elseif MP.iconPickerTab == 2 then
+            cacheKey = filter .. ':item:' .. tostring(MP.iconPickerItemType);
+        elseif MP.iconPickerTab == 3 then
             cacheKey = filter .. ':custom:' .. customIconCategory;
         end
 
         -- Reset page and invalidate cache if filter/type changed
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             if cacheKey ~= filteredSpellsCacheKey then
-                iconPickerPage[1] = 1;
+                MP.iconPickerPage[1] = 1;
                 currentPage = 1;
                 filteredSpellsCache = nil;
                 filteredSpellsCacheKey = cacheKey;
             end
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             if cacheKey ~= filteredItemsCacheKey then
-                iconPickerPage[2] = 1;
+                MP.iconPickerPage[2] = 1;
                 currentPage = 1;
                 filteredItemsCache = nil;
                 filteredItemsCacheKey = cacheKey;
             end
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             if cacheKey ~= customIconsCacheKey then
-                iconPickerPage[3] = 1;
+                MP.iconPickerPage[3] = 1;
                 currentPage = 1;
                 customIconsCacheKey = cacheKey;
+                filteredCustomIconsCache = nil;
+                filteredCustomIconsCacheKey = nil;
             end
         end
 
         -- Build filtered list (with caching to avoid rebuilding every frame)
         local filteredItems = {};
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             if filteredSpellsCache then
                 filteredItems = filteredSpellsCache;
             else
                 local allSpells = GetAllSpells();
                 for _, spell in ipairs(allSpells) do
                     local spellName = spell.name or '';
-                    local matchesFilter = (filter == '' or spellName:lower():find(filter, 1, true));
-                    local matchesType = (iconPickerSpellType == 'All' or spell.type == iconPickerSpellType);
+                    local matchesFilter = iconPickerNameMatchesFilter(spellName, filter);
+                    local matchesType = (MP.iconPickerSpellType == 'All' or spell.type == MP.iconPickerSpellType);
                     if matchesFilter and matchesType then
                         table.insert(filteredItems, spell);
                     end
                 end
                 filteredSpellsCache = filteredItems;
             end
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             -- Only use cache if: cache exists, not loading, and cache has items (or items DB is empty)
             local cacheValid = filteredItemsCache
                 and not itemIconLoadState.loading
@@ -2720,8 +5227,8 @@ local function DrawIconPicker()
             else
                 -- Use pre-filtered type list if available and a specific type is selected
                 local sourceItems;
-                if iconPickerItemType ~= 0 and itemIconLoadState.itemsByType[iconPickerItemType] then
-                    sourceItems = itemIconLoadState.itemsByType[iconPickerItemType];
+                if MP.iconPickerItemType ~= 0 and itemIconLoadState.itemsByType[MP.iconPickerItemType] then
+                    sourceItems = itemIconLoadState.itemsByType[MP.iconPickerItemType];
                 else
                     sourceItems = itemIconLoadState.items;
                 end
@@ -2735,7 +5242,7 @@ local function DrawIconPicker()
                         -- Apply text filter
                         for _, item in ipairs(sourceItems) do
                             local itemName = item.name or '';
-                            if itemName:lower():find(filter, 1, true) then
+                            if iconPickerNameMatchesFilter(itemName, filter) then
                                 table.insert(filteredItems, item);
                             end
                         end
@@ -2747,23 +5254,28 @@ local function DrawIconPicker()
                     filteredItemsCache = filteredItems;
                 end
             end
-        elseif iconPickerTab == 3 then
-            -- Custom icons - use pre-filtered category list
+        elseif MP.iconPickerTab == 3 then
+            if filteredCustomIconsCache and filteredCustomIconsCacheKey == cacheKey then
+                filteredItems = filteredCustomIconsCache;
+            else
             filteredItems = GetCustomIconsFiltered(customIconCategory, filter);
+                filteredCustomIconsCache = filteredItems;
+                filteredCustomIconsCacheKey = cacheKey;
+            end
         end
 
         local totalItems = #filteredItems;
         local totalPages = math.max(1, math.ceil(totalItems / ICONS_PER_PAGE));
 
         -- Show filtered count for spells and custom (items count shown near page navigation only)
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             local allSpells = GetAllSpells();
             local countText = string.format('%d of %d spells', totalItems, #allSpells);
-            if iconPickerSpellType ~= 'All' then
-                countText = countText .. ' (' .. (SPELL_TYPE_LABELS[iconPickerSpellType] or iconPickerSpellType) .. ')';
+            if MP.iconPickerSpellType ~= 'All' then
+                countText = countText .. ' (' .. (SPELL_TYPE_LABELS[MP.iconPickerSpellType] or MP.iconPickerSpellType) .. ')';
             end
             imgui.TextColored(COLORS.textMuted, countText);
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             local allCustom = LoadCustomIcons();
             local countText = string.format('%d of %d custom icons', totalItems, #allCustom);
             if customIconCategory ~= 'all' then
@@ -2790,16 +5302,10 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             imgui.PushStyleColor(ImGuiCol_Text, COLORS.goldDim);
             if imgui.Button('Refresh##refreshCustom', {60, 18}) then
-                -- Clear all caches to force rescan
-                customIconsCache = nil;
-                customIconsByCategoryCache = {};
-                customCategoryIconCache = {};
+                InvalidateCustomIconScanCaches();
                 customIconsCacheKey = nil;
-                -- Clear TextureManager custom icons cache
-                TextureManager.clearCategory('custom_icons');
-                -- Also clear the action module's custom icon cache
                 actions.ClearCustomIconCache();
-                -- Reset progressive loading
+                TextureManager.clearCategory('custom_icons');
                 ResetIconLoading();
             end
             imgui.PopStyleColor(3);
@@ -2813,7 +5319,7 @@ local function DrawIconPicker()
             imgui.PushStyleColor(ImGuiCol_Button, COLORS.bgMedium);
             imgui.PushStyleColor(ImGuiCol_ButtonHovered, COLORS.bgLight);
             
-            if imgui.BeginPopupModal('Delete Folder##deleteFolderPopup', nil, ImGuiWindowFlags_AlwaysAutoResize) then
+            if imgui.BeginPopup('Delete Folder##deleteFolderPopup') then
                 local categoryLabel = CUSTOM_ICON_LABELS[deleteFolderTarget] or deleteFolderTarget or '';
                 local iconCount = customIconsByCategoryCache[deleteFolderTarget] and #customIconsByCategoryCache[deleteFolderTarget] or 0;
                 
@@ -2857,7 +5363,7 @@ local function DrawIconPicker()
         -- Clamp current page
         if currentPage > totalPages then
             currentPage = totalPages;
-            iconPickerPage[iconPickerTab] = currentPage;
+            MP.iconPickerPage[MP.iconPickerTab] = currentPage;
         end
 
         -- Page navigation UI
@@ -2873,7 +5379,7 @@ local function DrawIconPicker()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textMuted);
             end
             if imgui.Button('<##prevPage', {30, 22}) and canGoPrev then
-                iconPickerPage[iconPickerTab] = currentPage - 1;
+                MP.iconPickerPage[MP.iconPickerTab] = currentPage - 1;
             end
             if not canGoPrev then
                 imgui.PopStyleColor(3);
@@ -2894,7 +5400,7 @@ local function DrawIconPicker()
                 imgui.PushStyleColor(ImGuiCol_Text, COLORS.textMuted);
             end
             if imgui.Button('>##nextPage', {30, 22}) and canGoNext then
-                iconPickerPage[iconPickerTab] = currentPage + 1;
+                MP.iconPickerPage[MP.iconPickerTab] = currentPage + 1;
             end
             if not canGoNext then
                 imgui.PopStyleColor(3);
@@ -2928,7 +5434,7 @@ local function DrawIconPicker()
 
         local displayedCount = 0;
 
-        if iconPickerTab == 1 then
+        if MP.iconPickerTab == 1 then
             -- Spell icons - render current page from filtered list
             if totalItems == 0 then
                 imgui.TextColored(COLORS.textMuted, 'No matching spells found');
@@ -2961,11 +5467,25 @@ local function DrawIconPicker()
                                 tooltipText = spell.name .. ' (' .. (SPELL_TYPE_LABELS[spell.type] or spell.type) .. ')';
                             end
 
-                            local isSelected = editingMacro.customIconType == 'spell' and editingMacro.customIconId == spell.id;
+                            local isSelected;
+                            if MP.iconPickerTargetIsJaBadge then
+                                isSelected = MP.editingMacro.jaBadgeCustomIconType == 'spell' and MP.editingMacro.jaBadgeCustomIconId == spell.id;
+                            else
+                                isSelected = MP.editingMacro.customIconType == 'spell' and MP.editingMacro.customIconId == spell.id;
+                            end
                             if DrawIconButton('##spell' .. spell.id, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                                editingMacro.customIconType = 'spell';
-                                editingMacro.customIconId = spell.id;
-                                iconPickerOpen = false;
+                                if MP.iconPickerTargetIsJaBadge then
+                                    MP.editingMacro.jaBadgeCustomIconType = 'spell';
+                                    MP.editingMacro.jaBadgeCustomIconId = spell.id;
+                                    MP.editingMacro.jaBadgeCustomIconPath = nil;
+                                    MP.editorJaBadgeManuallySet = true;
+                                else
+                                    MP.editingMacro.customIconType = 'spell';
+                                    MP.editingMacro.customIconId = spell.id;
+                                    MP.editingMacro.customIconPath = nil;
+                                end
+                                MP.editorAutoIconKey = nil;
+                                MP.iconPickerOpen = false;
                             end
 
                             displayedCount = displayedCount + 1;
@@ -2974,7 +5494,7 @@ local function DrawIconPicker()
                 end
             end
 
-        elseif iconPickerTab == 2 then
+        elseif MP.iconPickerTab == 2 then
             -- Item icons - render current page from filtered list with progressive loading
             if itemIconLoadState.loading and #itemIconLoadState.items == 0 then
                 imgui.TextColored(COLORS.textMuted, 'Loading item database...');
@@ -2985,7 +5505,7 @@ local function DrawIconPicker()
                 local loadCacheKey = cacheKey .. ':' .. tostring(currentPage);
                 if iconLoadState.currentCacheKey ~= loadCacheKey then
                     iconLoadState.currentPage = currentPage;
-                    iconLoadState.currentTab = iconPickerTab;
+                    iconLoadState.currentTab = MP.iconPickerTab;
                     iconLoadState.currentCacheKey = loadCacheKey;
                     iconLoadState.loadedCount = 0;
                     iconLoadState.pageIconCache = {};
@@ -3046,11 +5566,25 @@ local function DrawIconPicker()
                             tooltipText = item.name .. ' (' .. typeLabel .. ')';
                         end
 
-                        local isSelected = editingMacro.customIconType == 'item' and editingMacro.customIconId == item.id;
-                        if DrawIconButton('##item' .. item.id, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                            editingMacro.customIconType = 'item';
-                            editingMacro.customIconId = item.id;
-                            iconPickerOpen = false;
+                        local isSelectedItem;
+                        if MP.iconPickerTargetIsJaBadge then
+                            isSelectedItem = MP.editingMacro.jaBadgeCustomIconType == 'item' and MP.editingMacro.jaBadgeCustomIconId == item.id;
+                        else
+                            isSelectedItem = MP.editingMacro.customIconType == 'item' and MP.editingMacro.customIconId == item.id;
+                        end
+                        if DrawIconButton('##item' .. item.id, icon, ICON_GRID_SIZE, isSelectedItem, tooltipText) then
+                            if MP.iconPickerTargetIsJaBadge then
+                                MP.editingMacro.jaBadgeCustomIconType = 'item';
+                                MP.editingMacro.jaBadgeCustomIconId = item.id;
+                                MP.editingMacro.jaBadgeCustomIconPath = nil;
+                                MP.editorJaBadgeManuallySet = true;
+                            else
+                                MP.editingMacro.customIconType = 'item';
+                                MP.editingMacro.customIconId = item.id;
+                                MP.editingMacro.customIconPath = nil;
+                            end
+                            MP.editorAutoIconKey = nil;
+                            MP.iconPickerOpen = false;
                         end
 
                         displayedCount = displayedCount + 1;
@@ -3058,7 +5592,7 @@ local function DrawIconPicker()
                 end
             end
         
-        elseif iconPickerTab == 3 then
+        elseif MP.iconPickerTab == 3 then
             -- Custom icons - render from custom directory with progressive loading
             if totalItems == 0 then
                 if customIconCategory ~= 'all' then
@@ -3098,9 +5632,9 @@ local function DrawIconPicker()
             else
                 -- Check if page/tab/filter changed - reset icon cache
                 local loadCacheKey = cacheKey .. ':' .. tostring(currentPage);
-                if iconLoadState.currentCacheKey ~= loadCacheKey or iconLoadState.currentTab ~= iconPickerTab then
+                if iconLoadState.currentCacheKey ~= loadCacheKey or iconLoadState.currentTab ~= MP.iconPickerTab then
                     iconLoadState.currentPage = currentPage;
-                    iconLoadState.currentTab = iconPickerTab;
+                    iconLoadState.currentTab = MP.iconPickerTab;
                     iconLoadState.currentCacheKey = loadCacheKey;
                     iconLoadState.loadedCount = 0;
                     iconLoadState.pageIconCache = {};
@@ -3159,12 +5693,25 @@ local function DrawIconPicker()
                             tooltipText = customIcon.name .. ' (' .. categoryLabel .. ')';
                         end
 
-                        local isSelected = editingMacro.customIconType == 'custom' and editingMacro.customIconPath == customIcon.path;
-                        if DrawIconButton('##custom' .. itemIdx, icon, ICON_GRID_SIZE, isSelected, tooltipText) then
-                            editingMacro.customIconType = 'custom';
-                            editingMacro.customIconPath = customIcon.path;
-                            editingMacro.customIconId = nil;
-                            iconPickerOpen = false;
+                        local isSelectedCust;
+                        if MP.iconPickerTargetIsJaBadge then
+                            isSelectedCust = MP.editingMacro.jaBadgeCustomIconType == 'custom' and MP.editingMacro.jaBadgeCustomIconPath == customIcon.path;
+                        else
+                            isSelectedCust = MP.editingMacro.customIconType == 'custom' and MP.editingMacro.customIconPath == customIcon.path;
+                        end
+                        if DrawIconButton('##custom' .. itemIdx, icon, ICON_GRID_SIZE, isSelectedCust, tooltipText) then
+                            if MP.iconPickerTargetIsJaBadge then
+                                MP.editingMacro.jaBadgeCustomIconType = 'custom';
+                                MP.editingMacro.jaBadgeCustomIconPath = customIcon.path;
+                                MP.editingMacro.jaBadgeCustomIconId = nil;
+                                MP.editorJaBadgeManuallySet = true;
+                            else
+                                MP.editingMacro.customIconType = 'custom';
+                                MP.editingMacro.customIconPath = customIcon.path;
+                                MP.editingMacro.customIconId = nil;
+                            end
+                            MP.editorAutoIconKey = nil;
+                            MP.iconPickerOpen = false;
                         end
 
                         displayedCount = displayedCount + 1;
@@ -3181,12 +5728,13 @@ local function DrawIconPicker()
     PopWindowStyle();
 
     if not isOpen[1] then
-        iconPickerOpen = false;
-        iconPickerFilter[1] = '';
-        iconPickerPage = { 1, 1, 1 };  -- Reset pages
-        iconPickerLastFilter = { '', '', '' };
-        iconPickerSpellType = 'All';  -- Reset spell type filter
-        iconPickerItemType = 0;  -- Reset item type filter (0 = All)
+        MP.iconPickerOpen = false;
+        MP.iconPickerTargetIsJaBadge = false;
+        MP.iconPickerFilter[1] = '';
+        MP.iconPickerPage = { 1, 1, 1 };  -- Reset pages
+        MP.iconPickerLastFilter = { '', '', '' };
+        MP.iconPickerSpellType = 'All';  -- Reset spell type filter
+        MP.iconPickerItemType = 0;  -- Reset item type filter (0 = All)
         customIconCategory = 'all';  -- Reset custom category filter
         -- Clear filter caches when picker closes
         filteredSpellsCache = nil;
@@ -3194,626 +5742,570 @@ local function DrawIconPicker()
         filteredItemsCache = nil;
         filteredItemsCacheKey = nil;
         customIconsCacheKey = nil;
+        filteredCustomIconsCache = nil;
+        filteredCustomIconsCacheKey = nil;
         -- Reset progressive icon loading
         ResetIconLoading();
     end
 end
 
-function M.DrawMacroEditor()
-    if not editingMacro then
+-- When opening the icon picker (Change), align tab / filters with the resolved icon; search text is always the
+-- primary action name (what auto-pick matched against), not the resolved spell/item/custom label.
+-- Implemented on M (not a file-local) so M.DrawMacroEditor does not gain an extra upvalue (Lua 5.1 limit: 60).
+function M.ApplyIconPickerContextFromEditor(forJaBadgeArg)
+    if not MP.editingMacro then
         return;
     end
 
-    -- Initialize editor fields from editing macro
-    editorFields.actionType[1] = FindIndex(ACTION_TYPES, editingMacro.actionType or 'ma');
-    editorFields.action[1] = editingMacro.action or '';
-    editorFields.target[1] = FindIndex(TARGET_OPTIONS, editingMacro.target or 't');
-    editorFields.displayName[1] = editingMacro.displayName or '';
-    editorFields.equipSlot[1] = FindIndex(EQUIP_SLOTS, editingMacro.equipSlot or 'main');
-    editorFields.macroText[1] = editingMacro.macroText or '';
-    editorFields.recastSourceType[1] = FindIndex(RECAST_SOURCE_TYPES, editingMacro.recastSourceType or 'none');
-    editorFields.recastSourceAction[1] = editingMacro.recastSourceAction or '';
+    local forJaBadge = forJaBadgeArg and true or false;
+    MP.iconPickerTargetIsJaBadge = forJaBadge;
 
-    local title = isCreatingNew and 'Create Macro###MacroEditor' or 'Edit Macro###MacroEditor';
-    local isOpen = { true };
+    local pType;
+    local pName;
+    local jaBadgeName;
 
-    imgui.SetNextWindowSize({420, 480}, ImGuiCond_FirstUseEver);
+    if MP.editingMacro.actionType == 'macro' then
+        local mp = require('modules.hotbar.macroparse');
+        pType, pName, jaBadgeName = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+    else
+        pType = MP.editingMacro.actionType;
+        pName = MP.editingMacro.action;
+    end
 
-    -- Apply XIUI styling
-    PushWindowStyle();
-
-    if imgui.Begin(title, isOpen, ImGuiWindowFlags_NoCollapse) then
-        -- Icon preview section at the top right (uses window-relative positioning for scrolling)
-        local iconPreviewSize = 64;
-        local contentWidth = imgui.GetContentRegionAvail();
-        local iconPreviewX = contentWidth - iconPreviewSize - 10;
-
-        -- Draw icon preview and Change button together
-        local startCursorY = imgui.GetCursorPosY();
-        imgui.SetCursorPosX(iconPreviewX);
-
-        -- Get screen position for icon preview (DrawIconPreview needs screen coords)
-        local screenPos = {imgui.GetCursorScreenPos()};
-        DrawIconPreview(editingMacro, screenPos[1], screenPos[2], iconPreviewSize);
-
-        -- Change Icon button below preview (use window-relative SetCursorPos for scroll support)
-        imgui.SetCursorPos({iconPreviewX - 10, startCursorY + iconPreviewSize + 8});
-        imgui.PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
-        imgui.PushStyleColor(ImGuiCol_Border, COLORS.gold);
-        if imgui.Button('Change', {iconPreviewSize + 20, 22}) then
-            iconPickerOpen = true;
-            iconPickerFilter[1] = '';
+    if forJaBadge then
+        if not jaBadgeName or jaBadgeName == '' then
+            return;
         end
-        imgui.PopStyleColor();
-        imgui.PopStyleVar();
+        pType = 'ja';
+        pName = jaBadgeName;
+    end
 
-        -- Reset cursor for main content (left side, use window-relative positioning)
-        imgui.SetCursorPos({8, startCursorY});
+    if pName then
+        pName = tostring(pName);
+        pName = pName:match('^%s*(.-)%s*$') or pName;
+        if pName == '' then
+            pName = nil;
+        end
+    end
 
-        -- Action Type dropdown with label
-        imgui.TextColored(COLORS.goldDim, 'Action Type');
-        PushComboStyle();
-        imgui.SetNextItemWidth(240);
-        local currentType = ACTION_TYPES[editorFields.actionType[1]];
-        if imgui.BeginCombo('##actionType', ACTION_TYPE_LABELS[currentType] or 'Select...') then
-            for i, actionType in ipairs(ACTION_TYPES) do
-                local isSelected = editorFields.actionType[1] == i;
-                if isSelected then
-                    imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
-                end
-                if imgui.Selectable(ACTION_TYPE_LABELS[actionType], isSelected) then
-                    editorFields.actionType[1] = i;
-                    editingMacro.actionType = actionType;
-                    -- Clear action when type changes
-                    editingMacro.action = '';
-                    editorFields.action[1] = '';
-                    searchFilter[1] = '';
-                    -- Clear recast source fields when changing away from macro type
-                    if actionType ~= 'macro' then
-                        editingMacro.recastSourceType = nil;
-                        editingMacro.recastSourceAction = nil;
-                        editingMacro.recastSourceItemId = nil;
-                        editorFields.recastSourceType[1] = 1;  -- Reset to 'none'
-                        editorFields.recastSourceAction[1] = '';
+    local ct = forJaBadge and MP.editingMacro.jaBadgeCustomIconType or MP.editingMacro.customIconType;
+    local cid = forJaBadge and MP.editingMacro.jaBadgeCustomIconId or MP.editingMacro.customIconId;
+    local cp = forJaBadge and MP.editingMacro.jaBadgeCustomIconPath or MP.editingMacro.customIconPath;
+
+    local src = MP.editorIconAutoSource or 'all';
+
+    -- Custom XIUI icon actually on the macro, or the same match auto-pick would use first (/pet before spell, etc.).
+    local customEntryForPicker = nil;
+    if ct == 'custom' and cp and tostring(cp) ~= '' then
+        customEntryForPicker = FindCustomIconEntryBySavedPath(cp);
+        if not customEntryForPicker then
+            local base = tostring(cp):match('[^\\/]+$') or '';
+            base = base:gsub('%.png$', '');
+            if base ~= '' then
+                customEntryForPicker = { name = base, category = 'all' };
+            end
+        end
+    elseif ct ~= 'spell' and ct ~= 'item' and pName then
+        -- Match AutoPick order: item id â†’ spell id (for /ma) before inferring a custom PNG.
+        local exactItemId = (MP.editingMacro.itemId and tonumber(MP.editingMacro.itemId)) or actiondb.GetItemId(pName);
+        local maSpellId = (pType == 'ma' and pName) and actions.GetSpellIdByEnglishName(pName, 'ma') or nil;
+        local tryInfer = (pType == 'pet' or pType == 'ja' or pType == 'ws')
+            or (src == 'custom' and pType == 'ma')
+            or (pType == 'ma' and pName and not maSpellId and (src == 'all' or src == 'custom'))
+            or ((pType == 'item' or pType == 'equip') and (not exactItemId or exactItemId == 0));
+        if tryInfer then
+            customEntryForPicker = ResolveBestCustomIconMatchForActionName(pName, MP.editorCustomIconCategory or 'all');
                     end
                 end
-                if isSelected then
-                    imgui.PopStyleColor();
+
+    if customEntryForPicker then
+        MP.iconPickerTab = 3;
+    elseif src == 'items' then
+        MP.iconPickerTab = 2;
+    elseif src == 'custom' then
+        MP.iconPickerTab = 3;
+    elseif src == 'spells' then
+        MP.iconPickerTab = 1;
+    else
+        if pType == 'item' or pType == 'equip' then
+            MP.iconPickerTab = 2;
+        else
+            MP.iconPickerTab = 1;
+                end
+            end
+
+    MP.iconPickerPage[1] = 1;
+    MP.iconPickerPage[2] = 1;
+    MP.iconPickerPage[3] = 1;
+
+    filteredSpellsCache = nil;
+    filteredSpellsCacheKey = nil;
+    filteredItemsCache = nil;
+    filteredItemsCacheKey = nil;
+    customIconsCacheKey = nil;
+    filteredCustomIconsCache = nil;
+    filteredCustomIconsCacheKey = nil;
+    ResetIconLoading();
+
+    local function mapHorizonTypeToSpellFilter(dbType)
+        if not dbType or dbType == 'All' then
+            return nil;
+        end
+        if dbType == 'BloodPact' then
+            return 'SummonerPact';
+        end
+        for _, st in ipairs(SPELL_TYPE_ORDER) do
+            if st == dbType then
+                return dbType;
+            end
+        end
+        return nil;
+    end
+
+    if MP.iconPickerTab == 2 then
+        MP.iconPickerSpellType = 'All';
+        -- Search shows the action text auto-pick matched against, not the resolved item's canonical name.
+        if pName and (pType == 'item' or pType == 'equip') then
+            MP.iconPickerFilter[1] = pName;
+        else
+            MP.iconPickerFilter[1] = '';
+        end
+        return;
+    end
+
+    if MP.iconPickerTab == 3 then
+        MP.iconPickerSpellType = 'All';
+        -- Same: search = user/primary-line text that drove matching; folder still reflects the picked asset.
+        MP.iconPickerFilter[1] = pName or '';
+        if customEntryForPicker then
+            if customEntryForPicker.category and customEntryForPicker.category ~= 'root' then
+                customIconCategory = customEntryForPicker.category;
+            else
+                customIconCategory = 'all';
+            end
+        end
+        return;
+    end
+
+    -- Spells tab: spell-type filter from resolved id/row; search = primary action text (what matching used).
+    do
+        local horizonSpells = require('modules.hotbar.database.horizonspells');
+        local hid;
+
+        if ct == 'spell' and cid then
+            hid = tonumber(cid);
+        elseif not forJaBadge then
+            local at = tostring(MP.editingMacro.actionType or '');
+            local maOrPet = false;
+            if at == 'macro' then
+                local mp = require('modules.hotbar.macroparse');
+                local pt = mp.GetMacroPrimaryAndJaBadge(MP.editingMacro.macroText or '');
+                maOrPet = (pt == 'ma' or pt == 'pet');
+            elseif at == 'ma' or at == 'pet' then
+                maOrPet = true;
+            end
+            if maOrPet then
+                local _, rid = actions.GetBindIcon(MP.editingMacro);
+                if rid and type(rid) == 'number' and horizonSpells[rid] and horizonSpells[rid].en then
+                    hid = rid;
+                end
+            end
+        end
+
+        if hid then
+            local h = horizonSpells[hid];
+            if h and h.en then
+                local bt = mapHorizonTypeToSpellFilter(h.type);
+                if bt then
+                    MP.iconPickerSpellType = bt;
+                else
+                    MP.iconPickerSpellType = 'All';
+                end
+                MP.iconPickerFilter[1] = pName or '';
+                return;
+            end
+        end
+    end
+
+    local spellRow = nil;
+    if pName and (pType == 'ma' or pType == 'pet') then
+        spellRow = actions.GetHorizonSpellForIconResolution(pName, pType);
+    end
+
+    local bestType = spellRow and mapHorizonTypeToSpellFilter(spellRow.type) or nil;
+
+    if bestType then
+        MP.iconPickerSpellType = bestType;
+        MP.iconPickerFilter[1] = pName or '';
+    elseif pType == 'ma' or pType == 'pet' then
+        MP.iconPickerSpellType = 'All';
+        MP.iconPickerFilter[1] = pName or '';
+    else
+        MP.iconPickerSpellType = 'All';
+        MP.iconPickerFilter[1] = pName or '';
+    end
+end
+
+-- Title-bar display name for the macro editor (e.g. "WHM", "Global", "SMN (Ifrit)").
+function M.GetEditorSaveDisplayName()
+    local saveKey = MP.editorPaletteKey or GetEffectivePaletteType();
+    return GetPaletteDisplayName(saveKey);
+end
+
+-- Compact save-target toolbar drawn just below the title bar in create mode.
+function M.DrawMacroEditorSaveToSection(creatingNew, contentWidth)
+    local function applyEditorSaveKey(newKey)
+        MP.editorPaletteKey = newKey;
+        SyncMacroEditorSubtypeFieldsFromSaveKey();
+        M.ClampMacroEditorForItemsPalette();
+    end
+
+    local saveKey = MP.editorPaletteKey or GetEffectivePaletteType();
+    local currentPlayerJob = data.jobId or 1;
+
+    if not creatingNew then
+        return;
+    end
+
+    local function mc(k)
+        return CountMacrosInPalette(k);
+    end
+    local function labelTextWidth(str)
+        local sz = imgui.CalcTextSize(tostring(str or ''));
+        if type(sz) == 'table' then
+            return sz[1] or sz.x or 0;
+        end
+        return tonumber(sz) or 0;
+    end
+
+    imgui.TextColored(COLORS.textDim, 'Saving To');
+    imgui.SameLine(0, 6);
+
+    local maxOptW = labelTextWidth(GetPaletteDisplayName(saveKey));
+    local gCount = mc(GLOBAL_MACRO_KEY);
+    local gLabel = gCount > 0 and string.format('Global (%d)', gCount) or 'Global';
+    maxOptW = math.max(maxOptW, labelTextWidth(gLabel));
+    local iCount = mc(ITEMS_MACRO_KEY);
+    local iLabel = iCount > 0 and string.format('Items (%d)', iCount) or 'Items';
+    maxOptW = math.max(maxOptW, labelTextWidth(iLabel));
+    local eCount = mc(EQUIPMENT_MACRO_KEY);
+    local eLabel = eCount > 0 and string.format('Equipment (%d)', eCount) or 'Equipment';
+    maxOptW = math.max(maxOptW, labelTextWidth(eLabel));
+    local xCount = mc(XIUI_MACRO_KEY);
+    local xLabel = xCount > 0 and string.format('XIUI Commands (%d)', xCount) or 'XIUI Commands';
+    maxOptW = math.max(maxOptW, labelTextWidth(xLabel));
+    EnsureMacroCustomCategoriesList();
+    for _, cat in ipairs(gConfig.macroCustomCategories) do
+        local ck = cat.key;
+        local cCount = mc(ck);
+        local cLab = cat.label or ck;
+        if cCount > 0 then
+            cLab = string.format('%s (%d)', cLab, cCount);
+        end
+        maxOptW = math.max(maxOptW, labelTextWidth(cLab));
+    end
+    for _, job in ipairs(JOB_LIST) do
+        local jCount = mc(job.id);
+        local label = job.name;
+        if jCount > 0 then
+            label = string.format('%s (%d)', label, jCount);
+        end
+        if job.id == currentPlayerJob then
+            label = label .. '  *';
+        end
+        if job.id == data.subjobId then
+            label = label .. '  /sub';
+        end
+        maxOptW = math.max(maxOptW, labelTextWidth(label));
+    end
+    local fp = imgui.GetStyle().FramePadding;
+    local fpX = (type(fp) == 'table' and (fp.x or fp[1])) or 8;
+    local comboW = maxOptW + (fpX * 2) + 28;
+    comboW = math.max(80, math.min(comboW, contentWidth * 0.4));
+
+    PushComboStyle();
+    imgui.SetNextItemWidth(comboW);
+    if imgui.BeginCombo('##macroEditorSavePalette', GetPaletteDisplayName(saveKey), ImGuiComboFlags_None) then
+        local gSel = (saveKey == GLOBAL_MACRO_KEY);
+        if gSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif gCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(gLabel, gSel) then
+            applyEditorSaveKey(GLOBAL_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local itemsSel = (saveKey == ITEMS_MACRO_KEY);
+        if itemsSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif iCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(iLabel, itemsSel) then
+            applyEditorSaveKey(ITEMS_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local equipSel = (saveKey == EQUIPMENT_MACRO_KEY);
+        if equipSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif eCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(eLabel, equipSel) then
+            applyEditorSaveKey(EQUIPMENT_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        local xiuiSel = (saveKey == XIUI_MACRO_KEY);
+        if xiuiSel then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+        elseif xCount > 0 then
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+        else
+            imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+        end
+        if imgui.Selectable(xLabel, xiuiSel) then
+            applyEditorSaveKey(XIUI_MACRO_KEY);
+        end
+        imgui.PopStyleColor();
+
+        for _, cat in ipairs(gConfig.macroCustomCategories) do
+            local ck = cat.key;
+            local cCount = mc(ck);
+            local cLab = cat.label or ck;
+            if cCount > 0 then
+                cLab = string.format('%s (%d)', cLab, cCount);
+            end
+            local cSel = (saveKey == ck);
+            if cSel then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            elseif cCount > 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+            if imgui.Selectable(cLab, cSel) then
+                applyEditorSaveKey(ck);
+            end
+            imgui.PopStyleColor();
+        end
+
+        imgui.Separator();
+
+        for _, job in ipairs(JOB_LIST) do
+            local jCount = mc(job.id);
+            local label = job.name;
+            if jCount > 0 then
+                label = string.format('%s (%d)', label, jCount);
+            end
+            if job.id == currentPlayerJob then
+                label = label .. '  *';
+            end
+            if job.id == data.subjobId then
+                label = label .. '  /sub';
+            end
+            local jSel = (EditorSaveKeyToJobId(saveKey) == job.id);
+            if jSel then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold);
+            elseif jCount > 0 then
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
+            else
+                imgui.PushStyleColor(ImGuiCol_Text, COLORS.textDim);
+            end
+            if imgui.Selectable(label, jSel) then
+                applyEditorSaveKey(job.id);
+            end
+            imgui.PopStyleColor();
+        end
+        imgui.EndCombo();
+    end
+    PopComboStyle();
+
+    -- SMN sub-type combo on the same line
+    if EditorSaveKeyToJobId(saveKey) == petregistry.JOB_SMN then
+        imgui.SameLine(0, 10);
+        imgui.TextColored(COLORS.textDim, '/');
+        imgui.SameLine(0, 10);
+
+        local avatarList = petregistry.GetAvatarList();
+        local currentLabel = 'Base SMN';
+        if type(saveKey) == 'string' then
+            local jobId, petType, petId = saveKey:match('^(%d+):([^:]+):(.+)$');
+            if jobId and tonumber(jobId) == petregistry.JOB_SMN and petType == 'avatar' and petId then
+                for name, key in pairs(petregistry.avatars) do
+                    if key == petId then
+                        currentLabel = name;
+                        break;
+                    end
+                end
+            end
+        end
+
+        local subMaxW = labelTextWidth('Base SMN');
+        for _, av in ipairs(avatarList) do
+            subMaxW = math.max(subMaxW, labelTextWidth(av));
+        end
+        local subComboW = subMaxW + (fpX * 2) + 28;
+        subComboW = math.max(80, math.min(subComboW, contentWidth * 0.35));
+
+        PushComboStyle();
+        imgui.SetNextItemWidth(subComboW);
+        if imgui.BeginCombo('##SaveAvatarPalette', currentLabel, ImGuiComboFlags_None) then
+            local isBaseSelected = (type(saveKey) == 'number' and saveKey == petregistry.JOB_SMN);
+            if imgui.Selectable('Base SMN', isBaseSelected) then
+                applyEditorSaveKey(petregistry.JOB_SMN);
+            end
+            imgui.Separator();
+            for _, avatar in ipairs(avatarList) do
+                local avatarKey = petregistry.avatars[avatar];
+                local fullKey = avatarKey and string.format('%d:avatar:%s', petregistry.JOB_SMN, avatarKey) or nil;
+                local isSelected = (fullKey ~= nil and saveKey == fullKey);
+                if imgui.Selectable(avatar, isSelected) then
+                    applyEditorSaveKey(fullKey);
                 end
             end
             imgui.EndCombo();
         end
         PopComboStyle();
-
-        imgui.Spacing();
-        imgui.Spacing();
-
-        -- Dynamic fields based on action type
-        currentType = ACTION_TYPES[editorFields.actionType[1]];
-
-        if currentType == 'ma' then
-            -- Spell: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Spell');
-            local spells = GetCachedSpells();
-            if spells and #spells > 0 then
-                DrawSearchableCombo('##spellCombo', spells, editingMacro.action or '', function(spell)
-                    editingMacro.action = spell.name;
-                    editorFields.action[1] = spell.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = spell.name;
-                        editorFields.displayName[1] = spell.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No spells available for this job');
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'ja' then
-            -- Ability: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Ability');
-            local abilities = GetCachedAbilities();
-            if abilities and #abilities > 0 then
-                DrawSearchableCombo('##abilityCombo', abilities, editingMacro.action or '', function(ability)
-                    editingMacro.action = ability.name;
-                    editorFields.action[1] = ability.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = ability.name;
-                        editorFields.displayName[1] = ability.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No abilities available');
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'ws' then
-            -- Weaponskill: Show searchable dropdown
-            imgui.TextColored(COLORS.goldDim, 'Weaponskill');
-            local weaponskills = GetCachedWeaponskills();
-            if weaponskills and #weaponskills > 0 then
-                DrawSearchableCombo('##wsCombo', weaponskills, editingMacro.action or '', function(ws)
-                    editingMacro.action = ws.name;
-                    editorFields.action[1] = ws.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = ws.name;
-                        editorFields.displayName[1] = ws.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No weaponskills available');
-            end
-
-            -- Target dropdown (default to <t>)
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'item' then
-            -- Item: Searchable dropdown or manual input
-            imgui.TextColored(COLORS.goldDim, 'Item');
-            local items = GetCachedItems();
-            if items and #items > 0 then
-                DrawSearchableCombo('##itemCombo', items, editingMacro.action or '', function(item)
-                    editingMacro.action = item.name;
-                    editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
-                    editorFields.action[1] = item.name;
-                    editingMacro.displayName = item.name;
-                    editorFields.displayName[1] = item.name;
-                end, true);  -- Show icons
-                imgui.SameLine();
-                imgui.TextColored(COLORS.textMuted, '(' .. #items .. ')');
-            else
-                imgui.TextColored(COLORS.textMuted, 'No items found in storage');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type item name:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##itemName', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-        elseif currentType == 'equip' then
-            -- Equipment slot dropdown
-            imgui.TextColored(COLORS.goldDim, 'Equipment Slot');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##equipSlot', EQUIP_SLOT_LABELS[EQUIP_SLOTS[editorFields.equipSlot[1]]] or 'Select...') then
-                for i, slot in ipairs(EQUIP_SLOTS) do
-                    local isSelected = editorFields.equipSlot[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(EQUIP_SLOT_LABELS[slot], isSelected) then
-                        editorFields.equipSlot[1] = i;
-                        editingMacro.equipSlot = slot;
-                        -- Clear item selection when slot changes (old item may not fit new slot)
-                        editingMacro.action = '';
-                        editingMacro.itemId = nil;
-                        editingMacro.displayName = '';
-                        editorFields.action[1] = '';
-                        editorFields.displayName[1] = '';
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-
-            -- Item: Searchable dropdown or manual input (filtered by selected equipment slot)
-            imgui.Spacing();
-            local selectedSlot = EQUIP_SLOTS[editorFields.equipSlot[1]];
-            imgui.TextColored(COLORS.goldDim, 'Item (' .. EQUIP_SLOT_LABELS[selectedSlot] .. ')');
-            local equipItems = GetCachedItems();
-            if equipItems and #equipItems > 0 then
-                DrawSearchableCombo('##equipItemCombo', equipItems, editingMacro.action or '', function(item)
-                    editingMacro.action = item.name;
-                    editingMacro.itemId = item.id;  -- Store item ID for fast icon lookup
-                    editorFields.action[1] = item.name;
-                    editingMacro.displayName = item.name;
-                    editorFields.displayName[1] = item.name;
-                end, true, selectedSlot);  -- Show icons, filter by selected slot
-                imgui.SameLine();
-                imgui.TextColored(COLORS.textMuted, '(' .. #equipItems .. ')');
-            else
-                imgui.TextColored(COLORS.textMuted, 'No items found in storage');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type item name:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##equipItemName', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-        elseif currentType == 'macro' then
-            -- Raw macro command (8 lines like native FFXI macro editor)
-            imgui.TextColored(COLORS.goldDim, 'Macro Commands (8 lines)');
-
-            -- Style the multiline input
-            imgui.PushStyleColor(ImGuiCol_FrameBg, COLORS.bgMedium);
-            imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLORS.bgLight);
-            imgui.PushStyleColor(ImGuiCol_FrameBgActive, COLORS.bgLight);
-
-            -- 8 rows * ~16px line height + padding
-            local lineHeight = imgui.GetTextLineHeight();
-            local inputHeight = (lineHeight * 8) + 8;
-
-            if imgui.InputTextMultiline('##macroText', editorFields.macroText, MACRO_BUFFER_SIZE, {280, inputHeight}) then
-                editingMacro.macroText = editorFields.macroText[1];
-                editingMacro.action = editorFields.macroText[1];
-            end
-
-            imgui.PopStyleColor(3);
-            imgui.ShowHelp('Enter commands, one per line (e.g., /ma "Cure" <stpc>)');
-
-            -- Recast Source section (optional)
-            imgui.Spacing();
-            imgui.Spacing();
-            if imgui.TreeNode('Recast Source (Optional)##recastSource') then
-                imgui.TextColored(COLORS.textMuted, 'Show cooldown from a different action');
-                imgui.Spacing();
-
-                -- Recast source type dropdown
-                imgui.TextColored(COLORS.goldDim, 'Source Type');
-                PushComboStyle();
-                imgui.SetNextItemWidth(240);
-                local currentRecastType = RECAST_SOURCE_TYPES[editorFields.recastSourceType[1]] or 'none';
-                if imgui.BeginCombo('##recastSourceType', RECAST_SOURCE_LABELS[currentRecastType] or 'None') then
-                    for i, sourceType in ipairs(RECAST_SOURCE_TYPES) do
-                        local isSelected = editorFields.recastSourceType[1] == i;
-                        if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                        if imgui.Selectable(RECAST_SOURCE_LABELS[sourceType], isSelected) then
-                            editorFields.recastSourceType[1] = i;
-                            if sourceType == 'none' then
-                                editingMacro.recastSourceType = nil;
-                                editingMacro.recastSourceAction = nil;
-                                editingMacro.recastSourceItemId = nil;
-                            else
-                                editingMacro.recastSourceType = sourceType;
-                            end
-                            -- Clear action when type changes
-                            editingMacro.recastSourceAction = nil;
-                            editingMacro.recastSourceItemId = nil;
-                            editorFields.recastSourceAction[1] = '';
-                        end
-                        if isSelected then imgui.PopStyleColor(); end
-                    end
-                    imgui.EndCombo();
-                end
-                PopComboStyle();
-
-                -- Show action selector based on recast source type
-                currentRecastType = RECAST_SOURCE_TYPES[editorFields.recastSourceType[1]] or 'none';
-
-                if currentRecastType == 'ma' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Spell');
-                    local spells = GetCachedSpells();
-                    if spells and #spells > 0 then
-                        DrawSearchableCombo('##recastSpellCombo', spells, editingMacro.recastSourceAction or '', function(spell)
-                            editingMacro.recastSourceAction = spell.name;
-                            editorFields.recastSourceAction[1] = spell.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No spells available');
-                    end
-
-                elseif currentRecastType == 'ja' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Ability');
-                    local abilities = GetCachedAbilities();
-                    if abilities and #abilities > 0 then
-                        DrawSearchableCombo('##recastAbilityCombo', abilities, editingMacro.recastSourceAction or '', function(ability)
-                            editingMacro.recastSourceAction = ability.name;
-                            editorFields.recastSourceAction[1] = ability.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No abilities available');
-                    end
-
-                elseif currentRecastType == 'item' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Item');
-                    local items = GetCachedItems();
-                    if items and #items > 0 then
-                        DrawSearchableCombo('##recastItemCombo', items, editingMacro.recastSourceAction or '', function(item)
-                            editingMacro.recastSourceAction = item.name;
-                            editingMacro.recastSourceItemId = item.id;
-                            editorFields.recastSourceAction[1] = item.name;
-                        end, true);  -- Show icons
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No items available');
-                    end
-
-                elseif currentRecastType == 'pet' then
-                    imgui.Spacing();
-                    imgui.TextColored(COLORS.goldDim, 'Pet Command');
-                    -- Use current job for pet commands
-                    local viewedJobId = selectedPaletteType;
-                    if type(viewedJobId) ~= 'number' then
-                        viewedJobId = playerdata.GetCacheJobId() or 0;
-                    end
-                    local petCommands = GetPetCommandsForJob(viewedJobId, selectedAvatarPalette, nil);
-                    if petCommands and #petCommands > 0 then
-                        DrawSearchableCombo('##recastPetCombo', petCommands, editingMacro.recastSourceAction or '', function(cmd)
-                            editingMacro.recastSourceAction = cmd.name;
-                            editorFields.recastSourceAction[1] = cmd.name;
-                        end);
-                    else
-                        imgui.TextColored(COLORS.textMuted, 'No pet commands available');
-                    end
-                end
-
-                imgui.TreePop();
-            end
-
-        elseif currentType == 'pet' then
-            -- For SMN, show avatar filter dropdown
-            -- Use the VIEWED palette's job, not necessarily the player's current job
-            local viewedJobId = selectedPaletteType;
-            if type(viewedJobId) ~= 'number' then
-                viewedJobId = playerdata.GetCacheJobId() or 0;
-            end
-            local avatarList = petregistry.GetAvatarList();
-
-            if viewedJobId == petregistry.JOB_SMN then
-                imgui.TextColored(COLORS.goldDim, 'Avatar Filter');
-                PushComboStyle();
-                imgui.SetNextItemWidth(240);
-                local filterLabel = petAvatarFilter == 1 and 'All Avatars' or avatarList[petAvatarFilter - 1];
-                if imgui.BeginCombo('##avatarFilter', filterLabel) then
-                    -- "All" option
-                    local isAllSelected = petAvatarFilter == 1;
-                    if isAllSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable('All Avatars', isAllSelected) then
-                        petAvatarFilter = 1;
-                        cachedPetCommands = nil;  -- Clear cache to rebuild
-                    end
-                    if isAllSelected then imgui.PopStyleColor(); end
-
-                    imgui.Separator();
-
-                    -- Individual avatars
-                    for i, avatar in ipairs(avatarList) do
-                        local isSelected = petAvatarFilter == i + 1;
-                        if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                        if imgui.Selectable(avatar, isSelected) then
-                            petAvatarFilter = i + 1;
-                            cachedPetCommands = nil;  -- Clear cache to rebuild
-                        end
-                        if isSelected then imgui.PopStyleColor(); end
-                    end
-                    imgui.EndCombo();
-                end
-                PopComboStyle();
-                imgui.Spacing();
-            end
-
-            -- Build pet commands cache if needed
-            if not cachedPetCommands then
-                local avatarName = nil;
-                local activePetName = nil;
-                if viewedJobId == petregistry.JOB_SMN then
-                    -- Prefer the macro palette's avatar selection, then the filter
-                    if selectedAvatarPalette then
-                        avatarName = selectedAvatarPalette;
-                    elseif petAvatarFilter > 1 then
-                        avatarName = avatarList[petAvatarFilter - 1];
-                    end
-                elseif viewedJobId == petregistry.JOB_BST then
-                    -- Get the active pet's entity name for BST ready moves
-                    activePetName = petpalette.GetCurrentPetEntityName();
-                end
-                cachedPetCommands = GetPetCommandsForJob(viewedJobId, avatarName, activePetName);
-            end
-
-            -- Pet command dropdown
-            imgui.TextColored(COLORS.goldDim, 'Pet Command');
-            if cachedPetCommands and #cachedPetCommands > 0 then
-                DrawSearchableCombo('##petCommandCombo', cachedPetCommands, editingMacro.action or '', function(cmd)
-                    editingMacro.action = cmd.name;
-                    editorFields.action[1] = cmd.name;
-                    if (editingMacro.displayName or '') == '' then
-                        editingMacro.displayName = cmd.name;
-                        editorFields.displayName[1] = cmd.name;
-                    end
-                end);
-            else
-                imgui.TextColored(COLORS.textMuted, 'No pet commands available for this job');
-            end
-
-            -- Manual input fallback
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Or type command:');
-            imgui.SetNextItemWidth(220);
-            if imgui.InputText('##petCommandManual', editorFields.action, INPUT_BUFFER_SIZE) then
-                editingMacro.action = editorFields.action[1];
-            end
-
-            -- Target dropdown
-            imgui.Spacing();
-            imgui.TextColored(COLORS.goldDim, 'Target');
-            PushComboStyle();
-            imgui.SetNextItemWidth(240);
-            if imgui.BeginCombo('##targetType', TARGET_LABELS[TARGET_OPTIONS[editorFields.target[1]]] or 'Select...') then
-                for i, target in ipairs(TARGET_OPTIONS) do
-                    local isSelected = editorFields.target[1] == i;
-                    if isSelected then imgui.PushStyleColor(ImGuiCol_Text, COLORS.gold); end
-                    if imgui.Selectable(TARGET_LABELS[target], isSelected) then
-                        editorFields.target[1] = i;
-                        editingMacro.target = target;
-                    end
-                    if isSelected then imgui.PopStyleColor(); end
-                end
-                imgui.EndCombo();
-            end
-            PopComboStyle();
-        end
-
-        -- Slot Label input (for all types)
-        imgui.Spacing();
-        imgui.Spacing();
-        imgui.TextColored(COLORS.goldDim, 'Slot Label');
-        imgui.SetNextItemWidth(240);
-        if imgui.InputText('##displayName', editorFields.displayName, 32) then
-            editingMacro.displayName = editorFields.displayName[1];
-        end
-        if currentType ~= 'macro' then
-            imgui.ShowHelp('Short label shown on the slot (e.g., "Cure3"). Leave empty to use action name.');
-        else
-            imgui.ShowHelp('Label shown on the slot for this macro.');
-        end
-
-        imgui.Spacing();
-        imgui.Separator();
-        imgui.Spacing();
-
-        -- Save button with success styling
-        imgui.PushStyleColor(ImGuiCol_Button, COLORS.success);
-        imgui.PushStyleColor(ImGuiCol_ButtonHovered, {0.5, 0.8, 0.5, 1.0});
-        imgui.PushStyleColor(ImGuiCol_ButtonActive, {0.6, 0.9, 0.6, 1.0});
-        imgui.PushStyleColor(ImGuiCol_Text, {0.1, 0.1, 0.1, 1.0});
-
-        if imgui.Button('Save', {90, 28}) then
-            -- Validate before saving
-            local canSave = false;
-
-            if currentType == 'macro' then
-                canSave = (editingMacro.macroText or '') ~= '';
-                if canSave and (editingMacro.displayName or '') == '' then
-                    editingMacro.displayName = 'Macro';
-                end
-                -- Clear target for macro type (targets are embedded in macro text)
-                editingMacro.target = nil;
-            else
-                canSave = (editingMacro.action or '') ~= '';
-                if canSave and (editingMacro.displayName or '') == '' then
-                    editingMacro.displayName = editingMacro.action;
-                end
-            end
-
-            if canSave then
-                -- Look up itemId for item/equip macros if not already set
-                -- This handles cases where user typed item name manually instead of selecting from dropdown
-                if (currentType == 'item' or currentType == 'equip') and not editingMacro.itemId and editingMacro.action then
-                    editingMacro.itemId = actiondb.GetItemId(editingMacro.action);
-                end
-
-                if isCreatingNew then
-                    M.AddMacro(editingMacro);
-                    -- Navigate to last page to show the new macro
-                    local db = M.GetMacroDatabase();
-                    currentPalettePage = math.max(1, math.ceil(#db / PALETTE_MACROS_PER_PAGE));
-                else
-                    M.UpdateMacro(editingMacro.id, editingMacro);
-                end
-                editingMacro = nil;
-                isCreatingNew = false;
-                searchFilter[1] = '';
-                iconPickerOpen = false;
-                iconPickerFilter[1] = '';
-            end
-        end
-
-        imgui.PopStyleColor(4);
-
-        imgui.SameLine();
-
-        -- Cancel button
-        if imgui.Button('Cancel', {90, 28}) then
-            editingMacro = nil;
-            isCreatingNew = false;
-            searchFilter[1] = '';
-            iconPickerOpen = false;
-            iconPickerFilter[1] = '';
-        end
     end
 
-    imgui.End();
-    PopWindowStyle();
+    if EditorSaveKeyToJobId(saveKey) == petregistry.JOB_BST then
+        imgui.SameLine(0, 10);
+        imgui.TextColored(COLORS.textDim, '/');
+        imgui.SameLine(0, 10);
 
-    if not isOpen[1] then
-        editingMacro = nil;
-        isCreatingNew = false;
-        searchFilter[1] = '';
-        iconPickerOpen = false;
-        iconPickerFilter[1] = '';
+        local currentJugLabel = 'Base BST';
+        if type(saveKey) == 'string' then
+            local jobId, petType, petId = saveKey:match('^(%d+):([^:]+):(.+)$');
+            if jobId and tonumber(jobId) == petregistry.JOB_BST and petType == petregistry.PET_TYPE_JUG and petId then
+                currentJugLabel = petregistry.GetDisplayNameForKey(petregistry.PET_TYPE_JUG .. ':' .. petId);
+            end
+        end
+
+        local subMaxW = labelTextWidth('Base BST');
+        local bstPetKeys = petregistry.GetAvailablePetKeys(petregistry.JOB_BST);
+        for _, pk in ipairs(bstPetKeys) do
+            local slug = pk:match('^jug:(.+)$');
+            if slug then
+                subMaxW = math.max(subMaxW, labelTextWidth(petregistry.GetDisplayNameForKey(pk)));
+            end
+        end
+        local subComboW = subMaxW + (fpX * 2) + 28;
+        subComboW = math.max(80, math.min(subComboW, contentWidth * 0.35));
+
+        PushComboStyle();
+        imgui.SetNextItemWidth(subComboW);
+        if imgui.BeginCombo('##SaveBstJugPalette', currentJugLabel, ImGuiComboFlags_None) then
+            local isBaseSelected = (type(saveKey) == 'number' and saveKey == petregistry.JOB_BST);
+            if imgui.Selectable('Base BST', isBaseSelected) then
+                applyEditorSaveKey(petregistry.JOB_BST);
+            end
+            imgui.Separator();
+            for _, pk in ipairs(bstPetKeys) do
+                local slug = pk:match('^jug:(.+)$');
+                if slug then
+                    local fullKey = string.format('%d:%s:%s', petregistry.JOB_BST, petregistry.PET_TYPE_JUG, slug);
+                    local label = petregistry.GetDisplayNameForKey(pk);
+                    local isSelected = (saveKey == fullKey);
+                    if imgui.Selectable(label, isSelected) then
+                        applyEditorSaveKey(fullKey);
+                    end
+                end
+            end
+            imgui.EndCombo();
+        end
+        PopComboStyle();
     end
 
-    -- Draw icon picker if open
-    DrawIconPicker();
+    imgui.SameLine(0, 6);
+    imgui.ShowHelp('Palette this macro is saved to.');
+    imgui.Separator();
+    imgui.Spacing();
 end
+
+-- Macro editor: macropalette_macroeditor.lua (Lua 5.1 max 60 upvalues per function).
+do
+    MP.M = M;
+    MP.imgui = imgui;
+    MP.ffi = ffi;
+    MP.actions = actions;
+    MP.data = data;
+    MP.textures = textures;
+    MP.petregistry = petregistry;
+    MP.actiondb = actiondb;
+    MP.playerdata = playerdata;
+    MP.petpalette = petpalette;
+    MP.components = components;
+    MP.COLORS = COLORS;
+    MP.jobs = jobs;
+    MP.ACTION_TYPES = ACTION_TYPES;
+    MP.ACTION_TYPES_ITEMS_BUCKET = ACTION_TYPES_ITEMS_BUCKET;
+    MP.ACTION_TYPE_LABELS = ACTION_TYPE_LABELS;
+    MP.RECAST_SOURCE_TYPES = RECAST_SOURCE_TYPES;
+    MP.RECAST_SOURCE_LABELS = RECAST_SOURCE_LABELS;
+    MP.TARGET_OPTIONS = TARGET_OPTIONS;
+    MP.TARGET_LABELS = TARGET_LABELS;
+    MP.EQUIP_SLOTS = EQUIP_SLOTS;
+    MP.EQUIP_SLOT_LABELS = EQUIP_SLOT_LABELS;
+    MP.ICON_AUTO_SOURCES = ICON_AUTO_SOURCES;
+    MP.ICON_AUTO_SOURCE_LABELS = ICON_AUTO_SOURCE_LABELS;
+    MP.INPUT_BUFFER_SIZE = INPUT_BUFFER_SIZE;
+    MP.MACRO_BUFFER_SIZE = MACRO_BUFFER_SIZE;
+    MP.PALETTE_MACROS_PER_PAGE = PALETTE_MACROS_PER_PAGE;
+    MP.SPELL_TYPE_ORDER = SPELL_TYPE_ORDER;
+    MP.SPELL_TYPE_LABELS = SPELL_TYPE_LABELS;
+    MP.SPELL_TYPE_JOB_ICONS = SPELL_TYPE_JOB_ICONS;
+    MP.editorFields = editorFields;
+    MP.CUSTOM_ICON_CATEGORIES = CUSTOM_ICON_CATEGORIES;
+    MP.CUSTOM_ICON_LABELS = CUSTOM_ICON_LABELS;
+    MP.FindIndex = FindIndex;
+    MP.DrawSearchableCombo = DrawSearchableCombo;
+    MP.DrawIconButton = DrawIconButton;
+    MP.DrawIconPreview = DrawIconPreview;
+    MP.PushComboStyle = PushComboStyle;
+    MP.PopComboStyle = PopComboStyle;
+    MP.PushWindowStyle = PushWindowStyle;
+    MP.PopWindowStyle = PopWindowStyle;
+    MP.LoadCustomIcons = LoadCustomIcons;
+    MP.InvalidateCustomIconScanCaches = InvalidateCustomIconScanCaches;
+    MP.GetCachedSpells = GetCachedSpells;
+    MP.GetCachedAbilities = GetCachedAbilities;
+    MP.GetCachedWeaponskills = GetCachedWeaponskills;
+    MP.GetCachedItems = GetCachedItems;
+    MP.GetPetCommandsForJob = GetPetCommandsForJob;
+    MP.EditorSaveKeyToJobId = EditorSaveKeyToJobId;
+    MP.ITEMS_MACRO_KEY = ITEMS_MACRO_KEY;
+    MP.EQUIPMENT_MACRO_KEY = EQUIPMENT_MACRO_KEY;
+    MP.XIUI_MACRO_KEY = XIUI_MACRO_KEY;
+    MP.ResolveBestCustomIconMatchForActionName = ResolveBestCustomIconMatchForActionName;
+    MP.SyncSaveSubTypeFromPetAvatarFilter = SyncSaveSubTypeFromPetAvatarFilter;
+    MP.SyncSaveSubTypeFromBstJugFamily = SyncSaveSubTypeFromBstJugFamily;
+    MP.SyncPetAvatarFilterFromSaveSubType = SyncPetAvatarFilterFromSaveSubType;
+    MP.ClearEditorPreviewIconCache = ClearEditorPreviewIconCache;
+    MP.ClearPaletteJaBadgeIconCache = ClearPaletteJaBadgeIconCache;
+    MP.HydrateMacroEditorIconPrefs = HydrateMacroEditorIconPrefs;
+    MP.ValidateEditorCustomIconCategoryAgainstScan = ValidateEditorCustomIconCategoryAgainstScan;
+    MP.PersistMacroEditorIconPrefs = PersistMacroEditorIconPrefs;
+    MP.DrawIconPicker = DrawIconPicker;
+    MP.paletteMainIconCache = paletteMainIconCache;
+    MP.paletteJaBadgeIconCache = paletteJaBadgeIconCache;
+end
+
+local runMacroEditor = require('modules.hotbar.macropalette_macroeditor')(MP);
+
+function M.DrawMacroEditor()
+    runMacroEditor();
+end
+
 
 -- ============================================
 -- Dragdrop Library Accessors (for display.lua)
@@ -3857,3 +6349,4 @@ end
 data.SetSlotDataChangedCallback(MarkHotbarDirty);
 
 return M;
+

--- a/XIUI/modules/hotbar/pet_palette_allowlist.lua
+++ b/XIUI/modules/hotbar/pet_palette_allowlist.lua
@@ -1,0 +1,378 @@
+--[[
+ * Pet palette allowlist: petPalettePetKeys = array of type tokens, or nil = all types use pet storage.
+ * Crossbar stores the filter on hotbarCrossbar.petPalettePetKeys (character-wide, not per palette).
+ * Stored tokens (strings): 'avatars' | 'elementals' | 'beasts' | 'wyvern' | 'puppet'
+ *   avatars     → SMN avatars (runtime keys avatar:*)
+ *   elementals  → SMN elementals (runtime keys spirit:*)
+ *   beasts      → jug + jug:<family> + charm
+ *   wyvern      → wyvern
+ *   puppet      → automaton
+ * Legacy token 'summons' (old saves): treated as avatars+elementals for matching; editor upgrades to avatars+elementals.
+ * nil / absent = all types (default).
+ * Legacy saves may list individual pet keys; they are normalized to type tokens when the editor opens.
+]]--
+
+require('common');
+local imgui = require('imgui');
+
+local M = {};
+
+local TYPE_AVATARS = 'avatars';
+local TYPE_ELEMENTALS = 'elementals';
+local TYPE_BEASTS = 'beasts';
+local TYPE_WYVERN = 'wyvern';
+local TYPE_PUPPET = 'puppet';
+-- Legacy: previously meant both avatars and elementals; still honored in Allows() and migrated in the editor.
+local TYPE_LEGACY_SUMMONS = 'summons';
+
+local ALL_TYPES = { TYPE_AVATARS, TYPE_ELEMENTALS, TYPE_BEASTS, TYPE_WYVERN, TYPE_PUPPET };
+
+local TYPE_ROWS = {
+    { token = TYPE_AVATARS, label = 'Avatars' },
+    { token = TYPE_ELEMENTALS, label = 'Elementals' },
+    { token = TYPE_BEASTS, label = 'Beasts' },
+    { token = TYPE_WYVERN, label = 'Wyvern' },
+    { token = TYPE_PUPPET, label = 'Puppet' },
+};
+
+local function isKnownTypeToken(s)
+    return s == TYPE_AVATARS
+        or s == TYPE_ELEMENTALS
+        or s == TYPE_BEASTS
+        or s == TYPE_WYVERN
+        or s == TYPE_PUPPET
+        or s == TYPE_LEGACY_SUMMONS;
+end
+
+--- True if list contains any legacy per-pet entry (not only type tokens).
+local function isLegacyAllowlist(list)
+    if not list or type(list) ~= 'table' then
+        return false;
+    end
+    for i = 1, #list do
+        if not isKnownTypeToken(list[i]) then
+            return true;
+        end
+    end
+    return false;
+end
+
+local function legacyEntryImpliedType(entry)
+    if type(entry) ~= 'string' then
+        return nil;
+    end
+    if
+        entry == TYPE_AVATARS
+        or entry == TYPE_ELEMENTALS
+        or entry == TYPE_BEASTS
+        or entry == TYPE_WYVERN
+        or entry == TYPE_PUPPET
+    then
+        return entry;
+    end
+    if entry == TYPE_LEGACY_SUMMONS then
+        return nil;
+    end
+    if entry:match('^avatar:') then
+        return TYPE_AVATARS;
+    end
+    if entry:match('^spirit:') then
+        return TYPE_ELEMENTALS;
+    end
+    if entry:match('^jug:') then
+        return TYPE_BEASTS;
+    end
+    if entry == 'jug' or entry == 'charm' then
+        return TYPE_BEASTS;
+    end
+    if entry == 'wyvern' then
+        return TYPE_WYVERN;
+    end
+    if entry == 'automaton' then
+        return TYPE_PUPPET;
+    end
+    return nil;
+end
+
+--- Collapse legacy per-pet keys into type tokens (lossy; intentional).
+function M.NormalizeAllowlistToTypes(list)
+    if not list or type(list) ~= 'table' or #list == 0 then
+        return {};
+    end
+    local seen = {
+        [TYPE_AVATARS] = false,
+        [TYPE_ELEMENTALS] = false,
+        [TYPE_BEASTS] = false,
+        [TYPE_WYVERN] = false,
+        [TYPE_PUPPET] = false,
+    };
+    for i = 1, #list do
+        local e = list[i];
+        if e == TYPE_LEGACY_SUMMONS then
+            seen[TYPE_AVATARS] = true;
+            seen[TYPE_ELEMENTALS] = true;
+        else
+            local t = legacyEntryImpliedType(e);
+            if t then
+                seen[t] = true;
+            end
+        end
+    end
+    local out = {};
+    for _, tok in ipairs(ALL_TYPES) do
+        if seen[tok] then
+            table.insert(out, tok);
+        end
+    end
+    return out;
+end
+
+local function typeTokenMatchesPetKey(token, petKey)
+    if not petKey or type(petKey) ~= 'string' then
+        return false;
+    end
+    if token == TYPE_AVATARS then
+        return petKey:match('^avatar:') ~= nil;
+    end
+    if token == TYPE_ELEMENTALS then
+        return petKey:match('^spirit:') ~= nil;
+    end
+    if token == TYPE_LEGACY_SUMMONS then
+        return petKey:match('^avatar:') ~= nil or petKey:match('^spirit:') ~= nil;
+    end
+    if token == TYPE_BEASTS then
+        return petKey == 'jug' or petKey == 'charm' or petKey:match('^jug:') ~= nil;
+    end
+    if token == TYPE_WYVERN then
+        return petKey == 'wyvern';
+    end
+    if token == TYPE_PUPPET then
+        return petKey == 'automaton';
+    end
+    return false;
+end
+
+function M.Allows(settings, petKey)
+    if not petKey then
+        return false;
+    end
+    local list = settings and settings.petPalettePetKeys;
+    if list == nil then
+        return true;
+    end
+    if type(list) ~= 'table' then
+        return true;
+    end
+    for i = 1, #list do
+        local e = list[i];
+        if e == petKey then
+            return true;
+        end
+        if isKnownTypeToken(e) and typeTokenMatchesPetKey(e, petKey) then
+            return true;
+        end
+    end
+    return false;
+end
+
+local function listContains(arr, key)
+    for j = 1, #arr do
+        if arr[j] == key then
+            return true;
+        end
+    end
+    return false;
+end
+
+local function listRemoveToken(arr, token)
+    local out = {};
+    for j = 1, #arr do
+        if arr[j] ~= token then
+            table.insert(out, arr[j]);
+        end
+    end
+    return out;
+end
+
+local function listAddToken(arr, token)
+    if listContains(arr, token) then
+        return arr;
+    end
+    local out = {};
+    for j = 1, #arr do
+        out[j] = arr[j];
+    end
+    table.insert(out, token);
+    return out;
+end
+
+--- Replace legacy 'summons' with 'avatars'+'elementals' (same practical coverage).
+function M.UpgradeSummonsTokenInPlace(list)
+    if not list or type(list) ~= 'table' or not listContains(list, TYPE_LEGACY_SUMMONS) then
+        return list, false;
+    end
+    local newList = {};
+    for j = 1, #list do
+        if list[j] ~= TYPE_LEGACY_SUMMONS then
+            table.insert(newList, list[j]);
+        end
+    end
+    newList = listAddToken(newList, TYPE_AVATARS);
+    newList = listAddToken(newList, TYPE_ELEMENTALS);
+    return newList, true;
+end
+
+function M.CopyAllTypes()
+    local out = {};
+    for i = 1, #ALL_TYPES do
+        out[i] = ALL_TYPES[i];
+    end
+    return out;
+end
+
+--- For crossbar popup init: copy effective list, normalizing legacy shapes to type tokens.
+-- nil = all types (UI shows all checkboxes on).
+function M.CopyAllowlistForEditor(effList)
+    if effList == nil then
+        return M.CopyAllTypes();
+    end
+    if isLegacyAllowlist(effList) then
+        return M.NormalizeAllowlistToTypes(effList);
+    end
+    local out = {};
+    for i = 1, #effList do
+        out[i] = effList[i];
+    end
+    out = select(1, M.UpgradeSummonsTokenInPlace(out)) or out;
+    return out;
+end
+
+--- True if list means "all pet families" (nil or all five type tokens, or legacy equivalent).
+-- Empty table = no types.
+function M.IsEffectivelyAllTypes(list)
+    if list == nil then
+        return true;
+    end
+    if type(list) ~= 'table' or #list == 0 then
+        return false;
+    end
+    if isLegacyAllowlist(list) then
+        return #M.NormalizeAllowlistToTypes(list) == 5;
+    end
+    -- Legacy four-token "all" was summons+beasts+wyvern+puppet; summons covers avatars+elementals.
+    local hasA = listContains(list, TYPE_AVATARS) or listContains(list, TYPE_LEGACY_SUMMONS);
+    local hasE = listContains(list, TYPE_ELEMENTALS) or listContains(list, TYPE_LEGACY_SUMMONS);
+    if not hasA or not hasE then
+        return false;
+    end
+    for _, t in ipairs({ TYPE_BEASTS, TYPE_WYVERN, TYPE_PUPPET }) do
+        if not listContains(list, t) then
+            return false;
+        end
+    end
+    return true;
+end
+
+--- Draw allowlist checkboxes (Select all / Clear all + type toggles). Call from BeginPopup, hotbar pet popup, etc.
+function M.DrawEditorPanel(settingsWritable, _jobId, saveFn, invalidateFn, afterMutate)
+    if not settingsWritable then
+        return;
+    end
+
+    if settingsWritable.petPalettePetKeys and isLegacyAllowlist(settingsWritable.petPalettePetKeys) then
+        settingsWritable.petPalettePetKeys = M.NormalizeAllowlistToTypes(settingsWritable.petPalettePetKeys);
+        if afterMutate then
+            afterMutate(settingsWritable);
+        end
+        if saveFn then
+            saveFn();
+        end
+        if invalidateFn then
+            invalidateFn();
+        end
+    end
+
+    do
+        local newL, ch = M.UpgradeSummonsTokenInPlace(settingsWritable.petPalettePetKeys);
+        if ch then
+            settingsWritable.petPalettePetKeys = newL;
+            if afterMutate then
+                afterMutate(settingsWritable);
+            end
+            if saveFn then
+                saveFn();
+            end
+            if invalidateFn then
+                invalidateFn();
+            end
+        end
+    end
+
+    if imgui.Button('Select all##petallow') then
+        -- nil = all types (storable default)
+        settingsWritable.petPalettePetKeys = nil;
+        if afterMutate then
+            afterMutate(settingsWritable);
+        end
+        if saveFn then
+            saveFn();
+        end
+        if invalidateFn then
+            invalidateFn();
+        end
+    end
+    imgui.SameLine();
+    if imgui.Button('Clear all##petallow') then
+        settingsWritable.petPalettePetKeys = {};
+        if afterMutate then
+            afterMutate(settingsWritable);
+        end
+        if saveFn then
+            saveFn();
+        end
+        if invalidateFn then
+            invalidateFn();
+        end
+    end
+
+    imgui.Spacing();
+    local list = settingsWritable.petPalettePetKeys;
+    for _, row in ipairs(TYPE_ROWS) do
+        local on;
+        if list == nil then
+            on = true;
+        else
+            on = listContains(list, row.token);
+        end
+        local b = { on };
+        if imgui.Checkbox(row.label .. '##pt_' .. row.token, b) then
+            if b[1] then
+                if list == nil then
+                    list = M.CopyAllTypes();
+                end
+                settingsWritable.petPalettePetKeys = listAddToken(list, row.token);
+            else
+                if list == nil then
+                    list = M.CopyAllTypes();
+                end
+                settingsWritable.petPalettePetKeys = listRemoveToken(list, row.token);
+            end
+            if afterMutate then
+                afterMutate(settingsWritable);
+            end
+            if saveFn then
+                saveFn();
+            end
+            if invalidateFn then
+                invalidateFn();
+            end
+        end
+    end
+end
+
+--- Backwards compatible name: draw inside an open ImGui popup.
+function M.DrawEditorInPopup(settingsWritable, jobId, saveFn, invalidateFn, afterMutate)
+    M.DrawEditorPanel(settingsWritable, jobId, saveFn, invalidateFn, afterMutate);
+end
+
+return M;

--- a/XIUI/modules/hotbar/petpalette.lua
+++ b/XIUI/modules/hotbar/petpalette.lua
@@ -1,6 +1,7 @@
 --[[
 * XIUI Hotbar - Pet Palette Module
-* Manages pet-aware palette state and detection
+* Manages pet-aware palette state and detection.
+* Hotbar and crossbar share the same core logic via props (state table selection).
 ]]--
 
 require('common');
@@ -14,25 +15,14 @@ local M = {};
 -- ============================================
 
 local state = {
-    -- Current detected pet key (e.g., "avatar:ifrit", "wyvern", nil)
     currentPetKey = nil,
-
-    -- Last known pet name (for change detection)
     lastKnownPetName = nil,
 
-    -- Manual overrides per bar: [barIndex] = petKey or nil
-    manualOverrides = {},
+    -- Hotbar: keyed by barIndex
+    hotbar = { overrides = {}, cycleIndices = {} },
+    -- Crossbar: keyed by comboMode
+    crossbar = { overrides = {}, cycleIndices = {} },
 
-    -- Cycle indices per bar: [barIndex] = index into available palettes
-    cycleIndices = {},
-
-    -- Crossbar overrides per combo mode: [comboMode] = petKey or nil
-    crossbarOverrides = {},
-
-    -- Crossbar cycle indices per combo mode: [comboMode] = index into available palettes
-    crossbarCycleIndices = {},
-
-    -- Callbacks for pet change events
     onPetChangedCallbacks = {},
 };
 
@@ -40,7 +30,6 @@ local state = {
 -- Pet Detection
 -- ============================================
 
--- Get the current pet entity from the player
 local function GetPetEntity()
     local playerEntity = GetPlayerEntity();
     if playerEntity == nil or playerEntity.PetTargetIndex == 0 then
@@ -49,7 +38,6 @@ local function GetPetEntity()
     return GetEntity(playerEntity.PetTargetIndex);
 end
 
--- Get the primary pet job (main takes precedence)
 local function GetPetJob()
     local player = GetPlayerSafe();
     if player == nil then return nil; end
@@ -66,8 +54,6 @@ local function GetPetJob()
     return nil;
 end
 
--- Check current pet state and update if changed
--- Called on packet hints (0x0068 Pet Sync, 0x000B Zone)
 function M.CheckPetState()
     local petEntity = GetPetEntity();
     local petJob = GetPetJob();
@@ -80,23 +66,18 @@ function M.CheckPetState()
         newPetKey = petregistry.GetPetKey(newPetName, petJob);
     end
 
-    -- Check if pet changed
     if newPetName ~= state.lastKnownPetName then
         local oldPetKey = state.currentPetKey;
         state.lastKnownPetName = newPetName;
         state.currentPetKey = newPetKey;
 
-        -- Fire callbacks
         M.FirePetChangedCallbacks(oldPetKey, newPetKey);
-
-        -- Always clear manual overrides when pet changes (auto-switch behavior)
         M.ClearAllManualOverrides();
     end
 
     return newPetKey;
 end
 
--- Force clear pet state (for zone changes)
 function M.ClearPetState()
     local oldPetKey = state.currentPetKey;
     state.lastKnownPetName = nil;
@@ -111,76 +92,58 @@ end
 -- Pet Key Access
 -- ============================================
 
--- Get the current auto-detected pet key
 function M.GetCurrentPetKey()
     return state.currentPetKey;
 end
 
--- Get the current pet display name
 function M.GetCurrentPetDisplayName()
     return petregistry.GetDisplayNameForKey(state.currentPetKey);
 end
 
--- Get the current pet entity name (e.g., "HareFamiliar", "Ifrit")
 function M.GetCurrentPetEntityName()
     return state.lastKnownPetName;
 end
 
--- Check if player currently has a pet
 function M.HasPet()
     return state.currentPetKey ~= nil;
 end
 
 -- ============================================
--- Manual Override Management
+-- Shared Core (props-driven)
+-- Callers pass a context table: state.hotbar or state.crossbar
+-- and a key (barIndex for hotbar, comboMode for crossbar).
 -- ============================================
 
--- Get manual override for a bar (returns petKey or nil)
-function M.GetManualOverride(barIndex)
-    return state.manualOverrides[barIndex];
+local function getOverride(ctx, key)
+    return ctx.overrides[key];
 end
 
--- Check if a bar has a manual override
-function M.HasManualOverride(barIndex)
-    return state.manualOverrides[barIndex] ~= nil;
+local function hasOverride(ctx, key)
+    return ctx.overrides[key] ~= nil;
 end
 
--- Set manual override for a bar
-function M.SetManualOverride(barIndex, petKey)
-    state.manualOverrides[barIndex] = petKey;
+local function setOverride(ctx, key, petKey)
+    ctx.overrides[key] = petKey;
 end
 
--- Clear manual override for a bar (return to auto mode)
-function M.ClearManualOverride(barIndex)
-    state.manualOverrides[barIndex] = nil;
-    state.cycleIndices[barIndex] = nil;
+local function clearOverride(ctx, key)
+    ctx.overrides[key] = nil;
+    ctx.cycleIndices[key] = nil;
 end
 
--- Clear all manual overrides (including crossbar)
-function M.ClearAllManualOverrides()
-    state.manualOverrides = {};
-    state.cycleIndices = {};
-    state.crossbarOverrides = {};
-    state.crossbarCycleIndices = {};
+local function clearAllOverrides(ctx)
+    ctx.overrides = {};
+    ctx.cycleIndices = {};
 end
 
--- ============================================
--- Palette Cycling
--- ============================================
-
--- Get available palettes for a bar (includes base job + all pet palettes)
--- Returns: { { key = storageKey, displayName = "Name" }, ... }
--- Note: subjobId parameter is accepted but not used (pet keys don't depend on subjob)
 function M.GetAvailablePalettes(barIndex, jobId, subjobId)
     local palettes = {};
 
-    -- Always include base job palette first
     table.insert(palettes, {
-        key = nil,  -- nil means base job (no pet key)
+        key = nil,
         displayName = 'Base',
     });
 
-    -- Add pet-specific palettes based on job
     local petKeys = petregistry.GetAvailablePetKeys(jobId);
     for _, petKey in ipairs(petKeys) do
         table.insert(palettes, {
@@ -192,125 +155,27 @@ function M.GetAvailablePalettes(barIndex, jobId, subjobId)
     return palettes;
 end
 
--- Set a specific palette for a bar (by pet key)
--- petKey: The pet key to set (e.g., 'avatar:ifrit', 'spirit:fire'), or nil for Auto
-function M.SetPalette(barIndex, petKey)
+local function setPalette(ctx, key, petKey)
     if petKey == nil then
-        -- Clear override (Auto mode)
-        state.manualOverrides[barIndex] = nil;
-        state.cycleIndices[barIndex] = nil;
+        ctx.overrides[key] = nil;
+        ctx.cycleIndices[key] = nil;
     else
-        state.manualOverrides[barIndex] = petKey;
+        ctx.overrides[key] = petKey;
     end
     return true;
 end
 
--- Cycle through palettes for a bar
--- direction: 1 for next, -1 for previous
-function M.CyclePalette(barIndex, direction, jobId)
+local function cyclePalette(ctx, key, direction, jobId)
     direction = direction or 1;
     jobId = jobId or GetPetJob();
-
     if not jobId then return; end
 
-    local palettes = M.GetAvailablePalettes(barIndex, jobId);
-    if #palettes == 0 then return; end
-
-    -- Get current cycle index
-    local currentIndex = state.cycleIndices[barIndex] or 1;
-
-    -- If we have a manual override, find its index
-    local currentOverride = state.manualOverrides[barIndex];
-    if currentOverride then
-        for i, p in ipairs(palettes) do
-            if p.key == currentOverride then
-                currentIndex = i;
-                break;
-            end
-        end
-    elseif state.currentPetKey then
-        -- If no override but we have a pet, find auto-selected index
-        for i, p in ipairs(palettes) do
-            if p.key == state.currentPetKey then
-                currentIndex = i;
-                break;
-            end
-        end
-    end
-
-    -- Calculate new index
-    local newIndex = currentIndex + direction;
-    if newIndex < 1 then newIndex = #palettes; end
-    if newIndex > #palettes then newIndex = 1; end
-
-    -- Store cycle index and set override
-    state.cycleIndices[barIndex] = newIndex;
-    state.manualOverrides[barIndex] = palettes[newIndex].key;
-
-    return palettes[newIndex];
-end
-
--- ============================================
--- Crossbar Override Management
--- ============================================
-
--- Get crossbar manual override for a combo mode (returns petKey or nil)
-function M.GetCrossbarOverride(comboMode)
-    return state.crossbarOverrides[comboMode];
-end
-
--- Check if a combo mode has a manual override
-function M.HasCrossbarOverride(comboMode)
-    return state.crossbarOverrides[comboMode] ~= nil;
-end
-
--- Set manual override for a crossbar combo mode
-function M.SetCrossbarOverride(comboMode, petKey)
-    state.crossbarOverrides[comboMode] = petKey;
-end
-
--- Clear manual override for a crossbar combo mode (return to auto mode)
-function M.ClearCrossbarOverride(comboMode)
-    state.crossbarOverrides[comboMode] = nil;
-    state.crossbarCycleIndices[comboMode] = nil;
-end
-
--- Clear all crossbar overrides only
-function M.ClearAllCrossbarOverrides()
-    state.crossbarOverrides = {};
-    state.crossbarCycleIndices = {};
-end
-
--- Set a specific palette for a crossbar combo mode (by pet key)
--- petKey: The pet key to set (e.g., 'avatar:ifrit'), or nil for Auto
-function M.SetCrossbarPalette(comboMode, petKey)
-    if petKey == nil then
-        -- Clear override (Auto mode)
-        state.crossbarOverrides[comboMode] = nil;
-        state.crossbarCycleIndices[comboMode] = nil;
-    else
-        state.crossbarOverrides[comboMode] = petKey;
-    end
-    return true;
-end
-
--- Cycle through palettes for a crossbar combo mode
--- direction: 1 for next, -1 for previous
-function M.CycleCrossbarPalette(comboMode, direction, jobId)
-    direction = direction or 1;
-    jobId = jobId or GetPetJob();
-
-    if not jobId then return; end
-
-    -- Reuse same palette list as hotbar (palettes are job-based, not bar-based)
     local palettes = M.GetAvailablePalettes(1, jobId);
     if #palettes == 0 then return; end
 
-    -- Get current cycle index
-    local currentIndex = state.crossbarCycleIndices[comboMode] or 1;
+    local currentIndex = ctx.cycleIndices[key] or 1;
 
-    -- If we have a manual override, find its index
-    local currentOverride = state.crossbarOverrides[comboMode];
+    local currentOverride = ctx.overrides[key];
     if currentOverride then
         for i, p in ipairs(palettes) do
             if p.key == currentOverride then
@@ -319,7 +184,6 @@ function M.CycleCrossbarPalette(comboMode, direction, jobId)
             end
         end
     elseif state.currentPetKey then
-        -- If no override but we have a pet, find auto-selected index
         for i, p in ipairs(palettes) do
             if p.key == state.currentPetKey then
                 currentIndex = i;
@@ -328,99 +192,128 @@ function M.CycleCrossbarPalette(comboMode, direction, jobId)
         end
     end
 
-    -- Calculate new index
     local newIndex = currentIndex + direction;
     if newIndex < 1 then newIndex = #palettes; end
     if newIndex > #palettes then newIndex = 1; end
 
-    -- Store cycle index and set override
-    state.crossbarCycleIndices[comboMode] = newIndex;
-    state.crossbarOverrides[comboMode] = palettes[newIndex].key;
+    ctx.cycleIndices[key] = newIndex;
+    ctx.overrides[key] = palettes[newIndex].key;
 
     return palettes[newIndex];
 end
 
--- Get the effective pet key for a crossbar combo mode (considering overrides)
--- This is what data.lua will use to build the storage key
-function M.GetEffectivePetKeyForCombo(comboMode)
-    -- Check manual override first
-    local override = state.crossbarOverrides[comboMode];
-    if override then
-        return override;
-    end
-
-    -- No override - use auto-detected pet
+local function getEffectivePetKey(ctx, key)
+    local override = ctx.overrides[key];
+    if override then return override; end
     return state.currentPetKey;
 end
 
--- Get the current pet palette display name for a crossbar combo mode
--- Returns the name to show in the palette indicator overlay
-function M.GetCrossbarPaletteDisplayName(comboMode, jobId)
-    -- Check manual override first
-    local override = state.crossbarOverrides[comboMode];
+local function getPaletteDisplayName(ctx, key)
+    local override = ctx.overrides[key];
     if override then
         return petregistry.GetDisplayNameForKey(override);
     end
-
-    -- No override - use auto-detected pet
     if state.currentPetKey then
         return petregistry.GetDisplayNameForKey(state.currentPetKey);
     end
-
     return 'Base';
 end
 
 -- ============================================
--- Palette Display Name for Indicator
+-- Hotbar Public API (barIndex keyed)
 -- ============================================
 
--- Get the current palette display name for a bar
--- Returns the name to show in the palette indicator overlay
-function M.GetPaletteDisplayName(barIndex, jobId)
-    -- Check manual override first
-    local override = state.manualOverrides[barIndex];
-    if override then
-        return petregistry.GetDisplayNameForKey(override);
-    end
-
-    -- No override - use auto-detected pet
-    if state.currentPetKey then
-        return petregistry.GetDisplayNameForKey(state.currentPetKey);
-    end
-
-    return 'Base';
+function M.GetManualOverride(barIndex)
+    return getOverride(state.hotbar, barIndex);
 end
 
--- ============================================
--- Effective Storage Key Resolution
--- ============================================
+function M.HasManualOverride(barIndex)
+    return hasOverride(state.hotbar, barIndex);
+end
 
--- Get the effective pet key for a bar (considering overrides)
--- This is what data.lua will use to build the storage key
+function M.SetManualOverride(barIndex, petKey)
+    setOverride(state.hotbar, barIndex, petKey);
+end
+
+function M.ClearManualOverride(barIndex)
+    clearOverride(state.hotbar, barIndex);
+end
+
+function M.SetPalette(barIndex, petKey)
+    return setPalette(state.hotbar, barIndex, petKey);
+end
+
+function M.CyclePalette(barIndex, direction, jobId)
+    return cyclePalette(state.hotbar, barIndex, direction, jobId);
+end
+
 function M.GetEffectivePetKey(barIndex)
-    -- Check manual override first
-    local override = state.manualOverrides[barIndex];
-    if override then
-        return override;
-    end
+    return getEffectivePetKey(state.hotbar, barIndex);
+end
 
-    -- No override - use auto-detected pet
-    return state.currentPetKey;
+function M.GetPaletteDisplayName(barIndex, jobId)
+    return getPaletteDisplayName(state.hotbar, barIndex);
+end
+
+-- ============================================
+-- Crossbar Public API (comboMode keyed)
+-- ============================================
+
+function M.GetCrossbarOverride(comboMode)
+    return getOverride(state.crossbar, comboMode);
+end
+
+function M.HasCrossbarOverride(comboMode)
+    return hasOverride(state.crossbar, comboMode);
+end
+
+function M.SetCrossbarOverride(comboMode, petKey)
+    setOverride(state.crossbar, comboMode, petKey);
+end
+
+function M.ClearCrossbarOverride(comboMode)
+    clearOverride(state.crossbar, comboMode);
+end
+
+function M.ClearAllCrossbarOverrides()
+    clearAllOverrides(state.crossbar);
+end
+
+function M.SetCrossbarPalette(comboMode, petKey)
+    return setPalette(state.crossbar, comboMode, petKey);
+end
+
+function M.CycleCrossbarPalette(comboMode, direction, jobId)
+    return cyclePalette(state.crossbar, comboMode, direction, jobId);
+end
+
+function M.GetEffectivePetKeyForCombo(comboMode)
+    return getEffectivePetKey(state.crossbar, comboMode);
+end
+
+function M.GetCrossbarPaletteDisplayName(comboMode, jobId)
+    return getPaletteDisplayName(state.crossbar, comboMode);
+end
+
+-- ============================================
+-- Bulk Clear (clears both hotbar and crossbar)
+-- ============================================
+
+function M.ClearAllManualOverrides()
+    clearAllOverrides(state.hotbar);
+    clearAllOverrides(state.crossbar);
 end
 
 -- ============================================
 -- Callback System
 -- ============================================
 
--- Register a callback for pet changes
--- callback(oldPetKey, newPetKey)
 function M.OnPetChanged(callback)
     if callback then
         table.insert(state.onPetChangedCallbacks, callback);
     end
 end
 
--- Fire all pet changed callbacks
 function M.FirePetChangedCallbacks(oldPetKey, newPetKey)
     for _, callback in ipairs(state.onPetChangedCallbacks) do
         local success, err = pcall(callback, oldPetKey, newPetKey);
@@ -437,10 +330,8 @@ end
 function M.Reset()
     state.currentPetKey = nil;
     state.lastKnownPetName = nil;
-    state.manualOverrides = {};
-    state.cycleIndices = {};
-    state.crossbarOverrides = {};
-    state.crossbarCycleIndices = {};
+    clearAllOverrides(state.hotbar);
+    clearAllOverrides(state.crossbar);
 end
 
 return M;

--- a/XIUI/modules/hotbar/petregistry.lua
+++ b/XIUI/modules/hotbar/petregistry.lua
@@ -5,6 +5,27 @@
 
 local M = {};
 
+-- MP cost + SMN level: `horizon_bloodpacts.lua`. XIUI-only labels/icons: `horizon_bloodpacts_xiui.lua`.
+local horizonBloodPacts = require('modules.hotbar.database.horizon_bloodpacts');
+local horizonBloodPactsXiui = require('modules.hotbar.database.horizon_bloodpacts_xiui');
+local universalTwoHour = require('modules.hotbar.universal_two_hour');
+
+-- Ready pet command when horizon_abilities lists it with pet=true (HorizonXI includes Ready for jug gameplay).
+local function horizonDefinesBstReadyPetCommand()
+    local ha = require('modules.hotbar.database.horizon_abilities');
+    local row = ha['Ready'];
+    return row ~= nil and row.pet == true;
+end
+
+-- Jug-family Ready moves: only when Ready exists as a pet command and jug_moves is not explicitly false.
+local function horizonDefinesBstJugReadyMoves()
+    local ha = require('modules.hotbar.database.horizon_abilities');
+    local row = ha['Ready'];
+    return row ~= nil and row.pet == true and row.jug_moves ~= false;
+end
+
+M.IsBstJugReadyMovesEnabled = horizonDefinesBstJugReadyMoves;
+
 -- ============================================
 -- Job Constants
 -- ============================================
@@ -24,6 +45,13 @@ M.PET_TYPE_WYVERN = 'wyvern';
 M.PET_TYPE_AUTOMATON = 'automaton';
 M.PET_TYPE_JUG = 'jug';
 M.PET_TYPE_CHARM = 'charm';
+
+-- `petpalette:*` keys omitted from the Edit Full Palette Pets picker (no practical pet-entity hotbar to bind for these avatars in Horizon).
+M.PETBAR_EXCLUDED_STORAGE_KEYS = {
+    ['avatar:odin'] = true,
+    ['avatar:alexander'] = true,
+    ['avatar:atomos'] = true,
+};
 
 -- ============================================
 -- Avatar Mapping (petName -> storageKey)
@@ -184,8 +212,8 @@ function M.GetPetType(petName, jobId)
 end
 
 -- Get the storage key suffix for a pet
--- Returns: string like "avatar:ifrit", "wyvern", "jug", "automaton", etc.
--- For SMN avatars/spirits, returns per-entity keys
+-- Returns: string like "avatar:ifrit", "wyvern", "jug", "jug:rabbit", "automaton", etc.
+-- For SMN avatars/spirits and BST jug families, returns per-family keys when known
 -- For other jobs, returns per-type keys
 function M.GetPetKey(petName, jobId)
     if petName == nil then return nil; end
@@ -204,9 +232,15 @@ function M.GetPetKey(petName, jobId)
         if spiritKey then
             return M.PET_TYPE_SPIRIT .. ':' .. spiritKey;
         end
+    elseif petType == M.PET_TYPE_JUG then
+        local mk = M.GetJugPetPaletteMovesKeyForEntity(petName);
+        if mk then
+            return M.PET_TYPE_JUG .. ':' .. M.JugPaletteSlugFromMovesKey(mk);
+        end
+        return M.PET_TYPE_JUG;
     end
 
-    -- Other jobs: Per-type palettes (wyvern, automaton, jug, charm)
+    -- Other jobs: Per-type palettes (wyvern, automaton, charm)
     return petType;
 end
 
@@ -229,6 +263,17 @@ function M.GetDisplayNameForKey(petKey)
             for name, key in pairs(M.spirits) do
                 if key == petId then return name; end
             end
+        elseif petType == M.PET_TYPE_JUG then
+            for _, row in ipairs(M.bstJugReadyFamilyPicker) do
+                if row.movesKey:lower() == petId:lower() then
+                    return row.name;
+                end
+            end
+            local slugLabel = M.bstJugPaletteSlugLabels and M.bstJugPaletteSlugLabels[petId:lower()];
+            if slugLabel then
+                return slugLabel;
+            end
+            return 'Jug (' .. petId .. ')';
         end
     end
 
@@ -259,18 +304,53 @@ function M.GetAvailablePetKeys(jobId)
         table.insert(keys, M.PET_TYPE_AUTOMATON);
     elseif jobId == M.JOB_BST then
         table.insert(keys, M.PET_TYPE_JUG);
+        local seenSlug = {};
+        for _, row in ipairs(M.bstJugReadyFamilyPicker) do
+            local slug = row.movesKey:lower();
+            if not seenSlug[slug] then
+                seenSlug[slug] = true;
+                table.insert(keys, M.PET_TYPE_JUG .. ':' .. slug);
+            end
+        end
+        local function addJugSlugFromMovesKey(mk)
+            if not mk or mk == '' then
+                return;
+            end
+            local slug = mk:lower();
+            if not seenSlug[slug] then
+                seenSlug[slug] = true;
+                table.insert(keys, M.PET_TYPE_JUG .. ':' .. slug);
+            end
+        end
+        for _, mk in pairs(M.jugPetFamilies) do
+            addJugSlugFromMovesKey(mk);
+        end
+        for _, mk in pairs(M.jugPetPaletteMovesKeyOverrides) do
+            addJugSlugFromMovesKey(mk);
+        end
         table.insert(keys, M.PET_TYPE_CHARM);
     end
 
     return keys;
 end
 
--- Get ordered list of avatar names (for dropdowns, etc.)
+-- Get ordered list of avatar names (for dropdowns, macro editor, Edit Full Palette Pets, etc.)
 function M.GetAvatarList()
     return {
-        'Carbuncle', 'Ifrit', 'Shiva', 'Garuda', 'Titan', 'Ramuh',
-        'Leviathan', 'Fenrir', 'Diabolos', 'Atomos', 'Odin', 'Alexander',
-        'Cait Sith', 'Siren',
+        'Carbuncle',
+        'Ifrit',
+        'Titan',
+        'Leviathan',
+        'Garuda',
+        'Shiva',
+        'Ramuh',
+        'Fenrir',
+        'Diabolos',
+        'Alexander',
+        'Odin',
+        'Cait Sith',
+        'Atomos',
+        'Siren',
     };
 end
 
@@ -280,6 +360,30 @@ function M.GetSpiritList()
         'Fire Spirit', 'Ice Spirit', 'Air Spirit', 'Earth Spirit',
         'Thunder Spirit', 'Water Spirit', 'Light Spirit', 'Dark Spirit',
     };
+end
+
+-- Display order for SMN pet keys (matches GetAvatarList then GetSpiritList). Used to align pickers and Edit Palette Pets.
+local smnPetKeyOrderWeight;
+function M.GetSmnPetKeyOrderWeight(petKey)
+    if not smnPetKeyOrderWeight then
+        smnPetKeyOrderWeight = {};
+        local i = 1;
+        for _, name in ipairs(M.GetAvatarList()) do
+            local id = M.avatars[name];
+            if id then
+                smnPetKeyOrderWeight[M.PET_TYPE_AVATAR .. ':' .. id] = i;
+                i = i + 1;
+            end
+        end
+        for _, name in ipairs(M.GetSpiritList()) do
+            local id = M.spirits[name];
+            if id then
+                smnPetKeyOrderWeight[M.PET_TYPE_SPIRIT .. ':' .. id] = i;
+                i = i + 1;
+            end
+        end
+    end
+    return smnPetKeyOrderWeight[petKey] or 9999;
 end
 
 -- Get combined list of all summons (avatars + spirits)
@@ -309,20 +413,49 @@ function M.GetPetKeyForSummon(summonName)
     return nil;
 end
 
+-- True if `key` is a valid pet subtype string used in slot storage (avatar:ifrit, wyvern, jug, jug:rabbit, etc.)
+function M.IsValidPetKey(key)
+    if not key or key == '' then
+        return false;
+    end
+    if key == M.PET_TYPE_WYVERN or key == M.PET_TYPE_AUTOMATON
+        or key == M.PET_TYPE_JUG or key == M.PET_TYPE_CHARM then
+        return true;
+    end
+    local pt, pid = key:match('^([^:]+):(.+)$');
+    if not pt or not pid then
+        return false;
+    end
+    if pt == M.PET_TYPE_AVATAR then
+        for _, shortId in pairs(M.avatars) do
+            if shortId == pid then
+                return true;
+            end
+        end
+    elseif pt == M.PET_TYPE_SPIRIT then
+        for _, shortId in pairs(M.spirits) do
+            if shortId == pid then
+                return true;
+            end
+        end
+    elseif pt == M.PET_TYPE_JUG then
+        return M.MovesKeyFromBstMacroPaletteSlug(pid) ~= nil;
+    end
+    return false;
+end
+
 -- ============================================
 -- Pet Commands Data
 -- ============================================
 
--- Generic pet commands (all pet jobs)
-M.genericPetCommands = {
-    { name = 'Assault', category = 'Command' },
-    { name = 'Retreat', category = 'Command' },
-    { name = 'Stay', category = 'Command' },
-    { name = 'Heel', category = 'Command' },
-    { name = 'Release', category = 'Command' },
+-- SMN pet commands (not blood pacts)
+M.smnPetCommands = {
+    { name = 'Assault', category = 'Command', level = 1 },
+    { name = 'Release', category = 'Command', level = 1 },
+    { name = 'Retreat', category = 'Command', level = 1 },
 };
 
--- SMN Blood Pacts - Rage (offensive)
+-- SMN Blood Pacts - Rage (offensive). Retail-style layout: Shared Ifrit block, then per-avatar sections.
 M.bloodPactsRage = {
     -- Shared
     { name = 'Punch', avatars = {'Ifrit'} },
@@ -333,6 +466,7 @@ M.bloodPactsRage = {
     { name = 'Meteor Strike', avatars = {'Ifrit'} },
     { name = 'Conflag Strike', avatars = {'Ifrit'} },
     { name = 'Fire IV', avatars = {'Ifrit'} },
+    { name = 'Inferno', avatars = {'Ifrit'} },
     -- Shiva
     { name = 'Axe Kick', avatars = {'Shiva'} },
     { name = 'Blizzard II', avatars = {'Shiva'} },
@@ -340,50 +474,59 @@ M.bloodPactsRage = {
     { name = 'Blizzard IV', avatars = {'Shiva'} },
     { name = 'Rush', avatars = {'Shiva'} },
     { name = 'Heavenly Strike', avatars = {'Shiva'} },
+    { name = 'Diamond Dust', avatars = {'Shiva'} },
     -- Garuda
     { name = 'Claw', avatars = {'Garuda'} },
     { name = 'Aero II', avatars = {'Garuda'} },
     { name = 'Aero IV', avatars = {'Garuda'} },
     { name = 'Predator Claws', avatars = {'Garuda'} },
     { name = 'Wind Blade', avatars = {'Garuda'} },
+    { name = 'Aerial Blast', avatars = {'Garuda'} },
     -- Titan
     { name = 'Rock Throw', avatars = {'Titan'} },
     { name = 'Stone II', avatars = {'Titan'} },
-    { name = 'Stone IV', avatars = {'Titan'} },
     { name = 'Rock Buster', avatars = {'Titan'} },
     { name = 'Megalith Throw', avatars = {'Titan'} },
+    { name = 'Stone IV', avatars = {'Titan'} },
     { name = 'Mountain Buster', avatars = {'Titan'} },
     { name = 'Geocrush', avatars = {'Titan'} },
     { name = 'Crag Throw', avatars = {'Titan'} },
+    { name = 'Earthen Fury', avatars = {'Titan'} },
     -- Ramuh
     { name = 'Shock Strike', avatars = {'Ramuh'} },
     { name = 'Thunder II', avatars = {'Ramuh'} },
+    { name = 'Thunderspark', avatars = {'Ramuh'} },
     { name = 'Thunder IV', avatars = {'Ramuh'} },
     { name = 'Chaotic Strike', avatars = {'Ramuh'} },
     { name = 'Thunderstorm', avatars = {'Ramuh'} },
-    { name = 'Thunderspark', avatars = {'Ramuh'} },
     { name = 'Volt Strike', avatars = {'Ramuh'} },
+    { name = 'Judgment Bolt', avatars = {'Ramuh'} },
     -- Leviathan
     { name = 'Barracuda Dive', avatars = {'Leviathan'} },
     { name = 'Water II', avatars = {'Leviathan'} },
-    { name = 'Water IV', avatars = {'Leviathan'} },
     { name = 'Tail Whip', avatars = {'Leviathan'} },
+    { name = 'Water IV', avatars = {'Leviathan'} },
     { name = 'Spinning Dive', avatars = {'Leviathan'} },
     { name = 'Grand Fall', avatars = {'Leviathan'} },
+    { name = 'Tidal Wave', avatars = {'Leviathan'} },
     -- Fenrir
     { name = 'Moonlit Charge', avatars = {'Fenrir'} },
     { name = 'Crescent Fang', avatars = {'Fenrir'} },
     { name = 'Eclipse Bite', avatars = {'Fenrir'} },
-    { name = 'Howling Moon', avatars = {'Fenrir'} },
+    { name = 'Lunar Bay', avatars = {'Fenrir'} },
     { name = 'Impact', avatars = {'Fenrir'} },
+    { name = 'Howling Moon', avatars = {'Fenrir'} },
     -- Diabolos
     { name = 'Camisado', avatars = {'Diabolos'} },
     { name = 'Nether Blast', avatars = {'Diabolos'} },
     { name = 'Night Terror', avatars = {'Diabolos'} },
+    { name = 'Blindside', avatars = {'Diabolos'} },
+    { name = 'Ruinous Omen', avatars = {'Diabolos'} },
     -- Carbuncle
     { name = 'Poison Nails', avatars = {'Carbuncle'} },
     { name = 'Holy Mist', avatars = {'Carbuncle'} },
     { name = 'Meteorite', avatars = {'Carbuncle'} },
+    { name = 'Searing Light', avatars = {'Carbuncle'} },
     -- Odin
     { name = 'Zantetsuken', avatars = {'Odin'} },
     -- Cait Sith
@@ -404,6 +547,7 @@ M.bloodPactsWard = {
     -- Carbuncle
     { name = 'Soothing Ruby', avatars = {'Carbuncle'} },
     { name = 'Healing Ruby', avatars = {'Carbuncle'} },
+    { name = 'Poison Ruby', avatars = {'Carbuncle'} },
     { name = 'Shining Ruby', avatars = {'Carbuncle'} },
     { name = 'Glittering Ruby', avatars = {'Carbuncle'} },
     { name = 'Healing Ruby II', avatars = {'Carbuncle'} },
@@ -417,10 +561,12 @@ M.bloodPactsWard = {
     { name = 'Diamond Storm', avatars = {'Shiva'} },
     { name = 'Crystal Blessing', avatars = {'Shiva'} },
     -- Garuda
-    { name = 'Aerial Armor', avatars = {'Garuda'} },
     { name = 'Whispering Wind', avatars = {'Garuda'} },
     { name = 'Hastega', avatars = {'Garuda'} },
+    { name = 'Aerial Armor', avatars = {'Garuda'} },
     { name = 'Fleet Wind', avatars = {'Garuda'} },
+    { name = "Wind's Blessing", avatars = {'Garuda'} },
+    { name = 'Hastega II', avatars = {'Garuda'} },
     -- Titan
     { name = 'Earthen Ward', avatars = {'Titan'} },
     { name = 'Earthen Armor', avatars = {'Titan'} },
@@ -432,11 +578,13 @@ M.bloodPactsWard = {
     { name = 'Slowga', avatars = {'Leviathan'} },
     { name = 'Spring Water', avatars = {'Leviathan'} },
     { name = 'Tidal Roar', avatars = {'Leviathan'} },
+    { name = 'Soothing Current', avatars = {'Leviathan'} },
     -- Fenrir
     { name = 'Ecliptic Growl', avatars = {'Fenrir'} },
     { name = 'Ecliptic Howl', avatars = {'Fenrir'} },
     { name = 'Lunar Cry', avatars = {'Fenrir'} },
     { name = 'Lunar Roar', avatars = {'Fenrir'} },
+    { name = 'Heavenward Howl', avatars = {'Fenrir'} },
     -- Diabolos
     { name = 'Pavor Nocturnus', avatars = {'Diabolos'} },
     { name = 'Somnolence', avatars = {'Diabolos'} },
@@ -460,13 +608,71 @@ M.bloodPactsWard = {
     { name = 'Bitter Elegy', avatars = {'Siren'} },
 };
 
--- DRG Wyvern abilities
+-- ============================================
+-- SMN Blood Pact Lookup Index (name -> pact data)
+-- ============================================
+
+-- Overlay MP/level from horizon_bloodpacts + XIUI fields from horizon_bloodpacts_xiui.
+local function MergeBloodPactWithHorizonStats(base)
+    if not base or not base.name then
+        return base;
+    end
+    local merged = {};
+    for k, v in pairs(base) do
+        merged[k] = v;
+    end
+    local xiui = horizonBloodPactsXiui and horizonBloodPactsXiui[base.name];
+    if xiui then
+        for k, v in pairs(xiui) do
+            merged[k] = v;
+        end
+    end
+    local st = horizonBloodPacts.byName and horizonBloodPacts.byName[base.name];
+    if st then
+        merged.mp = st.mp_cost;
+        merged.level = (st.levels and st.levels[15]) or 0;
+    end
+    return merged;
+end
+
+-- Build a fast lookup table for Blood Pact data by name.
+-- This avoids scanning the pact lists every frame when rendering MP costs.
+local function BuildBloodPactIndex()
+    local idx = {};
+
+    for _, pact in ipairs(M.bloodPactsRage or {}) do
+        if pact and pact.name then
+            idx[pact.name] = MergeBloodPactWithHorizonStats(pact);
+        end
+    end
+    for _, pact in ipairs(M.bloodPactsWard or {}) do
+        if pact and pact.name then
+            idx[pact.name] = MergeBloodPactWithHorizonStats(pact);
+        end
+    end
+
+    return idx;
+end
+
+-- NOTE: This is built once at load time. If you mutate blood pact tables at runtime,
+-- call `M.RebuildBloodPactIndex()` after changes.
+M.bloodPactIndexByName = BuildBloodPactIndex();
+
+function M.RebuildBloodPactIndex()
+    M.bloodPactIndexByName = BuildBloodPactIndex();
+end
+
+-- Get Blood Pact data by name (Rage or Ward).
+-- Returns merged row: retail `avatars` + XIUI overlays + `mp`/`level` from horizon_bloodpacts, or nil.
+function M.GetBloodPactByName(name)
+    if not name then return nil; end
+    return M.bloodPactIndexByName and M.bloodPactIndexByName[name] or nil;
+end
+
+-- DRG Wyvern abilities (Horizon-era only)
 M.wyvernCommands = {
-    { name = 'Steady Wing', category = 'Ability' },
-    { name = 'Spirit Bond', category = 'Ability' },
-    { name = 'Dragon Breaker', category = 'Ability' },
-    { name = 'Spirit Jump', category = 'Ability' },
-    { name = 'Soul Jump', category = 'Ability' },
+    { name = 'Dismiss', category = 'Command', level = 1 },
+    { name = 'Steady Wing', category = 'Ability', level = 30 },
 };
 
 -- PUP Automaton commands
@@ -486,23 +692,28 @@ M.automatonCommands = {
     { name = 'Heady Artifice', category = 'Ability' },
 };
 
--- BST pet commands (not job abilities - those go in Ability section)
-M.bstReadyCommands = {
-    { name = 'Fight', category = 'Command' },
-    { name = 'Sic', category = 'Command' },
-    { name = 'Ready', category = 'Command' },
-    { name = 'Reward', category = 'Command' },
+-- BST pet commands (level-gated, displayed in pet section). Ready rows are inserted after Sic when progression allows.
+M.bstPetCommands = {
+    { name = 'Fight', category = 'Command', level = 1 },
+    { name = 'Heel', category = 'Command', level = 10 },
+    { name = 'Stay', category = 'Command', level = 15 },
+    { name = 'Sic', category = 'Command', level = 25 },
+    { name = 'Leave', category = 'Command', level = 35 },
 };
 
 -- ============================================
 -- BST Jug Pet Ready Moves by Family
--- ============================================
-
+-- Optional `familyVarianceReason`: tooltip + yellow * in searchable combos when only some jugs in the merged UI row learn the move (do not use `reason` for that — `reason` is for level/learn/unavailability elsewhere).
 M.petFamilyReadyMoves = {
     ['Rabbit'] = {
         { name = 'Foot Kick', category = 'Ready' },
         { name = 'Dust Cloud', category = 'Ready' },
         { name = 'Whirl Claws', category = 'Ready' },
+        {
+            name = 'Snow Cloud',
+            category = 'Ready',
+            familyVarianceReason = 'Arctic-line rabbit jugs only (standard rabbits do not get this Ready).',
+        },
         { name = 'Wild Carrot', category = 'Ready' },
     },
     ['Sheep'] = {
@@ -592,12 +803,16 @@ M.petFamilyReadyMoves = {
     ['Coeurl'] = {
         { name = 'Chaotic Eye', category = 'Ready' },
         { name = 'Blaster', category = 'Ready' },
-    },
-    ['Lynx'] = {
-        { name = 'Chaotic Eye', category = 'Ready' },
-        { name = 'Blaster', category = 'Ready' },
-        { name = 'Charged Whisker', category = 'Ready' },
-        { name = 'Frenzied Rage', category = 'Ready' },
+        {
+            name = 'Charged Whisker',
+            category = 'Ready',
+            familyVarianceReason = 'Lynx-line jugs only (standard Coeurl jugs do not include this Ready).',
+        },
+        {
+            name = 'Frenzied Rage',
+            category = 'Ready',
+            familyVarianceReason = 'Lynx-line jugs only (standard Coeurl jugs do not include this Ready).',
+        },
     },
     ['Ladybug'] = {
         { name = 'Sudden Lunge', category = 'Ready' },
@@ -632,7 +847,205 @@ M.petFamilyReadyMoves = {
         { name = 'Sweeping Gouge', category = 'Ready' },
         { name = 'Zealous Snort', category = 'Ready' },
     },
+    ['Leech'] = {
+        { name = 'Suction', category = 'Ready' },
+        { name = 'Drainkiss', category = 'Ready' },
+        { name = 'Acid Mist', category = 'Ready' },
+        { name = 'TP Drainkiss', category = 'Ready' },
+    },
+    ['Chapuli'] = {
+        { name = 'Sensilla Blades', category = 'Ready' },
+        { name = 'Tegmina Buffet', category = 'Ready' },
+    },
+    ['Adamantoise'] = {
+        { name = 'Tortoise Stomp', category = 'Ready' },
+        { name = 'Harden Shell', category = 'Ready' },
+        { name = 'Aqua Breath', category = 'Ready' },
+    },
+    ['Raptor'] = {
+        { name = 'Ripper Fang', category = 'Ready' },
+        { name = 'Scythe Tail', category = 'Ready' },
+        { name = 'Chomp Rush', category = 'Ready' },
+    },
+    ['Toad'] = {
+        { name = 'Croaker', category = 'Ready' },
+        { name = 'Poison Breath', category = 'Ready' },
+        { name = 'Toad Kick', category = 'Ready' },
+    },
+    ['Pugil'] = {
+        { name = 'Terror Touch', category = 'Ready' },
+        { name = 'Sucker Punch', category = 'Ready' },
+        { name = 'Intimidate', category = 'Ready' },
+    },
+    ['Apkallu'] = {
+        { name = 'Beak Lunge', category = 'Ready' },
+        { name = 'Frigid Shuffle', category = 'Ready' },
+        { name = 'Wisent Snort', category = 'Ready' },
+    },
+    ['Snapweed'] = {
+        { name = 'Seedspray', category = 'Ready' },
+        { name = 'Sprout Smack', category = 'Ready' },
+        { name = 'Infernal Pestilence', category = 'Ready' },
+    },
+    ['Spider'] = {
+        { name = 'Double Claw', category = 'Ready' },
+        { name = 'Grapple', category = 'Ready' },
+        { name = 'Spinning Top', category = 'Ready' },
+        { name = 'Filamented Hold', category = 'Ready' },
+    },
+    ['Manticore'] = {
+        { name = 'Thunderstrike', category = 'Ready' },
+        { name = 'Barbed Crescent', category = 'Ready' },
+        { name = 'Death Scissors', category = 'Ready' },
+    },
+    ['Mosquito'] = {
+        { name = 'Infectious Dusk', category = 'Ready' },
+        {
+            name = 'Absorbing Kiss',
+            category = 'Ready',
+            familyVarianceReason = 'Higher-tier / select mosquito jugs only (lower-tier familiar omits this Ready).',
+        },
+        {
+            name = 'Pandemic Nip',
+            category = 'Ready',
+            familyVarianceReason = 'Higher-tier / select mosquito jugs only (lower-tier familiar omits this Ready).',
+        },
+    },
 };
+
+-- Lynx / Arctic rabbits reuse merged family pools (aliases keep jug:lynx and jug:rabbitarctic palettes valid).
+M.petFamilyReadyMoves['Lynx'] = M.petFamilyReadyMoves['Coeurl'];
+M.petFamilyReadyMoves['RabbitArctic'] = M.petFamilyReadyMoves['Rabbit'];
+
+-- Display labels for jug palette slugs not listed as their own picker row (family consolidated in UI).
+M.bstJugPaletteSlugLabels = {
+    ['lynx'] = 'Lynx',
+    ['rabbitarctic'] = 'Rabbit (Arctic)',
+};
+
+-- Ordered jug-family rows for macro editor "Ready (Use)" — display label + petFamilyReadyMoves key (HorizonXI jug roster).
+M.bstJugReadyFamilyPicker = {
+    { name = 'Rabbit', movesKey = 'Rabbit' },
+    { name = 'Sheep', movesKey = 'Sheep' },
+    { name = 'Mandragora', movesKey = 'Mandragora' },
+    { name = 'Tiger', movesKey = 'Tiger' },
+    { name = 'Flytrap', movesKey = 'Flytrap' },
+    { name = 'Lizard', movesKey = 'Lizard' },
+    { name = 'Fly', movesKey = 'Fly' },
+    { name = 'Eft', movesKey = 'Eft' },
+    { name = 'Beetle', movesKey = 'Beetle' },
+    { name = 'Antlion', movesKey = 'Antlion' },
+    { name = 'Crab', movesKey = 'Crab' },
+    { name = 'Diremite', movesKey = 'Diremite' },
+    { name = 'Funguar', movesKey = 'Funguar' },
+    { name = 'Sabotender', movesKey = 'Sabotender' },
+    { name = 'Coeurl', movesKey = 'Coeurl' },
+    { name = 'Raptor', movesKey = 'Raptor' },
+    { name = 'Toad', movesKey = 'Toad' },
+    { name = 'Pugil', movesKey = 'Pugil' },
+    { name = 'Ladybug', movesKey = 'Ladybug' },
+    { name = 'Apkallu', movesKey = 'Apkallu' },
+    { name = 'Leech', movesKey = 'Leech' },
+    { name = 'Hippogryph', movesKey = 'Hippogryph' },
+    { name = 'Slug', movesKey = 'Slug' },
+    { name = 'Adamantoise', movesKey = 'Adamantoise' },
+    { name = 'Chapuli', movesKey = 'Chapuli' },
+    { name = 'Tulfaire', movesKey = 'Tulfaire' },
+    { name = 'Snapweed', movesKey = 'Snapweed' },
+    { name = 'Raaz', movesKey = 'Raaz' },
+    { name = 'Colibri', movesKey = 'Colibri' },
+    { name = 'Spider', movesKey = 'Spider' },
+    { name = 'Manticore', movesKey = 'Manticore' },
+    { name = 'Mosquito', movesKey = 'Mosquito' },
+    { name = 'Slime', movesKey = 'Slug' },
+};
+
+function M.JugPaletteSlugFromMovesKey(movesKey)
+    if not movesKey then
+        return nil;
+    end
+    return movesKey:lower();
+end
+
+--- Macro palette composite key `JOB_BST:jug:<slug>` from a Ready family movesKey (`petFamilyReadyMoves`).
+---@param movesKey string|nil
+---@return number|string
+function M.FormatBstMacroPaletteSaveKeyFromMovesKey(movesKey)
+    if not movesKey or movesKey == '' then
+        return M.JOB_BST;
+    end
+    return string.format('%d:%s:%s', M.JOB_BST, M.PET_TYPE_JUG, M.JugPaletteSlugFromMovesKey(movesKey));
+end
+
+--- Reverse `FormatBstMacroPaletteSaveKeyFromMovesKey` slug segment → canonical movesKey casing.
+---@param slug string|nil
+---@return string|nil
+function M.MovesKeyFromBstMacroPaletteSlug(slug)
+    if not slug or slug == '' then
+        return nil;
+    end
+    local lower = slug:lower();
+    for _, row in ipairs(M.bstJugReadyFamilyPicker) do
+        if row.movesKey:lower() == lower then
+            return row.movesKey;
+        end
+    end
+    for mk, _ in pairs(M.petFamilyReadyMoves) do
+        if mk:lower() == lower then
+            return mk;
+        end
+    end
+    return nil;
+end
+
+local bstJugReadyMoveNameSet = {};
+for _, familyMoves in pairs(M.petFamilyReadyMoves) do
+    for _, move in ipairs(familyMoves) do
+        bstJugReadyMoveNameSet[move.name] = true;
+    end
+end
+
+---@param name string|nil
+---@return boolean
+function M.IsBstJugReadyMoveName(name)
+    return name ~= nil and bstJugReadyMoveNameSet[name] == true;
+end
+
+--- Ready moves for a jug family key (`petFamilyReadyMoves`).
+---@param movesKey string|nil
+---@return table|nil
+function M.GetReadyMovesForFamilyMovesKey(movesKey)
+    if movesKey == nil or movesKey == '' then
+        return nil;
+    end
+    return M.petFamilyReadyMoves[movesKey];
+end
+
+--- Macro editor: ordered family rows (unique labels).
+---@return table
+function M.GetBstJugReadyFamilyPickerList()
+    return M.bstJugReadyFamilyPicker;
+end
+
+--- First picker-listed family whose move list contains this ability name (ambiguous moves pick earliest row).
+---@param moveName string|nil
+---@return string|nil movesKey
+function M.ResolveBstJugMovesKeyFromMoveName(moveName)
+    if moveName == nil or moveName == '' then
+        return nil;
+    end
+    for _, row in ipairs(M.bstJugReadyFamilyPicker) do
+        local moves = M.petFamilyReadyMoves[row.movesKey];
+        if moves then
+            for _, m in ipairs(moves) do
+                if m.name == moveName then
+                    return row.movesKey;
+                end
+            end
+        end
+    end
+    return nil;
+end
 
 -- ============================================
 -- Jug Pet to Family Mapping
@@ -722,6 +1135,23 @@ M.jugPetFamilies = {
     ['SlimeFamiliar'] = 'Slug',
 };
 
+-- Jug entity -> Ready/`petpalette` family key when it differs from `jugPetFamilies` (same slug as `petFamilyReadyMoves`).
+M.jugPetPaletteMovesKeyOverrides = {
+    ['LuckyLulush'] = 'RabbitArctic',
+};
+
+-- Get the Ready moves / jug palette family key for an entity name (jug jugpets naming table).
+function M.GetJugPetPaletteMovesKeyForEntity(petName)
+    if petName == nil then
+        return nil;
+    end
+    local ov = M.jugPetPaletteMovesKeyOverrides[petName];
+    if ov then
+        return ov;
+    end
+    return M.jugPetFamilies[petName];
+end
+
 -- Get the family for a jug pet name
 function M.GetJugPetFamily(petName)
     if petName == nil then return nil; end
@@ -730,7 +1160,7 @@ end
 
 -- Get ready moves for a jug pet by name
 function M.GetReadyMovesForPet(petName)
-    local family = M.GetJugPetFamily(petName);
+    local family = M.GetJugPetPaletteMovesKeyForEntity(petName);
     if family and M.petFamilyReadyMoves[family] then
         return M.petFamilyReadyMoves[family];
     end
@@ -815,21 +1245,18 @@ end
 function M.GetPetCommandsForJob(jobId, avatarName, activePetName)
     local commands = {};
 
-    -- Add generic commands first
-    for _, cmd in ipairs(M.genericPetCommands) do
-        table.insert(commands, { name = cmd.name, category = cmd.category });
-    end
-
     if jobId == M.JOB_SMN then
+        -- SMN-specific commands
+        for _, cmd in ipairs(M.smnPetCommands) do
+            table.insert(commands, { name = cmd.name, category = cmd.category, level = cmd.level });
+        end
         -- SMN: Blood Pacts
         if avatarName and M.avatars[avatarName] then
-            -- Specific avatar - add only their pacts
             local avatarPacts = M.GetBloodPactsForAvatar(avatarName);
             for _, pact in ipairs(avatarPacts) do
                 table.insert(commands, pact);
             end
         else
-            -- No specific avatar - add all pacts
             local allPacts = M.GetAllBloodPacts();
             for _, pact in ipairs(allPacts) do
                 table.insert(commands, pact);
@@ -838,7 +1265,7 @@ function M.GetPetCommandsForJob(jobId, avatarName, activePetName)
     elseif jobId == M.JOB_DRG then
         -- DRG: Wyvern commands
         for _, cmd in ipairs(M.wyvernCommands) do
-            table.insert(commands, { name = cmd.name, category = cmd.category });
+            table.insert(commands, { name = cmd.name, category = cmd.category, level = cmd.level });
         end
     elseif jobId == M.JOB_PUP then
         -- PUP: Automaton commands
@@ -846,28 +1273,210 @@ function M.GetPetCommandsForJob(jobId, avatarName, activePetName)
             table.insert(commands, { name = cmd.name, category = cmd.category });
         end
     elseif jobId == M.JOB_BST then
-        -- BST: Ready commands (abilities)
-        for _, cmd in ipairs(M.bstReadyCommands) do
-            table.insert(commands, { name = cmd.name, category = cmd.category });
-        end
-        -- BST: Ready moves for the active pet
-        if activePetName then
-            local readyMoves = M.GetReadyMovesForPet(activePetName);
-            if readyMoves then
-                for _, move in ipairs(readyMoves) do
-                    table.insert(commands, { name = move.name, category = move.category });
+        local haProgress = require('modules.hotbar.database.horizon_abilities');
+        local readyProg = haProgress['Ready'];
+        local readyLvl = (readyProg and readyProg.level) or 25;
+
+        -- BST-specific pet commands (Ready variants inserted after Sic when progression allows)
+        for _, cmd in ipairs(M.bstPetCommands) do
+            table.insert(commands, { name = cmd.name, category = cmd.category, level = cmd.level });
+            if cmd.name == 'Sic' and horizonDefinesBstReadyPetCommand() then
+                if horizonDefinesBstJugReadyMoves() then
+                    table.insert(commands, {
+                        name = 'Ready (Recast)',
+                        category = 'Command',
+                        level = readyLvl,
+                        petMacroAction = 'Ready',
+                        bstReadySynthetic = 'recast',
+                    });
+                    table.insert(commands, {
+                        name = 'Ready (Use)',
+                        category = 'Command',
+                        level = readyLvl,
+                        bstReadySynthetic = 'use',
+                    });
+                else
+                    table.insert(commands, {
+                        name = 'Ready',
+                        category = 'Command',
+                        level = readyLvl,
+                    });
                 end
-            end
-        else
-            -- No specific pet - add all ready moves
-            local allMoves = M.GetAllReadyMoves();
-            for _, move in ipairs(allMoves) do
-                table.insert(commands, move);
             end
         end
     end
 
     return commands;
 end
+
+-- ============================================
+-- "Show All" Expanded List Builders (level-gated)
+-- ============================================
+
+local STATUS_HAVE = 'have';
+local STATUS_UNAVAILABLE = 'unavailable';
+
+--- Get BST pet commands with level-gated status from horizon_abilities.
+--- When jug Ready moves are enabled, replaces plain Ready with "Ready (Recast)" + "Ready (Use)"; jug abilities are chosen via the macro editor sub-picker, not this flat list.
+---@param bstLevel number The player's BST level
+---@param activePetName string|nil Reserved for callers (jug list no longer merged here)
+---@return table Array of {name, category, level, status, reqStr}
+function M.GetBstPetCommandsExpanded(bstLevel, activePetName)
+    local horizonAbilities = require('modules.hotbar.database.horizon_abilities');
+    local commands = {};
+
+    for cmdName, info in pairs(horizonAbilities) do
+        if not info.pet then goto continue; end
+
+        if cmdName == 'Ready' and horizonDefinesBstJugReadyMoves() then
+            local status = (bstLevel >= info.level) and STATUS_HAVE or STATUS_UNAVAILABLE;
+            local reason = status == STATUS_UNAVAILABLE and ('Requires BST Lv. ' .. tostring(info.level)) or nil;
+            local reqStr = 'Lv.' .. tostring(info.level);
+            table.insert(commands, {
+                name = 'Ready (Recast)',
+                category = 'Command',
+                level = info.level,
+                status = status,
+                reqStr = reqStr,
+                reason = reason,
+                petMacroAction = 'Ready',
+                bstReadySynthetic = 'recast',
+            });
+            table.insert(commands, {
+                name = 'Ready (Use)',
+                category = 'Command',
+                level = info.level,
+                status = status,
+                reqStr = reqStr,
+                reason = reason,
+                bstReadySynthetic = 'use',
+            });
+            goto continue;
+        end
+
+        local status = (bstLevel >= info.level) and STATUS_HAVE or STATUS_UNAVAILABLE;
+        table.insert(commands, {
+            name = cmdName,
+            category = 'Command',
+            level = info.level,
+            status = status,
+            reqStr = 'Lv.' .. tostring(info.level),
+            reason = status == STATUS_UNAVAILABLE and ('Requires BST Lv. ' .. tostring(info.level)) or nil,
+        });
+        ::continue::
+    end
+
+    table.sort(commands, function(a, b)
+        local sa = a.status == STATUS_HAVE and 1 or 2;
+        local sb = b.status == STATUS_HAVE and 1 or 2;
+        if sa ~= sb then return sa < sb; end
+        local la = a.level or 999;
+        local lb = b.level or 999;
+        if la ~= lb then return la < lb; end
+        return a.name < b.name;
+    end);
+
+    return commands;
+end
+
+--- Get blood pacts for a specific avatar (or all) with level-gated status.
+---@param avatarName string|nil Avatar name to filter by, or nil for all
+---@param smnLevel number The player's SMN level
+---@return table Array of {name, category, level, mp, status, reqStr}
+function M.GetBloodPactsExpanded(avatarName, smnLevel)
+    local pacts = {};
+    local seen = {};
+
+    local function addPact(pact, cat)
+        if seen[pact.name] then return; end
+        if avatarName then
+            local match = false;
+            for _, av in ipairs(pact.avatars) do
+                if av == avatarName then match = true; break; end
+            end
+            if not match then return; end
+        end
+
+        local bpData = horizonBloodPacts.byName and horizonBloodPacts.byName[pact.name];
+        local level = 0;
+        local mp = 0;
+        if bpData then
+            level = (bpData.levels and bpData.levels[15]) or 0;
+            mp = bpData.mp_cost or 0;
+        end
+
+        local status;
+        if level <= 0 or smnLevel >= level then
+            status = STATUS_HAVE;
+        else
+            status = STATUS_UNAVAILABLE;
+        end
+
+        local reqStr;
+        if level > 0 then
+            reqStr = 'Lv.' .. tostring(level);
+        end
+
+        seen[pact.name] = true;
+        local mergedRow = M.GetBloodPactByName(pact.name);
+        local requiresAstralFlow = mergedRow and mergedRow.requiresFlow == true;
+        local pinkStarTooltip = requiresAstralFlow and universalTwoHour.PINK_STAR_ASTRAL_FLOW_TOOLTIP or nil;
+        table.insert(pacts, {
+            name = pact.name,
+            category = cat,
+            level = level,
+            mp = mp,
+            status = status,
+            reqStr = reqStr,
+            reason = (status == STATUS_UNAVAILABLE and level > 0) and ('Requires SMN Lv. ' .. tostring(level)) or nil,
+            pinkStarTooltip = pinkStarTooltip,
+            requiresAstralFlow = requiresAstralFlow,
+        });
+    end
+
+    -- SMN pet commands (Assault, Release, Retreat) — always available at level 1
+    for _, cmd in ipairs(M.smnPetCommands) do
+        local status = (smnLevel >= cmd.level) and STATUS_HAVE or STATUS_UNAVAILABLE;
+        table.insert(pacts, {
+            name = cmd.name,
+            category = 'Command',
+            level = cmd.level,
+            mp = 0,
+            status = status,
+            reqStr = 'Lv.' .. tostring(cmd.level),
+            reason = status == STATUS_UNAVAILABLE and ('Requires SMN Lv. ' .. tostring(cmd.level)) or nil,
+            requiresAstralFlow = false,
+        });
+    end
+
+    for _, pact in ipairs(M.bloodPactsRage) do
+        addPact(pact, 'BP: Rage');
+    end
+    for _, pact in ipairs(M.bloodPactsWard) do
+        addPact(pact, 'BP: Ward');
+    end
+
+    -- Sort: Astral Flow–only blood pacts first (SMN “two-hour style”), then Commands, BP: Rage, BP: Ward.
+    -- Within each band: availability, level, name.
+    local CAT_SORT = { ['Command'] = 1, ['BP: Rage'] = 2, ['BP: Ward'] = 3 };
+    table.sort(pacts, function(a, b)
+        local fa = a.requiresAstralFlow and 0 or 1;
+        local fb = b.requiresAstralFlow and 0 or 1;
+        if fa ~= fb then return fa < fb; end
+        local ca = CAT_SORT[a.category] or 9;
+        local cb = CAT_SORT[b.category] or 9;
+        if ca ~= cb then return ca < cb; end
+        local sa = a.status == STATUS_HAVE and 1 or 2;
+        local sb = b.status == STATUS_HAVE and 1 or 2;
+        if sa ~= sb then return sa < sb; end
+        if a.level ~= b.level then return a.level < b.level; end
+        return a.name < b.name;
+    end);
+
+    return pacts;
+end
+
+M.STATUS_HAVE = STATUS_HAVE;
+M.STATUS_UNAVAILABLE = STATUS_UNAVAILABLE;
 
 return M;


### PR DESCRIPTION
…y cost display

What changed
- pet_palette_allowlist.lua: New file. Type tokens: avatars, elementals, beasts, wyvern, puppet. Legacy "summons" still matches avatars+elementals and upgrades in the editor. Slot Configure and Pet Palette use the same type name constants.
- config/efp_pets_tab.lua, palettemanager.lua, crossbar.lua, petregistry.lua: Edit Full Palette pet family tabs (Avatars, Elementals, Beasts, Wyvern, Puppet). Avatar vs spirit elemental distinction. SMN sort and pet-bar omit rules applied consistently.
- macropalette.lua: Custom grid section header uses Elementals label for spirit pets. Add custom type (+) only in popup; red remove and Rename on the type row; delete confirms macro count.
- core/settings/factories.lua: petPalettePetKeys defaults; comments for new type tokens.
- modules/castcost/display.lua: BST Ready jug shows pet charge cost as 'Cost: N' (TP-gold color) instead of mislabeled MP when hovering spell rows fed from petregistry helpers.

Why
- SMN 'summons' split into avatars vs elementals for configuration and EFP so each family can be separately enabled/positioned. Custom macro categories can be managed from the type row with full cleanup of that palette bucket and revert of affected slots. BST Ready charge cost reads like gameplay (charges, not MP).