### PR TITLE
Add castbars to enemyList

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -87,6 +87,7 @@ local commandHelp = require('libs.help');
 local debuffHandler = require('handlers.debuffhandler');
 local petBuffHandler = require('handlers.petbuffhandler');
 local actionTracker = require('handlers.actiontracker');
+local enemyCasts = require('handlers.enemycasts');
 local mobInfo = require('modules.mobinfo.init');
 local statusHandler = require('handlers.statushandler');
 local progressbar = require('libs.progressbar');
@@ -96,7 +97,7 @@ local imtext = require('libs.imtext');
 local components = require('config.components');
 
 -- Global switch to hard-disable functionality that is limited on HX servers
-HzLimitedMode = true;
+HzLimitedMode = false;
 
 -- Flag to skip settings_update callback during internal saves
 local bInternalSave = false;
@@ -1690,6 +1691,12 @@ ashita.events.register('text_in', 'readycheck_text_in_cb', function (e)
     end
 end);
 
+-- Enemy cast bars (target bar + enemy list) share one packet-driven tracker.
+local function enemyCastTrackingEnabled()
+    return not HzLimitedMode and ((gConfig.showTargetBar and gConfig.showTargetBarCastBar)
+        or (gConfig.showEnemyList and gConfig.showEnemyListCastBar));
+end
+
 ashita.events.register('packet_in', 'packet_in_cb', function (e)
     if satchelModule.HandlePacketIn then
         satchelModule.HandlePacketIn(e);
@@ -1712,9 +1719,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         if actionPacket then
             if gConfig.showEnemyList then enemyList.HandleActionPacket(actionPacket); end
             if gConfig.showCastBar then castBar.HandleActionPacket(actionPacket); end
-            if gConfig.showTargetBar and gConfig.showTargetBarCastBar and not HzLimitedMode then
-                targetBar.HandleActionPacket(actionPacket);
-            end
+            if enemyCastTrackingEnabled() then enemyCasts.HandleActionPacket(actionPacket); end
             if gConfig.showPartyList then partyList.HandleActionPacket(actionPacket); end
             debuffHandler.HandleActionPacket(actionPacket);
             petBuffHandler.HandleActionPacket(actionPacket);
@@ -1734,6 +1739,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         notifications.HandleZonePacket();
         treasurePool.HandleZonePacket();
         enemyList.HandleZonePacket(e);
+        enemyCasts.HandleZonePacket();
         partyList.HandleZonePacket(e);
         debuffHandler.HandleZonePacket(e);
         petBuffHandler.HandleZonePacket();
@@ -1755,6 +1761,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         if messagePacket then
             debuffHandler.HandleMessagePacket(messagePacket);
             petBuffHandler.HandleMessagePacket(messagePacket);
+            if enemyCastTrackingEnabled() then enemyCasts.HandleMessagePacket(messagePacket); end
             if gConfig.showNotifications then
                 notifications.HandleMessagePacket(e, messagePacket, 0x0029);
             end

--- a/XIUI/config/enemylist.lua
+++ b/XIUI/config/enemylist.lua
@@ -19,6 +19,10 @@ function M.DrawSettings()
     if components.CollapsingSection('Display Options##enemyList') then
         components.DrawCheckbox('Show Distance', 'showEnemyDistance');
         components.DrawCheckbox('Show HP% Text', 'showEnemyHPPText');
+        if (not HzLimitedMode) then
+            components.DrawCheckbox('Show Cast Bar', 'showEnemyListCastBar');
+            imgui.ShowHelp('Shows a cast bar under enemies that are casting, with an interrupt flash.');
+        end
         components.DrawCheckbox('Show Enemy Targets', 'showEnemyListTargets');
         imgui.ShowHelp('Shows who each enemy is targeting based on their last action.');
         components.DrawCheckbox('Show Bookends', 'showEnemyListBookends');
@@ -100,11 +104,18 @@ end
 function M.DrawColorSettings()
     if components.CollapsingSection('HP Bar Color##enemyListColor') then
         components.DrawGradientPicker("Enemy HP Bar", gConfig.colorCustomization.enemyList.hpGradient, "Enemy HP bar color");
+        if (not HzLimitedMode) then
+            components.DrawGradientPicker("Enemy Cast Bar", gConfig.colorCustomization.enemyList.castBarGradient, "Enemy cast bar color");
+        end
     end
 
     if components.CollapsingSection('Text Colors##enemyListColor') then
         components.DrawTextColorPicker("Distance Text", gConfig.colorCustomization.enemyList, 'distanceTextColor', "Color of distance text");
         components.DrawTextColorPicker("HP% Text", gConfig.colorCustomization.enemyList, 'percentTextColor', "Color of HP percentage text");
+        if (not HzLimitedMode) then
+            components.DrawTextColorPicker("Cast Text", gConfig.colorCustomization.enemyList, 'castTextColor', "Color of enemy cast spell name");
+            components.DrawTextColorPicker("Cast Target Text", gConfig.colorCustomization.enemyList, 'castTargetTextColor', "Color of the cast target name");
+        end
         components.DrawTextColorPicker("Target Name Text", gConfig.colorCustomization.enemyList, 'targetNameTextColor', "Color of enemy's target name");
         imgui.ShowHelp("Enemy name colors are in the Global section");
     end

--- a/XIUI/core/settings/colors.lua
+++ b/XIUI/core/settings/colors.lua
@@ -64,6 +64,9 @@ function M.createColorCustomizationDefaults()
         -- Enemy List
         enemyList = T{
             hpGradient = T{ enabled = true, start = '#e16c6c', stop = '#fb9494' },
+            castBarGradient = T{ enabled = true, start = '#ffaa00', stop = '#ffcc44' },
+            castTextColor = 0xFFFFAA00,        -- Orange - enemy cast spell name
+            castTargetTextColor = 0xFF66CCFF,  -- Light blue - who the enemy is casting on
             distanceTextColor = 0xFFFFFFFF,
             percentTextColor = 0xFFFFFFFF,
             backgroundColor = 0x66000000,        -- Semi-transparent black - Alpha is the first byte: 0.4 * 255 = 102 = 0x66

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -425,7 +425,8 @@ function M.createUserSettingsDefaults()
 
         showSatchelModule = true,
         satchelVisible = false,
-        satchelOverrideCommand = true,
+        -- Horizon (limited mode) leaves /satchel to the game by default.
+        satchelOverrideCommand = (not HzLimitedMode),
         satchelCloseOnEscape = false,
         satchelHideDuringEvents = false,
         satchelHideOnMenuFocus = false,

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -308,6 +308,7 @@ function M.createUserSettingsDefaults()
         enemyListIconScale = 1,
         showEnemyDistance = true,
         showEnemyHPPText = true,
+        showEnemyListCastBar = true,
         showEnemyListBookends = false,
         showEnemyListBorders = true,
         showEnemyListBordersUseNameColor = false,

--- a/XIUI/handlers/debuffhandler.lua
+++ b/XIUI/handlers/debuffhandler.lua
@@ -73,6 +73,7 @@ local SPELL_DURATIONS = {
     [216] = {duration = 120}, -- Gravity
     [254] = {duration = 180}, -- Blind
     [276] = {duration = 180}, -- Blind II
+    [112] = {duration = 12},  -- Flash
     [59] = {duration = 120},  -- Silence
     [359] = {duration = 120}, -- Silencega
     [253] = {duration = 60},  -- Sleep

--- a/XIUI/handlers/enemycasts.lua
+++ b/XIUI/handlers/enemycasts.lua
@@ -1,0 +1,150 @@
+--[[
+* XIUI Enemy Cast Tracker
+* Shared tracking of enemy spellcasting for the target bar and enemy list.
+* Handles begin/finish/interrupt detection and the white "interrupted" flash.
+]]--
+
+require('common');
+local encoding = require('libs.encoding');
+
+local M = {};
+
+-- Battle-message ids that mean an in-progress cast broke: 16 = interrupted
+-- (damage/silence/move/range), 84 = paralyzed, 106 = intimidated.
+local INTERRUPT_MESSAGES = { [16] = true, [84] = true, [106] = true };
+
+-- How long the white "interrupted" flash lingers before the cast is removed.
+M.FLASH_DURATION = 0.5;
+-- Grace period after cast time before a bar with no finish packet is dropped.
+local FINISH_GRACE = 2.0;
+-- Absolute stale-cast cleanup (seconds).
+local STALE_TIMEOUT = 30;
+
+-- [serverId] = { spellName, spellId, castTime, startTime, timestamp,
+--                interrupted, interruptTime, interruptProgress }
+local casts = {};
+
+function M.GetCast(serverId)
+    return serverId ~= nil and casts[serverId] or nil;
+end
+
+function M.ClearCast(serverId)
+    if serverId ~= nil then
+        casts[serverId] = nil;
+    end
+end
+
+-- Mark a tracked cast interrupted so consumers flash it white, freezing the
+-- fill where it stopped. No-op if nothing is tracked for this actor.
+function M.BeginInterruptFlash(serverId)
+    local cast = M.GetCast(serverId);
+    if cast == nil or cast.interrupted then
+        return;
+    end
+    cast.interrupted = true;
+    cast.interruptTime = os.clock();
+    local elapsed = os.clock() - (cast.startTime or os.clock());
+    cast.interruptProgress = math.min(elapsed / (cast.castTime or 1), 1.0);
+end
+
+-- Per-frame render state for a cast bar. Returns whether to draw, progress
+-- (0..1), an optional white flash overlay { '#ffffff', alpha }, the spell name,
+-- and the cast target's server id. Clears finished/expired casts as a side effect.
+function M.GetRenderState(serverId)
+    local cast = M.GetCast(serverId);
+    if cast == nil then
+        return false;
+    end
+
+    if cast.interrupted then
+        local flashElapsed = os.clock() - (cast.interruptTime or os.clock());
+        if flashElapsed >= M.FLASH_DURATION then
+            casts[serverId] = nil;
+            return false;
+        end
+        return true, cast.interruptProgress or 1.0,
+            {'#ffffff', 1.0 - (flashElapsed / M.FLASH_DURATION)}, cast.spellName, cast.targetId;
+    end
+
+    local elapsed = os.clock() - cast.startTime;
+    if elapsed > cast.castTime + FINISH_GRACE then
+        casts[serverId] = nil;
+        return false;
+    end
+    return true, math.min(elapsed / cast.castTime, 1.0), nil, cast.spellName, cast.targetId;
+end
+
+-- 0x0028 action packets: Type 8 begins a cast, Type 4/11 finishes it.
+M.HandleActionPacket = function(actionPacket)
+    if actionPacket == nil or actionPacket.UserId == nil then
+        return;
+    end
+
+    if actionPacket.Type == 8 then
+        if actionPacket.Targets and #actionPacket.Targets > 0 and
+           actionPacket.Targets[1].Actions and #actionPacket.Targets[1].Actions > 0 then
+            local spellId = actionPacket.Targets[1].Actions[1].Param;
+            local existing = casts[actionPacket.UserId];
+
+            -- Second Type 8 for the same spell = interruption signal; flash then clear.
+            if existing ~= nil and existing.spellId == spellId then
+                M.BeginInterruptFlash(actionPacket.UserId);
+                return;
+            end
+            if existing ~= nil and existing.spellId ~= spellId then
+                casts[actionPacket.UserId] = nil;
+            end
+
+            local spell = AshitaCore:GetResourceManager():GetSpellById(spellId);
+            if spell ~= nil and spell.Name[1] ~= nil then
+                casts[actionPacket.UserId] = {
+                    spellName = encoding:ShiftJIS_To_UTF8(spell.Name[1], true),
+                    spellId = spellId,
+                    -- Cast target straight from the begin-cast packet (reliable,
+                    -- unlike the action tracker which ignores Type 8).
+                    targetId = actionPacket.Targets[1].Id,
+                    castTime = spell.CastTime / 4.0,  -- quarter seconds -> seconds
+                    startTime = os.clock(),
+                    timestamp = os.time(),
+                };
+            end
+        end
+    -- Type 4 = Magic (Finish); Type 11 = Monster Skill (Finish). Either resolved,
+    -- or broke via paralyze/intimidate (msg 84/106) which flashes instead.
+    elseif actionPacket.Type == 4 or actionPacket.Type == 11 then
+        local finishMsg;
+        if actionPacket.Targets and #actionPacket.Targets > 0 and
+           actionPacket.Targets[1].Actions and #actionPacket.Targets[1].Actions > 0 then
+            finishMsg = actionPacket.Targets[1].Actions[1].Message;
+        end
+        if finishMsg ~= nil and INTERRUPT_MESSAGES[finishMsg] then
+            M.BeginInterruptFlash(actionPacket.UserId);
+        else
+            casts[actionPacket.UserId] = nil;
+        end
+    end
+
+    local now = os.time();
+    for serverId, data in pairs(casts) do
+        if data.timestamp + STALE_TIMEOUT < now then
+            casts[serverId] = nil;
+        end
+    end
+end
+
+-- 0x0029 battle messages: the cleanest interrupt signal (msg 16 = interrupted).
+-- The message actor (sender) is the same server id casts are keyed on.
+M.HandleMessagePacket = function(messagePacket)
+    if messagePacket == nil or messagePacket.message == nil then
+        return;
+    end
+    if INTERRUPT_MESSAGES[messagePacket.message] then
+        M.BeginInterruptFlash(messagePacket.sender);
+    end
+end
+
+M.HandleZonePacket = function()
+    casts = {};
+end
+
+return M;

--- a/XIUI/modules/enemylist.lua
+++ b/XIUI/modules/enemylist.lua
@@ -5,6 +5,7 @@ local imtext = require('libs.imtext');
 local debuffHandler = require('handlers.debuffhandler');
 local statusHandler = require('handlers.statushandler');
 local actionTracker = require('handlers.actiontracker');
+local enemyCasts = require('handlers.enemycasts');
 local progressbar = require('libs.progressbar');
 local defaultPositions = require('libs.defaultpositions');
 
@@ -60,6 +61,12 @@ local previewTargets = {
     [9006] = nil,               -- No target
     [9007] = 'Longtargetname',
     [9008] = 'Redmage',
+};
+
+-- Preview cast spell names for config mode (keyed by preview enemy index)
+local previewCasts = {
+    [9002] = 'Fire III',
+    [9003] = 'Cure IV',
 };
 
 -- Cache for truncated names to avoid expensive binary search every frame
@@ -249,10 +256,28 @@ enemylist.DrawWindow = function(settings)
 					infoRowHeight = settings.percent_font_settings.font_height;
 				end
 
+				-- Cast bar: resolve render state once (also clears finished/interrupted casts).
+				local castBarHeight = barHeight;
+				local castTextHeight = settings.distance_font_settings.font_height;
+				local hasCast, castProgress, castOverlay, castSpellName, castTargetId = false;
+				if (gConfig.showEnemyListCastBar and not HzLimitedMode) then
+					if isPreviewMode then
+						castSpellName = previewCasts[k];
+						hasCast = castSpellName ~= nil;
+						castProgress = (os.clock() % 5.0) / 5.0;  -- looping demo fill
+					elseif ent.ServerId ~= nil then
+						hasCast, castProgress, castOverlay, castSpellName, castTargetId = enemyCasts.GetRenderState(ent.ServerId);
+					end
+				end
+
 				-- Calculate total height based on which rows are visible
 				local totalContentHeight = nameHeight + nameToBarGap + barHeight;
 				if (infoRowHeight > 0) then
 					totalContentHeight = totalContentHeight + barToInfoGap + infoRowHeight;
+				end
+				if (hasCast) then
+					totalContentHeight = totalContentHeight + barToInfoGap + castBarHeight
+						+ math.max(2 * scaleY, 1) + castTextHeight;
 				end
 				local entryHeight = (padding * 2) + totalContentHeight;
 
@@ -367,6 +392,50 @@ enemylist.DrawWindow = function(settings)
 						local hpColor = gConfig.colorCustomization.enemyList.percentTextColor;
 						local hpWidth, _ = imtext.Measure(hpText, settings.percent_font_settings.font_height);
 						imtext.Draw(drawList, hpText, entryStartX + entryWidth - padding - hpWidth, row3Y, hpColor, settings.percent_font_settings.font_height);
+					end
+				end
+
+				-- ROW 4: Cast bar + spell name (only while an enemy is casting)
+				if (hasCast) then
+					local contentBottomY = row2Y + barHeight;
+					if (infoRowHeight > 0) then
+						contentBottomY = contentBottomY + barToInfoGap + infoRowHeight;
+					end
+					local castBarY = contentBottomY + barToInfoGap;
+
+					imgui.SetCursorScreenPos({barX, castBarY});
+					local castGradient = GetCustomGradient(gConfig.colorCustomization.enemyList, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
+					progressbar.ProgressBar(
+						{{castProgress, castGradient, castOverlay}},
+						{barWidth, castBarHeight},
+						{decorate = gConfig.showEnemyListBookends}
+					);
+
+					-- "<spell> - <target>" centered below the bar; target in its own color.
+					imtext.SetConfigFromSettings(settings.distance_font_settings);
+					local castColor = gConfig.colorCustomization.enemyList.castTextColor or 0xFFFFAA00;
+
+					-- Who the enemy is casting on, from the begin-cast packet's target id.
+					-- Skip it when the enemy is casting on itself (buffs/self-heals).
+					local castTargetName;
+					if isPreviewMode then
+						castTargetName = previewTargets[k];
+					elseif castTargetId ~= nil and castTargetId ~= ent.ServerId then
+						local castTargetIdx = GetIndexFromId(castTargetId);
+						local castTargetEnt = castTargetIdx ~= nil and castTargetIdx > 0 and GetEntity(castTargetIdx) or nil;
+						castTargetName = castTargetEnt ~= nil and castTargetEnt.Name or nil;
+					end
+
+					local suffix = castTargetName and (' - ' .. castTargetName) or nil;
+					local spellWidth = imtext.Measure(castSpellName, castTextHeight);
+					local suffixWidth = suffix and imtext.Measure(suffix, castTextHeight) or 0;
+					local castTextX = barX + (barWidth / 2) - ((spellWidth + suffixWidth) / 2);
+					local castTextY = castBarY + castBarHeight + math.max(2 * scaleY, 1);
+
+					imtext.Draw(drawList, castSpellName, castTextX, castTextY, castColor, castTextHeight);
+					if (suffix) then
+						local castTargetColor = gConfig.colorCustomization.enemyList.castTargetTextColor or 0xFF66CCFF;
+						imtext.Draw(drawList, suffix, castTextX + spellWidth, castTextY, castTargetColor, castTextHeight);
 					end
 				end
 

--- a/XIUI/modules/satchel/init.lua
+++ b/XIUI/modules/satchel/init.lua
@@ -422,13 +422,17 @@ local function render_slot_grid(slots, key_prefix, stat)
         get_slot_border_color = items.get_slot_border_color,
         render_item_detail_tooltip = items.render_item_detail_tooltip,
         on_slot_right_click = function(slot)
+            -- Horizon forbids addon-driven item moves, so the satchel is view-only there.
+            if HzLimitedMode then return end
             satchel.context_menu.slot = copy_slot_ref(slot)
             satchel.context_menu.pending_open = true
         end,
         on_slot_double_click = function(slot)
+            if HzLimitedMode then return end
             handle_double_click_transfer(copy_slot_ref(slot))
         end,
         on_slot_drag_start = function(slot, icon_texture)
+            if HzLimitedMode then return end
             if satchel.drag.active then
                 return
             end

--- a/XIUI/modules/targetbar.lua
+++ b/XIUI/modules/targetbar.lua
@@ -4,11 +4,11 @@ local imgui = require('imgui');
 local statusHandler = require('handlers.statushandler');
 local debuffHandler = require('handlers.debuffhandler');
 local actionTracker = require('handlers.actiontracker');
+local enemyCasts = require('handlers.enemycasts');
 local progressbar = require('libs.progressbar');
 local statusIcons = require('libs.statusicons');
 local buffTable = require('libs.bufftable');
 local imtext = require('libs.imtext');
-local encoding = require('libs.encoding');
 local ffi = require("ffi");
 local defaultPositions = require('libs.defaultpositions');
 local TextureManager = require('libs.texturemanager');
@@ -23,7 +23,6 @@ local arrowTexture;
 local lockTexture;
 local targetbar = {
 	interpolation = {},
-	enemyCasts = {}, -- Track enemy casting: [serverId] = {spellName, timestamp}
 	-- Exported name text position for mob info snap feature
 	nameTextInfo = {
 		x = 0,        -- X position after name text ends
@@ -524,51 +523,48 @@ targetbar.DrawWindow = function(settings)
 			imtext.Draw(drawList, distString, distX, distY, desiredDistColor, distFontSize);
 		end
 
-		-- Draw enemy cast bar and text if casting (or in config mode) and if enabled
-		local castData = targetbar.enemyCasts[targetEntity.ServerId];
+		-- Draw enemy cast bar and text if casting (or in config mode) and if enabled.
+		-- Remembered so we can reserve matching layout space below.
+		local castBarDrawn = false;
+		if (gConfig.showTargetBarCastBar and not HzLimitedMode) then
+			local drawCast, progress, castOverlay, castDisplayText;
+			if (inConfigMode and enemyCasts.GetCast(targetEntity.ServerId) == nil) then
+				-- Demo cast that loops every 5s for config preview.
+				drawCast, progress, castDisplayText = true, (os.clock() % 5.0) / 5.0, "Fire III (Demo)";
+			else
+				drawCast, progress, castOverlay, castDisplayText = enemyCasts.GetRenderState(targetEntity.ServerId);
+			end
 
-		-- Create test cast data for config mode
-		if (inConfigMode and castData == nil) then
-			castData = T{
-				spellName = "Fire III",
-				castTime = 5.0,  -- 5 second cast
-				startTime = os.clock() - ((os.clock() % 5.0)),  -- Loops every 5 seconds
-			};
-		end
+			if (drawCast) then
+				castBarDrawn = true;
+				-- Draw cast bar under HP bar using user-configurable offsets and scaling
+				local castBarY = startY + settings.barHeight + settings.castBarOffsetY;
+				-- Right-align the cast bar with the HP bar (accounting for bookends and 12px padding)
+				local castBarX = startX + settings.barWidth - bookendWidth - settings.castBarWidth - 12 + settings.castBarOffsetX;
 
-		if (gConfig.showTargetBarCastBar and (not HzLimitedMode) and castData ~= nil and castData.spellName ~= nil and castData.castTime ~= nil and castData.startTime ~= nil) then
-			-- Calculate cast progress
-			local elapsed = os.clock() - castData.startTime;
-			local progress = math.min(elapsed / castData.castTime, 1.0);
+				-- Cast bar settings (using adjusted settings)
+				local castBarHeight = settings.castBarHeight;
+				local castBarWidth = settings.castBarWidth;
+				local castGradient = GetCustomGradient(gConfig.colorCustomization.targetBar, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
 
-			-- Draw cast bar under HP bar using user-configurable offsets and scaling
-			local castBarY = startY + settings.barHeight + settings.castBarOffsetY;
-			-- Right-align the cast bar with the HP bar (accounting for bookends and 12px padding)
-			local castBarX = startX + settings.barWidth - bookendWidth - settings.castBarWidth - 12 + settings.castBarOffsetX;
+				-- Draw cast bar with absolute positioning (doesn't affect ImGui layout)
+				progressbar.ProgressBar(
+					{{progress, castGradient, castOverlay}},
+					{castBarWidth, castBarHeight},
+					{
+						decorate = gConfig.showTargetBarBookends,
+						absolutePosition = {castBarX, castBarY}
+					}
+				);
 
-			-- Cast bar settings (using adjusted settings)
-			local castBarHeight = settings.castBarHeight;
-			local castBarWidth = settings.castBarWidth;
-			local castGradient = GetCustomGradient(gConfig.colorCustomization.targetBar, 'castBarGradient') or {'#ffaa00', '#ffcc44'};
-
-			-- Draw cast bar with absolute positioning (doesn't affect ImGui layout)
-			progressbar.ProgressBar(
-				{{progress, castGradient}},
-				{castBarWidth, castBarHeight},
-				{
-					decorate = gConfig.showTargetBarBookends,
-					absolutePosition = {castBarX, castBarY}
-				}
-			);
-
-			-- Draw cast text below the cast bar (centered on cast bar)
-			imtext.SetConfigFromSettings(settings.cast_font_settings);
-			local castFontSize = settings.cast_font_settings.font_height;
-			local castDisplayText = inConfigMode and "Fire III (Demo)" or castData.spellName;
-			local castWidth, _ = imtext.Measure(castDisplayText, castFontSize);
-			local centerX = castBarX + (castBarWidth / 2);
-			local castColor = gConfig.colorCustomization.targetBar.castTextColor;
-			imtext.Draw(drawList, castDisplayText, centerX - castWidth / 2, castBarY + castBarHeight + 2, castColor, castFontSize);
+				-- Draw cast text below the cast bar (centered on cast bar)
+				imtext.SetConfigFromSettings(settings.cast_font_settings);
+				local castFontSize = settings.cast_font_settings.font_height;
+				local castWidth, _ = imtext.Measure(castDisplayText, castFontSize);
+				local centerX = castBarX + (castBarWidth / 2);
+				local castColor = gConfig.colorCustomization.targetBar.castTextColor;
+				imtext.Draw(drawList, castDisplayText, centerX - castWidth / 2, castBarY + castBarHeight + 2, castColor, castFontSize);
+			end
 		end
 
 		-- Draw buffs and debuffs
@@ -670,7 +666,7 @@ targetbar.DrawWindow = function(settings)
 
 		-- Reserve space for cast bar at bottom of window to prevent clipping
 		-- Calculate total height needed: offset Y + bar height + text spacing + text height
-		if (gConfig.showTargetBarCastBar and (not HzLimitedMode) and castData ~= nil and castData.spellName ~= nil) then
+		if (castBarDrawn) then
 			local castTextHeight = settings.cast_font_settings.font_height;
 			local totalCastBarSpace = settings.castBarOffsetY + settings.castBarHeight + 2 + castTextHeight;
 			imgui.Dummy({0, totalCastBarSpace});
@@ -879,67 +875,6 @@ targetbar.ResetPositions = function()
 	end
 	if gConfig.appliedPositions then
 		gConfig.appliedPositions['TargetBar'] = nil;
-	end
-end
-
-targetbar.HandleActionPacket = function(actionPacket)
-	if (actionPacket == nil or actionPacket.UserId == nil) then
-		return;
-	end
-
-	-- Type 8 = Magic (Start) - Enemy begins casting
-	if (actionPacket.Type == 8) then
-		-- According to XiPackets: interrupted casts send ANOTHER Type 8 with "sp" prefix (vs "ca" for normal start)
-		-- We can't parse the prefix directly, but if we get Type 8 for the SAME spell that's already active,
-		-- it's likely the interruption packet - clear the cast instead of restarting it
-
-		-- Get the spell ID from the action
-		if (actionPacket.Targets and #actionPacket.Targets > 0 and
-		    actionPacket.Targets[1].Actions and #actionPacket.Targets[1].Actions > 0) then
-			local spellId = actionPacket.Targets[1].Actions[1].Param;
-			local existingCast = targetbar.enemyCasts[actionPacket.UserId];
-
-			-- If we already have an active cast for THE SAME spell, this is likely the interruption packet
-			if (existingCast ~= nil and existingCast.spellId == spellId) then
-				-- Second Type 8 for same spell = interruption signal, clear the cast
-				targetbar.enemyCasts[actionPacket.UserId] = nil;
-				return; -- Don't create new cast data
-			end
-
-			-- If we have a cast for a DIFFERENT spell, clear it (new cast started)
-			if (existingCast ~= nil and existingCast.spellId ~= spellId) then
-				targetbar.enemyCasts[actionPacket.UserId] = nil;
-			end
-
-			-- Create new cast data (first Type 8 for this spell)
-			local spell = AshitaCore:GetResourceManager():GetSpellById(spellId);
-			if (spell ~= nil and spell.Name[1] ~= nil) then
-				local spellName = encoding:ShiftJIS_To_UTF8(spell.Name[1], true);
-				-- Cast time is in quarter seconds (e.g., 40 = 10 seconds)
-				local castTime = spell.CastTime / 4.0;
-
-				targetbar.enemyCasts[actionPacket.UserId] = T{
-					spellName = spellName,
-					spellId = spellId,
-					castTime = castTime,
-					startTime = os.clock(),  -- High precision timestamp
-					timestamp = os.time()    -- For cleanup
-				};
-			end
-		end
-	-- Type 4 = Magic (Finish) - Cast completed
-	-- Type 11 = Monster Skill (Finish) - Some abilities
-	elseif (actionPacket.Type == 4 or actionPacket.Type == 11) then
-		-- Clear the cast for this enemy
-		targetbar.enemyCasts[actionPacket.UserId] = nil;
-	end
-
-	-- Cleanup stale casts (older than 30 seconds)
-	local now = os.time();
-	for serverId, data in pairs(targetbar.enemyCasts) do
-		if (data.timestamp + 30 < now) then
-			targetbar.enemyCasts[serverId] = nil;
-		end
 	end
 end
 


### PR DESCRIPTION
Enemy List Cast Bars + Interrupt Detection

Added cast bars to the enemy list so you can see what nearby mobs are casting at a glance. Each casting enemy now shows a progress bar with the spell name, plus the cast target (e.g. Fire III - PlayerName) in its own color, omitted when the enemy is casting on itself.

Cast tracking is packet-driven and shared with the target cast bar via a common handler. Interrupts are now detected reliably (from action/message packets, not just cast-time heuristics): when a cast is interrupted, the bar flashes white and clears instead of running to completion. A cast-time timeout fallback handles any missed packets.

Fully configurable — toggle the cast bar on/off and customize the bar gradient, spell-name color, and target-name color. Packet parsing only runs when the feature is enabled to avoid unnecessary overhead.

This feature is disabled for Horizon
<img width="256" height="497" alt="Screenshot 2026-07-02 201438" src="https://github.com/user-attachments/assets/3878e617-acb4-4881-a38a-b4eb28377aae" />

