### PR TITLE
Pet bar: global resize anchor, anchored-bottom math, snap-top fix, an…

### DIFF
--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -5,6 +5,8 @@
 
 local M = {};
 local profileManager = require('core.profile_manager');
+local macroXiuiDefaults = require('modules.hotbar.macro_xiui_defaults');
+local macroGlobalDefaults = require('modules.hotbar.macro_global_defaults');
 
 -- Migrate settings from HXUI to XIUI (one-time migration for users upgrading from HXUI)
 -- IMPORTANT: This must be called BEFORE settings.load() so that copied files are picked up
@@ -607,6 +609,20 @@ function M.MigrateIndividualSettings(gConfig, defaults)
             if petType.tpFontSize == nil then petType.tpFontSize = oldVitalsFontSize; end
         end
     end
+
+    if gConfig.petBarResizeAnchor == nil then
+        local wantsBottom = false;
+        for _, pt in ipairs(petTypeTables) do
+            if pt and pt.alignBottom then
+                wantsBottom = true;
+                break;
+            end
+        end
+        gConfig.petBarResizeAnchor = wantsBottom and 'bottom' or 'top';
+    end
+    if gConfig.petTargetSnapAnchor == 'top' and type(gConfig.petTargetSnapOffsetX) == 'number' and gConfig.petTargetSnapOffsetX >= 100 then
+        gConfig.petTargetSnapOffsetX = 0;
+    end
 end
 
 -- Migrate flat castCost* settings to nested castCost table
