### PR TITLE
Fixed Crash On First Load When No Settings Exist

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -307,7 +307,7 @@ local migrationResult = settingsMigration.MigrateFromHXUI();
 -- Load raw settings to detect legacy data (without default filtering)
 -- Use pcall to handle first-load case where no settings exist
 local rawSettingsSuccess, rawSettings = pcall(function()
-    return settings.load({});
+    return settings.load(T{ });
 end);
 if not rawSettingsSuccess then
     rawSettings = {}; -- No existing settings, nothing to migrate
@@ -460,7 +460,7 @@ end
 -- ==========================================================
 
 -- Load character settings (tracks which profile is active)
-local charSettings = settings.load({ currentProfile = 'Default' });
+local charSettings = settings.load(T{ currentProfile = 'Default' });
 config = charSettings; -- Keep reference to character config
 
 -- Global profiles list


### PR DESCRIPTION
Resolves Discord Issue: [Link to Discord Post](https://discord.com/channels/1070070739761381507/1503834590618320906/1505437232276705352)

<img width="635" height="153" alt="image" src="https://github.com/user-attachments/assets/7185a347-a64b-4461-8588-caa452052ae8" />


- Fixed an error that caused XIUI to crash and unload when a user had no existing settings files.
  - This mainly affected new users loading the addon for the first time or switching characters without saved settings.
  - Changed settings tables to use the correct format expected by the Ashita settings library.