### PR TITLE
Fixed Keep Macro Palette Visible Wording

### DIFF
--- a/XIUI/config/components.lua
+++ b/XIUI/config/components.lua
@@ -479,7 +479,7 @@ function components.DrawHideWhenMenuOpenOptions(hideOnMenuFocusKey, hideMacroPal
 
     imgui.Indent(components.INDENT_SIZE);
     if showMacroPaletteOption then
-        components.DrawCheckbox('Hide Macro Palette', hideMacroPaletteKey);
+        components.DrawCheckbox('Keep Macro Palette Visible', hideMacroPaletteKey);
         imgui.ShowHelp('Keep this module visible when the in-game macro palette is open.');
     end
     if hideOnlyAllianceKey then


### PR DESCRIPTION
- Fixes wording on the new option that PR #354 introduced, which was to keep the macro palette visible when using the `Hide When Menu Open` is enabled.