@@ -1053,7 +1069,116 @@ end
 
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
+-- Split legacy hotbarCrossbar.mode ('hotbar'|'crossbar'|'both') into separate visibility flags
+function M.MigrateCrossbarModuleFlags(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.crossbarEnabled == nil then
+        if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.showCrossbar ~= nil then
+            gConfig.crossbarEnabled = gConfig.hotbarCrossbar.showCrossbar;
+        else
+            gConfig.crossbarEnabled = true;
+        end
+    end
+    local hg = gConfig.hotbarGlobal;
+    if hg and hg.logPaletteNameCrossbar == nil then
+        hg.logPaletteNameCrossbar = hg.logPaletteName;
+    end
+    if hg and hg.logPaletteNameCrossbarCycleHint == nil then
+        hg.logPaletteNameCrossbarCycleHint = true;
+    end
+end
+
+function M.MigrateHotbarCrossbarLayoutFlags(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local m = gConfig.hotbarCrossbar.mode;
+    if m ~= nil then
+        if m == 'hotbar' then
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = false;
+        elseif m == 'crossbar' then
+            gConfig.hotbarShowKeyboardBars = false;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        else
+            gConfig.hotbarShowKeyboardBars = true;
+            gConfig.hotbarCrossbar.showCrossbar = true;
+        end
+        gConfig.hotbarCrossbar.mode = nil;
+    end
+    if gConfig.hotbarShowKeyboardBars == nil then
+        gConfig.hotbarShowKeyboardBars = true;
+    end
+    if gConfig.hotbarCrossbar.showCrossbar == nil then
+        gConfig.hotbarCrossbar.showCrossbar = true;
+    end
+end
+
+-- Fold legacy hotbarShowKeyboardBars into hotbarEnabled (same intent as Hotbar → Enabled today).
+function M.MigrateHotbarShowKeyboardBarsRemoval(gConfig)
+    if not gConfig then
+        return;
+    end
+    if gConfig.hotbarShowKeyboardBars == false and gConfig.hotbarEnabled ~= false then
+        gConfig.hotbarEnabled = false;
+    end
+    gConfig.hotbarShowKeyboardBars = nil;
+end
+
+-- Drop deprecated keys from profiles saved during older builds (macros/skillchain are hotbarGlobal only now).
+function M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig)
+    if not gConfig or type(gConfig.hotbarCrossbar) ~= 'table' then
+        return;
+    end
+    local xb = gConfig.hotbarCrossbar;
+    xb.crossbarDisableXiMacros = nil;
+    xb.skillchainHighlightEnabled = nil;
+    xb.skillchainHighlightColor = nil;
+    xb.skillchainIconScale = nil;
+    xb.skillchainIconOffsetX = nil;
+    xb.skillchainIconOffsetY = nil;
+end
+
+function M.MigrateMacroGlobalUniversalTwoHour(gConfig)
+    if not gConfig then
+        return;
+    end
+    macroGlobalDefaults.SeedUniversalTwoHourIfNeeded(gConfig);
+end
+
+function M.MigrateMacroXiuiDefaults(gConfig)
+    if not gConfig then
+        return;
+    end
+    local inserted = macroXiuiDefaults.SeedIfNeeded(gConfig);
+    if inserted then
+        local ok, hotbarData = pcall(require, 'modules.hotbar.data');
+        if ok and hotbarData and hotbarData.MarkMacroLookupDirty then
+            hotbarData.MarkMacroLookupDirty();
+        end
+    end
+end
+
 function M.RunStructureMigrations(gConfig, defaults)
+    -- Run before anything touches macroDB: coalesce "4" vs 4 and dedupe macro ids (fixes wrong macro on hotbar / drag)
+    if gConfig then
+        local ok, data = pcall(require, 'modules.hotbar.data');
+        if ok and data and data.EnsureMacroDatabaseCoherence then
+            data.EnsureMacroDatabaseCoherence(gConfig);
+        end
+    end
+    M.MigrateCrossbarModuleFlags(gConfig);
+    M.MigrateHotbarCrossbarLayoutFlags(gConfig);
+    M.MigrateHotbarShowKeyboardBarsRemoval(gConfig);
+    M.MigrateCrossbarRemoveDeprecatedMirroredKeys(gConfig);
+    if gConfig then
+        local ok, hbData = pcall(require, 'modules.hotbar.data');
+        if ok and hbData and hbData.MigrateSlotDualMacroBindings then
+            hbData.MigrateSlotDualMacroBindings(gConfig);
+        end
+    end
     M.MigratePartyListLayoutSettings(gConfig, defaults);
     M.MigratePerPartySettings(gConfig, defaults);
     M.MigratePerPetTypeSettings(gConfig, defaults);
@@ -1067,6 +1192,8 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
     M.MigrateSlotMacroRefs(gConfig);
+    M.MigrateMacroXiuiDefaults(gConfig);
+    M.MigrateMacroGlobalUniversalTwoHour(gConfig);
 end
 
 -- Legacy function for backward compatibility (if any external code calls it)

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -63,10 +63,31 @@ function M.createUserSettingsDefaults()
         treasurePoolExpanded = false,         -- Expanded view (false = collapsed)
 
         -- Hotbar settings (global)
-        hotbarEnabled = true,                 -- Show hotbar module
-        -- Lock movement: when true, disables drag/drop and slot swapping for hotbar bars
+        hotbarEnabled = true,                 -- Show hotbar module (keyboard strips when enabled; use Crossbar category for controller UI)
+
+        crossbarEnabled = true,               -- Load controller crossbar (L2/R2 UI); independent from keyboard hotbars
+        -- Lock movement: when true, disables drag/drop and slot swapping for keyboard hotbars only
         hotbarLockMovement = false,
+        -- Lock crossbar: when true, disables drag/drop/slot moves and window drag for controller crossbar
+        crossbarLockMovement = false,
         hotbarPreview = false,                -- Show preview with test data
+
+        -- Macro palette editor: icon auto-source + custom/ subfolder (persists per profile)
+        macroEditorIconPrefs = {
+            iconAutoSource = 'all',   -- 'all' | 'spells' | 'items' | 'custom'
+            customIconFolder = 'all', -- 'all' or a top-level folder name under assets/hotbar/custom/
+        },
+
+        -- Macro palette: custom dropdown categories (keys "custom:N" under macroDB)
+        macroCustomCategories = T{},
+        macroCustomNextSeq = 1,
+        -- When false, empty "xiui" macro bucket gets default /xiui slash shortcuts once (see macro_xiui_defaults.lua)
+        macroXiuiDefaultsSeeded = false,
+        -- When false, Global bucket may receive default "Universal 2 Hour" macro once (see macro_global_defaults.lua)
+        macroGlobalUniversalTwoHourSeeded = false,
+
+        -- "profile" = macros in this profile's lua only; "shared" = one global library (SharedMacros.lua) for all characters using Shared.
+        macroStorageScope = 'profile',
 
         -- Global hotbar visual settings (used when bar's useGlobalSettings = true)
         hotbarGlobal = factories.createHotbarGlobalDefaults(),
@@ -665,6 +686,7 @@ function M.createUserSettingsDefaults()
         petBarScaleY = 1.0,
         petBarHideDuringEvents = true,
         petBarPreview = true,
+        petBarResizeAnchor = 'top',              -- Pet bar resize: 'top' or 'bottom' fixed edge when height changes
         petBarPreviewType = 2, -- Avatar (SMN)
         petBarShowDistance = true,
         petBarShowTarget = true,
@@ -792,10 +814,14 @@ function M.createUserSettingsDefaults()
         petTargetDistanceOffsetY = 44,
 
         -- Pet Target snap to petbar (positions pet target directly below petbar)
-        petTargetSnapToPetBar = true,        -- When enabled, pet target snaps below petbar
-        petTargetSnapAnchor = 'bottom',      -- 'bottom' = offset from bottom of pet bar, 'top' = offset from top (static when buffs change height)
+        petTargetSnapToPetBar = true,        -- When enabled, pet target snaps relative to pet bar geometry
+        petTargetSnapAnchor = 'bottom',      -- bottom: pet target window below pet bar; top: above pet bar
         petTargetSnapOffsetX = 0,            -- Horizontal offset from petbar position
         petTargetSnapOffsetY = 16,           -- Vertical offset below petbar (accounts for background border)
+        -- Extra pixels between Pet Target bottom and pet bar top when snap anchor is Top (0 = use offset Y only)
+        petTargetSnapTopGap = 5,
+        -- Last measured PetBarTarget window height (top snap only); avoids first-frame placement jump after load
+        petTargetSnapCachedHeight = nil,
 
         -- Per-pet-type settings (Avatar, Charm, Jug, Automaton, Wyvern each have independent visual settings)
         petBarAvatar = factories.createPetBarTypeDefaults(),

--- a/XIUI/handlers/helpers.lua
+++ b/XIUI/handlers/helpers.lua
@@ -39,6 +39,9 @@ local imgui = require('imgui');
 -- ========================================
 
 -- Window Positioning Helper
+-- Returns true on the one frame that the saved position is applied (first open after load/relog).
+-- Callers use this to suppress stale-state corrections that would otherwise fire immediately
+-- after the position is restored, before live size data is re-established.
 function ApplyWindowPosition(windowName)
     if (gConfig and gConfig.windowPositions and gConfig.windowPositions[windowName]) then
         if (not gConfig.appliedPositions) then gConfig.appliedPositions = {}; end

--- a/XIUI/handlers/imgui_compat.lua
+++ b/XIUI/handlers/imgui_compat.lua
@@ -129,6 +129,18 @@ else
 
 end
 
+-- ImGuiWindowFlags_NoInputs: skip missing on some Ashita builds (PetBarTarget mouse pass-through during drag-drop)
+if ImGuiWindowFlags_NoInputs == nil then
+    if ImGuiWindowFlags_NoMouseInputs ~= nil and ImGuiWindowFlags_NoNavInputs ~= nil then
+        ImGuiWindowFlags_NoInputs = bit.bor(ImGuiWindowFlags_NoMouseInputs, ImGuiWindowFlags_NoNavInputs);
+    elseif ImGuiWindowFlags_NoMouseInputs ~= nil then
+        ImGuiWindowFlags_NoInputs = ImGuiWindowFlags_NoMouseInputs;
+    else
+        -- Dear ImGui 1.83-style composite (NoMouseInputs|NoNavInputs); used when Ashita exposes neither constant
+        ImGuiWindowFlags_NoInputs = 1536;
+    end
+end
+
 -- Return module info for debugging
 return {
     version = '1.0.0',

--- a/XIUI/modules/petbar/data.lua
+++ b/XIUI/modules/petbar/data.lua
@@ -526,7 +526,13 @@ data.recastMaxTimers = {};
 -- Window positioning (shared with pet target)
 data.lastMainWindowPosX = 0;
 data.lastMainWindowTop = 0;   -- Top of pet bar (stable anchor for snap Y offset)
+data.petBarSnapTopReferenceY = nil; -- ImGui top minus themed border outset (top snap; see display.lua)
 data.lastMainWindowBottom = 0;
+data.lastPetBarWindowHeight = nil; -- pet bar GetWindowSize height (for snap math when moving cluster from pet target)
+data.petBarTargetHitRect = nil; -- last PetBarTarget outer rect {x,y,w,h} for cluster drag while snap+NoInputs
+data.petBarClusterDragActive = false;
+data.petBarSyncResizeAnchorNextFrame = false; -- after SetWindowPos PetBar from pet target; refresh bottom anchor
+data.lastPetBarTargetWindowHeight = nil; -- last PetBarTarget height (top snap); profile also stores petTargetSnapCachedHeight
 data.lastTotalRowWidth = 150;
 data.lastWindowFlags = nil;
 data.lastColorConfig = nil;

--- a/XIUI/modules/petbar/display.lua
+++ b/XIUI/modules/petbar/display.lua
@@ -20,11 +20,15 @@ local defaultPositions = require('libs.defaultpositions');
 
 local display = {};
 
--- Window state for bottom alignment + previous-frame size cache (used for bg layering)
+-- Window state for bottom alignment + previous-frame size cache (used for bg layering).
+-- anchorBottom: locked screen Y of the window bottom edge while petBarResizeAnchor='bottom'
+-- and AlwaysAutoResize is on. Stable across +/-1px height steps that the old
+-- "delta > 1px" gate skipped, which caused the window to crawl upward over time.
 local windowState = {
     x = nil,
     y = nil,
     height = nil,
+    anchorBottom = nil,
     cachedWidth = nil,
     cachedHeight = nil,
 };
@@ -607,6 +611,52 @@ local function DrawRecastFullCharged(drawList, x, y, timerInfo, colorConfig, ful
     return barHeight;
 end
 
+-- gConfig.petBarResizeAnchor: 'top' | 'bottom' pins which edge when AlwaysAutoResize changes height.
+-- When unset/nil (should not persist after migrate), falls back to per-type alignBottom for legacy saves.
+local function PetBarResizeAnchoredBottom(typeSettings)
+    local mode = gConfig.petBarResizeAnchor;
+    if mode == 'bottom' then
+        return true;
+    end
+    if mode == 'top' then
+        return false;
+    end
+    return typeSettings.alignBottom == true;
+end
+
+-- Resize-anchor preview stripe (shown when Pet Bar Preview + XIUI config open): a thin colored
+-- band on the top or bottom edge indicating which edge is pinned during auto-resize.
+local function DrawResizeAnchorEdgePreview(px, py, w, h, anchorBottom)
+    if not (showConfig and showConfig[1] and gConfig.petBarPreview) then
+        return;
+    end
+
+    local strip = math.min(7, math.max(5, math.floor(h * 0.04)));
+    local inset = 3;
+    local x0 = px + inset;
+    local x1 = px + w - inset;
+
+    local dl = imgui.GetWindowDrawList();
+    local fillCol;
+    local outlineCol;
+    local y0;
+    local y1;
+    if anchorBottom then
+        fillCol = imgui.GetColorU32({1.0, 0.52, 0.1, 0.76});
+        outlineCol = imgui.GetColorU32({1.0, 1.0, 0.95, 0.92});
+        y0 = py + h - strip;
+        y1 = py + h;
+    else
+        fillCol = imgui.GetColorU32({0.15, 0.82, 0.95, 0.74});
+        outlineCol = imgui.GetColorU32({0.95, 0.98, 1.0, 0.9});
+        y0 = py;
+        y1 = py + strip;
+    end
+
+    dl:AddRectFilled({ x0, y0 }, { x1, y1 }, fillCol);
+    dl:AddRect({ x0, y0 }, { x1, y1 }, outlineCol, 0, ImDrawCornerFlags_All, 1.5);
+end
+
 -- ============================================
 -- DrawWindow - Main Pet Bar Rendering
 -- ============================================
@@ -636,6 +686,7 @@ function display.DrawWindow(settings)
         windowState.x = nil;
         windowState.y = nil;
         windowState.height = nil;
+        windowState.anchorBottom = nil;
         return false;
     end
 
@@ -734,7 +785,8 @@ function display.DrawWindow(settings)
     if imgui.Begin('PetBar', true, windowFlags) then
         local drawList = drawing.GetUIDrawList();
         imtext.SetConfigFromSettings(settings.name_font_settings);
-        SaveWindowPosition('PetBar');
+        -- SaveWindowPosition moved to AFTER the bottom-anchor correction below so the
+        -- corrected Y (not the pre-correction one) gets persisted.
         windowPosX, windowPosY = imgui.GetWindowPos();
         local startX, startY = imgui.GetCursorScreenPos();
 
@@ -1175,40 +1227,63 @@ function display.DrawWindow(settings)
         -- Get final window size for background
         local windowWidth, windowHeight = imgui.GetWindowSize();
 
-        -- Handle bottom alignment
-        if typeSettings.alignBottom then
-            -- Detect external position change (forced reset, user drag, etc.)
-            local positionChanged = windowState.y ~= nil and windowState.y ~= windowPosY;
+        local resizeAnchoredBottom = PetBarResizeAnchoredBottom(typeSettings);
 
-            if positionJustApplied or positionChanged then
-                -- Position was externally moved; clear tracking so height adjustment
-                -- doesn't fire until state is re-established on the next frame
-                windowState.x = nil;
-                windowState.y = nil;
-                windowState.height = nil;
-            elseif windowState.height ~= nil and windowState.height ~= windowHeight then
-                -- Height changed, adjust Y to keep bottom edge fixed
-                local newPosY = windowState.y + windowState.height - windowHeight;
-                imgui.SetWindowPos('PetBar', { windowPosX, newPosY });
-                windowPosY = newPosY;
-                windowState.x = windowPosX;
-                windowState.y = windowPosY;
-                windowState.height = windowHeight;
+        -- Bottom alignment: lock the on-screen Y of the window's bottom edge so AlwaysAutoResize
+        -- height changes pin to the bottom (instead of the simple "delta > 1px" gate which let
+        -- +/-1px steps slip through and made the bar crawl upward over time). Skip the correction
+        -- while the user is dragging the window so their placement isn't fought.
+        local petBarCanMove = not gConfig.lockPositions or (showConfig and showConfig[1] and gConfig.petBarPreview);
+        local petBarDragging = petBarCanMove and imgui.IsMouseDragging(0) and imgui.IsWindowHovered();
+        if resizeAnchoredBottom then
+            local curBottom = windowPosY + windowHeight;
+            if data.petBarSyncResizeAnchorNextFrame then
+                -- Cluster drag from PetBarTarget just moved us; re-sync the anchor to the new bottom.
+                windowState.anchorBottom = curBottom;
+                data.petBarSyncResizeAnchorNextFrame = false;
+            elseif windowState.anchorBottom == nil or positionJustApplied then
+                -- First frame after open / save-restore: seed the anchor from the current bottom.
+                windowState.anchorBottom = curBottom;
+            elseif petBarDragging then
+                -- User is dragging; track the bottom edge live so the anchor follows.
+                windowState.anchorBottom = curBottom;
             else
-                windowState.x = windowPosX;
-                windowState.y = windowPosY;
-                windowState.height = windowHeight;
+                local newPosY = windowState.anchorBottom - windowHeight;
+                if math.abs(newPosY - windowPosY) > 0.01 then
+                    imgui.SetWindowPos('PetBar', { windowPosX, newPosY });
+                    windowPosY = newPosY;
+                end
             end
+
+            windowState.x = windowPosX;
+            windowState.y = windowPosY;
+            windowState.height = windowHeight;
+        else
+            windowState.x = nil;
+            windowState.y = nil;
+            windowState.height = nil;
+            windowState.anchorBottom = nil;
         end
 
-        -- Store main window position for pet target window (top = stable anchor for snap Y offset)
-        data.lastMainWindowPosX = windowPosX;
-        data.lastMainWindowTop = windowPosY;
-        data.lastMainWindowBottom = windowPosY + windowHeight + 4;
+        -- Store main window position for pet target window snap (rounded to integers so saved
+        -- snap offsets aren't drifted by subpixel noise across re-renders).
+        data.lastMainWindowPosX = math.floor(windowPosX + 0.5);
+        data.lastMainWindowTop = math.floor(windowPosY + 0.5);
+        -- Themed window borders extend above/below the ImGui outer rect (~NoBackground + windowBg).
+        -- Top snap must reference a line above the ImGui top edge or the visual gap collapses
+        -- to zero; +4 below remains the bottom-snap default that pairs with petTargetSnapOffsetY.
+        local petBarTopSnapOutset = 8;
+        data.petBarSnapTopReferenceY = data.lastMainWindowTop - petBarTopSnapOutset;
+        data.lastMainWindowBottom = math.floor(windowPosY + windowHeight + 0.5) + 4;
+        data.lastPetBarWindowHeight = math.floor(windowHeight + 0.5);
+
+        DrawResizeAnchorEdgePreview(windowPosX, windowPosY, windowWidth, windowHeight, resizeAnchoredBottom);
 
         -- Cache window size for next frame's bg draw at the top of this function.
         windowState.cachedWidth = windowWidth;
         windowState.cachedHeight = windowHeight;
+
+        SaveWindowPosition('PetBar');
     end
     imgui.End();
 
@@ -1226,6 +1301,11 @@ display.ResetPositions = function()
     if gConfig.appliedPositions then
         gConfig.appliedPositions['PetBar'] = nil;
     end
+    -- Clear bottom-anchor tracking so the next frame re-seeds against the default position.
+    windowState.x = nil;
+    windowState.y = nil;
+    windowState.height = nil;
+    windowState.anchorBottom = nil;
 end
 
 return display;

--- a/XIUI/modules/petbar/pettarget.lua
+++ b/XIUI/modules/petbar/pettarget.lua
@@ -1,11 +1,12 @@
 --[[
 * XIUI Pet Bar - Pet Target Module
 * Displays information about what the pet is targeting
-* Separate window that appears below the main pet bar
+* Separate window that can snap below or above the main pet bar (Snap to Pet Bar settings)
 ]]--
 
 require('common');
 require('handlers.helpers');
+require('handlers.imgui_compat');
 local imgui = require('imgui');
 local imtext = require('libs.imtext');
 local windowBg = require('libs.windowbackground');
@@ -17,6 +18,81 @@ local pettarget = {};
 
 -- Previous-frame window size cache (used for bg layering below content on the draw list)
 local cachedWindowSize = { width = nil, height = nil };
+
+-- ============================================
+-- Snap + Cluster Drag State Helpers
+-- ============================================
+
+local function clearPetTargetSpatialState()
+    data.petBarTargetHitRect = nil;
+    data.petBarClusterDragActive = false;
+end
+
+local function pointInPetTargetHitRect(px, py, r)
+    return r and px >= r.x and px <= r.x + r.w and py >= r.y and py <= r.y + r.h;
+end
+
+local function anyImGuiItemHovered()
+    local ok, v = pcall(function() return imgui.IsAnyItemHovered(); end);
+    return ok and v;
+end
+
+-- While Pet Target is snapped + NoInputs (so it can't steal clicks from hotbars
+-- stacked underneath), ImGui won't report hover/drag on this window. We instead
+-- use the last-frame outer-rect (data.petBarTargetHitRect) + MouseDelta to drag
+-- the whole pet bar cluster (PetBar) when the user click-drags within the rect.
+local function maybeDragSnappedPetClusterFromTarget(snapEnabled)
+    local canClusterMove = not gConfig.lockPositions or (showConfig and showConfig[1] and gConfig.petBarPreview);
+    if not (snapEnabled and canClusterMove and data.petBarTargetHitRect) then
+        if not snapEnabled then
+            data.petBarClusterDragActive = false;
+        end
+        return;
+    end
+
+    local r = data.petBarTargetHitRect;
+    local mx, my = imgui.GetMousePos();
+    local inRect = pointInPetTargetHitRect(mx, my, r);
+
+    if imgui.IsMouseClicked(0) then
+        -- Begin cluster drag only when click lands in our rect AND no ImGui item
+        -- claims the click (so e.g. an icon button doesn't get hijacked).
+        if inRect and not anyImGuiItemHovered() then
+            data.petBarClusterDragActive = true;
+        else
+            data.petBarClusterDragActive = false;
+        end
+    end
+    if imgui.IsMouseReleased(0) then
+        data.petBarClusterDragActive = false;
+    end
+
+    if data.petBarClusterDragActive and imgui.IsMouseDown(0) and imgui.IsMouseDragging(0) then
+        local io = imgui.GetIO();
+        local mdx, mdy = 0, 0;
+        if io then
+            if io.MouseDelta then
+                mdx = tonumber(io.MouseDelta.x) or 0;
+                mdy = tonumber(io.MouseDelta.y) or 0;
+            end
+            if mdx == 0 and mdy == 0 then
+                mdx = tonumber(io.MouseDeltaX) or 0;
+                mdy = tonumber(io.MouseDeltaY) or 0;
+            end
+        end
+        if mdx ~= 0 or mdy ~= 0 then
+            local bx = tonumber(data.lastMainWindowPosX) or 0;
+            local by = tonumber(data.lastMainWindowTop) or 0;
+            imgui.SetWindowPos('PetBar', { bx + mdx, by + mdy });
+            data.petBarSyncResizeAnchorNextFrame = true;
+            data.lastMainWindowPosX = math.floor(bx + mdx + 0.5);
+            data.lastMainWindowTop = math.floor(by + mdy + 0.5);
+            data.petBarSnapTopReferenceY = data.lastMainWindowTop - 8;
+            local ph = tonumber(data.lastPetBarWindowHeight) or 0;
+            data.lastMainWindowBottom = math.floor(data.lastMainWindowTop + ph + 0.5) + 4;
+        end
+    end
+end
 
 local function DrawBackground(drawList, x, y, width, height, settings)
     -- Get scale from active pet type settings (same pattern as petbar data.lua)
@@ -60,6 +136,7 @@ function pettarget.DrawWindow(settings)
 
     -- Only show if we have a valid pet (prevents showing when "Always Visible" is on but no pet)
     if data.GetPetData() == nil then
+        clearPetTargetSpatialState();
         return;
     end
 
@@ -73,18 +150,21 @@ function pettarget.DrawWindow(settings)
     else
         -- Only show if pet target tracking is enabled and we have a target
         if gConfig.petBarShowTarget == false or data.petTargetServerId == nil then
+            clearPetTargetSpatialState();
             return;
         end
 
         -- Check if pet is targeting itself (e.g., after self-buff like Aerial Armor)
         local petEntity = data.GetPetEntity();
         if petEntity and petEntity.ServerId and data.petTargetServerId == petEntity.ServerId then
+            clearPetTargetSpatialState();
             return;
         end
 
         local targetEnt = data.GetEntityByServerId(data.petTargetServerId);
         if targetEnt == nil or targetEnt.ActorPointer == 0 or targetEnt.HPPercent <= 0 then
             data.petTargetServerId = nil;
+            clearPetTargetSpatialState();
             return;
         end
 
@@ -102,23 +182,79 @@ function pettarget.DrawWindow(settings)
     -- Get pet target specific color config
     local colorConfig = gConfig.colorCustomization and gConfig.colorCustomization.petTarget or {};
 
-    -- Handle snap to petbar positioning (anchor: bottom = offset from bottom, top = offset from top so it stays static when buffs change height)
+    -- Snap-to-petbar positioning.
+    -- Anchor semantics (pet bar uses AlwaysAutoResize; coordinates are ImGui outer rect, NoDecoration):
+    --   bottom: PetBarTarget window TOP = pet bar bottom (+ small border fudge in lastMainWindowBottom) + offsetY (positive = down).
+    --   top:    PetBarTarget window TOP = pet bar visual top - target height + offsetY - topGap (see petBarSnapTopReferenceY).
+    -- Snap must win over ApplyWindowPosition (otherwise first-frame Always apply from disk overwrites the snapped position).
     local snapEnabled = gConfig.petTargetSnapToPetBar;
-    local anchor = gConfig.petTargetSnapAnchor or 'bottom';
-    local anchorY = (anchor == 'top' and data.lastMainWindowTop) or data.lastMainWindowBottom;
-    if snapEnabled and data.lastMainWindowPosX ~= nil and anchorY ~= nil then
-        local snapOffsetX = (gConfig.petTargetSnapOffsetX or 0) * gs;
-        local snapOffsetY = (gConfig.petTargetSnapOffsetY or 16) * gs;
-        local snapX = data.lastMainWindowPosX + snapOffsetX;
-        local snapY = anchorY + snapOffsetY;
-        imgui.SetNextWindowPos({snapX, snapY}, ImGuiCond_Always);
+    local snapAnchor = gConfig.petTargetSnapAnchor or 'bottom';
+    local snapOffsetX = (gConfig.petTargetSnapOffsetX or 0) * gs;
+    local snapOffsetY = gConfig.petTargetSnapOffsetY;
+    if snapOffsetY == nil then
+        snapOffsetY = (snapAnchor == 'top') and -6 or 16;
+    end
+    -- Bottom-anchor uses positive Y below the bar; top-anchor uses non-positive Y. A leftover +16 from bottom mode would otherwise leave a visible gap.
+    if snapAnchor == 'top' and snapOffsetY > 0 then
+        snapOffsetY = 0;
+    end
+    snapOffsetY = snapOffsetY * gs;
+
+    maybeDragSnappedPetClusterFromTarget(snapEnabled);
+
+    if not snapEnabled then
+        -- Only apply persisted position when we're not snapping; snap mode positions us ourselves.
+        ApplyWindowPosition('PetBarTarget');
+    end
+    if snapEnabled and data.lastMainWindowPosX ~= nil then
+        local snapX = math.floor(data.lastMainWindowPosX + snapOffsetX + 0.5);
+        local snapY;
+        if snapAnchor == 'top' then
+            -- Height: prefer last-frame measurement, then profile cache (stable across loads), then a safe default.
+            local th = tonumber(data.lastPetBarTargetWindowHeight)
+                or tonumber(gConfig.petTargetSnapCachedHeight)
+                or 52;
+            th = math.floor(th + 0.5);
+            -- petTargetSnapTopGap: buffer between target window bottom and pet bar top (nil = default 5).
+            local topGap = tonumber(gConfig.petTargetSnapTopGap);
+            if topGap == nil then
+                topGap = 5;
+            end
+            if topGap < 0 then topGap = 0; end
+            topGap = math.floor(topGap + 0.5);
+            local barTopY = math.floor(tonumber(data.petBarSnapTopReferenceY) or tonumber(data.lastMainWindowTop) or 0);
+            snapY = math.floor(barTopY - th + snapOffsetY - topGap + 0.5);
+        else
+            local bottomY = data.lastMainWindowBottom;
+            if bottomY ~= nil then
+                snapY = math.floor(bottomY + snapOffsetY + 0.5);
+            end
+        end
+        if snapY ~= nil then
+            imgui.SetNextWindowPos({ snapX, snapY }, ImGuiCond_Always);
+        end
     end
 
     if (gConfig.lockPositions and not isPreview) or snapEnabled then
         windowFlags = bit.bor(windowFlags, ImGuiWindowFlags_NoMove);
     end
 
-    ApplyWindowPosition('PetBarTarget');
+    -- When snapped, treat as part of the pet bar cluster: don't steal mouse from hotbars
+    -- stacked underneath (NoInputs). Cluster drag is implemented via maybeDragSnappedPetClusterFromTarget.
+    -- When unsnapped, omit NoInputs so user can move/drop normally.
+    if snapEnabled then
+        local noInputs = ImGuiWindowFlags_NoInputs;
+        if noInputs == nil or noInputs == 0 then
+            if ImGuiWindowFlags_NoMouseInputs and ImGuiWindowFlags_NoNavInputs then
+                noInputs = bit.bor(ImGuiWindowFlags_NoMouseInputs, ImGuiWindowFlags_NoNavInputs);
+            else
+                noInputs = 1536; -- NoMouseInputs|NoNavInputs (Dear ImGui ~1.83); last resort if globals missing
+            end
+        end
+        if noInputs ~= 0 then
+            windowFlags = bit.bor(windowFlags, noInputs);
+        end
+    end
     if imgui.Begin('PetBarTarget', true, windowFlags) then
         SaveWindowPosition('PetBarTarget');
         local targetWinPosX, targetWinPosY = imgui.GetWindowPos();
@@ -224,8 +360,27 @@ function pettarget.DrawWindow(settings)
         end
         imtext.Draw(drawList, distStr, distDrawX, distDrawY, distanceColor, targetDistanceFontSize);
 
-        -- Cache window size for next frame's bg draw
-        cachedWindowSize.width, cachedWindowSize.height = imgui.GetWindowSize();
+        -- Cache window size for next frame's bg draw and for top-snap height math
+        local targetWinWidth, targetWinHeight = imgui.GetWindowSize();
+        cachedWindowSize.width, cachedWindowSize.height = targetWinWidth, targetWinHeight;
+
+        -- Persist height for cluster math + next-session top-snap placement.
+        local hRounded = math.floor(tonumber(targetWinHeight) + 0.5);
+        data.lastPetBarTargetWindowHeight = hRounded;
+        if snapEnabled and snapAnchor == 'top' then
+            local prev = gConfig.petTargetSnapCachedHeight;
+            if prev ~= hRounded then
+                gConfig.petTargetSnapCachedHeight = hRounded;
+            end
+        end
+
+        -- Outer rect used by maybeDragSnappedPetClusterFromTarget when NoInputs blocks hover detection.
+        data.petBarTargetHitRect = {
+            x = math.floor(targetWinPosX + 0.5),
+            y = math.floor(targetWinPosY + 0.5),
+            w = math.floor(tonumber(targetWinWidth) + 0.5),
+            h = math.floor(tonumber(targetWinHeight) + 0.5),
+        };
     end
     imgui.End();
 end
@@ -238,6 +393,9 @@ function pettarget.UpdateVisuals(settings)
 end
 
 function pettarget.SetHidden(hidden)
+    if hidden then
+        clearPetTargetSpatialState();
+    end
 end
 
 function pettarget.Cleanup()


### PR DESCRIPTION
…d cluster drag

What changed
- display.lua / data.lua: Global gConfig.petBarResizeAnchor (top vs bottom pinned edge when auto-resize changes height). PetBarResizeAnchoredBottom prefers that value and falls back to legacy per-type alignBottom until migration runs. Stable bottom-edge math for align-bottom resize. Preview Mode stripes the anchored edge. Cache lastPetBarTargetWindowHeight for snap placement. petBarTargetHitRect for cluster drag. petBarSyncResizeAnchorNextFrame for cluster drag anchor sync.
- pettarget.lua: Snap-with-top places Pet Target above the pet bar using last-frame window height plus offsets. Skips ApplyWindowPosition when snap wins. Snap Y/X defaults corrected (no sideways offset for top preset). Input-blocking (NoInputs flag) when snapped so pet bar input events do not pass through. petTargetSnapCachedHeight persisted across sessions. clearPetTargetSpatialState() on hide paths.
- config/petbar.lua: Resize anchor combo above Preview Mode. Pet Target anchor help/presets ASCII-only labels.
- migration.lua / user.lua: Migrate petBarResizeAnchor from legacy per-type alignBottom. Repair petTargetSnapOffsetX >= 100 when anchor is top. Default petBarResizeAnchor in factory defaults.
- handlers/imgui_compat.lua: Hover detection helpers used by pet target cluster drag.
- handlers/helpers.lua: ApplyWindowPosition returns true on the frame it applies a saved position so callers can distinguish load/relog from user drag.

Why
- Resize behavior is one global HUD choice regardless of Pet Target snapping or disconnected target window. Top snap aligns vertically above the pet bar instead of drifting sideways from old preset offsets. Cluster drag moves pet bar and pet target together as a single unit.