### PR TITLE
Expanded Menu Hiding Options

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -153,6 +153,7 @@ uiModules.Register('playerBar', {
     configKey = 'showPlayerBar',
     hideOnEventKey = 'playerBarHideDuringEvents',
     hideOnMenuFocusKey = 'playerBarHideOnMenuFocus',
+    hideMacroPaletteKey = 'playerBarHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('targetBar', {
@@ -161,6 +162,7 @@ uiModules.Register('targetBar', {
     configKey = 'showTargetBar',
     hideOnEventKey = 'targetBarHideDuringEvents',
     hideOnMenuFocusKey = 'targetBarHideOnMenuFocus',
+    hideMacroPaletteKey = 'targetBarHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('enemyList', {
@@ -168,6 +170,7 @@ uiModules.Register('enemyList', {
     settingsKey = 'enemyListSettings',
     configKey = 'showEnemyList',
     hideOnMenuFocusKey = 'enemyListHideOnMenuFocus',
+    hideMacroPaletteKey = 'enemyListHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('expBar', {
@@ -175,6 +178,7 @@ uiModules.Register('expBar', {
     settingsKey = 'expBarSettings',
     configKey = 'showExpBar',
     hideOnMenuFocusKey = 'expBarHideOnMenuFocus',
+    hideMacroPaletteKey = 'expBarHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('gilTracker', {
@@ -182,6 +186,7 @@ uiModules.Register('gilTracker', {
     settingsKey = 'gilTrackerSettings',
     configKey = 'showGilTracker',
     hideOnMenuFocusKey = 'gilTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'gilTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('inventoryTracker', {
@@ -189,6 +194,7 @@ uiModules.Register('inventoryTracker', {
     settingsKey = 'inventoryTrackerSettings',
     configKey = 'showInventoryTracker',
     hideOnMenuFocusKey = 'inventoryTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'inventoryTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('satchelTracker', {
@@ -196,6 +202,7 @@ uiModules.Register('satchelTracker', {
     settingsKey = 'satchelTrackerSettings',
     configKey = 'showSatchelTracker',
     hideOnMenuFocusKey = 'inventoryTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'inventoryTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('lockerTracker', {
@@ -203,6 +210,7 @@ uiModules.Register('lockerTracker', {
     settingsKey = 'lockerTrackerSettings',
     configKey = 'showLockerTracker',
     hideOnMenuFocusKey = 'inventoryTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'inventoryTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('safeTracker', {
@@ -210,6 +218,7 @@ uiModules.Register('safeTracker', {
     settingsKey = 'safeTrackerSettings',
     configKey = 'showSafeTracker',
     hideOnMenuFocusKey = 'inventoryTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'inventoryTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('storageTracker', {
@@ -217,6 +226,7 @@ uiModules.Register('storageTracker', {
     settingsKey = 'storageTrackerSettings',
     configKey = 'showStorageTracker',
     hideOnMenuFocusKey = 'inventoryTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'inventoryTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('wardrobeTracker', {
@@ -224,6 +234,7 @@ uiModules.Register('wardrobeTracker', {
     settingsKey = 'wardrobeTrackerSettings',
     configKey = 'showWardrobeTracker',
     hideOnMenuFocusKey = 'inventoryTrackerHideOnMenuFocus',
+    hideMacroPaletteKey = 'inventoryTrackerHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('partyList', {
@@ -232,6 +243,8 @@ uiModules.Register('partyList', {
     configKey = 'showPartyList',
     hideOnEventKey = 'partyListHideDuringEvents',
     hideOnMenuFocusKey = 'partyListHideOnMenuFocus',
+    hideMacroPaletteKey = 'partyListHideMacroPalette',
+    hideOnlyAllianceOnMenuFocusKey = 'partyListHideOnlyAllianceOnMenuFocus',
     hasSetHidden = true,
 });
 uiModules.Register('castBar', {
@@ -239,6 +252,7 @@ uiModules.Register('castBar', {
     settingsKey = 'castBarSettings',
     configKey = 'showCastBar',
     hideOnMenuFocusKey = 'castBarHideOnMenuFocus',
+    hideMacroPaletteKey = 'castBarHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('castCost', {
@@ -246,6 +260,7 @@ uiModules.Register('castCost', {
     settingsKey = 'castCostSettings',
     configKey = 'showCastCost',
     hideOnMenuFocusKey = 'castCostHideOnMenuFocus',
+    hideMacroPaletteKey = 'castCostHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('mobInfo', {
@@ -253,6 +268,7 @@ uiModules.Register('mobInfo', {
     settingsKey = 'mobInfoSettings',
     configKey = 'showMobInfo',
     hideOnMenuFocusKey = 'mobInfoHideOnMenuFocus',
+    hideMacroPaletteKey = 'mobInfoHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('petBar', {
@@ -261,6 +277,7 @@ uiModules.Register('petBar', {
     configKey = 'showPetBar',
     hideOnEventKey = 'petBarHideDuringEvents',
     hideOnMenuFocusKey = 'petBarHideOnMenuFocus',
+    hideMacroPaletteKey = 'petBarHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('notifications', {
@@ -269,6 +286,7 @@ uiModules.Register('notifications', {
     configKey = 'showNotifications',
     hideOnEventKey = 'notificationsHideDuringEvents',
     hideOnMenuFocusKey = 'notificationsHideOnMenuFocus',
+    hideMacroPaletteKey = 'notificationsHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('treasurePool', {
@@ -276,6 +294,7 @@ uiModules.Register('treasurePool', {
     settingsKey = 'treasurePoolSettings',
     configKey = 'treasurePoolEnabled',
     hideOnMenuFocusKey = 'treasurePoolHideOnMenuFocus',
+    hideMacroPaletteKey = 'treasurePoolHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('hotbar', {
@@ -284,6 +303,7 @@ uiModules.Register('hotbar', {
     configKey = 'showhotbar',
     hideOnEventKey = 'hotbarHideDuringEvents',
     hideOnMenuFocusKey = 'hotbarHideOnMenuFocus',
+    hideMacroPaletteKey = 'hotbarHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('readyCheck', {

--- a/XIUI/config/castbar.lua
+++ b/XIUI/config/castbar.lua
@@ -24,8 +24,7 @@ end
 -- Section: Cast Bar Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showCastBar', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'castBarHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('castBarHideOnMenuFocus', 'castBarHideMacroPalette');
 
     if components.CollapsingSection('Display Options##castBar') then
         components.DrawCheckbox('Show Bookends', 'showCastBarBookends');

--- a/XIUI/config/castcost.lua
+++ b/XIUI/config/castcost.lua
@@ -14,8 +14,7 @@ local M = {};
 -- Section: Cast Cost Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showCastCost', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'castCostHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('castCostHideOnMenuFocus', 'castCostHideMacroPalette');
 
     if components.CollapsingSection('Display Options##castCost') then
         components.DrawPartyCheckbox(gConfig.castCost, 'Spell/Ability Name', 'showName');

--- a/XIUI/config/components.lua
+++ b/XIUI/config/components.lua
@@ -458,6 +458,36 @@ function components.DrawCheckbox(label, configKey, callback)
     end
 end
 
+-- Draw "Hide When Menu Open" with optional indented sub-options
+-- @param hideOnMenuFocusKey: config key for hide when menu open
+-- @param hideMacroPaletteKey: optional config key for macro palette exception
+-- @param hideOnlyAllianceKey: optional config key for party list alliance-only hide
+function components.DrawHideWhenMenuOpenOptions(hideOnMenuFocusKey, hideMacroPaletteKey, hideOnlyAllianceKey)
+    components.DrawCheckbox('Hide When Menu Open', hideOnMenuFocusKey);
+    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+
+    if not gConfig[hideOnMenuFocusKey] then
+        return;
+    end
+
+    local showMacroPaletteOption = hideMacroPaletteKey
+        and not (gConfig.hotbarGlobal and gConfig.hotbarGlobal.disableMacroBars);
+    if not showMacroPaletteOption and not hideOnlyAllianceKey then
+        return;
+    end
+
+    imgui.Indent(components.INDENT_SIZE);
+    if showMacroPaletteOption then
+        components.DrawCheckbox('Hide Macro Palette', hideMacroPaletteKey);
+        imgui.ShowHelp('Keep this module visible when the in-game macro palette is open.');
+    end
+    if hideOnlyAllianceKey then
+        components.DrawCheckbox('Hide Only Alliance', hideOnlyAllianceKey);
+        imgui.ShowHelp('Keep main party visible when a game menu is open(equipment, map, etc.).');
+    end
+    imgui.Unindent(components.INDENT_SIZE);
+end
+
 -- Helper function for slider with deferred save (top-level gConfig keys)
 function components.DrawSlider(label, configKey, min, max, format, callback)
     local value = { gConfig[configKey] };

--- a/XIUI/config/enemylist.lua
+++ b/XIUI/config/enemylist.lua
@@ -13,8 +13,7 @@ local M = {};
 -- Section: Enemy List Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showEnemyList', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'enemyListHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('enemyListHideOnMenuFocus', 'enemyListHideMacroPalette');
     components.DrawCheckbox('Preview Enemies (when config open)', 'enemyListPreview');
 
     if components.CollapsingSection('Display Options##enemyList') then

--- a/XIUI/config/expbar.lua
+++ b/XIUI/config/expbar.lua
@@ -13,8 +13,7 @@ local M = {};
 -- Section: Exp Bar Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showExpBar', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'expBarHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('expBarHideOnMenuFocus', 'expBarHideMacroPalette');
 
     if components.CollapsingSection('Display Options##expBar') then
         components.DrawCheckbox('Limit Points Mode', 'expBarLimitPointsMode');

--- a/XIUI/config/giltracker.lua
+++ b/XIUI/config/giltracker.lua
@@ -14,8 +14,7 @@ local M = {};
 -- Section: Gil Tracker Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showGilTracker', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'gilTrackerHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('gilTrackerHideOnMenuFocus', 'gilTrackerHideMacroPalette');
 
     if components.CollapsingSection('Display Options##gilTracker') then
         components.DrawCheckbox('Show Icon', 'gilTrackerShowIcon');

--- a/XIUI/config/hotbar.lua
+++ b/XIUI/config/hotbar.lua
@@ -2537,8 +2537,7 @@ function M.DrawSettings(state)
         DeferredUpdateVisuals();
     end);
     imgui.ShowHelp('When enabled, prevents dragging/dropping and swapping of hotbar and crossbar slots.');
-    components.DrawCheckbox('Hide When Menu Open', 'hotbarHideOnMenuFocus');
-    imgui.ShowHelp('Hide hotbars when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('hotbarHideOnMenuFocus', 'hotbarHideMacroPalette');
 
     -- Disable XI macros checkbox (stored in hotbarGlobal)
     local disableMacroBars = { gConfig.hotbarGlobal.disableMacroBars or false };

--- a/XIUI/config/inventory.lua
+++ b/XIUI/config/inventory.lua
@@ -66,8 +66,7 @@ end
 -- Helper function to draw settings for a tracker
 local function DrawTrackerSettings(tab)
     components.DrawCheckbox('Enabled', tab.configKey, CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'inventoryTrackerHideOnMenuFocus');
-    imgui.ShowHelp('Hide all inventory trackers when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('inventoryTrackerHideOnMenuFocus', 'inventoryTrackerHideMacroPalette');
 
     if components.CollapsingSection('Display Options##' .. tab.colorKey) then
         components.DrawCheckbox('Show Dots', tab.showDotsKey);

--- a/XIUI/config/notifications.lua
+++ b/XIUI/config/notifications.lua
@@ -221,8 +221,7 @@ end
 -- Section: Notifications Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showNotifications', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'notificationsHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('notificationsHideOnMenuFocus', 'notificationsHideMacroPalette');
     components.DrawCheckbox('Hide During Events', 'notificationsHideDuringEvents');
 
     -- Group count slider (outside collapsible sections)

--- a/XIUI/config/partylist.lua
+++ b/XIUI/config/partylist.lua
@@ -298,8 +298,11 @@ function M.DrawSettings(state)
     local selectedPartyTab = state.selectedPartyTab or 1;
 
     components.DrawCheckbox('Enabled', 'showPartyList', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'partyListHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions(
+        'partyListHideOnMenuFocus',
+        'partyListHideMacroPalette',
+        'partyListHideOnlyAllianceOnMenuFocus'
+    );
     components.DrawCheckbox('Preview Full Party (when config open)', 'partyListPreview');
 
     -- Global settings (shared across all parties)

--- a/XIUI/config/petbar.lua
+++ b/XIUI/config/petbar.lua
@@ -1045,8 +1045,7 @@ end
 -- Helper: Draw Pet Bar specific settings (used in tab)
 local function DrawPetBarSettingsContent()
     components.DrawCheckbox('Enabled', 'showPetBar', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'petBarHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('petBarHideOnMenuFocus', 'petBarHideMacroPalette');
     components.DrawCheckbox('Hide During Events', 'petBarHideDuringEvents');
     components.DrawCheckbox('Preview Mode', 'petBarPreview');
     imgui.ShowHelp('Show the pet bar with mock data. Preview shows the pet type from the selected tab below.');

--- a/XIUI/config/playerbar.lua
+++ b/XIUI/config/playerbar.lua
@@ -13,8 +13,7 @@ local M = {};
 -- Section: Player Bar Settings
 function M.DrawSettings()
     components.DrawCheckbox('Enabled', 'showPlayerBar', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'playerBarHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('playerBarHideOnMenuFocus', 'playerBarHideMacroPalette');
 
     if components.CollapsingSection('Display Options##playerBar') then
         components.DrawCheckbox('Show Bookends', 'showPlayerBarBookends');

--- a/XIUI/config/targetbar.lua
+++ b/XIUI/config/targetbar.lua
@@ -36,8 +36,7 @@ end
 -- Helper: Draw Target Bar specific settings (used in tab)
 local function DrawTargetBarSettingsContent()
     components.DrawCheckbox('Enabled', 'showTargetBar', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'targetBarHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('targetBarHideOnMenuFocus', 'targetBarHideMacroPalette');
 
     if components.CollapsingSection('Display Options##targetBar') then
         -- Show Name with position dropdown
@@ -174,8 +173,7 @@ end
 -- Helper: Draw Mob Info specific settings (used in tab)
 local function DrawMobInfoSettingsContent(githubTexture)
     components.DrawCheckbox('Enabled', 'showMobInfo', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'mobInfoHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('mobInfoHideOnMenuFocus', 'mobInfoHideMacroPalette');
 
     -- Attribution for Thorny's MobDB (on same line as Enabled)
     imgui.SameLine();

--- a/XIUI/config/treasurepool.lua
+++ b/XIUI/config/treasurepool.lua
@@ -63,8 +63,7 @@ function M.DrawSettings()
     ensureDefaults();
 
     components.DrawCheckbox('Enabled', 'treasurePoolEnabled', CheckVisibility);
-    components.DrawCheckbox('Hide When Menu Open', 'treasurePoolHideOnMenuFocus');
-    imgui.ShowHelp('Hide this module when a game menu is open (equipment, map, etc.).');
+    components.DrawHideWhenMenuOpenOptions('treasurePoolHideOnMenuFocus', 'treasurePoolHideMacroPalette');
     components.DrawCheckbox('Preview', 'treasurePoolPreview', onPreviewChanged);
 
     if components.CollapsingSection('Display Settings', true) then

--- a/XIUI/core/gamestate.lua
+++ b/XIUI/core/gamestate.lua
@@ -67,14 +67,45 @@ local IGNORED_MENUS = {
     magic    = true,  -- Magic / Trust menu
     abiselec = true,  -- Abilities side menu
     ability  = true,  -- JA, WS, Pet commands
+    mount    = true,  -- Mount menu
 };
 
-function M.IsMenuOpen()
+local MACRO_PALETTE_MENUS = {
+    mcr1pall = true,  -- Macro palette page 1
+    mcr2pall = true,  -- Macro palette page 2
+};
+
+function M.GetMenuShortName()
     local menuName = M.GetMenuName():gsub('%s+$', '');
-    if menuName == '' then return false; end
-    -- Extract the short name (strip "menu" prefix and internal whitespace)
-    local shortName = menuName:match('^menu%s+(.+)') or menuName;
+    if menuName == '' then return ''; end
+    return menuName:match('^menu%s+(.+)') or menuName;
+end
+
+function M.IsMacroPaletteOpen()
+    return MACRO_PALETTE_MENUS[M.GetMenuShortName()] == true;
+end
+
+function M.IsMenuOpen()
+    local shortName = M.GetMenuShortName();
+    if shortName == '' then return false; end
     return not IGNORED_MENUS[shortName];
+end
+
+-- Whether a module with "Hide When Menu Open" should hide for the current menu state
+function M.ShouldHideModuleOnMenuFocus(gConfig, hideOnMenuFocusKey, hideMacroPaletteKey)
+    if not hideOnMenuFocusKey or not gConfig[hideOnMenuFocusKey] then
+        return false;
+    end
+    if not M.IsMenuOpen() then
+        return false;
+    end
+    if hideMacroPaletteKey and gConfig[hideMacroPaletteKey] then
+        local disableMacroBars = gConfig.hotbarGlobal and gConfig.hotbarGlobal.disableMacroBars;
+        if not disableMacroBars and M.IsMacroPaletteOpen() then
+            return false;
+        end
+    end
+    return true;
 end
 
 -- Check if Ashita's FontManager has been hidden (e.g., by autohide addon)

--- a/XIUI/core/moduleregistry.lua
+++ b/XIUI/core/moduleregistry.lua
@@ -4,6 +4,7 @@
 ]]--
 
 local chat = require('chat');
+local gameState = require('core.gamestate');
 
 local M = {};
 
@@ -14,6 +15,8 @@ local M = {};
 --   configKey: key in gConfig for visibility (optional)
 --   hideOnEventKey: config key for hiding during events (optional)
 --   hideOnMenuFocusKey: config key for hiding when game menu is open (optional)
+--   hideMacroPaletteKey: config key to keep module visible when macro palette is open (optional)
+--   hideOnlyAllianceOnMenuFocusKey: config key to hide only alliance parties on menu open (optional)
 --   hasSetHidden: whether module has SetHidden function
 local registry = {};
 
@@ -103,8 +106,16 @@ function M.RenderModule(name, gConfig, gAdjustedSettings, eventSystemActive, men
     end
 
     -- Check menu focus hiding
-    if shouldShow and entry.hideOnMenuFocusKey and menuOpen then
-        shouldShow = not gConfig[entry.hideOnMenuFocusKey];
+    local menuHideActive = gameState.ShouldHideModuleOnMenuFocus(
+        gConfig,
+        entry.hideOnMenuFocusKey,
+        entry.hideMacroPaletteKey
+    );
+    local partialAllianceHide = menuHideActive and entry.hideOnlyAllianceOnMenuFocusKey
+        and gConfig[entry.hideOnlyAllianceOnMenuFocusKey];
+
+    if shouldShow and menuHideActive and not partialAllianceHide then
+        shouldShow = false;
     end
 
     if shouldShow then

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -46,6 +46,22 @@ function M.createUserSettingsDefaults()
         hotbarHideOnMenuFocus = false,
         mobInfoHideOnMenuFocus = false,
 
+        playerBarHideMacroPalette = false,
+        targetBarHideMacroPalette = false,
+        enemyListHideMacroPalette = false,
+        expBarHideMacroPalette = false,
+        gilTrackerHideMacroPalette = false,
+        inventoryTrackerHideMacroPalette = false,
+        partyListHideMacroPalette = false,
+        partyListHideOnlyAllianceOnMenuFocus = false,
+        castBarHideMacroPalette = false,
+        petBarHideMacroPalette = false,
+        castCostHideMacroPalette = false,
+        notificationsHideMacroPalette = false,
+        treasurePoolHideMacroPalette = false,
+        hotbarHideMacroPalette = false,
+        mobInfoHideMacroPalette = false,
+
         -- Treasure Pool settings
         treasurePoolEnabled = true,           -- Show treasure pool when items in pool
         treasurePoolShowTimerBar = true,      -- Show countdown progress bar

--- a/XIUI/modules/partylist/display.lua
+++ b/XIUI/modules/partylist/display.lua
@@ -17,6 +17,7 @@ local ashita_settings = require('settings');
 local castcostShared = require('modules.castcost.shared');
 local defaultPositions = require('libs.defaultpositions');
 local imtext = require('libs.imtext');
+local gameState = require('core.gamestate');
 
 local data = require('modules.partylist.data');
 
@@ -1413,8 +1414,17 @@ function display.DrawWindow(settings)
     -- Main party window
     display.DrawPartyWindow(settings, party, 1);
 
+    local hideAllianceOnMenu = gameState.ShouldHideModuleOnMenuFocus(
+        gConfig,
+        'partyListHideOnMenuFocus',
+        'partyListHideMacroPalette'
+    ) and gConfig.partyListHideOnlyAllianceOnMenuFocus;
+
     -- Alliance party windows
-    if (gConfig.partyListAlliance) then
+    if hideAllianceOnMenu then
+        data.UpdateTextVisibility(false, 2);
+        data.UpdateTextVisibility(false, 3);
+    elseif (gConfig.partyListAlliance) then
         display.DrawPartyWindow(settings, party, 2);
         display.DrawPartyWindow(settings, party, 3);
     else


### PR DESCRIPTION
Resolves #354 

---

- Added a handler to `gamestate.lua` to handle the Menu Hiding logic.
- Added a new option to keep modules visible when the macro palette is open.
- Added a party list option to hide only alliance windows when a menu is open.
- Added the mount menu to the ignored menu list so it does not hide UI.
- Updated all module settings to show these new options under Hide When Menu Open.