### PR TITLE
[TargetBar] Add support for enemy TP abilities

### DIFF
--- a/XIUI/modules/targetbar.lua
+++ b/XIUI/modules/targetbar.lua
@@ -887,6 +887,35 @@ targetbar.HandleActionPacket = function(actionPacket)
 		return;
 	end
 
+	-- Type 7 = Abillity
+	if (actionPacket.Type == 7) then
+		local abilityId = actionPacket.Targets[1].Actions[1].Param;
+		local actionMessage = actionPacket.Targets[1].Actions[1].Message
+
+		-- Handle interrupted ability
+		if (actionMessage == 0) then
+			targetbar.enemyCasts[actionPacket.UserId] = nil;
+			return; -- Don't create new cast data
+		end
+
+		local abilityNameRaw = nil;
+		if (abilityId < 256) then
+			local ability = AshitaCore:GetResourceManager():GetAbilityById(abilityId);
+			abilityNameRaw = ability.Name[1]
+		else
+			abilityNameRaw = AshitaCore:GetResourceManager():GetString('monsters.abilities', abilityId - 256);
+		end
+
+		local abilityName = encoding:ShiftJIS_To_UTF8(abilityNameRaw, true);
+		targetbar.enemyCasts[actionPacket.UserId] = T{
+			spellName = abilityName,
+			spellId = abilityId,
+			castTime = 1, -- Cast time varies by ability
+			startTime = os.clock(),  -- High precision timestamp
+			timestamp = os.time()    -- For cleanup
+		};
+	end
+
 	-- Type 8 = Magic (Start) - Enemy begins casting
 	if (actionPacket.Type == 8) then
 		-- According to XiPackets: interrupted casts send ANOTHER Type 8 with "sp" prefix (vs "ca" for normal start)


### PR DESCRIPTION
Figured it'd be nice to have some way of knowing when an enemy is readying an ability for the sake of interrupting, without having to stare at the combat log.

Ability interrupt and name parsing logic is from https://github.com/ShiyoKozuki/CombatMessages

Caveat: ability cast time is variable per ability and doesn't seem to be exposed by Ashita's `GetAbilityById`. I have it set to `1` by default, which matches the shortest cast time for an enemy ability. If the ability channel is longer, it'll hang at full cast bar for a bit, but I figure that visual error is probably preferable to the cast resolving before the bar fills up? (I think ideally I'd like abilities to just not have a bar at all, unless there's a way to grab an ability ready time).