### PR TITLE
Added Anchored Hotbar Layout Option

### DIFF
--- a/XIUI/config/hotbar.lua
+++ b/XIUI/config/hotbar.lua
@@ -1502,6 +1502,71 @@ function M.IsCapturingKeybind()
 end
 
 -- Helper: Draw visual settings (shared between global and per-bar when not using global)
+
+local POSITION_MODE_LABELS = { 'Absolute', 'Anchored' };
+local ANCHORED_CHECKBOX_COLUMN_WIDTH = 200;
+
+local function DrawAnchoredBarCheckbox(barSettings, barIndex, configKey)
+    if not barSettings then
+        return;
+    end
+
+    local isEnabled = barSettings.enabled ~= false;
+    if not isEnabled then
+        barSettings.anchoredInStack = false;
+        imgui.BeginDisabled();
+    end
+
+    components.DrawPartyCheckbox(
+        barSettings,
+        'Hotbar ' .. barIndex .. '##' .. configKey .. 'anchored',
+        'anchoredInStack',
+        DeferredUpdateVisuals
+    );
+
+    if not isEnabled then
+        imgui.EndDisabled();
+    end
+end
+
+local function DrawHotbarPositionSettings(configKey)
+    if configKey ~= 'hotbarGlobal' then
+        return;
+    end
+
+    local globalSettings = gConfig.hotbarGlobal;
+    local currentPositionMode = (globalSettings.positionMode == 'anchored') and 'Anchored' or 'Absolute';
+    components.DrawComboBox('Position Mode##hotbarPosition', currentPositionMode, POSITION_MODE_LABELS, function(newValue)
+        globalSettings.positionMode = (newValue == 'Anchored') and 'anchored' or 'absolute';
+        SaveSettingsOnly();
+        DeferredUpdateVisuals();
+    end);
+    imgui.ShowHelp('Absolute: each hotbar moves independently.\nAnchored: selected hotbars stack bottom-up as one group.');
+
+    if globalSettings.positionMode ~= 'anchored' then
+        return;
+    end
+
+    imgui.Spacing();
+    imgui.TextColored({0.75, 0.75, 0.75, 1.0}, 'Bars to anchor (stacked bottom-up):');
+
+    local columnStartX = imgui.GetCursorPosX();
+    for row = 1, 3 do
+        imgui.SetCursorPosX(columnStartX);
+        DrawAnchoredBarCheckbox(gConfig['hotbarBar' .. row], row, 'hotbarBar' .. row);
+
+        imgui.SameLine();
+        imgui.SetCursorPosX(columnStartX + ANCHORED_CHECKBOX_COLUMN_WIDTH);
+        local rightBar = row + 3;
+        DrawAnchoredBarCheckbox(gConfig['hotbarBar' .. rightBar], rightBar, 'hotbarBar' .. rightBar);
+    end
+
+    imgui.Spacing();
+    components.DrawPartySliderInt(globalSettings, 'Hotbar Spacing##' .. configKey, 'hotbarSpacing', 0, 32, '%d', DeferredUpdateVisuals, 0);
+    imgui.ShowHelp('Vertical gap between hotbars when anchored.');
+    imgui.Spacing();
+end
+
 local function DrawVisualSettingsContent(settings, configKey)
     if components.CollapsingSection('Background##' .. configKey, false) then
         local bgThemes = {'-None-', 'Plain', 'Window1', 'Window2', 'Window3', 'Window4', 'Window5', 'Window6', 'Window7', 'Window8'};
@@ -1519,9 +1584,17 @@ local function DrawVisualSettingsContent(settings, configKey)
 
         components.DrawPartySlider(settings, 'Border Opacity##' .. configKey, 'borderOpacity', 0.0, 1.0, '%.2f');
         imgui.ShowHelp('Opacity of the window borders (Window themes only).');
+
+        components.DrawPartySliderInt(settings, 'Background Padding X##' .. configKey, 'backgroundPaddingX', 0, 32, '%d', nil, 0);
+        imgui.ShowHelp('Horizontal space between the window background and the slot grid.');
+
+        components.DrawPartySliderInt(settings, 'Background Padding Y##' .. configKey, 'backgroundPaddingY', 0, 32, '%d', nil, 0);
+        imgui.ShowHelp('Vertical space between the window background and the slot grid. In Anchored mode, padding applies only to the outer top and bottom of the stacked group.');
     end
 
     if components.CollapsingSection('Slot Settings##' .. configKey, false) then
