### PR TITLE
Fixed Hotbar Macros To Wait For Subtarget Selection

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -1410,6 +1410,10 @@ ashita.events.register('command', 'command_cb', function (e)
                 -- Toggle hotbar debug mode
                 local currentState = hotbar.IsDebugEnabled();
                 hotbar.SetDebugEnabled(not currentState);
+            elseif moduleName == 'subtarget' then
+                -- Toggle subtarget macro debug (ST wait/confirm/cancel only)
+                local currentState = hotbar.IsSubtargetDebugEnabled();
+                hotbar.SetSubtargetDebugEnabled(not currentState);
             elseif moduleName == 'macroblock' then
                 -- Toggle macro block debug mode (both memory patches AND controller)
                 local macrosLib = require('libs.ffxi.macros');
@@ -1428,7 +1432,7 @@ ashita.events.register('command', 'command_cb', function (e)
                 local currentState = hotbar.IsPaletteDebugEnabled();
                 hotbar.SetPaletteDebugEnabled(not currentState);
             else
-                print('[XIUI] Debug modules: hotbar, macroblock, rawinput, palette');
+                print('[XIUI] Debug modules: hotbar, subtarget, macroblock, rawinput, palette');
                 print('[XIUI] Usage: /xiui debug <module>');
             end
             return;

--- a/XIUI/libs/target.lua
+++ b/XIUI/libs/target.lua
@@ -50,14 +50,40 @@ function M.GetSubTargetActive()
         return true;
     end
 
-    -- Fallback: Check if there's a valid entity in sub-target slot (index 1)
-    -- that differs from main target - indicates sub-targeting even if API doesn't report it
+    -- Fallback: stpc/st with no main target still puts cursor in sub slot
     local mainTarget = playerTarget:GetTargetIndex(0);
     local subTarget = playerTarget:GetTargetIndex(1);
-    if mainTarget ~= 0 and subTarget ~= 0 and subTarget ~= mainTarget then
+    if mainTarget == 0 and subTarget ~= 0 then
         return true;
     end
 
+    return false;
+end
+
+--- Raw main/sub target slot indices from the game (slot 0 = main, slot 1 = sub/cursor).
+function M.GetTargetSlotIndices()
+    local playerTarget = AshitaCore:GetMemoryManager():GetTarget();
+    if playerTarget == nil then
+        return 0, 0;
+    end
+    return playerTarget:GetTargetIndex(0) or 0, playerTarget:GetTargetIndex(1) or 0;
+end
+
+--- True when the player has a main target selected (slot 0).
+function M.HasMainTarget()
+    local main, _ = M.GetTargetSlotIndices();
+    return main ~= 0;
+end
+
+--- True when the game reports target/subtarget selection was dismissed without confirm.
+function M.GetTargetDeactivate()
+    local playerTarget = AshitaCore:GetMemoryManager():GetTarget();
+    if playerTarget == nil then
+        return false;
+    end
+    if playerTarget.GetTargetDeactivate ~= nil then
+        return playerTarget:GetTargetDeactivate() == 1;
+    end
     return false;
 end
 

--- a/XIUI/modules/hotbar/actions.lua
+++ b/XIUI/modules/hotbar/actions.lua
@@ -9,10 +9,16 @@ local data = require('modules.hotbar.data');
 local horizonSpells = require('modules.hotbar.database.horizonspells');
 local textures = require('modules.hotbar.textures');
 local macrosLib = require('libs.ffxi.macros');
+package.loaded['libs.target'] = nil;
+local targetLib = require('libs.target');
+if not targetLib.GetSubTargetActive or not targetLib.HasMainTarget then
+    error('[XIUI] libs/target.lua is missing subtarget helpers; update the addon files and reload.');
+end
 local palette = require('modules.hotbar.palette');
 
--- Debug logging (controlled via /xiui debug hotbar)
+-- Debug logging (controlled via /xiui debug hotbar and /xiui debug subtarget)
 local DEBUG_ENABLED = false;
+local DEBUG_SUBTARGET = false;
 
 local function DebugLog(msg)
     if DEBUG_ENABLED then
@@ -20,10 +26,20 @@ local function DebugLog(msg)
     end
 end
 
+local function SubtargetDebugLog(msg)
+    if DEBUG_SUBTARGET then
+        print('[XIUI Hotbar ST] ' .. msg);
+    end
+end
+
 --- Set debug mode for actions module
 --- @param enabled boolean
 local function SetDebugEnabled(enabled)
     DEBUG_ENABLED = enabled;
+end
+
+local function SetSubtargetDebugEnabled(enabled)
+    DEBUG_SUBTARGET = enabled;
 end
 
 -- ============================================
@@ -875,11 +891,440 @@ local function macroHasWait(lines)
     return false;
 end
 
+-- Slash commands that accept target arguments and can open subtarget selection UI
+local TARGETABLE_COMMANDS = {
+    ma = true,
+    magic = true,
+    ja = true,
+    jobability = true,
+    ws = true,
+    weaponskill = true,
+    ra = true,
+    ranged = true,
+    item = true,
+    pet = true,
+    ta = true,
+    target = true,
+    na = true,
+    ninjutsu = true,
+};
+
+--- Macro mode (2) is only for action commands that need native fallthrough.
+--- Other lines (/echo, etc.) use AshitaParse so literal <stpc> text in messages
+--- is not re-processed by the macro subtarget subsystem.
+local function getMacroCommandQueueMode(commandLine)
+    local cmd = commandLine:match('^/%s*(%S+)');
+    if cmd and TARGETABLE_COMMANDS[cmd:lower()] then
+        return 2;
+    end
+    return -1;
+end
+
+-- Subtarget tags that open the in-game selection UI (<lastst> excluded - reuses prior target)
+local SUBTARGET_TAGS = { 'stpc', 'stpt', 'stal', 'stnpc', 'st' };
+
+local function extractSubtargetTag(line)
+    local unquoted = line:gsub('"[^"]*"', '');
+    for _, tag in ipairs(SUBTARGET_TAGS) do
+        if unquoted:match('<' .. tag .. '>') then
+            return tag;
+        end
+    end
+    return nil;
+end
+
+--- Action command with an ST tag outside quotes (not /echo etc.).
+local function lineRequiresSubtargetPause(line)
+    local cmd = line:match('^/%s*(%S+)');
+    if not cmd or not TARGETABLE_COMMANDS[cmd:lower()] then
+        return false;
+    end
+    return extractSubtargetTag(line) ~= nil;
+end
+
+--- Check if any line in a macro opens subtarget selection
+--- @param lines table Array of command line strings
+--- @return boolean hasSubtarget True if any line requires a subtarget pause
+local function macroHasSubtarget(lines)
+    for _, line in ipairs(lines) do
+        if lineRequiresSubtargetPause(line) then
+            return true;
+        end
+    end
+    return false;
+end
+
+local SUBTARGET_POLL_INTERVAL = 0.05;
+local SUBTARGET_CHOICE_TIMEOUT_SEC = 30.0;
+local SUBTARGET_NO_OPEN_FALLTHROUGH_SEC = 1.0;
+local ST_PRETARGET_MAX_WAIT_SEC = 0.1;
+
+-- Ashita ST re-process modes (command event nType).
+local ST_TAG_MODES = {
+    st = 3, stpc = 4, stnpc = 5, stpt = 6, stal = 7,
+};
+
+-- Pre-target when main slot is empty so ST UI initializes reliably.
+local ST_PRETARGET_COMMANDS = {
+    stpc = '/target <me>',
+    stnpc = '/targetnpc',
+    st = '/target <me>',
+    stpt = '/target <me>',
+    stal = '/target <me>',
+};
+
+local pendingSubtargetWait = nil;
+
+local function shouldApplyStPreTarget(stTag)
+    return stTag ~= nil
+        and ST_PRETARGET_COMMANDS[stTag] ~= nil
+        and not targetLib.HasMainTarget();
+end
+
+local function queueStPreTarget(stTag)
+    local preTarget = ST_PRETARGET_COMMANDS[stTag];
+    if not preTarget then
+        return false;
+    end
+    local ok, err = pcall(function()
+        local chatManager = AshitaCore:GetChatManager();
+        if chatManager then
+            chatManager:QueueCommand(-1, preTarget);
+        end
+    end);
+    if not ok then
+        print('[XIUI] ST pre-target error: ' .. tostring(err));
+        return false;
+    end
+    SubtargetDebugLog(('ST pre-target queued for <%s>: %s'):format(stTag, preTarget));
+    return true;
+end
+
+local function runAfterStPreTarget(onReady, cancelCheck)
+    local deadline = os.clock() + ST_PRETARGET_MAX_WAIT_SEC;
+
+    local function poll()
+        if cancelCheck and cancelCheck() then
+            return;
+        end
+        if targetLib.HasMainTarget() then
+            onReady();
+            return;
+        end
+        if os.clock() >= deadline then
+            SubtargetDebugLog('ST pre-target wait timed out, continuing anyway');
+            onReady();
+            return;
+        end
+        ashita.tasks.once(0, poll);
+    end
+
+    ashita.tasks.once(0, poll);
+end
+
+local function isSubtargetMode(mode)
+    return mode ~= nil and mode >= 3 and mode <= 7;
+end
+
+--- ST re-processing mode (3-7) may appear on nType even when e.mode is still Macro (2).
+local function getSubtargetEventMode(e, nType)
+    if isSubtargetMode(nType) then
+        return nType;
+    end
+    if e ~= nil and isSubtargetMode(e.mode) then
+        return e.mode;
+    end
+    return nil;
+end
+
+local function normalizeCommand(cmd)
+    cmd = tostring(cmd or '');
+    return cmd:lower():gsub('%s+', ' '):match('^%s*(.-)%s*$') or '';
+end
+
+--- Strip <target> tokens so the confirm pass can match even if the tag changes.
+local function stripTargetTokens(cmd)
+    return normalizeCommand(cmd):gsub('<[^>]+>', ''):gsub('%s+', ' '):match('^%s*(.-)%s*$') or '';
+end
+
+local function getExpectedSubtargetMode(stTag)
+    if not stTag then
+        return nil;
+    end
+    return ST_TAG_MODES[stTag];
+end
+
+--- Match /ma "Cure" across both <stpc> and confirm passes like /ma "Cure" 3762.
+local function getCommandActionKey(cmd)
+    local norm = normalizeCommand(cmd);
+    local verb = norm:match('^(/%S+)');
+    local quoted = norm:match('"([^"]*)"');
+    if verb and quoted then
+        return verb .. ':"' .. quoted .. '"';
+    end
+    return stripTargetTokens(norm):gsub('%s+%d+$', '');
+end
+
+local function commandHasStTag(cmd, stTag)
+    if not cmd or not stTag then
+        return false;
+    end
+    return normalizeCommand(cmd):find('<' .. stTag .. '>', 1, true) ~= nil;
+end
+
+local function commandMatchesActionKey(wait, incomingCmd)
+    if not wait or not incomingCmd then
+        return false;
+    end
+    return getCommandActionKey(incomingCmd) == wait.actionKey;
+end
+
+local function isStActivationEvent(e, nType, wait)
+    if not commandMatchesActionKey(wait, e.command) then
+        return false;
+    end
+
+    local stMode = getSubtargetEventMode(e, nType);
+    if stMode == wait.expectedMode and commandHasStTag(e.command, wait.stTag) then
+        return true;
+    end
+
+    -- Initial forward before ST re-process (observed as Typed/Macro with tag still present).
+    if (e.mode == 1 or e.mode == 2) and commandHasStTag(e.command, wait.stTag) then
+        return true;
+    end
+
+    return false;
+end
+
+local function isStResolvedTargetPass(e, nType, wait)
+    if wait.stPassCount < 1 then
+        return false;
+    end
+
+    if getSubtargetEventMode(e, nType) ~= wait.expectedMode then
+        return false;
+    end
+
+    if not commandMatchesActionKey(wait, e.command) then
+        return false;
+    end
+
+    -- Resolved-target passes replace the tag with a concrete target (e.g. server id).
+    if commandHasStTag(e.command, wait.stTag) then
+        return false;
+    end
+
+    return true;
+end
+
+local function clearSubtargetWait(wait)
+    if wait == nil or pendingSubtargetWait == wait then
+        pendingSubtargetWait = nil;
+    end
+end
+
+local function finishSubtargetAdvance(wait, logMsg)
+    if not wait or wait.finished or pendingSubtargetWait ~= wait then
+        return;
+    end
+    wait.finished = true;
+    local onComplete = wait.onComplete;
+    local cancelCheck = wait.cancelCheck;
+    clearSubtargetWait(wait);
+
+    SubtargetDebugLog(logMsg);
+
+    ashita.tasks.once(0, function()
+        if cancelCheck and cancelCheck() then
+            return;
+        end
+        onComplete();
+    end);
+end
+
+local function finishSubtargetTimeout(wait)
+    if not wait or wait.finished or pendingSubtargetWait ~= wait then
+        return;
+    end
+    wait.finished = true;
+    local onAbort = wait.onAbort;
+    local cancelCheck = wait.cancelCheck;
+    clearSubtargetWait(wait);
+
+    SubtargetDebugLog('ST wait timed out, aborting macro');
+
+    if cancelCheck and cancelCheck() then
+        return;
+    end
+    if onAbort then
+        onAbort();
+    end
+end
+
+--- True while ST selection is open and the confirm pass has not arrived yet.
+local function isWaitingForStChoice(wait)
+    if wait.finished then
+        return false;
+    end
+    return wait.sawStOpen or wait.sawStActive;
+end
+
+--- ST selection closed without confirm (cancel / dismiss).
+local function isSubtargetDismissedWithoutConfirm(wait, stActive)
+    if not isWaitingForStChoice(wait) or stActive then
+        return false;
+    end
+    if targetLib.GetTargetDeactivate() then
+        return true;
+    end
+    return wait.sawStActive;
+end
+
+local function onSubtargetCommandEvent(e, nType)
+    local wait = pendingSubtargetWait;
+    if not wait or wait.finished then
+        return;
+    end
+
+    if wait.cancelCheck and wait.cancelCheck() then
+        wait.finished = true;
+        clearSubtargetWait(wait);
+        return;
+    end
+
+    local stMode = getSubtargetEventMode(e, nType);
+
+    SubtargetDebugLog(('ST cmd event e.mode=%s nType=%s stMode=%s expect=%s pass=%d resolved=%d st=%s: %s'):format(
+        tostring(e.mode),
+        tostring(nType),
+        tostring(stMode),
+        tostring(wait.expectedMode),
+        wait.stPassCount,
+        wait.resolvedPassCount or 0,
+        tostring(targetLib.GetSubTargetActive()),
+        tostring(e.command)
+    ));
+
+    if isStActivationEvent(e, nType, wait) and wait.stPassCount == 0 then
+        wait.stPassCount = 1;
+        SubtargetDebugLog('ST activation pass recorded');
+        return;
+    end
+
+    if not isStResolvedTargetPass(e, nType, wait) then
+        return;
+    end
+
+    if targetLib.GetSubTargetActive() then
+        wait.sawStActive = true;
+    end
+
+    if wait.resolvedPassCount == 0 then
+        wait.resolvedPassCount = 1;
+        wait.sawStOpen = true;
+        SubtargetDebugLog('ST open pass (cursor default) recorded');
+        return;
+    end
+
+    if not wait.sawStOpen then
+        SubtargetDebugLog('ST confirm pass ignored (no open pass yet)');
+        return;
+    end
+
+    wait.resolvedPassCount = 2;
+    SubtargetDebugLog('ST confirm pass matched');
+    finishSubtargetAdvance(wait, 'ST wait confirmed, advancing macro');
+end
+
+ashita.events.register('command', 'xiui_subtarget_cmd', function(e, nType)
+    onSubtargetCommandEvent(e, nType);
+end);
+
+--- Pause macro until ST confirm (2nd command pass) or dismiss. Both advance; timeout aborts.
+local function waitForSubtargetComplete(commandLine, onComplete, onAbort, cancelCheck)
+    local stTag = extractSubtargetTag(commandLine);
+    local expectedMode = getExpectedSubtargetMode(stTag);
+
+    pendingSubtargetWait = {
+        actionKey = getCommandActionKey(commandLine),
+        stTag = stTag,
+        expectedMode = expectedMode,
+        stPassCount = 0,
+        resolvedPassCount = 0,
+        sawStOpen = false,
+        sawStActive = false,
+        choiceDeadline = nil,
+        noOpenDeadline = os.clock() + SUBTARGET_NO_OPEN_FALLTHROUGH_SEC,
+        finished = false,
+        cancelCheck = cancelCheck,
+        onComplete = onComplete,
+        onAbort = onAbort,
+    };
+
+    local myWait = pendingSubtargetWait;
+
+    SubtargetDebugLog(('ST wait begin tag=%s expectMode=%s cmd=%s'):format(
+        tostring(stTag),
+        tostring(expectedMode),
+        commandLine
+    ));
+
+    local function poll()
+        if pendingSubtargetWait ~= myWait or myWait.finished then
+            return;
+        end
+
+        local wait = myWait;
+
+        if cancelCheck and cancelCheck() then
+            SubtargetDebugLog('ST wait superseded by newer macro');
+            myWait.finished = true;
+            clearSubtargetWait(myWait);
+            return;
+        end
+
+        local stActive = targetLib.GetSubTargetActive();
+        if stActive then
+            wait.sawStActive = true;
+        end
+
+        if isWaitingForStChoice(wait) then
+            if not wait.choiceDeadline then
+                wait.choiceDeadline = os.clock() + SUBTARGET_CHOICE_TIMEOUT_SEC;
+            end
+
+            if isSubtargetDismissedWithoutConfirm(wait, stActive) then
+                finishSubtargetAdvance(wait, 'ST wait ended (cancelled), advancing macro');
+                return;
+            end
+
+            if os.clock() >= wait.choiceDeadline then
+                finishSubtargetTimeout(wait);
+                return;
+            end
+
+            ashita.tasks.once(SUBTARGET_POLL_INTERVAL, poll);
+            return;
+        end
+
+        if os.clock() >= wait.noOpenDeadline then
+            finishSubtargetAdvance(wait, 'ST wait fallthrough (selection never opened)');
+            return;
+        end
+
+        ashita.tasks.once(SUBTARGET_POLL_INTERVAL, poll);
+    end
+
+    ashita.tasks.once(0, poll);
+end
+
 --- Execute a command string (handles multi-line macros with /wait support)
 --- Splits by newlines and executes each non-empty line in sequence
---- For macros WITHOUT waits: queues all lines synchronously using Macro mode (2)
---- so the game processes them as a native macro batch with fallthrough behavior.
---- For macros WITH waits: uses Ashita's task scheduler for proper delay handling.
+--- For macros WITHOUT waits or subtarget pauses: queues all lines synchronously using
+--- Macro mode (2) so the game processes them as a native macro batch with fallthrough.
+--- For macros WITH waits or subtarget lines: sequential execution via task scheduler.
+--- ST lines pause until confirm or dismiss (Ashita command events + target memory).
 --- Also handles inline <wait #> subcommands at end of command lines.
 --- @param commandText string The command text (may contain newlines)
 --- @param isMacro boolean|nil If true, enforces single-macro-at-a-time execution
@@ -905,17 +1350,22 @@ function M.ExecuteCommandString(commandText, isMacro)
 
     local myMacroId = nil;
     if isMacro then
+        -- Block new macros only while the game reports subtarget mode is active.
+        if targetLib.GetSubTargetActive() then
+            SubtargetDebugLog('Ignoring macro keypress while game subtarget mode is active');
+            return false;
+        end
         activeMacroId = activeMacroId + 1;
         myMacroId = activeMacroId;
     end
 
-    -- SYNCHRONOUS FAST PATH: For macros without any wait directives, queue all
+    -- SYNCHRONOUS FAST PATH: For macros without wait or subtarget directives, queue all
     -- lines in the same frame using mode 2 (Macro). This tells the game engine
     -- these commands come from the macro subsystem, enabling native fallthrough
     -- behavior where failed commands (e.g., wrong WS for equipped weapon) are
     -- skipped and the next line is tried automatically.
     -- NOTE: The game's macro command stack is LIFO, so we queue in reverse order.
-    if isMacro and not macroHasWait(lines) then
+    if isMacro and not macroHasWait(lines) and not macroHasSubtarget(lines) then
         local ok, err = pcall(function()
             local chatManager = AshitaCore:GetChatManager();
             if chatManager then
@@ -933,24 +1383,37 @@ function M.ExecuteCommandString(commandText, isMacro)
         return true;
     end
 
-    -- ASYNC PATH: For macros with wait directives or non-macro commands.
-    -- Recursive function to execute lines with proper /wait handling.
+    -- ASYNC PATH: For macros with wait/subtarget directives or non-macro commands.
+    -- Recursive function to execute lines with proper /wait and subtarget handling.
     -- This chains tasks instead of scheduling them all at once.
-    local function executeNextLine(index)
+    local function isMacroCancelled()
+        return myMacroId ~= nil and myMacroId ~= activeMacroId;
+    end
+
+    local executeNextLine;
+
+    local function scheduleNextLine(index, delay)
+        if index > #lines then
+            return;
+        end
+        ashita.tasks.once(delay or 0, function()
+            executeNextLine(index);
+        end);
+    end
+
+    executeNextLine = function(index)
         if index > #lines then
             return;
         end
 
         -- If this is a macro flow, bail out when a newer macro has started
-        if myMacroId and myMacroId ~= activeMacroId then
+        if isMacroCancelled() then
             return;
         end
 
         local line = lines[index]:match('^%s*(.-)%s*$');  -- Trim whitespace
         if line == '' then
-            ashita.tasks.once(0, function()
-                executeNextLine(index + 1);
-            end);
+            scheduleNextLine(index + 1, 0);
             return;
         end
 
@@ -962,35 +1425,56 @@ function M.ExecuteCommandString(commandText, isMacro)
         if waitMatch then
             -- It's a wait command - schedule the next line after the delay
             local delay = tonumber(waitMatch) or 1;
-            ashita.tasks.once(delay, function()
-                executeNextLine(index + 1);
-            end);
+            scheduleNextLine(index + 1, delay);
         else
             -- Parse inline <wait #> subcommand
             local commandToExecute, inlineWait = parseInlineWait(line);
+            local requiresSubtargetPause = lineRequiresSubtargetPause(commandToExecute);
 
             -- PROTECTED command execution
-            -- Use mode 2 (Macro) for macro flows to get native fallthrough,
-            -- mode -1 (AshitaParse) for non-macro single commands
-            local cmdMode = isMacro and 2 or -1;
-            local ok, err = pcall(function()
-                local chatManager = AshitaCore:GetChatManager();
-                if chatManager then
-                    chatManager:QueueCommand(cmdMode, commandToExecute);
+            -- Use mode 2 (Macro) for macro action commands to get native fallthrough,
+            -- mode -1 (AshitaParse) for /echo and other non-action lines
+            local cmdMode = isMacro and getMacroCommandQueueMode(commandToExecute) or -1;
+            local stTag = requiresSubtargetPause and extractSubtargetTag(commandToExecute) or nil;
+
+            local function queueActionLine()
+                if requiresSubtargetPause then
+                    waitForSubtargetComplete(commandToExecute, function()
+                        if index < #lines then
+                            scheduleNextLine(index + 1, inlineWait or 0);
+                        end
+                    end, function()
+                        if myMacroId == activeMacroId then
+                            activeMacroId = activeMacroId + 1;
+                        end
+                    end, isMacroCancelled);
                 end
-            end);
 
-            if not ok then
-                print('[XIUI] Command execution error: ' .. tostring(err));
-            end
-
-            -- Schedule next line with inline wait delay if found
-            if index < #lines then
-                local delay = inlineWait or 0;
-                ashita.tasks.once(delay, function()
-                    executeNextLine(index + 1);
+                local ok, err = pcall(function()
+                    local chatManager = AshitaCore:GetChatManager();
+                    if chatManager then
+                        chatManager:QueueCommand(cmdMode, commandToExecute);
+                    end
                 end);
+
+                if not ok then
+                    print('[XIUI] Command execution error: ' .. tostring(err));
+                end
+
+                if index < #lines and not requiresSubtargetPause then
+                    scheduleNextLine(index + 1, inlineWait or 0);
+                end
             end
+
+            local function executeCommandLine()
+                if stTag and shouldApplyStPreTarget(stTag) and queueStPreTarget(stTag) then
+                    runAfterStPreTarget(queueActionLine, isMacroCancelled);
+                    return;
+                end
+                queueActionLine();
+            end
+
+            executeCommandLine();
         end
     end
 
@@ -1270,6 +1754,16 @@ end
 --- Get debug mode state
 function M.IsDebugEnabled()
     return DEBUG_ENABLED;
+end
+
+--- Set subtarget debug mode (called via /xiui debug subtarget)
+function M.SetSubtargetDebugEnabled(enabled)
+    SetSubtargetDebugEnabled(enabled);
+end
+
+--- Get subtarget debug mode state
+function M.IsSubtargetDebugEnabled()
+    return DEBUG_SUBTARGET;
 end
 
 --- Set palette debug mode (called via /xiui debug palette)

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -587,9 +587,21 @@ function M.SetDebugEnabled(enabled)
     print('[XIUI] Hotbar debug mode: ' .. state);
 end
 
+-- Toggle subtarget macro debug (actions only)
+-- Usage: /xiui debug subtarget
+function M.SetSubtargetDebugEnabled(enabled)
+    actions.SetSubtargetDebugEnabled(enabled);
+    local state = enabled and 'ON' or 'OFF';
+    print('[XIUI] Subtarget debug mode: ' .. state);
+end
+
 -- Check if debug is enabled
 function M.IsDebugEnabled()
     return actions.IsDebugEnabled() or controller.IsDebugEnabled();
+end
+
+function M.IsSubtargetDebugEnabled()
+    return actions.IsSubtargetDebugEnabled();
 end
 
 -- Toggle palette key debug mode


### PR DESCRIPTION
- Resolves #280 

---

- Made hotbar macros pause on subtarget lines until you confirmed or canceled the subtarget select.
- Matched native game behavior where canceling a subtarget still continued the macro instead of stopping it.
- Matched native game behavior where executing a new macro will be blocked while the game already had subtarget mode open.
- Added a short pre-target step when you had nothing selected so subtarget macro lines executed reliably.
  - This is to workaround an issue where a macro would not continue if a target was not present before going into subtarget mode.
- Fixed echo and wait lines in macros so they ran at the right time and did not get stuck on subtarget text.
- Added /xiui debug subtarget to help troubleshoot subtarget macro behavior.
- Cleaned up target helper code used by the hotbar.