### PR TITLE
Improved Ready Check Module

### DIFF
--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -721,11 +721,13 @@ config.DrawWindow = function(us)
         imgui.PushStyleVar(ImGuiStyleVar_FramePadding, {8, 6});
 
         -- Profiles Button
-        imgui.PushStyleColor(ImGuiCol_Button, bgLight);
+        imgui.PushStyleColor(ImGuiCol_Button, buttonColor);
+        imgui.PushStyleColor(ImGuiCol_ButtonHovered, buttonHoverColor);
+        imgui.PushStyleColor(ImGuiCol_ButtonActive, buttonActiveColor);
         if (imgui.Button("Profiles", { 0, 26 })) then
             showProfilesWindow[1] = true;
         end
-        imgui.PopStyleColor();
+        imgui.PopStyleColor(3);
         
         imgui.SameLine();
         imgui.PushItemWidth(300); -- Increased width for profile select

--- a/XIUI/config/readycheck.lua
+++ b/XIUI/config/readycheck.lua
@@ -5,62 +5,56 @@
 require('common');
 local imgui      = require('imgui');
 local components = require('config.components');
+local rcSlider   = require('modules.readycheck.slider');
 local readycheck = require('modules.readycheck.init');
 
 local M = {};
 
-function M.DrawSettings()
-    components.DrawCheckbox('Enabled', 'showReadyCheck', CheckVisibility);
-    imgui.Spacing();
-    imgui.Separator();
-    imgui.Spacing();
+local SOUND_DIR          = addon.path .. 'modules\\readycheck\\sound\\';
+local DEFAULT_SOUND_FILE = 'ffxiv-notification.wav';
+local VOLUME_DETENTS     = { 50, 100 };
 
-    -- Sound toggles
-    local sound_on_checker = readycheck.GetSoundOnCheckerFlag();
-    imgui.Checkbox('Play sound when sending a ready check##rc_cfg',   sound_on_checker);
+local function ensureDefaults()
+    if gConfig.readyCheckSoundFile == nil or gConfig.readyCheckSoundFile == '' then
+        gConfig.readyCheckSoundFile = DEFAULT_SOUND_FILE;
+    end
+    gConfig.readyCheckSoundVolume = math.max(0, math.min(150, gConfig.readyCheckSoundVolume or 50));
+end
 
-    local sound_on_prompt  = readycheck.GetSoundOnPromptFlag();
-    imgui.Checkbox('Play sound when receiving a ready check##rc_cfg', sound_on_prompt);
+local function getSoundFiles()
+    return ashita.fs.get_directory(SOUND_DIR, '.*\\.wav$') or {};
+end
 
-    imgui.Spacing();
-
-    -- Sound file dropdown
+local function drawSoundFileRow()
     imgui.Text('Sound file:');
-    local files, sel_idx = readycheck.GetSoundFileList();
-    if files and #files > 0 then
-        local preview = files[sel_idx[1]] or '';
+    local files = getSoundFiles();
+    if #files > 0 then
         imgui.SetNextItemWidth(280);
-        if imgui.BeginCombo('##rc_cfg_sound', preview, ImGuiComboFlags_None) then
-            for i, fname in ipairs(files) do
-                local selected = (i == sel_idx[1]);
-                if imgui.Selectable(fname, selected) then
-                    sel_idx[1] = i;
-                end
-                if selected then imgui.SetItemDefaultFocus(); end
-            end
-            imgui.EndCombo();
-        end
-        imgui.SameLine();
-        if imgui.Button('Refresh##rc_cfg') then
-            readycheck.ScanSoundFiles();
-        end
+        components.Combo('##rc_cfg', gConfig, 'readyCheckSoundFile', files, nil, DEFAULT_SOUND_FILE);
     else
         imgui.TextDisabled('No .wav files found in sound\\ folder.');
-        imgui.SameLine();
-        if imgui.Button('Refresh##rc_cfg') then
-            readycheck.ScanSoundFiles();
-        end
     end
 
-    imgui.Spacing();
-
+    imgui.SameLine();
     if imgui.Button('Test Sound##rc_cfg') then
         readycheck.TestSound();
     end
-    imgui.SameLine();
-    if imgui.Button('Save##rc_cfg') then
-        readycheck.SaveSettings();
-    end
+end
+
+function M.DrawSettings()
+    ensureDefaults();
+
+    components.DrawCheckbox('Enabled', 'showReadyCheck', CheckVisibility);
+    components.DrawCheckbox('Play sound when sending a ready check', 'readyCheckSoundOnChecker');
+    components.DrawCheckbox('Play sound when receiving a ready check', 'readyCheckSoundOnPrompt');
+
+    imgui.Spacing();
+    drawSoundFileRow();
+
+    imgui.Spacing();
+    local volume = { gConfig.readyCheckSoundVolume };
+    rcSlider.DrawInt('Volume:##rc_cfg', volume, 0, 150, '%d%%', VOLUME_DETENTS, 280, SaveSettingsToDisk);
+    gConfig.readyCheckSoundVolume = volume[1];
 end
 
 function M.DrawColorSettings()

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -30,6 +30,12 @@ function M.createUserSettingsDefaults()
         showNotifications = true,
         showReadyCheck = true,
 
+        -- Ready Check module settings (per profile)
+        readyCheckSoundFile = 'ffxiv-notification.wav',
+        readyCheckSoundOnChecker = true,
+        readyCheckSoundOnPrompt = true,
+        readyCheckSoundVolume = 50,
+
         -- Hide when game menu is open (default off)
         playerBarHideOnMenuFocus = false,
         targetBarHideOnMenuFocus = false,

--- a/XIUI/modules/readycheck/init.lua
+++ b/XIUI/modules/readycheck/init.lua
@@ -4,31 +4,27 @@
 *
 * Usage (via XIUI command handler):
 *   /readycheck              - Sends a ready check to party chat.
-*   /readycheck config       - Opens the configuration UI (sound settings).
 *   /readycheck sound <file> - Sets the sound file.
+*   /readycheck volume <number>   - Sets the sound volume (0-150).
 *
-* Assets (icons/ and sound/) live in modules/readycheck/ inside the XIUI folder.
+* Assets (sound/) live in modules/readycheck/ inside the XIUI folder.
 ]]--
 
 local bit = require('bit')
 local ui  = require('modules.readycheck.ui')
+local soundPlayer = require('modules.readycheck.sound')
 
 local M = {}
 
--- Path to this module's assets folder (icons/, sound/, settings.txt)
+-- Path to this module's assets folder (sound/)
 local MODULE_PATH = addon.path .. 'modules\\readycheck\\'
 
 -- ── Marker strings ────────────────────────────────────────────────────────────
-local RC_PREFIX   = '[RC]'
-local TRIGGER_MSG = RC_PREFIX .. 'check'
-local YES_MSG     = RC_PREFIX .. 'yes'
-local NO_MSG      = RC_PREFIX .. 'no'
+local TRIGGER_MSG = 'Ready Check!'
+local YES_MSG     = 'Yes'
+local NO_MSG      = 'No'
 
--- ── Sound settings ────────────────────────────────────────────────────────────
-local SOUND_FILE       = MODULE_PATH .. 'sound\\wow-readycheck.wav'
-local SOUND_ON_CHECKER = true
-local SOUND_ON_PROMPT  = true
-local SETTINGS_FILE    = MODULE_PATH .. 'settings.txt'
+local DEFAULT_SOUND_FILE = 'ffxiv-notification.wav'
 
 -- Chat modes that carry party / alliance messages
 local PARTY_MODES = { [13] = true, [215] = true }
