### PR TITLE
Add horizon specific mobinfo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "XIUI/submodules/xiui-icons"]
 	path = XIUI/submodules/xiui-icons
 	url = https://github.com/Vincerno/xiui-icons.git
+[submodule "XIUI/submodules/mobdb_horizon"]
+	path = XIUI/submodules/mobdb_horizon
+	url = https://github.com/Mr-Sithel/HorizonXI-Dynamis-Mobdb.git

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -425,7 +425,8 @@ function M.createUserSettingsDefaults()
 
         showSatchelModule = true,
         satchelVisible = false,
-        satchelOverrideCommand = true,
+        -- Horizon (limited mode) leaves /satchel to the game by default.
+        satchelOverrideCommand = (not HzLimitedMode),
         satchelCloseOnEscape = false,
         satchelHideDuringEvents = false,
         satchelHideOnMenuFocus = false,

--- a/XIUI/modules/mobinfo/data.lua
+++ b/XIUI/modules/mobinfo/data.lua
@@ -23,6 +23,16 @@ local function GetMobDataPath()
     return path .. '/submodules/mobdb/addons/mobdb/data/';
 end
 
+-- Horizon-specific mob data overrides (Dynamis zone name/job changes for the
+-- HorizonXI rebase). Only a handful of zones exist here; any zone not present
+-- falls back to the base MobDB data above.
+-- Source: https://github.com/Mr-Sithel/HorizonXI-Dynamis-Mobdb (edits by Mr-Sithel,
+-- original MobDB data by Thorny).
+local function GetHorizonMobDataPath()
+    local path = string.gsub(addon.path, '\\\\', '\\');
+    return path .. '/submodules/mobdb_horizon/mobdb/data/';
+end
+
 --[[
     Load mob data for a specific zone
     @param zoneId: The zone ID to load data for
@@ -44,8 +54,17 @@ mobdata.LoadZone = function(zoneId)
         return false;
     end
 
-    -- Construct file path
+    -- Construct file path. On Horizon, prefer the Dynamis override data if it
+    -- exists for this zone; otherwise fall back to the base MobDB data.
     local filePath = GetMobDataPath() .. tostring(zoneId) .. '.lua';
+    if HzLimitedMode then
+        local hzPath = GetHorizonMobDataPath() .. tostring(zoneId) .. '.lua';
+        local hzFile = io.open(hzPath, 'r');
+        if hzFile ~= nil then
+            hzFile:close();
+            filePath = hzPath;
+        end
+    end
 
     -- Check if file exists
     local file = io.open(filePath, 'r');

--- a/XIUI/modules/satchel/init.lua
+++ b/XIUI/modules/satchel/init.lua
@@ -422,13 +422,17 @@ local function render_slot_grid(slots, key_prefix, stat)
         get_slot_border_color = items.get_slot_border_color,
         render_item_detail_tooltip = items.render_item_detail_tooltip,
         on_slot_right_click = function(slot)
+            -- Horizon forbids addon-driven item moves, so the satchel is view-only there.
+            if HzLimitedMode then return end
             satchel.context_menu.slot = copy_slot_ref(slot)
             satchel.context_menu.pending_open = true
         end,
         on_slot_double_click = function(slot)
+            if HzLimitedMode then return end
             handle_double_click_transfer(copy_slot_ref(slot))
         end,
         on_slot_drag_start = function(slot, icon_texture)
+            if HzLimitedMode then return end
             if satchel.drag.active then
                 return
             end


### PR DESCRIPTION
Add the horizon specific mobdb and override the specific zones if horizon mode is set. Falls back to normal mobdb for all other zones.

Thanks @Mr-Sithel!