+        DrawHotbarPositionSettings(configKey);
+
         components.DrawPartySliderInt(settings, 'Slot Size (px)##' .. configKey, 'slotSize', 16, 64, '%d', nil, 48);
         imgui.ShowHelp('Size of each slot in pixels.');
 
@@ -1706,6 +1779,9 @@ local function DrawBarVisualSettings(configKey, barLabel)
 
     -- Enabled checkbox at top
     components.DrawPartyCheckbox(barSettings, 'Enabled##' .. configKey, 'enabled');
+    if barSettings.enabled == false then
+        barSettings.anchoredInStack = false;
+    end
     imgui.ShowHelp('Enable or disable this hotbar.');
 
     -- Use Global Settings checkbox

--- a/XIUI/core/settings/factories.lua
+++ b/XIUI/core/settings/factories.lua
@@ -312,6 +312,14 @@ function M.createHotbarGlobalDefaults()
         slotXPadding = 8,
         slotYPadding = 6,
 
+        -- Bar positioning (hotbar only; crossbar unchanged)
+        positionMode = 'absolute',  -- 'absolute' or 'anchored'
+        hotbarSpacing = 0,        -- Vertical gap between anchored hotbars
+
+        -- Gap between window background edge and slot grid
+        backgroundPaddingX = 0,
+        backgroundPaddingY = 0,
+
         -- Slot appearance
         slotBackgroundColor = 0x55000000,
 
@@ -375,6 +383,7 @@ function M.createHotbarBarDefaults(overrides)
 
         -- Layout settings (always per-bar)
         enabled = true,
+        anchoredInStack = true,  -- Include in bottom-up stack when positionMode is anchored
         rows = 1,               -- Number of rows (1-12)
         columns = 12,           -- Number of columns (1-12)
         slots = 12,             -- Total slots, auto-calculated from rows*columns
@@ -397,6 +406,10 @@ function M.createHotbarBarDefaults(overrides)
         -- Slot padding (gap between slots)
         slotXPadding = 8,       -- Horizontal gap between slots
         slotYPadding = 6,       -- Vertical gap between rows
+
+        -- Gap between window background edge and slot grid (used when bar overrides global visuals)
+        backgroundPaddingX = 0,
+        backgroundPaddingY = 0,
 
         -- Slot appearance
         slotBackgroundColor = 0x55000000,  -- ARGB color for slot backgrounds (black at 33% opacity)

--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -607,6 +607,44 @@ function M.MigrateIndividualSettings(gConfig, defaults)
             if petType.tpFontSize == nil then petType.tpFontSize = oldVitalsFontSize; end
         end
     end
+
+    -- Hotbar anchored layout settings
+    M.MigrateHotbarLayoutSettings(gConfig, defaults);
+end
+
+function M.MigrateHotbarLayoutSettings(gConfig, defaults)
+    local globalDefaults = defaults.hotbarGlobal or {};
+    local globalSettings = gConfig.hotbarGlobal;
+    if globalSettings then
+        if globalSettings.positionMode == nil then
+            globalSettings.positionMode = globalDefaults.positionMode or 'absolute';
+        end
+        if globalSettings.backgroundPaddingX == nil then
+            globalSettings.backgroundPaddingX = globalDefaults.backgroundPaddingX or 0;
+        end
+        if globalSettings.backgroundPaddingY == nil then
+            globalSettings.backgroundPaddingY = globalDefaults.backgroundPaddingY or 0;
+        end
+        if globalSettings.hotbarSpacing == nil then
+            globalSettings.hotbarSpacing = globalDefaults.hotbarSpacing or 0;
+        end
+    end
+
+    for barIndex = 1, 6 do
+        local barCfg = gConfig['hotbarBar' .. barIndex];
+        local barDefaults = defaults['hotbarBar' .. barIndex] or {};
+        if barCfg then
+            if barCfg.anchoredInStack == nil then
+                barCfg.anchoredInStack = barDefaults.anchoredInStack ~= false;
+            end
+            if barCfg.backgroundPaddingX == nil then
+                barCfg.backgroundPaddingX = barDefaults.backgroundPaddingX or 0;
+            end
+            if barCfg.backgroundPaddingY == nil then
+                barCfg.backgroundPaddingY = barDefaults.backgroundPaddingY or 0;
+            end
+        end
+    end
 end
 
 -- Migrate flat castCost* settings to nested castCost table