@@ -47,13 +43,8 @@ local state = {
     prompt_deadline = nil,
     prompt_sender   = nil,
 
-    config_open = { false },
-    cfg = {
-        sound_files      = {},
-        sound_sel_idx    = { 1 },
-        sound_on_checker = { false },
-        sound_on_prompt  = { false },
-    },
+    prompt_center_next  = false,
+    tracker_center_next = false,
 }
 
 -- ── Helpers ───────────────────────────────────────────────────────────────────
@@ -112,6 +103,12 @@ end
 local function clean_message(text)
     local s = strip_color_codes(text):lower()
     return s:gsub('^%s*|%d+|%s*', ''):gsub('^%s*%[%d%d:%d%d:?%d?%d?%]%s*', '')
+end
+
+local function is_exact_response(text, word)
+    local _, body = parse_sender(strip_color_codes(text))
+    local normalized = (body or strip_color_codes(text)):match('^%s*(.-)%s*$')
+    return normalized:lower() == word:lower()
 end
 
 local function update_member_status(name, status)
@@ -176,87 +173,47 @@ local function send_party(msg)
     AshitaCore:GetChatManager():QueueCommand(-1, '/p ' .. msg)
 end
 
-local function load_settings()
-    local f = io.open(SETTINGS_FILE, 'r')
-    if f then
-        for line in f:lines() do
-            if line ~= '' then
-                local key, val = line:match('^([%a][%w_]*)=(.-)$')
-                if key == 'sound_file' and val then
-                    SOUND_FILE = val
-                elseif key == 'sound_on_checker' and val then
-                    SOUND_ON_CHECKER = (val == 'true')
-                elseif key == 'sound_on_prompt' and val then
-                    SOUND_ON_PROMPT = (val == 'true')
-                elseif not key then
-                    SOUND_FILE = line
-                end
-            end
-        end
-        f:close()
+local function sound_path_from_filename(filename)
+    if filename == nil or filename == '' then
+        filename = DEFAULT_SOUND_FILE
     end
-    state.cfg.sound_on_checker[1] = SOUND_ON_CHECKER
-    state.cfg.sound_on_prompt[1]  = SOUND_ON_PROMPT
+    if filename:find('[/\\]') then
+        return filename
+    end
+    return MODULE_PATH .. 'sound\\' .. filename
 end
 
-local function save_settings()
-    local f = io.open(SETTINGS_FILE, 'w')
-    if f then
-        f:write('sound_file='       .. SOUND_FILE .. '\n')
-        f:write('sound_on_checker=' .. tostring(SOUND_ON_CHECKER) .. '\n')
-        f:write('sound_on_prompt='  .. tostring(SOUND_ON_PROMPT)  .. '\n')
-        f:close()
+local function filename_from_sound_path(path)
+    if path == nil or path == '' then return DEFAULT_SOUND_FILE end
+    return path:match('[^\\/]+$') or DEFAULT_SOUND_FILE
+end
+
+local function get_sound_path()
+    if gConfig == nil then
+        return sound_path_from_filename(DEFAULT_SOUND_FILE)
     end
+    return sound_path_from_filename(gConfig.readyCheckSoundFile)
+end
+
+local function get_sound_volume()
+    if gConfig == nil then return 50 end
+    return math.max(0, math.min(150, gConfig.readyCheckSoundVolume or 50))
+end
+
+local function clamp_volume(volume)
+    return math.max(0, math.min(150, math.floor(volume + (volume >= 0 and 0.5 or -0.5))))
+end
+
+local function sound_enabled_for_checker()
+    return gConfig == nil or gConfig.readyCheckSoundOnChecker ~= false
+end
+
+local function sound_enabled_for_prompt()
+    return gConfig == nil or gConfig.readyCheckSoundOnPrompt ~= false
 end
 
 local function play_readycheck_sound()
-    ashita.misc.play_sound(SOUND_FILE)
-end
-
-local function scan_sound_files()
-    local sound_dir = MODULE_PATH .. 'sound\\'
-    local files = ashita.fs.get_directory(sound_dir, '.*\\.wav$') or {}
-    state.cfg.sound_files = files
-    local current_name = SOUND_FILE:match('[^\\/]+$') or ''
-    state.cfg.sound_sel_idx[1] = 1
-    for i, fname in ipairs(files) do
-        if fname:lower() == current_name:lower() then
-            state.cfg.sound_sel_idx[1] = i
-            break
-        end
-    end
-end
-
-local function get_selected_sound_path()
-    local files = state.cfg.sound_files
-    local idx   = state.cfg.sound_sel_idx[1]
-    if files and files[idx] then
-        return MODULE_PATH .. 'sound\\' .. files[idx]
-    end
-    return SOUND_FILE
-end
-
-local function open_config()
-    state.cfg.sound_on_checker[1] = SOUND_ON_CHECKER
-    state.cfg.sound_on_prompt[1]  = SOUND_ON_PROMPT
-    scan_sound_files()
-    state.config_open[1] = true
-end
-
-local function save_config()
-    SOUND_FILE       = get_selected_sound_path()
-    SOUND_ON_CHECKER = state.cfg.sound_on_checker[1]
-    SOUND_ON_PROMPT  = state.cfg.sound_on_prompt[1]
-    save_settings()
-    print('[ReadyCheck] Settings saved.')
-end
-
-local function test_config_sound()
-    ashita.misc.play_sound(get_selected_sound_path())
-end
-
-local function everyone_answered()
-    return state.pending_count == 0
+    soundPlayer.Play(get_sound_path(), get_sound_volume())
 end
 
 local function announce_ready_check_summary(mark_unanswered)
@@ -306,45 +263,32 @@ local function start_ready_check()
     state.party_members        = collect_party_members()
     state.pending_count        = #state.party_members
     state.checker_open[1]      = true
+    state.tracker_center_next  = true
     state.checker_deadline     = os.clock() + 30
     state.checker_summary_sent = false
     local my_name = get_player_name()
     if my_name then
         update_member_status(my_name, 'ready')
     end
-    if SOUND_ON_CHECKER then play_readycheck_sound() end
-    send_party(TRIGGER_MSG .. ' Are you ready? Answer Yes, No or /')
+    if sound_enabled_for_checker() then play_readycheck_sound() end
+    send_party(TRIGGER_MSG .. ' Are you ready? Answer Yes, No, or /')
 end
 
 -- ── Handlers table (allocated once) ──────────────────────────────────────────
 local handlers = {
-    answer_yes        = answer_yes,
-    answer_no         = answer_no,
-    close_checker     = close_checker,
-    open_config       = open_config,
-    save_config       = save_config,
-    test_config_sound = test_config_sound,
-    scan_sound_files  = scan_sound_files,
+    answer_yes    = answer_yes,
+    answer_no     = answer_no,
+    close_checker = close_checker,
 }
 
 -- ── Public module API ─────────────────────────────────────────────────────────
 
---- Called by the module registry to show/hide this module.
---- ReadyCheck has no persistent fonts, so nothing needs to be hidden here.
-function M.SetHidden(hidden)
+function M.SetHidden(_hidden)
 end
 
