### PR TITLE
Fixed Macro Crashes and Item Dropdown Performance

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -968,6 +968,11 @@ ashita.events.register('d3d_present', 'present_cb', function ()
         -- triggers another cache clear.
         TextureManager.FlushPendingReleases();
 
+        -- Process deferred icon cache clears scheduled by macro CRUD last frame.
+        -- Must run AFTER FlushPendingReleases (so prior evictions are safe) and
+        -- BEFORE any rendering this frame (so stale caches don't produce wrong icons).
+        macropalette.FlushPendingFrameWork();
+
         -- Clear internal save flag (deferred for Ashita 4.3+ async callbacks)
         if bPendingInternalSaveClear then
             bInternalSave = false;

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -433,6 +433,8 @@ end
 -- ============================================
 
 function M.HandleZonePacket()
+    -- Flush any pending macro/slot saves before zone transition
+    macropalette.FlushPendingSave();
     data.Clear();
     petpalette.ClearPetState();
     -- Clear availability cache since player state is invalid during zone

--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -66,6 +66,12 @@ local function MarkHotbarDirty()
     hotbarDataDirty = true;
 end
 
+-- Deferred icon cache clear: dropping texture references mid-render-frame lets
+-- GC release D3D COM objects whose pointers are still queued in ImGui's draw
+-- list, causing EXCEPTION_ACCESS_VIOLATION. We schedule the clear and execute
+-- it at the TOP of the next d3d_present (after TextureManager.FlushPendingReleases).
+local pendingIconCacheClear = false;
+
 -- Helper to generate abbreviated text from action name (max 4 chars)
 -- If preferAction is true, prioritize action name over displayName (for previews)
 local function GetActionAbbreviation(macro, preferAction)
@@ -105,6 +111,11 @@ local function GetActionAbbreviation(macro, preferAction)
 end
 
 -- Helper to clear all hotbar/crossbar icon caches (full clear - expensive)
+-- IMPORTANT: This must only run at the TOP of d3d_present, never mid-frame.
+-- Clearing texturePtrCache mid-frame drops the last Lua reference to D3D
+-- texture tables, making them GC-eligible. If GC fires (e.g. from the heavy
+-- string allocations in SerializeLegacy), it releases COM objects whose
+-- pointers are still queued in the current frame's ImGui draw list → crash.
 local slotrenderer = nil;  -- Lazy-loaded
 local function ClearAllIconCaches()
     -- Lazy-load display to avoid circular dependency
@@ -144,6 +155,20 @@ local function ClearAllIconCaches()
     -- on edited macros are picked up next frame.
     if actions and actions.ClearNoIconCache then
         actions.ClearNoIconCache();
+    end
+end
+
+-- When true, FlushPendingFrameWork also calls slotrenderer.ClearAllCache
+-- (needed for pet palette switches that change which abilities are visible).
+local pendingFullSlotCacheClear = false;
+
+-- Schedule icon cache clear for the start of the next frame instead of
+-- executing it immediately. Call this from mid-frame code paths (button
+-- handlers, save callbacks) that must not drop texture references.
+local function ScheduleIconCacheClear(includeFullSlotCache)
+    pendingIconCacheClear = true;
+    if includeFullSlotCache then
+        pendingFullSlotCacheClear = true;
     end
 end
 
@@ -476,6 +501,21 @@ local itemIconLoadState = {
     batchSize = 500,  -- Load 500 items per frame (fast since we're just reading names)
 };
 
+-- Browsing icon cache for DrawSearchableCombo dropdowns.
+-- Creating a D3D texture via D3DXCreateTextureFromFileInMemoryEx for every
+-- item every frame while a dropdown is open tanks FPS (461 items → 15 FPS).
+-- Instead we pre-load all icons once into this cache in batches spread across
+-- frames, and show "Loading..." until ready.
+local browsingIconCache = {
+    icons = {},       -- icons[itemId] = { image = cdata, ... } or false (no icon)
+    itemIds = nil,    -- array of item IDs to load (set when loading starts)
+    loadIndex = 0,    -- how far through itemIds we've loaded
+    loaded = false,   -- true when all icons are cached
+    loading = false,  -- true while batches are in progress
+    batchSize = 25,   -- D3D texture creations per frame (heavier than name reads)
+    generation = 0,   -- bumped when item list changes, invalidates stale caches
+};
+
 -- ============================================
 -- Spell/Ability/Weaponskill Retrieval (via shared playerdata module)
 -- ============================================
@@ -621,6 +661,93 @@ local function GetItemLoadProgress()
         return 100;
     end
     return math.floor((itemIconLoadState.currentId / itemIconLoadState.maxId) * 100);
+end
+
+-- Start pre-loading browsing icons for a list of items.
+-- Returns immediately; call LoadBrowsingIconBatch() each frame to make progress.
+local function StartBrowsingIconLoad(items)
+    if not items or #items == 0 then
+        browsingIconCache.loaded = true;
+        browsingIconCache.loading = false;
+        return;
+    end
+
+    -- Build the list of item IDs that need loading
+    local ids = {};
+    for _, item in ipairs(items) do
+        if item.id and item.id > 0 and item.id ~= 65535 then
+            -- Skip if already cached from a previous load
+            if browsingIconCache.icons[item.id] == nil then
+                ids[#ids + 1] = item.id;
+            end
+        end
+    end
+
+    if #ids == 0 then
+        browsingIconCache.loaded = true;
+        browsingIconCache.loading = false;
+        return;
+    end
+
+    browsingIconCache.itemIds = ids;
+    browsingIconCache.loadIndex = 0;
+    browsingIconCache.loaded = false;
+    browsingIconCache.loading = true;
+end
+
+-- Load a batch of browsing icons (call once per frame while loading).
+local function LoadBrowsingIconBatch()
+    if browsingIconCache.loaded or not browsingIconCache.loading then
+        return;
+    end
+
+    local ids = browsingIconCache.itemIds;
+    if not ids then return; end
+
+    local endIdx = math.min(browsingIconCache.loadIndex + browsingIconCache.batchSize, #ids);
+
+    for i = browsingIconCache.loadIndex + 1, endIdx do
+        local itemId = ids[i];
+        if browsingIconCache.icons[itemId] == nil then
+            local icon = textures:LoadItemIconFromMemory(itemId);
+            -- Store the texture (or false as a negative cache entry)
+            browsingIconCache.icons[itemId] = icon or false;
+        end
+    end
+
+    browsingIconCache.loadIndex = endIdx;
+
+    if browsingIconCache.loadIndex >= #ids then
+        browsingIconCache.loaded = true;
+        browsingIconCache.loading = false;
+        browsingIconCache.itemIds = nil;
+    end
+end
+
+-- Get a browsing icon from the pre-built cache (O(1), no D3D calls).
+local function GetBrowsingIcon(itemId)
+    local cached = browsingIconCache.icons[itemId];
+    if cached and cached ~= false then
+        return cached;
+    end
+    return nil;
+end
+
+-- Get browsing icon load progress (0-100).
+local function GetBrowsingIconProgress()
+    if browsingIconCache.loaded then return 100; end
+    if not browsingIconCache.itemIds or #browsingIconCache.itemIds == 0 then return 0; end
+    return math.floor((browsingIconCache.loadIndex / #browsingIconCache.itemIds) * 100);
+end
+
+-- Invalidate browsing icon cache (call when player inventory changes).
+local function InvalidateBrowsingIconCache()
+    browsingIconCache.icons = {};
+    browsingIconCache.itemIds = nil;
+    browsingIconCache.loadIndex = 0;
+    browsingIconCache.loaded = false;
+    browsingIconCache.loading = false;
+    browsingIconCache.generation = browsingIconCache.generation + 1;
 end
 
 -- ============================================
@@ -912,12 +1039,25 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
     -- Get the slot mask for filtering if provided
     local slotMask = equipSlotFilter and EQUIP_SLOT_MASKS[equipSlotFilter] or nil;
 
+    local iconsReady = not showIcons;  -- true when icons aren't requested
+
     -- Apply XIUI styling to combo popup
     PushComboStyle();
 
     imgui.SetNextItemWidth(220);
     -- Use HeightLargest so popup fits our child window without its own scrollbar
     if imgui.BeginCombo(label, displayText, ImGuiComboFlags_HeightLargest) then
+        -- Kick off batched icon loading when the popup is open so we never
+        -- call D3DXCreateTextureFromFileInMemoryEx inside the item loop.
+        if showIcons and items and #items > 0 then
+            if not browsingIconCache.loaded and not browsingIconCache.loading then
+                StartBrowsingIconLoad(items);
+            end
+            if browsingIconCache.loading then
+                LoadBrowsingIconBatch();
+            end
+            iconsReady = browsingIconCache.loaded;
+        end
         -- Search input at top (fixed, not scrollable)
         imgui.SetNextItemWidth(200);
         imgui.PushStyleColor(ImGuiCol_Text, COLORS.text);
@@ -932,6 +1072,13 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
         end
 
         imgui.Separator();
+
+        -- Show loading indicator while icons are being cached
+        if showIcons and not iconsReady then
+            local progress = GetBrowsingIconProgress();
+            imgui.TextColored(COLORS.textMuted, string.format('Loading icons... %d%%', progress));
+            imgui.Separator();
+        end
 
         -- Scrollable child region for items only
         local childHeight = 200;
@@ -966,10 +1113,9 @@ local function DrawSearchableCombo(label, items, currentValue, onSelect, showIco
                     imgui.PushStyleColor(ImGuiCol_Text, textColor);
                 end
 
-                -- Show icon if enabled and item has an id
-                if showIcons and item.id then
-                    -- Use memory-only loading (no PNG creation) for browsing
-                    local icon = actions.GetItemIconForBrowsing(item.id);
+                -- Show icon from pre-built cache (no D3D calls during rendering)
+                if showIcons and iconsReady and item.id then
+                    local icon = GetBrowsingIcon(item.id);
                     if icon and icon.image then
                         local iconPtr = tonumber(ffi.cast("uint32_t", icon.image));
                         if iconPtr then
@@ -1068,6 +1214,7 @@ function M.SyncToCurrentJob()
     end
     -- Clear spell/ability/item caches so they rebuild for new job
     playerdata.ClearCache();
+    InvalidateBrowsingIconCache();
     cachedPetCommands = nil;
     petAvatarFilter = 1;
     selectedAvatarPalette = nil;
@@ -1120,7 +1267,7 @@ function M.AddMacro(macroData)
 
     macroData.id = maxId + 1;
     table.insert(db, macroData);
-    SaveSettingsToDisk();
+    MarkHotbarDirty();
     data.MarkMacroLookupDirty();
 
     return macroData.id;
@@ -1134,9 +1281,10 @@ function M.UpdateMacro(macroId, macroData)
         if macro.id == macroId then
             macroData.id = macroId;  -- Preserve ID
             db[i] = macroData;
-            SaveSettingsToDisk();
-            -- Clear icon cache so hotbar slots referencing this macro update
-            ClearAllIconCaches();
+            MarkHotbarDirty();
+            -- Defer icon cache clear to next frame start to avoid dropping
+            -- D3D texture references while ImGui draw list still holds pointers
+            ScheduleIconCacheClear();
             data.MarkMacroLookupDirty();
             return true;
         end
@@ -1200,9 +1348,9 @@ function M.DeleteMacro(macroId)
             table.remove(db, i);
             -- Clear any hotbar/crossbar slots referencing this macro
             ClearSlotsReferencingMacro(macroId, typeKey);
-            SaveSettingsToDisk();
-            -- Clear icon cache so hotbar slots update immediately
-            ClearAllIconCaches();
+            MarkHotbarDirty();
+            -- Defer icon cache clear to next frame start
+            ScheduleIconCacheClear();
             data.MarkMacroLookupDirty();
             return true;
         end
@@ -1411,6 +1559,7 @@ function M.ClosePalette()
     editingMacro = nil;
     isCreatingNew = false;
     currentPalettePage = 1;  -- Reset to page 1
+    InvalidateBrowsingIconCache();
 end
 
 function M.IsPaletteOpen()
@@ -1678,6 +1827,7 @@ function M.DrawPalette()
                 currentPalettePage = 1;
                 -- Clear caches to force refresh
                 playerdata.ClearCache();
+                InvalidateBrowsingIconCache();
                 cachedPetCommands = nil;
                 petAvatarFilter = 1;
             end
@@ -1729,6 +1879,7 @@ function M.DrawPalette()
                     currentPalettePage = 1;    -- Reset to page 1 when switching types
                     -- Clear caches to force refresh
                     playerdata.ClearCache();
+                    InvalidateBrowsingIconCache();
                     cachedPetCommands = nil;
                     petAvatarFilter = 1;
                 end
@@ -1893,9 +2044,7 @@ function M.DrawPalette()
 
                         if imgui.Selectable('Automatic', isAutoSelected) then
                             petpalette.SetPalette(barIndex, nil);
-                            local slotrenderer = require('modules.hotbar.slotrenderer');
-                            slotrenderer.ClearAllCache();
-                            ClearAllIconCaches();
+                            ScheduleIconCacheClear(true);
                         end
                         imgui.PopStyleColor();
 
@@ -1920,9 +2069,7 @@ function M.DrawPalette()
 
                                 if imgui.Selectable('  ' .. summon.name, isSelected) then
                                     petpalette.SetPalette(barIndex, petKey);
-                                    local slotrenderer = require('modules.hotbar.slotrenderer');
-                                    slotrenderer.ClearAllCache();
-                                    ClearAllIconCaches();
+                                    ScheduleIconCacheClear(true);
                                 end
                                 imgui.PopStyleColor();
 
@@ -1949,9 +2096,7 @@ function M.DrawPalette()
 
                                 if imgui.Selectable('  ' .. summon.name, isSelected) then
                                     petpalette.SetPalette(barIndex, petKey);
-                                    local slotrenderer = require('modules.hotbar.slotrenderer');
-                                    slotrenderer.ClearAllCache();
-                                    ClearAllIconCaches();
+                                    ScheduleIconCacheClear(true);
                                 end
                                 imgui.PopStyleColor();
 
@@ -3839,6 +3984,26 @@ function M.FlushPendingSave()
     if hotbarDataDirty then
         SaveSettingsToDisk();
         hotbarDataDirty = false;
+    end
+end
+
+-- Process deferred work at the start of each frame.
+-- Call AFTER TextureManager.FlushPendingReleases so that any textures queued
+-- for release last frame have already been handled before we drop new refs.
+function M.FlushPendingFrameWork()
+    if pendingIconCacheClear then
+        pendingIconCacheClear = false;
+        if pendingFullSlotCacheClear then
+            pendingFullSlotCacheClear = false;
+            if slotrenderer == nil then
+                local success, mod = pcall(require, 'modules.hotbar.slotrenderer');
+                if success then slotrenderer = mod; end
+            end
+            if slotrenderer and slotrenderer.ClearAllCache then
+                slotrenderer.ClearAllCache();
+            end
+        end
+        ClearAllIconCaches();
     end
 end
 


### PR DESCRIPTION
- Resolves #351 

---

This is an attempt to fix the following:
- Fixed a crash that occurred when saving, editing, or renaming macros in the macro palette.
- The crash was caused by D3D textures being freed mid-render frame when icon caches were cleared during a save, leading to the game accessing released memory.
- Changed macro saves to use the existing dirty flag system instead of writing the entire profile to disk immediately during the render frame.
- Moved icon cache clearing to the start of the next frame so texture references are safely dropped after rendering completes.
- Added a save flush on zone change so macro changes are not lost if the player zones before closing the palette.

Additionally this commit also fixes the following (with video proof):
- Fixed severe FPS drops when opening item or equipment dropdown menus in the macro editor.
- Item icons are now pre-loaded in small batches across multiple frames instead of creating a new D3D texture for every item every frame.
- Added a loading indicator that shows progress while item icons are being cached
- Items are still browsable and selectable while icons load in the background.

I've attached the following 2 videos that show the fps drop from BEFORE this PR (first video) and AFTER this PR (second video):

https://github.com/user-attachments/assets/ca32aecf-6f42-40b9-9b6c-04c23d74edde

https://github.com/user-attachments/assets/6b59773e-68df-4362-a3c2-fb0e52aef9be