### PR TITLE
Fixed Gil Tracker Not Rendering

### DIFF
--- a/XIUI/modules/giltracker.lua
+++ b/XIUI/modules/giltracker.lua
@@ -117,7 +117,7 @@ giltracker.DrawWindow = function(settings)
 
 	-- Detect invalid reads: if gil changes by millions in a single frame, it's likely
 	-- garbage data from zoning - skip this frame but don't reset tracking
-	if lastKnownGil ~= nil then
+	if lastKnownGil ~= nil and lastKnownGil > 0 then
 		local frameDiff = math.abs(currentGil - lastKnownGil);
 		-- If changed by more than 10 million in one frame, skip (likely zone garbage)
 		if frameDiff > 10000000 then


### PR DESCRIPTION
- Reverted the relaxed framediff change which caused the tracker to not render for players with over 10m gil https://github.com/tirem/XIUI/commit/5d3d7820e79e32f02f2fd8a76a53818f0391ee37
  - The issue is that when `lastKnownGil` is 0 (initialized or legitimately zero gil), any real gil amount over 10M triggers the garbage check and causes a `return`. Adding `lastKnownGil > 0` means the garbage filter only activates once a real non-zero baseline is established, so players with 10M+ gil won't get stuck after a zone where `lastKnownGil` was briefly 0.