---- Called once after XIUI settings are loaded.
-function M.Initialize()
-    load_settings()
-end
-
---- Called every frame by the XIUI module registry (via RenderModule).
---- Handles timeout logic and delegates rendering to ui.lua.
 function M.DrawWindow(_settings)
     local now = os.clock()
 
-    -- Refresh job indices for members whose job was 0 at snapshot time.
     if state.checker_open[1] then
         local party = AshitaCore:GetMemoryManager():GetParty()
         if party then
@@ -358,32 +302,29 @@ function M.DrawWindow(_settings)
         end
     end
 
-    -- Auto-close prompt on timeout.
     if state.prompt_open[1] and not state.prompt_answered
             and state.prompt_deadline ~= nil and now >= state.prompt_deadline then
         state.prompt_open[1]  = false
         state.prompt_deadline = nil
     end
 
-    -- Checker timeout / all-answered summary.
     if state.checker_open[1] and not state.checker_summary_sent then
         if state.checker_deadline ~= nil and now >= state.checker_deadline then
             announce_ready_check_summary(true)
-        elseif everyone_answered() then
+        elseif state.pending_count == 0 then
             state.checker_deadline = nil
             announce_ready_check_summary(false)
         end
     end
 
     ui.render(state, handlers)
+    soundPlayer.Tick()
 
     if not state.checker_open[1] then
         close_checker()
     end
 end
 
---- Called by XIUI's command event handler.
---- Returns true if the command was consumed (so the caller can set e.blocked).
 function M.HandleCommand(e)
     local args = e.command:args()
     if #args == 0 or args[1] ~= '/readycheck' then return false end
@@ -393,18 +334,40 @@ function M.HandleCommand(e)
         return true;
     end
 
+    if #args >= 2 and args[2]:lower() == 'volume' then
+        if #args >= 3 then
+            local volume = tonumber(args[3])
+            if volume == nil then
+                print('[XIUI] Ready Check Invalid volume. Usage: /readycheck volume <0-150>')
+                return true
+            end
+            volume = clamp_volume(volume)
+            if gConfig then
+                gConfig.readyCheckSoundVolume = volume
+                SaveSettingsOnly()
+            end
+            print(('[XIUI] Ready Check sound volume set to: %d%%'):format(volume))
+        else
+            print(('[XIUI] Ready Check current sound volume: %d%%'):format(get_sound_volume()))
+            print('[XIUI] Ready Check usage: /readycheck volume <0-150>')
+        end
+        return true
+    end
+
     if #args >= 2 and args[2]:lower() == 'sound' then
         if #args >= 3 then
             local path = table.concat(args, ' ', 3)
             if not path:find('[/\\]') then
                 path = MODULE_PATH .. 'sound\\' .. path
             end
-            SOUND_FILE = path
-            save_settings()
-            print('[ReadyCheck] Sound file set to: ' .. SOUND_FILE)
+            if gConfig then
+                gConfig.readyCheckSoundFile = filename_from_sound_path(path)
+                SaveSettingsOnly()
+            end
+            print('[XIUI] Ready Check sound file set to: ' .. get_sound_path())
         else
-            print('[ReadyCheck] Current sound file: ' .. SOUND_FILE)
-            print('[ReadyCheck] Usage: /readycheck sound <filename or full path>')
+            print('[XIUI] Ready Check current sound file: ' .. get_sound_path())
+            print('[XIUI] Ready Check usage: /readycheck sound <filename or full path>')
         end
         return true
     end
@@ -413,17 +376,15 @@ function M.HandleCommand(e)
     return true
 end
 
---- Called by XIUI's text_in event handler.
 function M.HandleTextIn(e)
-    -- When the module is disabled, let all messages through unblocked.
     if gConfig.showReadyCheck == false then return end
 
     local mode = bit.band(e.mode_modified or e.mode or 0, 0x000000FF)
     local raw   = e.message_modified or e.message or ''
     local clean      = strip_color_codes(raw)
     local is_trigger = clean:find(TRIGGER_MSG, 1, true) ~= nil
-    local is_yes     = not is_trigger and clean:find(YES_MSG, 1, true) ~= nil
-    local is_no      = not is_trigger and not is_yes and clean:find(NO_MSG, 1, true) ~= nil
+    local is_yes     = not is_trigger and is_exact_response(raw, YES_MSG)
+    local is_no      = not is_trigger and not is_yes and is_exact_response(raw, NO_MSG)
     local is_marker  = is_trigger or is_yes or is_no
 
     local is_manual_yes = false
@@ -447,11 +408,12 @@ function M.HandleTextIn(e)
         if not state.is_checker then
             state.prompt_answered = false
             state.prompt_open[1]  = true
+            state.prompt_center_next = true
             state.prompt_deadline = os.clock() + 30
             state.prompt_sender   = resolve_sender_from_live_party(e.message or raw)
                                   or parse_sender(e.message or '')
                                   or parse_sender(raw)
-            if SOUND_ON_PROMPT then play_readycheck_sound() end
+            if sound_enabled_for_prompt() then play_readycheck_sound() end
         end
         return
     end
@@ -478,39 +440,8 @@ function M.HandleTextIn(e)
     end
 end
 
--- ── Config UI accessors (used by config/readycheck.lua) ───────────────────────
-
---- Returns the sound file list and the current selection index table {[1]=idx}.
-function M.GetSoundFileList()
-    if #state.cfg.sound_files == 0 then
-        scan_sound_files()
-    end
-    return state.cfg.sound_files, state.cfg.sound_sel_idx
-end
-
---- Returns the ImGui bool-table for the "sound on checker" checkbox.
-function M.GetSoundOnCheckerFlag()
-    return state.cfg.sound_on_checker
-end
-
---- Returns the ImGui bool-table for the "sound on prompt" checkbox.
-function M.GetSoundOnPromptFlag()
-    return state.cfg.sound_on_prompt
-end
-
---- Sync and persist the current config UI state to disk.
-function M.SaveSettings()
-    save_config()
-end
-
---- Re-scan the sound folder (e.g. after the user added a file).
-function M.ScanSoundFiles()
-    scan_sound_files()
-end
-
---- Play a preview of the currently selected sound file.
 function M.TestSound()
-    test_config_sound()
+    soundPlayer.Play(get_sound_path(), get_sound_volume())
 end
 
 return M