--- a/XIUI/modules/hotbar/data.lua
+++ b/XIUI/modules/hotbar/data.lua
@@ -225,6 +225,7 @@ end
 -- Keys that are always per-bar (never pulled from global)
 local PER_BAR_ONLY_KEYS = {
     enabled = true,
+    anchoredInStack = true,
     rows = true,
     columns = true,
     slots = true,

--- a/XIUI/modules/hotbar/display.lua
+++ b/XIUI/modules/hotbar/display.lua
@@ -27,11 +27,66 @@ local imtext = require('libs.imtext');
 local M = {};
 
 -- ============================================
--- Constants
+-- Anchored Layout Helpers (hotbar only)
 -- ============================================
 
-local KEYBIND_OFFSET_X = 2;
-local KEYBIND_OFFSET_Y = 2;
+local function GetHotbarBarConfig(barIndex)
+    return gConfig and gConfig['hotbarBar' .. barIndex];
+end
+
+local function IsAnchoredMode()
+    return gConfig.hotbarGlobal and gConfig.hotbarGlobal.positionMode == 'anchored';
+end
+
+local function IsBarInAnchorStack(barIndex)
+    if not IsAnchoredMode() then
+        return false;
+    end
+
+    local barConfig = GetHotbarBarConfig(barIndex);
+    if not barConfig or barConfig.enabled == false then
+        return false;
+    end
+
+    return barConfig.anchoredInStack ~= false;
+end
+
+local function GetAnchoredStackBars()
+    local stack = {};
+    if not IsAnchoredMode() then
+        return stack;
+    end
+
+    for barIndex = 1, data.NUM_BARS do
+        if IsBarInAnchorStack(barIndex) then
+            stack[#stack + 1] = barIndex;
+        end
+    end
+
+    return stack;
+end
+
+local function GetBackgroundPadding(barSettings)
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local padX = (barSettings and barSettings.backgroundPaddingX) or 0;
+    local padY = (barSettings and barSettings.backgroundPaddingY) or 0;
+    return padX * gs, padY * gs;
+end
+
+local function GetBarSavedPosition(barIndex, defaultX, defaultY)
+    local windowName = string.format('Hotbar%d', barIndex);
+    local saved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+    if saved then
+        return saved.x, saved.y;
+    end
+    return defaultX, defaultY;
+end
+
+-- Forward declarations (defined after GetBarDimensions)
+local GetBarMetrics;
+local ComputeAnchoredLayout;
+local DrawWindowBackground;
+local DrawBarBackground;
 
 -- ============================================
 -- State
@@ -215,6 +270,122 @@ local function GetBarDimensions(barIndex)
     return width, height, slotSize, slotGap, rowGap, layout;
 end
 
+GetBarMetrics = function(barIndex, inAnchoredStack)
+    local barSettings = data.GetBarSettings(barIndex);
+    local contentW, contentH, buttonSize, buttonGap, rowGap, layout = GetBarDimensions(barIndex);
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+
+    if inAnchoredStack then
+        return {
+            contentW = contentW,
+            contentH = contentH,
+            windowW = contentW,
+            windowH = contentH,
+            bgPadX = 0,
+            bgPadY = 0,
+            buttonSize = buttonSize,
+            buttonGap = buttonGap,
+            rowGap = rowGap,
+            layout = layout,
+            slotPadding = data.PADDING * gs,
+        };
+    end
+
+    local bgPadX, bgPadY = GetBackgroundPadding(barSettings);
+
+    return {
+        contentW = contentW,
+        contentH = contentH,
+        windowW = contentW + (bgPadX * 2),
+        windowH = contentH + (bgPadY * 2),
+        bgPadX = bgPadX,
+        bgPadY = bgPadY,
+        buttonSize = buttonSize,
+        buttonGap = buttonGap,
+        rowGap = rowGap,
+        layout = layout,
+        slotPadding = data.PADDING * gs,
+    };
+end
+
+ComputeAnchoredLayout = function(stack)
+    local layout = {};
+    if #stack == 0 then
+        return layout;
+    end
+
+    local anchorBar = stack[1];
+    local defaultX, defaultY = GetDefaultBarPosition(anchorBar);
+    local anchorX, anchorY = GetBarSavedPosition(anchorBar, defaultX, defaultY);
+    local globalSettings = gConfig.hotbarGlobal or {};
+    local bgPadX, bgPadY = GetBackgroundPadding(globalSettings);
+    local gs = (gConfig and gConfig.globalScale) or 1.0;
+    local stackSpacing = (globalSettings.hotbarSpacing or 0) * gs;
+    local currentY = anchorY;
+    local maxContentW = 0;
+    local topBarY = anchorY;
+
+    for i, barIndex in ipairs(stack) do
+        if i > 1 then
+            currentY = currentY - stackSpacing;
+        end
+
+        local metrics = GetBarMetrics(barIndex, true);
+        maxContentW = math.max(maxContentW, metrics.contentW);
+        layout[barIndex] = {
+            x = anchorX,
+            y = currentY,
+            metrics = metrics,
+        };
+        topBarY = currentY;
+        currentY = currentY - metrics.contentH;
+    end
+
+    local bottomEntry = layout[anchorBar];
+    local bottomY = bottomEntry.y + bottomEntry.metrics.contentH;
+    -- Outer background rect for the whole anchored stack (not per-bar).
+    layout._stackBackground = {
+        x = anchorX - bgPadX,
+        y = topBarY - bgPadY,
+        width = maxContentW + (bgPadX * 2),
+        height = (bottomY - topBarY) + (bgPadY * 2),
+    };
+
+    return layout;
+end
+
+local function BuildWindowBgOptions(settings)
+    return {
+        theme = settings.backgroundTheme or '-None-',
+        padding = 0,
+        paddingY = 0,
+        bgScale = settings.bgScale or 1.0,
+        borderScale = settings.borderScale or 1.0,
+        bgOpacity = settings.backgroundOpacity or 0.87,
+        borderOpacity = settings.borderOpacity or 1.0,
+        bgColor = settings.bgColor or 0xFFFFFFFF,
+        borderColor = settings.borderColor or 0xFFFFFFFF,
+    };
+end
+
+DrawWindowBackground = function(x, y, width, height, settings)
+    local bgOptions = BuildWindowBgOptions(settings);
+    if bgOptions.theme == '-None-' then
+        return;
+    end
+
+    local drawList = GetUIDrawList();
+    if not drawList then
+        return;
+    end
+
+    windowBg.Draw(drawList, x, y, width, height, bgOptions);
+end
+
+DrawBarBackground = function(windowPosX, windowPosY, metrics, barSettings)
+    DrawWindowBackground(windowPosX, windowPosY, metrics.windowW, metrics.windowH, barSettings);
+end
+
 -- Cached asset path
 local assetsPath = nil;
 
@@ -344,7 +515,9 @@ local function DrawSlot(barIndex, slotIndex, x, y, buttonSize, bind, barSettings
 end
 
 -- Draw a single hotbar window
-local function DrawBarWindow(barIndex, settings)
+local function DrawBarWindow(barIndex, settings, drawContext)
+    drawContext = drawContext or {};
+
     -- Get per-bar settings
     local barSettings = data.GetBarSettings(barIndex);
 
@@ -353,35 +526,44 @@ local function DrawBarWindow(barIndex, settings)
         return;
     end
 
-    -- Get default position for fallback
+    local metrics = drawContext.metrics or GetBarMetrics(barIndex);
+    local barWidth = metrics.windowW;
+    local barHeight = metrics.windowH;
+    local buttonSize = metrics.buttonSize;
+    local buttonGap = metrics.buttonGap;
+    local rowGap = metrics.rowGap;
+    local layout = metrics.layout;
+    local bgPadX = metrics.bgPadX;
+    local bgPadY = metrics.bgPadY;
+    local slotPadding = metrics.slotPadding;
+
     local defaultX, defaultY = GetDefaultBarPosition(barIndex);
     local windowName = string.format('Hotbar%d', barIndex);
-
-    -- Apply saved position if exists (using helper for profile support), otherwise set default
     local hasSaved = gConfig.windowPositions and gConfig.windowPositions[windowName];
+    local useAnchoredPosition = drawContext.resolvedPosition ~= nil;
+    local skipBackground = drawContext.skipBackground == true;
+    local isAnchorBar = drawContext.isAnchorBar == true;
+    local savePosition = drawContext.savePosition ~= false;
+    local anchorDragging = drawing.IsAnchorDragging(windowName);
 
-    if hasSaved then
+    if useAnchoredPosition then
+        if isAnchorBar and (anchorDragging or forcePositionReset) then
+            local targetX, targetY = GetBarSavedPosition(barIndex, defaultX, defaultY);
+            imgui.SetNextWindowPos({targetX, targetY}, ImGuiCond_Always);
+        else
+            imgui.SetNextWindowPos({drawContext.resolvedPosition.x, drawContext.resolvedPosition.y}, ImGuiCond_Always);
+        end
+    elseif hasSaved then
         ApplyWindowPosition(windowName);
     else
         imgui.SetNextWindowPos({defaultX, defaultY}, ImGuiCond_FirstUseEver);
     end
 
-    -- Get dimensions (now includes layout)
-    local barWidth, barHeight, buttonSize, buttonGap, rowGap, layout = GetBarDimensions(barIndex);
-
-    local slotCount = layout.slots;
-
     -- Window flags (dummy window for positioning)
     local windowFlags = GetBaseWindowFlags(gConfig.lockPositions);
 
-    -- Check if anchor is currently being dragged or positions are being reset - if so, force position
-    local anchorDragging = drawing.IsAnchorDragging(windowName);
-    
-    if anchorDragging or forcePositionReset then
-        -- Force position update during drag
-        local saved = gConfig.windowPositions and gConfig.windowPositions[windowName];
-        local targetX = saved and saved.x or defaultX;
-        local targetY = saved and saved.y or defaultY;
+    if not useAnchoredPosition and (anchorDragging or forcePositionReset) then
+        local targetX, targetY = GetBarSavedPosition(barIndex, defaultX, defaultY);
         imgui.SetNextWindowPos({targetX, targetY}, ImGuiCond_Always);
     end
 
@@ -390,43 +572,22 @@ local function DrawBarWindow(barIndex, settings)
     local windowPosX, windowPosY;
 
     if imgui.Begin(windowName, true, windowFlags) then
-        -- Save position if moved
-        SaveWindowPosition(windowName);
+        if savePosition then
+            SaveWindowPosition(windowName);
+        end
         windowPosX, windowPosY = imgui.GetWindowPos();
 
         -- Reserve space
         imgui.Dummy({barWidth, barHeight});
 
-        -- Update background using per-bar settings
-        local bgTheme = barSettings.backgroundTheme or '-None-';
-        local bgScale = barSettings.bgScale or 1.0;
-        local borderScale = barSettings.borderScale or 1.0;
-        local bgOpacity = barSettings.backgroundOpacity or 0.87;
-        local borderOpacity = barSettings.borderOpacity or 1.0;
-
-        -- Use per-bar color settings
-        local bgColor = barSettings.bgColor or 0xFFFFFFFF;
-        local borderColor = barSettings.borderColor or 0xFFFFFFFF;
-
-        local bgOptions = {
-            theme = bgTheme,
-            padding = 0,  -- Padding already included in barWidth/barHeight
-            paddingY = 0,
-            bgScale = bgScale,
-            borderScale = borderScale,
-            bgOpacity = bgOpacity,
-            borderOpacity = borderOpacity,
-            bgColor = bgColor,
-            borderColor = borderColor,
-        };
-
-        windowBg.Draw(GetUIDrawList(), windowPosX, windowPosY, barWidth, barHeight, bgOptions);
+        if not skipBackground then
+            DrawBarBackground(windowPosX, windowPosY, metrics, barSettings);
+        end
 
         -- Draw hotbar number to the LEFT of the bar (outside container)
         local showNumber = barSettings.showHotbarNumber;
         if showNumber == nil then showNumber = true; end
         if showNumber then
-            -- Position to the left of the bar with optional offsets
             local hbnOffsetX = barSettings.hotbarNumberOffsetX or 0;
             local hbnOffsetY = barSettings.hotbarNumberOffsetY or 0;
             local hbnText = tostring(barIndex);
@@ -439,24 +600,16 @@ local function DrawBarWindow(barIndex, settings)
         end
 
         -- Draw slots based on layout (rows x columns)
-        local gs = (gConfig and gConfig.globalScale) or 1.0;
-        local padding = data.PADDING * gs;
-        local slotCount = layout.slots;
+        slotCount = layout.slots;
         local slotIndex = 1;
 
-        -- Get palette change animation opacity
         local animOpacity = GetPaletteAnimationOpacity(barIndex);
 
-        -- Check if we should hide empty slots
         local hideEmptySlots = barSettings.hideEmptySlots or false;
         local paletteOpen = macropalette.IsPaletteOpen();
         local keybindEditorOpen = hotbarConfig.IsKeybindModalOpen();
-        -- Use both IsDragging and IsDragPending to show empty slots during entire drag process
-        -- IsDragging only returns true after drag threshold is met, but we need to show
-        -- drop zones earlier so they're registered when the drag activates
         local isDragging = dragdrop.IsDragging() or dragdrop.IsDragPending();
 
-        -- Get target server ID for skillchain prediction (cached for all slots)
         local targetServerId = nil;
         local skillchainEnabled = gConfig.hotbarGlobal.skillchainHighlightEnabled ~= false;
         if skillchainEnabled then
@@ -472,19 +625,16 @@ local function DrawBarWindow(barIndex, settings)
         for row = 1, layout.rows do
             for col = 1, layout.columns do
                 if slotIndex <= slotCount then
-                    local slotX = windowPosX + padding + (col - 1) * (buttonSize + buttonGap);
-                    local slotY = windowPosY + padding + (row - 1) * (buttonSize + rowGap);
+                    local slotX = windowPosX + bgPadX + slotPadding + (col - 1) * (buttonSize + buttonGap);
+                    local slotY = windowPosY + bgPadY + slotPadding + (row - 1) * (buttonSize + rowGap);
 
                     local bind = data.GetKeybindForSlot(barIndex, slotIndex);
 
-                    -- Hide empty slots if setting enabled and not editing/dragging
                     if hideEmptySlots and not paletteOpen and not keybindEditorOpen and not isDragging and not bind then
-                        -- Empty slot: skip rendering (ImGui draws are stateless, nothing to hide)
+                        -- Empty slot: skip rendering
                     else
-                        -- Check for skillchain prediction on weapon skill slots
                         local slotSkillchainName = nil;
                         if skillchainEnabled and bind and bind.actionType == 'ws' and bind.action then
-                            -- Pass WS name directly - skillchain module handles name->ID conversion
                             slotSkillchainName = skillchain.GetSkillchainForSlot(targetServerId, bind.action);
                         end
                         DrawSlot(barIndex, slotIndex, slotX, slotY, buttonSize, bind, barSettings, animOpacity, slotSkillchainName);
@@ -494,27 +644,23 @@ local function DrawBarWindow(barIndex, settings)
             end
         end
 
-
         imgui.End();
     end
 
     -- Draw pet palette indicator dot OUTSIDE window bounds (above bar number)
-    -- Must be after End() and use ForegroundDrawList to avoid clipping
-    -- Only shows for pet-aware bars (gold indicator)
     local hasPetIndicator = barSettings.petAware and barSettings.showPetIndicator ~= false;
 
     if windowPosX and hasPetIndicator then
-        local dotX = windowPosX - 12;  -- Centered above bar number
-        local dotY = windowPosY + (barHeight / 2) - 20;  -- Above the number
+        local dotX = windowPosX - 12;
+        local dotY = windowPosY + (barHeight / 2) - 20;
         local dotRadius = 5;
         local fgDrawList = GetUIDrawList();
 
-        local indicatorColor = {1.0, 0.8, 0.2, 1.0};  -- Gold
+        local indicatorColor = {1.0, 0.8, 0.2, 1.0};
 
         fgDrawList:AddCircleFilled({dotX, dotY}, dotRadius, imgui.GetColorU32(indicatorColor), 12);
         fgDrawList:AddCircle({dotX, dotY}, dotRadius, imgui.GetColorU32({0.0, 0.0, 0.0, 1.0}), 12, 1.0);
 
-        -- Check hover for tooltip
         local mouseX, mouseY = imgui.GetMousePos();
         local dx = mouseX - dotX;
         local dy = mouseY - dotY;
@@ -525,7 +671,6 @@ local function DrawBarWindow(barIndex, settings)
             imgui.TextColored({1.0, 0.8, 0.2, 1.0}, 'Pet Palette Bar ' .. barIndex);
             imgui.Separator();
 
-            -- Current pet info
             local currentPet = petpalette.GetCurrentPetDisplayName();
             if currentPet then
                 imgui.Text('Current Pet: ' .. currentPet);
@@ -533,7 +678,6 @@ local function DrawBarWindow(barIndex, settings)
                 imgui.TextColored({0.6, 0.6, 0.6, 1.0}, 'No pet summoned');
             end
 
-            -- Palette mode
             local hasOverride = petpalette.HasManualOverride(barIndex);
             if hasOverride then
                 local overrideName = petpalette.GetPaletteDisplayName(barIndex, data.jobId);
@@ -547,19 +691,16 @@ local function DrawBarWindow(barIndex, settings)
     end
 
     -- Draw move anchor (only visible when config is open)
-    -- Must be called after we have window position
     if windowPosX ~= nil then
-        -- Only show anchor when movement is NOT locked (global setting)
         local globalLocked = gConfig and gConfig.hotbarLockMovement;
-        if not globalLocked then
-            -- Use same window name as ImGui window so positions are shared
+        local showAnchor = not globalLocked and (not useAnchoredPosition or isAnchorBar);
+        if showAnchor then
             local anchorName = string.format('Hotbar%d', barIndex);
             local anchorNewX, anchorNewY = drawing.DrawMoveAnchor(anchorName, windowPosX, windowPosY);
             if anchorNewX ~= nil then
                 windowPosX = anchorNewX;
                 windowPosY = anchorNewY;
-                
-                -- Update config immediately so next frame's positioning logic picks it up
+
                 if not gConfig.windowPositions then gConfig.windowPositions = {}; end
                 gConfig.windowPositions[anchorName] = { x = anchorNewX, y = anchorNewY };
             end
@@ -580,12 +721,36 @@ function M.DrawWindow(settings)
         texturesInitialized = true;
     end
 
-    -- Draw each bar as its own window (per-bar themes handled in DrawBarWindow)
-    for barIndex = 1, data.NUM_BARS do
-        DrawBarWindow(barIndex, settings);
+    local anchoredStack = GetAnchoredStackBars();
+    local anchoredLayout = ComputeAnchoredLayout(anchoredStack);
+    local anchorBar = anchoredStack[1];
+
+    local stackBackground = anchoredLayout._stackBackground;
+    if stackBackground then
+        DrawWindowBackground(
+            stackBackground.x,
+            stackBackground.y,
+            stackBackground.width,
+            stackBackground.height,
+            gConfig.hotbarGlobal or {}
+        );
     end
 
-    -- Clear force position reset flag after all bars have been drawn
+    for barIndex = 1, data.NUM_BARS do
+        local drawContext = {};
+        local anchoredEntry = anchoredLayout[barIndex];
+
+        if anchoredEntry then
+            drawContext.resolvedPosition = { x = anchoredEntry.x, y = anchoredEntry.y };
+            drawContext.metrics = anchoredEntry.metrics;
+            drawContext.skipBackground = true;
+            drawContext.isAnchorBar = (barIndex == anchorBar);
+            drawContext.savePosition = (barIndex == anchorBar);
+        end
+
+        DrawBarWindow(barIndex, settings, drawContext);
+    end
+
     if forcePositionReset then
         forcePositionReset = false;
     end


### PR DESCRIPTION
This one is more of a personal commit, but I do think a lot of people would love this as it allows you to have more control over the look of your bars. You can create looks like these:

<img width="608" height="239" alt="image" src="https://github.com/user-attachments/assets/e23fe4bf-e6de-406d-bbf9-45afc5617dff" />


- Added a new way to stack hotbars together so they move and look like one group instead of separate bars.
- Added a position mode setting with absolute and anchored options.
  - Absolute is the default option, and will continue to make the hotbar work like it has been. Anchored is just an additional option for when you want just one window with one border.
- Added checkboxes to choose which hotbars are included in the anchored stack.
- Added a spacing slider to set the gap between stacked hotbars.
  - This is for when you want to add space for slot labels or other things to prevent overlap with other bars.
- Added background padding settings that apply around the outside of the whole anchored group.
- Updates disabled hotbars so they are automatically removed from the anchored stack.
- Added settings migration so existing profiles get the new options with safe defaults.
- Cleaned up the hotbar layout and settings code to make it easier to maintain.


https://github.com/user-attachments/assets/6ada900e-e1ee-4750-ba49-0f691fd74d5c

