### PR TITLE
Fixed SetCursorPos Error In Ashita 4.3

### DIFF
--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -3235,6 +3235,7 @@ function M.DrawMacroEditor()
         -- Get screen position for icon preview (DrawIconPreview needs screen coords)
         local screenPos = {imgui.GetCursorScreenPos()};
         DrawIconPreview(editingMacro, screenPos[1], screenPos[2], iconPreviewSize);
+        imgui.Dummy({iconPreviewSize, iconPreviewSize});
 
         -- Change Icon button below preview (use window-relative SetCursorPos for scroll support)
         imgui.SetCursorPos({iconPreviewX - 10, startCursorY + iconPreviewSize + 8});

--- a/XIUI/modules/targetbar.lua
+++ b/XIUI/modules/targetbar.lua
@@ -675,6 +675,11 @@ targetbar.DrawWindow = function(settings)
 			local totalCastBarSpace = settings.castBarOffsetY + settings.castBarHeight + 2 + castTextHeight;
 			imgui.Dummy({0, totalCastBarSpace});
 		end
+
+		-- ImGui 1.91+: SetCursorPos/SetCursorScreenPos no longer auto-extends window
+		-- content boundaries. Submit a zero-sized Dummy to commit any pending extensions
+		-- from SetCursorPosY (buffsOffsetY) or SetCursorScreenPos (arrow/ToT positioning).
+		imgui.Dummy({0, 0});
     end
     imgui.End();
 


### PR DESCRIPTION
Resolves Discord Issue: [Link to Discord Post](https://discord.com/channels/1070070739761381507/1507662497740488735/1507662497740488735)

<img width="1017" height="371" alt="image" src="https://github.com/user-attachments/assets/0932c3be-4364-4d5e-b594-64aae91070bd" />

- Fixed the `SetCursorPos()/SetCursorScreenPos() to extend window/parent boundaries` error that appeared in Ashita 4.3 due to a newer version of ImGui.
- Added a layout fix to the TargetBar window so the window properly sizes itself after positioning elements like buffs, arrows, and the target of target bar.
- Added a layout fix to the Macro Editor icon preview so the preview area is properly accounted for in the window layout.