--- a/XIUI/modules/readycheck/slider.lua
+++ b/XIUI/modules/readycheck/slider.lua
@@ -1,0 +1,221 @@
+--[[
+* Integer slider with optional visual tick marks and release snap checkpoints.
+* Checkpoint sliders use custom draw + InvisibleButton input.
+]]--
+
+local imgui = require('imgui');
+
+local M = {};
+
+local dragPrev = {};
+
+local GRAB_PADDING     = 2.0;
+local TICK_ALIGN_SHIFT = 4;
+local SNAP_TOLERANCE   = 4;
+
+local function clamp_int(value, minVal, maxVal)
+    value = math.floor(value + (value >= 0 and 0.5 or -0.5));
+    if value < minVal then return minVal; end
+    if value > maxVal then return maxVal; end
+    return value;
+end
+
+local function clamp01(t)
+    if t < 0 then return 0; end
+    if t > 1 then return 1; end
+    return t;
+end
+
+local function get_visible_label(label)
+    return label:match('^(.-)##') or '';
+end
+
+local function get_format_text_width(format, minVal, maxVal)
+    local style = imgui.GetStyle();
+    local wMin = imgui.CalcTextSize(string.format(format, minVal));
+    local wMax = imgui.CalcTextSize(string.format(format, maxVal));
+    return math.max(wMin, wMax) + style.ItemInnerSpacing.x;
+end
+
+local function get_slider_track_bounds(minX, maxX, minY, maxY, minVal, maxVal, format)
+    local style = imgui.GetStyle();
+    local framePadX = style.FramePadding.x or 8;
+
+    local frameMinX = minX + framePadX;
+    local frameMaxX = maxX - framePadX - get_format_text_width(format, minVal, maxVal);
+    local trackY = (minY + maxY) * 0.5;
+
+    local sliderSz = (frameMaxX - frameMinX) - GRAB_PADDING * 2;
+    if sliderSz < 1 then
+        local grabMinSize = style.GrabMinSize or 12;
+        return frameMinX, frameMaxX, trackY, grabMinSize;
+    end
+
+    local vRange = maxVal - minVal;
+    local grabMinSize = style.GrabMinSize or 12;
+    local grabSz = math.max(sliderSz / (vRange + 1), grabMinSize);
+    grabSz = math.min(grabSz, sliderSz);
+
+    local usableMin = frameMinX + GRAB_PADDING + grabSz * 0.5;
+    local usableMax = frameMaxX - GRAB_PADDING - grabSz * 0.5;
+
+    if usableMax <= usableMin then
+        return frameMinX + GRAB_PADDING, frameMaxX - GRAB_PADDING, trackY, grabSz;
+    end
+
+    return usableMin, usableMax, trackY, grabSz;
+end
+
+local function align_track_bounds(trackMinX, trackMaxX, minVal, maxVal)
+    local vRange = maxVal - minVal;
+    if vRange <= 0 then return trackMinX, trackMaxX; end
+
+    local span = trackMaxX - trackMinX;
+    local pxShift = (TICK_ALIGN_SHIFT / vRange) * span;
+    return trackMinX - pxShift, trackMaxX - pxShift;
+end
+
+local function value_to_track_x(value, trackMinX, trackMaxX, minVal, maxVal)
+    local span = maxVal - minVal;
+    if span <= 0 then return trackMinX; end
+
+    local t = (value - minVal) / span;
+    return trackMinX + t * (trackMaxX - trackMinX);
+end
+
+local function mouse_to_value(mouseX, trackMinX, trackMaxX, minVal, maxVal)
+    if trackMaxX <= trackMinX then
+        return minVal;
+    end
+
+    local t = clamp01((mouseX - trackMinX) / (trackMaxX - trackMinX));
+    return minVal + t * (maxVal - minVal);
+end
+
+local function snap_near_detents(value, detents)
+    local best = value;
+    local bestDist = SNAP_TOLERANCE + 1;
+
+    for _, detent in ipairs(detents) do
+        local dist = math.abs(value - detent);
+        if dist <= SNAP_TOLERANCE and dist < bestDist then
+            best = detent;
+            bestDist = dist;
+        end
+    end
+
+    return best;
+end
+
+local function draw_custom_slider(minX, minY, maxY, value, minVal, maxVal, format, isHovered, isActive, trackMinX, trackMaxX, grabSz)
+    if not imgui.GetWindowDrawList then return; end
+
+    local style = imgui.GetStyle();
+    local drawList = imgui.GetWindowDrawList();
+    local rounding = style.FrameRounding or 0;
+
+    local frameCol = ImGuiCol_FrameBg;
+    if isActive then
+        frameCol = ImGuiCol_FrameBgActive;
+    elseif isHovered then
+        frameCol = ImGuiCol_FrameBgHovered;
+    end
+
+    local alignedMinX, alignedMaxX = align_track_bounds(trackMinX, trackMaxX, minVal, maxVal);
+    local grabX = value_to_track_x(value, alignedMinX, alignedMaxX, minVal, maxVal);
+    local grabHalf = grabSz * 0.5;
+    local trackEndX = alignedMaxX + grabHalf;
+    local innerMinX = minX + GRAB_PADDING;
+
+    drawList:AddRectFilled({ minX, minY }, { trackEndX, maxY }, imgui.GetColorU32(frameCol), rounding);
+
+    local fillMaxX = math.max(innerMinX, grabX + grabHalf);
+    if fillMaxX > innerMinX then
+        drawList:AddRectFilled(
+            { innerMinX, minY + GRAB_PADDING },
+            { fillMaxX, maxY - GRAB_PADDING },
+            imgui.GetColorU32(ImGuiCol_SliderGrabActive),
+            rounding
+        );
+    end
+
+    local grabCol = isActive and ImGuiCol_SliderGrabActive or ImGuiCol_SliderGrab;
+    drawList:AddRectFilled(
+        { grabX - grabHalf, minY + GRAB_PADDING },
+        { grabX + grabHalf, maxY - GRAB_PADDING },
+        imgui.GetColorU32(grabCol),
+        style.GrabRounding or rounding
+    );
+
+    local text = string.format(format, clamp_int(value, minVal, maxVal));
+    drawList:AddText(
+        { trackEndX + style.ItemInnerSpacing.x, minY + style.FramePadding.y },
+        imgui.GetColorU32(ImGuiCol_Text),
+        text
+    );
+end
+
+local function draw_tick_marks(minVal, maxVal, detents, trackMinX, trackMaxX, trackY)
+    if not imgui.GetWindowDrawList then return; end
+
+    local alignedMinX, alignedMaxX = align_track_bounds(trackMinX, trackMaxX, minVal, maxVal);
+    local drawList = imgui.GetWindowDrawList();
+    local tickColor = imgui.GetColorU32({ 0.75, 0.68, 0.47, 0.95 });
+    for _, detent in ipairs(detents) do
+        local x = value_to_track_x(detent, alignedMinX, alignedMaxX, minVal, maxVal);
+        drawList:AddLine({ x, trackY - 5 }, { x, trackY + 5 }, tickColor, 1.5);
+    end
+end
+
+local function draw_checkpoint_slider(label, valueRef, minVal, maxVal, format, detents, width, onCommit)
+    local stateId = label;
+    local visibleLabel = get_visible_label(label);
+
+    if visibleLabel ~= '' then
+        imgui.AlignTextToFramePadding();
+        imgui.Text(visibleLabel);
+        imgui.SameLine();
+    end
+
+    if width then
+        imgui.SetNextItemWidth(width);
+    end
+
+    local sliderW = width or imgui.CalcItemWidth();
+    local sliderH = imgui.GetFrameHeight();
+    imgui.InvisibleButton('##rc_slider_' .. stateId, { sliderW, sliderH });
+
+    local isHovered = imgui.IsItemHovered();
+    local isActive = imgui.IsItemActive();
+    local minX, minY = imgui.GetItemRectMin();
+    local maxX, maxY = imgui.GetItemRectMax();
+
+    local trackMinX, trackMaxX, trackY, grabSz = get_slider_track_bounds(
+        minX, maxX, minY, maxY, minVal, maxVal, format
+    );
+    local alignedMinX, alignedMaxX = align_track_bounds(trackMinX, trackMaxX, minVal, maxVal);
+
+    if isActive and imgui.IsMouseDown(0) then
+        local mouseX = imgui.GetMousePos();
+        local target = mouse_to_value(mouseX, alignedMinX, alignedMaxX, minVal, maxVal);
+        dragPrev[stateId] = target;
+        valueRef[1] = clamp_int(target, minVal, maxVal);
+    elseif not imgui.IsMouseDown(0) then
+        if dragPrev[stateId] ~= nil then
+            valueRef[1] = snap_near_detents(valueRef[1], detents);
+            if onCommit then onCommit(valueRef[1]); end
+        end
+        dragPrev[stateId] = nil;
+    end
+
+    local visualValue = dragPrev[stateId] or (valueRef[1] + 0.0);
+    draw_custom_slider(minX, minY, maxY, visualValue, minVal, maxVal, format, isHovered, isActive, trackMinX, trackMaxX, grabSz);
+    draw_tick_marks(minVal, maxVal, detents, trackMinX, trackMaxX, trackY);
+end
+
+--- Draw an integer slider with optional tick marks and snap checkpoints at detent values.
+function M.DrawInt(label, valueRef, minVal, maxVal, format, detents, width, onCommit)
+    draw_checkpoint_slider(label, valueRef, minVal, maxVal, format or '%d', detents or {}, width, onCommit);
+end
+
+return M;

