### PR TITLE
Fix/spell availability

### DIFF
--- a/XIUI/modules/hotbar/actions.lua
+++ b/XIUI/modules/hotbar/actions.lua
@@ -411,7 +411,10 @@ local function buildSpellByNameLookup()
     spellByNameLookup = {};
     for _, spell in pairs(horizonSpells) do
         if spell.en then
-            spellByNameLookup[spell.en] = spell;
+            local existing = spellByNameLookup[spell.en];
+            if not existing or (existing.unlearnable and not spell.unlearnable) then
+                spellByNameLookup[spell.en] = spell;
+            end
         end
     end
 end

--- a/XIUI/modules/hotbar/actions.lua
+++ b/XIUI/modules/hotbar/actions.lua
@@ -59,6 +59,8 @@ local NATIVE_MACRO_NUMBER_KEYS = {
     [53] = true, [54] = true, [55] = true, [56] = true, [57] = true,  -- 5-9
 };
 
+local MAX_JOB_LEVEL = 99;
+
 -- Arrow keys for macro set switching
 local VK_UP = 0x26;
 local VK_DOWN = 0x28;
@@ -649,9 +651,9 @@ function M.IsActionAvailable(bind)
         local mainReqLevel = levels[mainJobId];
         local subReqLevel = subJobId and levels[subJobId] or nil;
 
-        -- Check main job first
+        -- Check main job first (Job Point spells report level > 99)
         if mainReqLevel then
-            if mainJobLevel >= mainReqLevel then
+            if mainJobLevel >= mainReqLevel or mainReqLevel > MAX_JOB_LEVEL then
                 return true, nil;  -- Can cast with main job
             end
         end

--- a/XIUI/modules/hotbar/playerdata.lua
+++ b/XIUI/modules/hotbar/playerdata.lua
@@ -19,6 +19,8 @@ local cachedItems = nil;
 local cacheJobId = nil;
 local cacheSubJobId = nil;
 
+local MAX_JOB_LEVEL = 99;
+
 -- ============================================
 -- Container Definitions
 -- ============================================
@@ -201,8 +203,8 @@ function M.GetPlayerSpells()
                     local validMainReq = mainReqLevel > 0 and mainReqLevel < 255;
                     local validSubReq = subReqLevel > 0 and subReqLevel < 255;
 
-                    -- Check if castable by main job
-                    local canCastMain = validMainReq and mainReqLevel <= mainJobLevel;
+                    -- Check if castable by main job (Job Point spells report level > 99)
+                    local canCastMain = validMainReq and (mainReqLevel <= mainJobLevel or mainReqLevel > MAX_JOB_LEVEL);
                     -- Check if castable by sub job
                     local canCastSub = validSubReq and subReqLevel <= subJobLevel;
 


### PR DESCRIPTION
Fixes two spell availability bugs.

Job Point spells (Fire VI, etc.) were getting hidden from the spell
list and shown as unavailable on the hotbar. Their level requirement
is 100, which is above the actual level cap of 99, so the level check
always failed even when the player had already unlocked the spell.

Sleepga and Sleepga II also showed wrong info sometimes. Both have a
second, unlearnable entry under the same name (a monster-only version
with different cast time and recast). The recent fix for duplicate
spell names (#383) only patched the lookup used for availability
checks, not the separate one used for spell stats, so Sleepga II could
still pull cast time and recast from the wrong entry. This patches
that second lookup too