--- a/XIUI/modules/readycheck/sound.lua
+++ b/XIUI/modules/readycheck/sound.lua
@@ -1,0 +1,233 @@
+--[[
+* ReadyCheck sound playback with configurable volume (0-150%).
+* At 100% uses ashita.misc.play_sound (native wav volume).
+* Other levels scale PCM samples via waveOut; values above 100% boost amplitude.
+]]--
+
+local bit = require('bit');
+local ffi = require('ffi');
+
+ffi.cdef[[
+    typedef unsigned int UINT;
+    typedef unsigned long DWORD;
+    typedef unsigned short WORD;
+    typedef unsigned long long DWORD_PTR;
+    typedef long MMRESULT;
+    typedef void* HWAVEOUT;
+
+    typedef struct {
+        WORD  wFormatTag;
+        WORD  nChannels;
+        DWORD nSamplesPerSec;
+        DWORD nAvgBytesPerSec;
+        WORD  nBlockAlign;
+        WORD  wBitsPerSample;
+        WORD  cbSize;
+    } WAVEFORMATEX;
+
+    typedef struct {
+        char*  lpData;
+        DWORD  dwBufferLength;
+        DWORD  dwBytesRecorded;
+        void*  dwUser;
+        DWORD  dwFlags;
+        DWORD  dwLoops;
+        void*  lpNext;
+        DWORD  reserved;
+    } WAVEHDR;
+
+    MMRESULT waveOutOpen(HWAVEOUT* phwo, UINT uDeviceID, const WAVEFORMATEX* pwfx,
+        DWORD_PTR dwCallback, DWORD_PTR dwInstance, DWORD fdwOpen);
+    MMRESULT waveOutPrepareHeader(HWAVEOUT hwo, WAVEHDR* pwh, UINT cbwh);
+    MMRESULT waveOutWrite(HWAVEOUT hwo, WAVEHDR* pwh, UINT cbwh);
+    MMRESULT waveOutUnprepareHeader(HWAVEOUT hwo, WAVEHDR* pwh, UINT cbwh);
+    MMRESULT waveOutReset(HWAVEOUT hwo);
+    MMRESULT waveOutClose(HWAVEOUT hwo);
+]];
+
+local winmm = ffi.load('winmm');
+
+local WAVE_FORMAT_PCM = 1;
+local WAVE_MAPPER     = 0xFFFFFFFF;
+local CALLBACK_NULL   = 0;
+local WHDR_DONE       = 0x00000001;
+
+local active = nil;
+
+local M = {};
+
+local function cleanup_active()
+    if not active then return; end
+
+    if active.hwo ~= nil then
+        winmm.waveOutReset(active.hwo);
+        if active.header then
+            winmm.waveOutUnprepareHeader(active.hwo, active.header, ffi.sizeof('WAVEHDR'));
+        end
+        winmm.waveOutClose(active.hwo);
+    end
+
+    active = nil;
+end
+
+function M.Tick()
+    if not active or not active.header then return; end
+    if bit.band(active.header.dwFlags, WHDR_DONE) ~= 0 then
+        cleanup_active();
+    end
+end
+
+local function read_u16(data, offset)
+    local lo = data:byte(offset) or 0;
+    local hi = data:byte(offset + 1) or 0;
+    return bit.bor(lo, bit.lshift(hi, 8));
+end
+
+local function read_u32(data, offset)
+    local b1 = data:byte(offset) or 0;
+    local b2 = data:byte(offset + 1) or 0;
+    local b3 = data:byte(offset + 2) or 0;
+    local b4 = data:byte(offset + 3) or 0;
+    return b1 + bit.lshift(b2, 8) + bit.lshift(b3, 16) + bit.lshift(b4, 24);
+end
+
+local function parse_wav_pcm(path)
+    local f = io.open(path, 'rb');
+    if not f then return nil; end
+    local data = f:read('*all');
+    f:close();
+
+    if not data or #data < 44 or data:sub(1, 4) ~= 'RIFF' or data:sub(9, 12) ~= 'WAVE' then
+        return nil;
+    end
+
+    local fmt = nil;
+    local pcm = nil;
+    local pos = 13;
+
+    while pos + 8 <= #data do
+        local chunkId = data:sub(pos, pos + 3);
+        local chunkSize = read_u32(data, pos + 4);
+        local chunkStart = pos + 8;
+
+        if chunkId == 'fmt ' and chunkSize >= 16 then
+            fmt = {
+                wFormatTag      = read_u16(data, chunkStart),
+                nChannels       = read_u16(data, chunkStart + 2),
+                nSamplesPerSec  = read_u32(data, chunkStart + 4),
+                nAvgBytesPerSec = read_u32(data, chunkStart + 8),
+                nBlockAlign     = read_u16(data, chunkStart + 12),
+                wBitsPerSample  = read_u16(data, chunkStart + 14),
+            };
+        elseif chunkId == 'data' then
+            pcm = data:sub(chunkStart, chunkStart + chunkSize - 1);
+        end
+
+        pos = chunkStart + chunkSize + (chunkSize % 2);
+    end
+
+    if not fmt or not pcm then return nil; end
+    if fmt.wFormatTag ~= WAVE_FORMAT_PCM then return nil; end
+    if fmt.wBitsPerSample ~= 16 then return nil; end
+
+    return fmt, pcm;
+end
+
+local function scale_pcm16(pcm, multiplier)
+    local sampleCount = math.floor(#pcm / 2);
+    local dst = ffi.new('char[?]', #pcm);
+
+    for i = 0, sampleCount - 1 do
+        local offset = i * 2 + 1;
+        local lo = pcm:byte(offset) or 0;
+        local hi = pcm:byte(offset + 1) or 0;
+        local sample = bit.bor(lo, bit.lshift(hi, 8));
+        if sample >= 32768 then
+            sample = sample - 65536;
+        end
+
+        sample = math.floor(sample * multiplier + (sample >= 0 and 0.5 or -0.5));
+        if sample > 32767 then
+            sample = 32767;
+        elseif sample < -32768 then
+            sample = -32768;
+        end
+
+        local unsigned = sample >= 0 and sample or (sample + 65536);
+        dst[i * 2]     = bit.band(unsigned, 0xFF);
+        dst[i * 2 + 1] = bit.band(bit.rshift(unsigned, 8), 0xFF);
+    end
+
+    return dst, #pcm;
+end
+
+local function play_scaled(path, volumePercent)
+    local fmt, pcm = parse_wav_pcm(path);
+    if not fmt or not pcm then
+        ashita.misc.play_sound(path);
+        return;
+    end
+
+    cleanup_active();
+
+    local multiplier = volumePercent / 100;
+    local buffer, length = scale_pcm16(pcm, multiplier);
+
+    local wfx = ffi.new('WAVEFORMATEX');
+    wfx.wFormatTag      = fmt.wFormatTag;
+    wfx.nChannels       = fmt.nChannels;
+    wfx.nSamplesPerSec  = fmt.nSamplesPerSec;
+    wfx.nAvgBytesPerSec = fmt.nAvgBytesPerSec;
+    wfx.nBlockAlign     = fmt.nBlockAlign;
+    wfx.wBitsPerSample  = fmt.wBitsPerSample;
+    wfx.cbSize          = 0;
+
+    local hwo = ffi.new('HWAVEOUT[1]');
+    local result = winmm.waveOutOpen(hwo, WAVE_MAPPER, wfx, 0, 0, CALLBACK_NULL);
+    if result ~= 0 then
+        ashita.misc.play_sound(path);
+        return;
+    end
+
+    local header = ffi.new('WAVEHDR');
+    header.lpData         = buffer;
+    header.dwBufferLength = length;
+    header.dwFlags        = 0;
+    header.dwLoops        = 0;
+
+    result = winmm.waveOutPrepareHeader(hwo[0], header, ffi.sizeof('WAVEHDR'));
+    if result ~= 0 then
+        winmm.waveOutClose(hwo[0]);
+        ashita.misc.play_sound(path);
+        return;
+    end
+
+    result = winmm.waveOutWrite(hwo[0], header, ffi.sizeof('WAVEHDR'));
+    if result ~= 0 then
+        winmm.waveOutUnprepareHeader(hwo[0], header, ffi.sizeof('WAVEHDR'));
+        winmm.waveOutClose(hwo[0]);
+        ashita.misc.play_sound(path);
+        return;
+    end
+
+    active = {
+        hwo    = hwo[0],
+        header = header,
+        buffer = buffer,
+    };
+end
+
+function M.Play(path, volumePercent)
+    volumePercent = tonumber(volumePercent) or 100;
+    if volumePercent <= 0 then
+        return;
+    end
+    if volumePercent == 100 then
+        cleanup_active();
+        ashita.misc.play_sound(path);
+        return;
+    end
+    play_scaled(path, volumePercent);
+end
+
+return M;

--- a/XIUI/modules/readycheck/ui.lua
+++ b/XIUI/modules/readycheck/ui.lua
@@ -18,88 +18,44 @@ local ui = {}
 -- unmatched and surface as "missing End()" / "missing popStyleColor()").
 local SetWindowFontScale = imgui.SetWindowFontScale or function() end
 
--- ── Job icon loader ────────────────────────────────────────────────────────────
--- Delegate to XIUI's statusHandler so we reuse its TextureManager cache and
--- respect the user's chosen job icon theme (gConfig.jobIconTheme).
-local function load_job_icon(jobIdx)
-    return statusHandler.GetJobIcon(jobIdx)
-end
-
--- ── XIDB theme ─────────────────────────────────────────────────────────────────
-local THEME_COLORS = {
-    { ImGuiCol_WindowBg,             { 0.000, 0.000, 0.000, 1.00 } },
-    { ImGuiCol_ChildBg,              { 0.000, 0.000, 0.000, 1.00 } },
-    { ImGuiCol_TitleBg,              { 0.098, 0.090, 0.075, 1.00 } },
-    { ImGuiCol_TitleBgActive,        { 0.137, 0.125, 0.106, 1.00 } },
-    { ImGuiCol_TitleBgCollapsed,     { 0.000, 0.000, 0.000, 1.00 } },
-    { ImGuiCol_FrameBg,              { 0.125, 0.110, 0.086, 0.98 } },
-    { ImGuiCol_FrameBgHovered,       { 0.173, 0.153, 0.122, 0.98 } },
-    { ImGuiCol_FrameBgActive,        { 0.231, 0.200, 0.157, 0.98 } },
-    { ImGuiCol_Header,               { 0.137, 0.125, 0.106, 1.00 } },
-    { ImGuiCol_HeaderHovered,        { 0.176, 0.161, 0.137, 1.00 } },
-    { ImGuiCol_HeaderActive,         { 0.957, 0.855, 0.592, 0.30 } },
-    { ImGuiCol_Border,               { 0.765, 0.684, 0.474, 0.85 } },
-    { ImGuiCol_Text,                 { 0.878, 0.855, 0.812, 1.00 } },
-    { ImGuiCol_TextDisabled,         { 0.765, 0.684, 0.474, 1.00 } },
-    { ImGuiCol_Button,               { 0.176, 0.149, 0.106, 0.95 } },
-    { ImGuiCol_ButtonHovered,        { 0.286, 0.239, 0.165, 0.95 } },
-    { ImGuiCol_ButtonActive,         { 0.420, 0.353, 0.243, 0.95 } },
-    { ImGuiCol_CheckMark,            { 0.957, 0.855, 0.592, 1.00 } },
-    { ImGuiCol_SliderGrab,           { 0.765, 0.684, 0.474, 1.00 } },
-    { ImGuiCol_SliderGrabActive,     { 0.957, 0.855, 0.592, 1.00 } },
-    { ImGuiCol_ScrollbarBg,          { 0.098, 0.090, 0.075, 1.00 } },
-    { ImGuiCol_ScrollbarGrab,        { 0.176, 0.161, 0.137, 1.00 } },
-    { ImGuiCol_ScrollbarGrabHovered, { 0.300, 0.275, 0.235, 1.00 } },
-    { ImGuiCol_ScrollbarGrabActive,  { 0.765, 0.684, 0.474, 1.00 } },
-    { ImGuiCol_Separator,            { 0.300, 0.275, 0.235, 1.00 } },
-    { ImGuiCol_PopupBg,              { 0.098, 0.090, 0.075, 1.00 } },
-    { ImGuiCol_ResizeGrip,           { 0.573, 0.512, 0.355, 1.00 } },
-    { ImGuiCol_ResizeGripHovered,    { 0.765, 0.684, 0.474, 1.00 } },
-    { ImGuiCol_ResizeGripActive,     { 0.957, 0.855, 0.592, 1.00 } },
+-- Styles used by the prompt/tracker windows (text, buttons, separators, title bar).
+local WINDOW_COLORS = {
+    { ImGuiCol_WindowBg,          { 0.051, 0.051, 0.051, 0.95 } },
+    { ImGuiCol_TitleBg,           { 0.098, 0.090, 0.075, 1.00 } },
+    { ImGuiCol_TitleBgActive,     { 0.137, 0.125, 0.106, 1.00 } },
+    { ImGuiCol_TitleBgCollapsed,  { 0.051, 0.051, 0.051, 0.95 } },
+    { ImGuiCol_Border,            { 0.300, 0.275, 0.235, 1.00 } },
+    { ImGuiCol_Text,              { 0.878, 0.855, 0.812, 1.00 } },
+    { ImGuiCol_TextDisabled,      { 0.765, 0.684, 0.474, 1.00 } },
+    { ImGuiCol_Button,            { 0.098, 0.090, 0.075, 1.00 } },
+    { ImGuiCol_ButtonHovered,     { 0.137, 0.125, 0.106, 1.00 } },
+    { ImGuiCol_ButtonActive,      { 0.176, 0.161, 0.137, 1.00 } },
+    { ImGuiCol_Separator,         { 0.300, 0.275, 0.235, 1.00 } },
+    { ImGuiCol_ResizeGrip,        { 0.573, 0.512, 0.355, 1.00 } },
+    { ImGuiCol_ResizeGripHovered, { 0.765, 0.684, 0.474, 1.00 } },
+    { ImGuiCol_ResizeGripActive,  { 0.957, 0.855, 0.592, 1.00 } },
 }
 
-local THEME_VARS = {
-    { ImGuiStyleVar_WindowPadding,     { 12, 12 } },
-    { ImGuiStyleVar_FramePadding,      { 8,  6  } },
-    { ImGuiStyleVar_ItemSpacing,       { 8,  7  } },
-    { ImGuiStyleVar_FrameRounding,     4.0        },
-    { ImGuiStyleVar_WindowRounding,    6.0        },
-    { ImGuiStyleVar_ChildRounding,     4.0        },
-    { ImGuiStyleVar_PopupRounding,     4.0        },
-    { ImGuiStyleVar_ScrollbarRounding, 4.0        },
-    { ImGuiStyleVar_GrabRounding,      4.0        },
-    { ImGuiStyleVar_WindowBorderSize,  1.0        },
-    { ImGuiStyleVar_ChildBorderSize,   1.0        },
-    { ImGuiStyleVar_FrameBorderSize,   1.0        },
-    { ImGuiStyleVar_WindowTitleAlign,  { 0.5, 0.5 } },
+local WINDOW_VARS = {
+    { ImGuiStyleVar_WindowPadding,    { 12, 12 } },
+    { ImGuiStyleVar_FramePadding,     { 6,  4  } },
+    { ImGuiStyleVar_ItemSpacing,      { 8,  6  } },
+    { ImGuiStyleVar_FrameRounding,    4.0        },
+    { ImGuiStyleVar_WindowRounding,   6.0        },
+    { ImGuiStyleVar_WindowBorderSize, 1.0        },
+    { ImGuiStyleVar_WindowTitleAlign, { 0.5, 0.5 } },
 }
 
-local THEME_COLOR_COUNT = #THEME_COLORS
-local THEME_VAR_COUNT   = #THEME_VARS
+local WINDOW_COLOR_COUNT = #WINDOW_COLORS
+local WINDOW_VAR_COUNT   = #WINDOW_VARS
 
--- Pre-computed window flags
-local PROMPT_FLAGS = bit.bor(
-    ImGuiWindowFlags_NoCollapse,
-    ImGuiWindowFlags_NoResize,
-    ImGuiWindowFlags_NoScrollbar,
-    ImGuiWindowFlags_AlwaysAutoResize,
-    ImGuiWindowFlags_NoSavedSettings,
-    ImGuiWindowFlags_NoMove
-)
-local TRACKER_FLAGS = bit.bor(
+local WINDOW_FLAGS = bit.bor(
     ImGuiWindowFlags_NoCollapse,
     ImGuiWindowFlags_AlwaysAutoResize,
     ImGuiWindowFlags_NoScrollbar,
-    ImGuiWindowFlags_NoSavedSettings,
-    ImGuiWindowFlags_NoMove
+    ImGuiWindowFlags_NoSavedSettings
 )
-local CONFIG_FLAGS = bit.bor(
-    ImGuiWindowFlags_NoCollapse,
-    ImGuiWindowFlags_AlwaysAutoResize,
-    ImGuiWindowFlags_NoScrollbar,
-    ImGuiWindowFlags_NoSavedSettings,
-    ImGuiWindowFlags_NoMove
-)
+local PROMPT_FLAGS = bit.bor(WINDOW_FLAGS, ImGuiWindowFlags_NoResize)
 
 -- Pre-allocated per-frame constants (zero GC per frame)
 local COLOR_READY     = { 0.20, 1.00, 0.20, 1.0 }
@@ -111,7 +67,6 @@ local ICON_UV1        = { 1, 1 }
 local ICON_TINT       = { 1, 1, 1, 1 }
 local ICON_BORDER     = { 0, 0, 0, 0 }
 local PIVOT_CENTER    = { 0.5, 0.5 }
-local BTN_YES_NO      = { 100, 28 }
 local BTN_CLOSE       = { -1, 24 }
 local FONT_SCALE      = 1.2
 local BTN_PROMPT      = { 120, 36 }
@@ -125,21 +80,43 @@ local COLOR_GOLD_BRIGHT  = { 0.957, 0.855, 0.592, 1.0 }
 local MIN_PARTY_COL_W    = 125
 local WIN_CENTER         = { 0, 0 }
 
-local function push_xidb_theme()
-    for i = 1, THEME_COLOR_COUNT do
-        local e = THEME_COLORS[i]
+local function push_window_styles()
+    for i = 1, WINDOW_COLOR_COUNT do
+        local e = WINDOW_COLORS[i]
         imgui.PushStyleColor(e[1], e[2])
     end
-    for i = 1, THEME_VAR_COUNT do
-        local e = THEME_VARS[i]
+    for i = 1, WINDOW_VAR_COUNT do
+        local e = WINDOW_VARS[i]
         imgui.PushStyleVar(e[1], e[2])
     end
+end
+
+local function member_status_color(status)
+    if status == 'ready' then return COLOR_READY end
+    if status == 'not_ready' then return COLOR_NOT_READY end
+    return COLOR_PENDING
+end
+
+local function draw_member_row(member)
+    imgui.PushStyleColor(ImGuiCol_Text, member_status_color(member.status))
+    local icon_ptr = statusHandler.GetJobIcon(member.job)
+    if icon_ptr then
+        imgui.Image(icon_ptr, ICON_SIZE, ICON_UV0, ICON_UV1, ICON_TINT, ICON_BORDER)
+    else
+        imgui.Dummy(ICON_SIZE)
+    end
+    imgui.SameLine()
+    imgui.Text(member.name)
+    imgui.PopStyleColor(1)
 end
 
 local function render_prompt(state, handlers)
     if not state.prompt_open[1] then return end
 
-    imgui.SetNextWindowPos(WIN_CENTER, ImGuiCond_Always, PIVOT_CENTER)
+    if state.prompt_center_next then
+        imgui.SetNextWindowPos(WIN_CENTER, ImGuiCond_Always, PIVOT_CENTER)
+        state.prompt_center_next = false
+    end
     imgui.SetNextWindowBgAlpha(0.95)
 
     if imgui.Begin('Ready Check##prompt', state.prompt_open, PROMPT_FLAGS) then
@@ -200,10 +177,13 @@ end
 local function render_tracker(state, handlers)
     if not state.checker_open[1] then return end
 
-    imgui.SetNextWindowPos(WIN_CENTER, ImGuiCond_Always, PIVOT_CENTER)
+    if state.tracker_center_next then
+        imgui.SetNextWindowPos(WIN_CENTER, ImGuiCond_Always, PIVOT_CENTER)
+        state.tracker_center_next = false
+    end
     imgui.SetNextWindowBgAlpha(0.90)
 
-    if imgui.Begin('Ready Check##tracker', state.checker_open, TRACKER_FLAGS) then
+    if imgui.Begin('Ready Check##tracker', state.checker_open, WINDOW_FLAGS) then
         SetWindowFontScale(FONT_SCALE)
         imgui.Text('Party / Alliance Status')
         imgui.SameLine()
@@ -261,20 +241,7 @@ local function render_tracker(state, handlers)
                     for col = 1, num_cols do
                         local member = parties[col][row]
                         if member then
-                            local status = member.status
-                            local col_c = status == 'ready'     and COLOR_READY
-                                       or status == 'not_ready' and COLOR_NOT_READY
-                                       or COLOR_PENDING
-                            imgui.PushStyleColor(ImGuiCol_Text, col_c)
-                            local icon_ptr = load_job_icon(member.job)
-                            if icon_ptr then
-                                imgui.Image(icon_ptr, ICON_SIZE, ICON_UV0, ICON_UV1, ICON_TINT, ICON_BORDER)
-                            else
-                                imgui.Dummy(ICON_SIZE)
-                            end
-                            imgui.SameLine()
-                            imgui.Text(member.name)
-                            imgui.PopStyleColor(1)
+                            draw_member_row(member)
                         else
                             imgui.Dummy({ 1, ICON_SIZE[2] })
                         end
@@ -286,21 +253,7 @@ local function render_tracker(state, handlers)
             else
                 local grp = parties[1]
                 for i = 1, #grp do
-                    local member = grp[i]
-                    local status = member.status
-                    local col_c = status == 'ready'     and COLOR_READY
-                               or status == 'not_ready' and COLOR_NOT_READY
-                               or COLOR_PENDING
-                    imgui.PushStyleColor(ImGuiCol_Text, col_c)
-                    local icon_ptr = load_job_icon(member.job)
-                    if icon_ptr then
-                        imgui.Image(icon_ptr, ICON_SIZE, ICON_UV0, ICON_UV1, ICON_TINT, ICON_BORDER)
-                    else
-                        imgui.Dummy(ICON_SIZE)
-                    end
-                    imgui.SameLine()
-                    imgui.Text(member.name)
-                    imgui.PopStyleColor(1)
+                    draw_member_row(grp[i])
                 end
             end
         end
@@ -317,91 +270,18 @@ local function render_tracker(state, handlers)
     imgui.End()
 end
 
-local function render_config(state, handlers)
-    if not state.config_open[1] then return end
-
-    imgui.SetNextWindowPos(WIN_CENTER, ImGuiCond_Always, PIVOT_CENTER)
-    imgui.SetNextWindowBgAlpha(0.95)
-
-    if imgui.Begin('ReadyCheck Config##config', state.config_open, CONFIG_FLAGS) then
-        SetWindowFontScale(FONT_SCALE)
-
-        imgui.PushStyleColor(ImGuiCol_Text, COLOR_GOLD_BRIGHT)
-        imgui.Text('Sound Settings')
-        imgui.PopStyleColor(1)
-        imgui.Separator()
-        imgui.Spacing()
-
-        imgui.Checkbox('Play sound when sending a ready check',   state.cfg.sound_on_checker)
-        imgui.Checkbox('Play sound when receiving a ready check', state.cfg.sound_on_prompt)
-        imgui.Spacing()
-
-        imgui.Text('Sound file:')
-        local files   = state.cfg.sound_files
-        local sel_idx = state.cfg.sound_sel_idx
-        if files and #files > 0 then
-            local preview = files[sel_idx[1]] or ''
-            imgui.SetNextItemWidth(300)
-            if imgui.BeginCombo('##rc_sound_combo', preview, ImGuiComboFlags_None) then
-                for i, fname in ipairs(files) do
-                    local selected = (i == sel_idx[1])
-                    if imgui.Selectable(fname, selected) then
-                        sel_idx[1] = i
-                    end
-                    if selected then imgui.SetItemDefaultFocus() end
-                end
-                imgui.EndCombo()
-            end
-            imgui.SameLine()
-            if imgui.Button('Refresh##rc_refresh', { 70, 0 }) then
-                handlers.scan_sound_files()
-            end
-            imgui.PushStyleColor(ImGuiCol_Text, { 0.55, 0.55, 0.55, 1.0 })
-            imgui.Text(addon.path .. 'modules\\readycheck\\sound\\' .. (files[sel_idx[1]] or ''))
-            imgui.PopStyleColor(1)
-        else
-            imgui.PushStyleColor(ImGuiCol_Text, { 0.80, 0.45, 0.20, 1.0 })
-            imgui.Text('No .wav files found in sound\\ folder.')
-            imgui.PopStyleColor(1)
-            imgui.SameLine()
-            if imgui.Button('Refresh##rc_refresh', { 70, 0 }) then
-                handlers.scan_sound_files()
-            end
-        end
-
-        imgui.Spacing()
-        imgui.Separator()
-        imgui.Spacing()
-
-        if imgui.Button('Test Sound', BTN_YES_NO) then
-            handlers.test_config_sound()
-        end
-        imgui.SameLine()
-        if imgui.Button('Save', BTN_YES_NO) then
-            handlers.save_config()
-        end
-        imgui.SameLine()
-        if imgui.Button('Close', BTN_YES_NO) then
-            state.config_open[1] = false
-        end
-        imgui.Spacing()
-    end
-    imgui.End()
-end
-
 function ui.render(state, handlers)
-    if not (state.prompt_open[1] or state.checker_open[1] or state.config_open[1]) then return end
+    if not (state.prompt_open[1] or state.checker_open[1]) then return end
 
     local display = imgui.GetIO().DisplaySize
     WIN_CENTER[1] = display.x * 0.5
     WIN_CENTER[2] = display.y * 0.5
 
-    push_xidb_theme()
+    push_window_styles()
     render_prompt(state, handlers)
     render_tracker(state, handlers)
-    render_config(state, handlers)
-    imgui.PopStyleVar(THEME_VAR_COUNT)
-    imgui.PopStyleColor(THEME_COLOR_COUNT)
+    imgui.PopStyleVar(WINDOW_VAR_COUNT)
+    imgui.PopStyleColor(WINDOW_COLOR_COUNT)
 end
 
 return ui


### PR DESCRIPTION
- Added a volume slider for ready check sounds.
  - Added soft stops at 50 and 100 percent on the volume slider.
  - Changed default volume to 50 percent. (Some sound files can be loud)
- Changed default sound file to `ffxiv-notification.wav` as it fits the FFXI theme more.
- Changed how ready check sound settings are saved to use the active profile instead of a separate settings file.
- Removed the separate ready check config window and the `/readycheck config` command since XIUI config already handles this.
- Added `/readycheck volume` and `/readycheck sound` chat commands to change settings quickly.
- Updated ready check chat messages so they work better for players without XIUI.
- Centered the ready check prompt and tracker when they open and kept them movable without saving their position.
- Matched the ready check windows to the XIUI look and cleaned up unused code.
- Updated the Profiles button styling in the XIUI config window.

<img width="349" height="361" alt="image" src="https://github.com/user-attachments/assets/a68b27b1-efb6-418b-b6af-45fbb7208551" />
