### PR TITLE
Improved Satchel Module Performance And Switched Search To Live Search

### DIFF
--- a/XIUI/config/satchel.lua
+++ b/XIUI/config/satchel.lua
@@ -30,7 +30,7 @@ function M.DrawSettings()
     imgui.ShowHelp('Let XIUI handle the /satchel command (toggles this window). When off, /satchel is left for the game or other addons. /xiui satchel always works.');
 
     components.DrawCheckbox('Close on ESC', 'satchelCloseOnEscape');
-    imgui.ShowHelp('When any Satchel window is open, pressing ESC closes the most recently opened Satchel window first (slip viewers, pickers, alt inventories, then the main window). Does not close the XIUI config. Window and search state are not saved between sessions.');
+    imgui.ShowHelp('ESC always clears an active search first. When enabled, a second ESC closes the most recently opened Satchel window (slip viewers, pickers, alt inventories, then main). Does not close the XIUI config.');
 
     components.DrawCheckbox('Auto Sort Bags', 'satchelAutoSortBags');
     if HzLimitedMode then

--- a/XIUI/modules/satchel/init.lua
+++ b/XIUI/modules/satchel/init.lua
@@ -1,7 +1,6 @@
 require('common')
 local imgui = require('imgui')
 local struct = require('struct')
-local ffi = require('ffi')
 local persistedWindow = require('libs.persisted_window')
 
 local ui = require('modules.satchel.ui')
@@ -23,42 +22,7 @@ local M = {}
 local band = bit.band
 local bor = bit.bor
 
-local VK_RETURN = 0x0D
-local SCAN_RETURN = 0x1C
-local KEYEVENTF_KEYUP = 0x0002
-local KEYEVENTF_EXTENDEDKEY = 0x0001
--- Ashita does not deliver Enter to HandleKey while ImGui text input is active.
--- Arm a short trail from the draw-path poll; after focus drops, HandleKey can
--- eat key-up/repeats. 400ms covers a realistic commit press.
-local ENTER_BLOCK_TRAIL_SEC = 0.4
 local GIL_ICON_PATH = addon.path .. '..\\satchel\\assets\\gil.png'
-
-pcall(function()
-    ffi.cdef[[
-        short __stdcall GetAsyncKeyState(int vKey);
-        void __stdcall keybd_event(unsigned char bVk, unsigned char bScan, unsigned long dwFlags, unsigned long dwExtraInfo);
-    ]]
-end)
-
-local function is_enter_physically_down()
-    local ok, state = pcall(function()
-        return ffi.C.GetAsyncKeyState(VK_RETURN)
-    end)
-    return ok and state and band(state, 0x8000) ~= 0
-end
-
--- Both Enter keys map to VK_RETURN; release main and extended scan codes together.
-local function release_enter_keys()
-    pcall(function()
-        ffi.C.keybd_event(VK_RETURN, SCAN_RETURN, KEYEVENTF_KEYUP, 0)
-        ffi.C.keybd_event(
-            VK_RETURN,
-            SCAN_RETURN,
-            bor(KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP),
-            0
-        )
-    end)
-end
 
 local WINDOW_FLAGS = bor(
     ImGuiWindowFlags_NoResize or 0,
@@ -159,25 +123,15 @@ local satchel = T{
         active_tab = nil,
     },
     search = {
-        -- Shared by main satchel and the player's storage-slip windows.
         draft = { '' },
-        active = '',
-        -- Per-alt-character search (bags + that alt's slip picker/content):
-        -- [entry.key] = { draft = { '' }, active = '' }
-        alt = {},
-        -- True while any satchel search field is focused (cleared end-of-frame).
+        alt = {}, -- [entry.key] = { draft = { '' } }
         input_focused = false,
-        -- Set each frame when a search field reports focus.
         focus_seen = false,
-        -- Sticky gate: set on focus/commit, cleared only after enter_block_until.
-        consume_enter = false,
-        -- 'shared' or 'alt' — which search Enter/ESC should act on.
-        input_scope = 'shared',
+        input_scope = 'shared', -- 'shared' or 'alt'
         input_alt_key = nil,
-        -- os.clock() deadline; Enter stays blocked until this time.
-        enter_block_until = 0,
-        -- Previous-frame Enter key state for poll edge detection.
-        enter_poll_down = false,
+        -- Bumped when inventory changes so search match cache can refresh.
+        match_inv_gen = 0,
+        index = nil, -- rebuilt when query or match_inv_gen changes
     },
     window_stack = {},
 }
@@ -343,42 +297,8 @@ local function normalize_search_text(query)
     return (query:match('^%s*(.-)%s*$') or '')
 end
 
-local function compute_search_chrome(query, slots_by_container, slip_ids, slip_items_fn)
-    local containers = {}
-    local slips = {}
-    local has_slip_matches = false
-    query = normalize_search_text(query)
-    if query == '' then
-        return containers, slips, has_slip_matches
-    end
-
-    for container_id, slots in pairs(slots_by_container or {}) do
-        local cid = tonumber(container_id) or container_id
-        for _, slot in ipairs(slots or {}) do
-            if items.matches_search(slot, query) then
-                containers[cid] = true
-                break
-            end
-        end
-    end
-
-    for _, slip_id in ipairs(slip_ids or {}) do
-        local stored = slip_items_fn and slip_items_fn(slip_id) or {}
-        for _, entry in ipairs(stored) do
-            local item_id = type(entry) == 'table' and (entry.id or entry.Id or entry.item_id) or entry
-            if items.matches_search(item_id, query) then
-                slips[slip_id] = true
-                has_slip_matches = true
-                break
-            end
-        end
-    end
-
-    return containers, slips, has_slip_matches
-end
-
-local function get_active_search()
-    return normalize_search_text(satchel.search.active)
+local function current_search_inv_gen()
+    return satchel.search.match_inv_gen or 0
 end
 
 local function get_draft_search()
@@ -386,45 +306,10 @@ local function get_draft_search()
     return normalize_search_text(draft and draft[1])
 end
 
-local function arm_enter_block(trail_sec)
-    satchel.search.consume_enter = true
-    local until_t = os.clock() + (trail_sec or ENTER_BLOCK_TRAIL_SEC)
-    if until_t > (satchel.search.enter_block_until or 0) then
-        satchel.search.enter_block_until = until_t
-    end
-end
-
-local function imgui_wants_text_input()
-    local ok, io = pcall(function()
-        return imgui.GetIO()
-    end)
-    return ok and io and io.WantTextInput == true
-end
-
-local function enter_block_active()
-    if satchel.search.input_focused or imgui_wants_text_input() then
-        return true
-    end
-    if not satchel.search.consume_enter then
-        return false
-    end
-    if os.clock() < (satchel.search.enter_block_until or 0) then
-        return true
-    end
-    satchel.search.consume_enter = false
-    return false
-end
-
-local function commit_search()
-    satchel.search.active = get_draft_search()
-    arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-end
-
 local function clear_search()
     if satchel.search.draft then
         satchel.search.draft[1] = ''
     end
-    satchel.search.active = ''
 end
 
 local function alt_search_key(entry_or_key)
@@ -440,15 +325,9 @@ local function get_alt_search_state(entry_or_key)
     if not by_alt[key] then
         by_alt[key] = {
             draft = { '' },
-            active = '',
         }
     end
     return by_alt[key], key
-end
-
-local function get_alt_active_search(entry_or_key)
-    local state = get_alt_search_state(entry_or_key)
-    return normalize_search_text(state.active)
 end
 
 local function get_alt_draft_search(entry_or_key)
@@ -461,22 +340,69 @@ local function get_alt_draft_buffer(entry_or_key)
     return state.draft
 end
 
-local function commit_alt_search(entry_or_key)
-    local state = get_alt_search_state(entry_or_key)
-    state.active = get_alt_draft_search(entry_or_key)
-    arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-end
-
 local function clear_alt_search(entry_or_key)
     local state = get_alt_search_state(entry_or_key)
     if state.draft then
         state.draft[1] = ''
     end
-    state.active = ''
 end
 
 local function clear_all_alt_searches()
     satchel.search.alt = {}
+end
+
+-- Scan inventory once when the query or inventory generation changes; render only lookups.
+local function ensure_search_index(query, slots_by_container, slip_ids, slip_items_fn)
+    local normalized = normalize_search_text(query)
+    local inv_gen = current_search_inv_gen()
+    local cached = satchel.search.index
+    if cached and cached.query == normalized and cached.inv_gen == inv_gen then
+        return cached
+    end
+
+    satchel.search.index = items.build_search_index(
+        normalized,
+        inv_gen,
+        slots_by_container,
+        slip_ids,
+        slip_items_fn
+    )
+    return satchel.search.index
+end
+
+local function ensure_alt_search_index(alt_key, query, slots_by_container, slip_ids, slip_items_fn)
+    local state = get_alt_search_state(alt_key)
+    local normalized = normalize_search_text(query)
+    local inv_gen = current_search_inv_gen()
+    if state.index and state.index.query == normalized and state.index.inv_gen == inv_gen then
+        return state.index
+    end
+
+    state.index = items.build_search_index(
+        normalized,
+        inv_gen,
+        slots_by_container,
+        slip_ids,
+        slip_items_fn
+    )
+    return state.index
+end
+
+local function ensure_slip_page_search_index(query, slots)
+    local normalized = normalize_search_text(query)
+    local inv_gen = current_search_inv_gen()
+    local view = satchel.slip_view
+    local cached = view.search_index
+    if cached
+        and cached.query == normalized
+        and cached.inv_gen == inv_gen
+        and cached.page == view.page then
+        return cached
+    end
+
+    view.search_index = items.build_search_index_for_slots(normalized, inv_gen, slots)
+    view.search_index.page = view.page
+    return view.search_index
 end
 
 local function note_search_input_focused(focused, scope, alt_key)
@@ -485,8 +411,6 @@ local function note_search_input_focused(focused, scope, alt_key)
         satchel.search.input_focused = true
         satchel.search.input_scope = scope or 'shared'
         satchel.search.input_alt_key = alt_key
-        -- Refresh the trail while focused so it starts from focus-loss/commit.
-        arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
     end
 end
 
@@ -495,23 +419,6 @@ local function finish_search_focus_frame()
         satchel.search.input_focused = false
     end
     satchel.search.focus_seen = false
-end
-
-local function commit_focused_search()
-    if satchel.search.input_scope == 'alt' and satchel.search.input_alt_key then
-        local key = satchel.search.input_alt_key
-        if get_alt_draft_search(key) ~= '' then
-            commit_alt_search(key)
-        elseif get_alt_active_search(key) ~= '' then
-            clear_alt_search(key)
-            arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-        end
-    elseif get_draft_search() ~= '' then
-        commit_search()
-    elseif get_active_search() ~= '' then
-        clear_search()
-        arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-    end
 end
 
 local function annotate_display_indices(slots)
@@ -758,6 +665,7 @@ local function invalidate_slot_cache()
     satchel.slot_cache.all_slots = nil
     satchel.slot_cache.slots_by_container = nil
     satchel.slot_cache.stats = nil
+    satchel.search.match_inv_gen = (satchel.search.match_inv_gen or 0) + 1
 end
 
 local function get_slot_data(force_refresh)
@@ -1483,7 +1391,8 @@ end
 
 local render_context_menu = menus.render
 
-local function build_grid_context(include_gil)
+local function build_grid_context(include_gil, search_index)
+    search_index = search_index or satchel.search.index
     local grid_ctx = {
         settings = satchel.settings,
         default_slot_size = default_settings.slot_size,
@@ -1494,9 +1403,16 @@ local function build_grid_context(include_gil)
         end,
         tex_ptr = icons.tex_ptr,
         get_slot_border_color = items.get_slot_border_color,
+        get_slot_border_u32 = items.get_slot_border_color_u32,
+        get_empty_border_u32 = items.get_empty_slot_border_u32,
+        prepare_slot_render = items.ensure_equipped_lookup,
         render_item_detail_tooltip = items.render_item_detail_tooltip,
-        item_matches_search = items.matches_search,
-        search_query = get_active_search(),
+        item_matches_search = function(slot, _)
+            return items.index_matches_slot(search_index, slot)
+        end,
+        search_query = (search_index and search_index.query) or '',
+        search_active = search_index ~= nil and search_index.query ~= '',
+        search_index = search_index,
         scale = ui.get_global_scale(),
         hide_gil = not include_gil,
     }
@@ -1590,8 +1506,8 @@ local function build_grid_context(include_gil)
     return grid_ctx
 end
 
-local function build_slip_grid_context()
-    local grid_ctx = build_grid_context(false)
+local function build_slip_grid_context(search_index)
+    local grid_ctx = build_grid_context(false, search_index)
     grid_ctx.read_only = true
     grid_ctx.visual_sort_only = true
     configure_visual_drag_context(grid_ctx, DRAG_SCOPE_SLIP, function(drag_state, target_slot)
@@ -1641,9 +1557,8 @@ local function build_slip_grid_context()
     return grid_ctx
 end
 
-local function build_alt_grid_context(entry)
-    local grid_ctx = build_grid_context(false)
-    grid_ctx.search_query = get_alt_active_search(entry)
+local function build_alt_grid_context(entry, search_index)
+    local grid_ctx = build_grid_context(false, search_index)
     grid_ctx.read_only = true
     grid_ctx.visual_sort_only = true
     configure_visual_drag_context(grid_ctx, DRAG_SCOPE_ALT, function(drag_state, target_slot)
@@ -1713,7 +1628,7 @@ local function ensure_active_tab(active_tab, available_tabs)
 end
 
 local function render_slot_grid(slots, key_prefix, stat)
-    local grid_ctx = build_grid_context(true)
+    local grid_ctx = build_grid_context(true, satchel.search.index)
     ui.render_slot_grid(slots, key_prefix, stat, grid_ctx)
 end
 
@@ -1792,37 +1707,57 @@ local function alt_entry_for_window(window_key)
     return nil
 end
 
--- Clears search for the topmost window that has draft/active text.
+-- Clears search for a scope. Returns true when text was cleared.
+local function search_has_text(scope, alt_key)
+    if scope == 'alt' and alt_key then
+        return get_alt_draft_search(alt_key) ~= ''
+    end
+    return get_draft_search() ~= ''
+end
+
+local function clear_search_for(scope, alt_key)
+    if scope == 'alt' and alt_key then
+        clear_alt_search(alt_key)
+    else
+        clear_search()
+    end
+end
+
+-- Clears search for the topmost visible window that has draft text.
 -- Returns true when ESC should be consumed without closing a window.
+local function clear_search_for_window(window_key)
+    local alt_entry = alt_entry_for_window(window_key)
+    if alt_entry then
+        local alt_key = alt_search_key(alt_entry)
+        if search_has_text('alt', alt_key) then
+            clear_search_for('alt', alt_key)
+            return true
+        end
+        return false
+    end
+
+    if window_key == 'main' or window_key == 'slip_view' or window_key == 'slips_picker' then
+        if search_has_text('shared') then
+            clear_search_for('shared')
+            return true
+        end
+        return false
+    end
+
+    return false
+end
+
 local function try_clear_search()
     for i = #satchel.window_stack, 1, -1 do
         local window_key = satchel.window_stack[i]
         if is_satchel_window_visible(window_key) then
-            local alt_entry = alt_entry_for_window(window_key)
-            if alt_entry then
-                local alt_key = alt_search_key(alt_entry)
-                if get_alt_active_search(alt_key) ~= '' or get_alt_draft_search(alt_key) ~= '' then
-                    clear_alt_search(alt_key)
-                    return true
-                end
-                return false
-            end
-
-            if window_key == 'main' or window_key == 'slip_view' or window_key == 'slips_picker' then
-                if get_active_search() ~= '' or get_draft_search() ~= '' then
-                    clear_search()
-                    return true
-                end
-                return false
-            end
-
-            return false
+            return clear_search_for_window(window_key)
         end
+        table.remove(satchel.window_stack, i)
     end
 
-    if is_satchel_window_visible('main')
-        and (get_active_search() ~= '' or get_draft_search() ~= '') then
-        clear_search()
+    if is_satchel_window_visible('main') and search_has_text('shared') then
+        clear_search_for('shared')
         return true
     end
 
@@ -1835,29 +1770,6 @@ local function any_satchel_window_visible()
         or is_satchel_window_visible('slip_view')
         or is_satchel_window_visible('alt_picker')
         or is_satchel_window_visible('alt_view')
-end
-
--- Poll Enter while satchel is open. ImGui text focus swallows Ashita key events, so
--- the draw path arms the post-commit trail and cancels the game-side key-down.
-local function tick_search_enter_guard()
-    if not any_satchel_window_visible() then
-        satchel.search.enter_poll_down = false
-        return
-    end
-
-    local down = is_enter_physically_down()
-    local was_down = satchel.search.enter_poll_down == true
-    local in_search = satchel.search.input_focused == true
-
-    if down and (in_search or satchel.search.consume_enter) then
-        arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-        -- Cancel game-side Enter holds; ImGui may not deliver these to HandleKey.
-        release_enter_keys()
-    elseif not down and was_down and satchel.search.consume_enter then
-        arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-    end
-
-    satchel.search.enter_poll_down = down
 end
 
 local function toggle_satchel_command()
@@ -1940,19 +1852,31 @@ local function open_alt_view(entry)
     register_window_open('alt_view')
 end
 
-local function compute_content_window_size(scale, toolbar_h, toolbar_opts, tab_count)
+local function get_content_region_layout(scale, tab_count)
     local metrics = ui.compute_grid_metrics(satchel.settings, DISPLAY_SLOTS, scale, { layout_size = true })
     local needs_tab_sb = ui.tab_sidebar_needs_scrollbar(tab_count, metrics.grid_height, scale)
-    local tab_width = ui.get_tab_sidebar_width(scale, needs_tab_sb)
+    local sidebar_width = ui.get_tab_sidebar_width(scale, needs_tab_sb)
+    local sidebar_gap = ui.scaled(8, scale)
+    return {
+        metrics = metrics,
+        sidebar_width = sidebar_width,
+        sidebar_gap = sidebar_gap,
+        grid_h = metrics.grid_height,
+        grid_block_width = metrics.grid_width + metrics.scrollbar_w,
+        toolbar_align_width = ui.get_toolbar_grid_align_width(metrics, scale, tab_count, metrics.grid_height),
+    }
+end
+
+local function compute_inventory_window_size(scale, toolbar_opts, tab_count)
+    local layout = get_content_region_layout(scale, tab_count)
     local footer_h = ui.get_footer_row_height(scale)
-    local toolbar_height = toolbar_h or ui.scaled(34, scale)
+    local toolbar_height = ui.scaled(34, scale)
     local spacing_h = ui.scaled(8, scale)
     local chrome_h = ui.get_title_bar_height(scale) + ui.scaled(16, scale)
-    local sidebar_gap = ui.scaled(8, scale)
-    -- Extra width so right-edge slot chrome (search ants) is not clipped.
+    -- Extra width so right-edge slot search highlight is not clipped.
     local pad_x = ui.scaled(24, scale) + ui.scaled(4, scale)
-    local win_w = tab_width + sidebar_gap + metrics.grid_width + metrics.scrollbar_w + pad_x
-    local win_h = chrome_h + toolbar_height + spacing_h + metrics.grid_height + footer_h
+    local win_w = layout.sidebar_width + layout.sidebar_gap + layout.grid_block_width + pad_x
+    local win_h = chrome_h + toolbar_height + spacing_h + layout.grid_h + footer_h
 
     toolbar_opts = toolbar_opts or {}
     if toolbar_opts.enabled then
@@ -1968,13 +1892,21 @@ local function compute_content_window_size(scale, toolbar_h, toolbar_opts, tab_c
         win_w = math.max(win_w, toolbar_min_w + pad_x)
     end
 
-    return win_w, win_h, metrics, tab_width
+    return win_w, win_h, layout
 end
 
 local function compute_main_window_size(scale, show_slips_button, tab_count)
-    return compute_content_window_size(scale, ui.scaled(34, scale), {
+    return compute_inventory_window_size(scale, {
         enabled = true,
         show_alt_button = true,
+        show_slips_button = show_slips_button == true,
+    }, tab_count)
+end
+
+local function compute_alt_window_size(scale, show_slips_button, tab_count)
+    return compute_inventory_window_size(scale, {
+        enabled = true,
+        show_alt_button = false,
         show_slips_button = show_slips_button == true,
     }, tab_count)
 end
@@ -2027,19 +1959,25 @@ local function draw_slips_picker_window(scale)
 
     local alt_entry = satchel.slips_picker.alt_entry
     local owned_slip_ids = get_slip_picker_ids(alt_entry)
-    local chrome_query = alt_entry and get_alt_active_search(alt_entry) or get_active_search()
-    local _, slips_with_matches = compute_search_chrome(
-        chrome_query,
-        nil,
-        owned_slip_ids,
-        function(slip_id)
-            if alt_entry then
+    local chrome_query = alt_entry and get_alt_draft_search(alt_entry) or get_draft_search()
+    local search_index = alt_entry
+        and ensure_alt_search_index(
+            alt_search_key(alt_entry),
+            chrome_query,
+            nil,
+            owned_slip_ids,
+            function(slip_id)
                 return slipslogic.get_stored_items_from_cache(alt_entry.slips, slip_id)
             end
-            return slipslogic.get_stored_items(slip_id)
-        end
-    )
-
+        )
+        or ensure_search_index(
+            chrome_query,
+            nil,
+            owned_slip_ids,
+            function(slip_id)
+                return slipslogic.get_stored_items(slip_id)
+            end
+        )
     ui.push_config_window_style()
     local picker_w = ui.scaled(220, scale)
     local picker_h = get_picker_window_height(math.max(1, #owned_slip_ids), scale)
@@ -2056,7 +1994,7 @@ local function draw_slips_picker_window(scale)
             end,
             scale,
             format_slip_button_label,
-            slips_with_matches,
+            search_index.slips,
             chrome_query ~= '',
             any_drag_active()
         )
@@ -2077,7 +2015,7 @@ local function compute_slip_window_size(scale)
     local footer_h = ui.get_footer_row_height(scale)
     local pad_x = ui.scaled(24, scale)
     local chrome_h = ui.get_title_bar_height(scale) + ui.scaled(16, scale)
-    -- Slight extra width so right-edge search ants are not clipped.
+    -- Slight extra width so right-edge search highlight is not clipped.
     local win_w = metrics.grid_width + metrics.scrollbar_w + (pad_x * 2) + ui.scaled(4, scale)
     local win_h = chrome_h + toolbar_h + spacing_h + metrics.grid_height + footer_h
     return win_w, win_h, metrics, footer_h
@@ -2116,9 +2054,9 @@ local function draw_slip_content_window(scale)
     if began then
         local chrome_pushed = begin_chrome_font(scale)
         local alt_key = alt_entry and alt_search_key(alt_entry) or nil
-        local active_search = alt_key and get_alt_active_search(alt_key) or get_active_search()
+        local active_search = alt_key and get_alt_draft_search(alt_key) or get_draft_search()
         local draft_buffer = alt_key and get_alt_draft_buffer(alt_key) or satchel.search.draft
-        local slip_toolbar_clicks, slip_search_focused = ui.render_toolbar_with_search(
+        local _, slip_search_focused = ui.render_toolbar_with_search(
             draft_buffer,
             scale,
             alt_key and ('slip_alt_%s'):format(alt_key) or 'slip',
@@ -2127,7 +2065,6 @@ local function draw_slip_content_window(scale)
                 align_width = metrics.grid_width + metrics.scrollbar_w,
                 centered = true,
                 search_active = active_search ~= '',
-                active_search_text = active_search,
             }
         )
         if alt_key then
@@ -2135,27 +2072,12 @@ local function draw_slip_content_window(scale)
         else
             note_search_input_focused(slip_search_focused, 'shared')
         end
-        if slip_toolbar_clicks.search then
-            if alt_key then
-                commit_alt_search(alt_key)
-                active_search = get_alt_active_search(alt_key)
-            else
-                commit_search()
-                active_search = get_active_search()
-            end
-        elseif slip_toolbar_clicks.cancel then
-            if alt_key then
-                clear_alt_search(alt_key)
-            else
-                clear_search()
-            end
-            active_search = ''
-        end
+        active_search = alt_key and get_alt_draft_search(alt_key) or get_draft_search()
         imgui.Spacing()
 
         ui.begin_child('##satchel_slip_body', { 0, metrics.grid_height }, false, ui.NO_SCROLL_CHILD_FLAGS)
-        local grid_ctx = build_slip_grid_context()
-        grid_ctx.search_query = active_search
+        local slip_search_index = ensure_slip_page_search_index(active_search, slots)
+        local grid_ctx = build_slip_grid_context(slip_search_index)
         grid_ctx.centered = true
         grid_ctx.grid_slot_count = slipslogic.PAGE_SIZE
         ui.render_slot_grid(slots, ('slip_%d_%d'):format(slip_id, satchel.slip_view.page), {
@@ -2252,14 +2174,9 @@ local function draw_alt_inventory_window(scale)
         end
     end
 
-    local win_w, win_h, metrics, tab_width = compute_content_window_size(
+    local win_w, win_h, layout = compute_alt_window_size(
         scale,
-        ui.scaled(40, scale),
-        {
-            enabled = true,
-            show_alt_button = false,
-            show_slips_button = slipslogic.has_cached_slips(entry.slips),
-        },
+        slipslogic.has_cached_slips(entry.slips),
         #available_tabs
     )
 
@@ -2277,8 +2194,9 @@ local function draw_alt_inventory_window(scale)
     if began then
         local chrome_pushed = begin_chrome_font(scale)
         local alt_key = alt_search_key(entry)
-        local alt_search = get_alt_active_search(alt_key)
-        local alt_match_containers, _, alt_has_slip_matches = compute_search_chrome(
+        local alt_search = get_alt_draft_search(alt_key)
+        local alt_search_index = ensure_alt_search_index(
+            alt_key,
             alt_search,
             alt_slots_by_container,
             alt_slip_ids,
@@ -2286,6 +2204,8 @@ local function draw_alt_inventory_window(scale)
                 return slipslogic.get_stored_items_from_cache(entry.slips, slip_id)
             end
         )
+        local alt_match_containers = alt_search_index.containers
+        local alt_has_slip_matches = items.index_has_slip_matches(alt_search_index)
         local toolbar_clicks, alt_search_focused = ui.render_toolbar_with_search(
             get_alt_draft_buffer(alt_key),
             scale,
@@ -2294,9 +2214,8 @@ local function draw_alt_inventory_window(scale)
                 { id = 'slips', label = 'Storage Slips', visible = slipslogic.has_cached_slips(entry.slips) },
             },
             {
-                align_width = ui.get_toolbar_grid_align_width(metrics, scale, #available_tabs, metrics.grid_height),
+                align_width = layout.toolbar_align_width,
                 search_active = alt_search ~= '',
-                active_search_text = alt_search,
                 is_dragging = satchel.drag.alt.active == true,
                 highlight_button_ids = alt_search ~= '' and {
                     slips = alt_has_slip_matches,
@@ -2304,31 +2223,28 @@ local function draw_alt_inventory_window(scale)
             }
         )
         note_search_input_focused(alt_search_focused, 'alt', alt_key)
-        if toolbar_clicks.search then
-            commit_alt_search(alt_key)
-            alt_search = get_alt_active_search(alt_key)
-            alt_match_containers, _, alt_has_slip_matches = compute_search_chrome(
-                alt_search,
-                alt_slots_by_container,
-                alt_slip_ids,
-                function(slip_id)
-                    return slipslogic.get_stored_items_from_cache(entry.slips, slip_id)
-                end
-            )
-        elseif toolbar_clicks.cancel then
-            clear_alt_search(alt_key)
-            alt_search = ''
-            alt_match_containers = {}
-            alt_has_slip_matches = false
-        end
+        alt_search = get_alt_draft_search(alt_key)
+        alt_search_index = ensure_alt_search_index(
+            alt_key,
+            alt_search,
+            alt_slots_by_container,
+            alt_slip_ids,
+            function(slip_id)
+                return slipslogic.get_stored_items_from_cache(entry.slips, slip_id)
+            end
+        )
+        alt_match_containers = alt_search_index.containers
+        alt_has_slip_matches = items.index_has_slip_matches(alt_search_index)
         if toolbar_clicks.slips then
             open_slips_picker(entry)
         end
         imgui.Spacing()
 
-        local grid_h = metrics.grid_height
-        local sidebar_width = tab_width
-        local sidebar_gap = ui.scaled(8, scale)
+        local sidebar_width = layout.sidebar_width
+        local sidebar_gap = layout.sidebar_gap
+        local grid_h = layout.grid_h
+        local grid_ctx = build_alt_grid_context(entry, alt_search_index)
+        apply_cached_gil_display(grid_ctx, entry.gil)
 
         ui.begin_child('##satchel_alt_body', { 0, grid_h }, false, ui.NO_SCROLL_CHILD_FLAGS)
         local current_tab = ui.render_scrollable_tab_sidebar(
@@ -2361,8 +2277,6 @@ local function draw_alt_inventory_window(scale)
 
         imgui.SameLine(0, sidebar_gap)
         ui.begin_child('##satchel_alt_grid', { 0, grid_h }, false, ui.NO_SCROLL_CHILD_FLAGS)
-        local grid_ctx = build_alt_grid_context(entry)
-        apply_cached_gil_display(grid_ctx, entry.gil)
         ui.render_slot_grid(active_slots, ('alt_%s_%d'):format(entry.key or 'alt', active_tab or 0), {
             used = used,
             total = DISPLAY_SLOTS,
@@ -2378,6 +2292,7 @@ local function draw_alt_inventory_window(scale)
             scale = scale,
             sidebar_width = sidebar_width,
             gap = sidebar_gap,
+            grid_block_width = layout.grid_block_width,
         })
 
         render_context_menu()
@@ -2458,7 +2373,6 @@ function M.DrawWindow()
 
     if not satchel.visible[1] then
         draw_auxiliary_windows(scale)
-        tick_search_enter_guard()
         finish_search_focus_frame()
         finalize_drag_frame()
         return
@@ -2476,7 +2390,7 @@ function M.DrawWindow()
     end
     local display_tab = get_display_tab()
 
-    local win_w, win_h, metrics = compute_main_window_size(scale, show_slips_button, #display_tabs)
+    local win_w, win_h, layout = compute_main_window_size(scale, show_slips_button, #display_tabs)
     ui.push_config_window_style()
     ui.set_window_size(win_w, win_h)
 
@@ -2485,8 +2399,8 @@ function M.DrawWindow()
         satchel.settings.visible = satchel.visible[1]
         local chrome_pushed = begin_chrome_font(scale)
         local main_dragging = satchel.drag.main.active == true
-        local main_search = get_active_search()
-        local match_containers, slips_with_matches, has_slip_matches = compute_search_chrome(
+        local main_search = get_draft_search()
+        local main_search_index = ensure_search_index(
             main_search,
             slots_by_container,
             owned_slip_ids,
@@ -2494,6 +2408,9 @@ function M.DrawWindow()
                 return slipslogic.get_stored_items(slip_id)
             end
         )
+        local match_containers = main_search_index.containers
+        local slips_with_matches = main_search_index.slips
+        local has_slip_matches = items.index_has_slip_matches(main_search_index)
 
         local toolbar_clicks, main_search_focused = ui.render_toolbar_with_search(
             satchel.search.draft,
@@ -2504,11 +2421,9 @@ function M.DrawWindow()
                 { id = 'slips', label = 'Storage Slips', visible = show_slips_button },
             },
             {
-                align_width = ui.get_toolbar_grid_align_width(metrics, scale, #display_tabs, metrics.grid_height),
+                align_width = layout.toolbar_align_width,
                 search_active = main_search ~= '',
-                active_search_text = main_search,
                 is_dragging = main_dragging,
-                -- true = ant border; false = dim only (alt never matches, dimmed for uniformity).
                 highlight_button_ids = main_search ~= '' and {
                     alt = false,
                     slips = has_slip_matches,
@@ -2516,29 +2431,18 @@ function M.DrawWindow()
             }
         )
         note_search_input_focused(main_search_focused, 'shared')
-        if toolbar_clicks.search then
-            commit_search()
-            main_search = get_active_search()
-            match_containers, slips_with_matches, has_slip_matches = compute_search_chrome(
-                main_search,
-                slots_by_container,
-                owned_slip_ids,
-                function(slip_id)
-                    return slipslogic.get_stored_items(slip_id)
-                end
-            )
-        elseif toolbar_clicks.cancel then
-            clear_search()
-            main_search = ''
-            match_containers, slips_with_matches, has_slip_matches = compute_search_chrome(
-                main_search,
-                slots_by_container,
-                owned_slip_ids,
-                function(slip_id)
-                    return slipslogic.get_stored_items(slip_id)
-                end
-            )
-        end
+        main_search = get_draft_search()
+        main_search_index = ensure_search_index(
+            main_search,
+            slots_by_container,
+            owned_slip_ids,
+            function(slip_id)
+                return slipslogic.get_stored_items(slip_id)
+            end
+        )
+        match_containers = main_search_index.containers
+        slips_with_matches = main_search_index.slips
+        has_slip_matches = items.index_has_slip_matches(main_search_index)
         if toolbar_clicks.alt then
             open_alt_picker()
         end
@@ -2548,13 +2452,10 @@ function M.DrawWindow()
 
         imgui.Spacing()
 
-        local sidebar_width = ui.get_tab_sidebar_width(
-            scale,
-            ui.tab_sidebar_needs_scrollbar(#display_tabs, metrics.grid_height, scale)
-        )
-        local sidebar_gap = ui.scaled(8, scale)
-        local grid_h = metrics.grid_height
-        local grid_ctx = build_grid_context(true)
+        local sidebar_width = layout.sidebar_width
+        local sidebar_gap = layout.sidebar_gap
+        local grid_h = layout.grid_h
+        local grid_ctx = build_grid_context(true, main_search_index)
 
         if #display_tabs == 0 then
             satchel.active_tab = nil
@@ -2635,6 +2536,7 @@ function M.DrawWindow()
                 scale = scale,
                 sidebar_width = sidebar_width,
                 gap = sidebar_gap,
+                grid_block_width = layout.grid_block_width,
             })
         end
 
@@ -2652,7 +2554,6 @@ function M.DrawWindow()
     ui.pop_config_window_style()
 
     draw_auxiliary_windows(scale)
-    tick_search_enter_guard()
     finish_search_focus_frame()
     finalize_drag_frame()
 end
@@ -2747,37 +2648,28 @@ function M.HandleKey(e)
     local is_key_down = band(e.lparam, 0x80000000) == 0
     local vk = tonumber(e.wparam) or e.wparam
 
-    -- Eat Enter while search is active (and briefly after commit). Do not synthesize
-    -- key-ups here — tick_search_enter_guard handles that without re-entering this handler.
-    if vk == VK_RETURN and enter_block_active() then
-        if is_key_down and (satchel.search.input_focused or imgui_wants_text_input()) then
-            commit_focused_search()
+    if vk ~= 0x1B or not is_key_down then
+        return
+    end
+
+    local close_on_esc = gConfig and gConfig.satchelCloseOnEscape == true
+
+    -- Focused: ImGui clears InputText on ESC — never block that path.
+    if satchel.search.input_focused then
+        if close_on_esc and not search_has_text(satchel.search.input_scope or 'shared', satchel.search.input_alt_key) then
+            if close_top_satchel_window() then
+                e.blocked = true
+            end
         end
-        arm_enter_block(ENTER_BLOCK_TRAIL_SEC)
-        e.blocked = true
         return
     end
 
-    -- Only intercept ESC when the user has opted in; otherwise ESC behaves normally.
-    if not (gConfig and gConfig.satchelCloseOnEscape == true) then
-        return
-    end
-
-    if vk ~= 0x1B then
-        return
-    end
-
-    if not is_key_down then
-        return
-    end
-
-    -- Search takes precedence: clear draft/active search before closing a window.
     if try_clear_search() then
         e.blocked = true
         return
     end
 
-    if close_top_satchel_window() then
+    if close_on_esc and close_top_satchel_window() then
         e.blocked = true
     end
 end

--- a/XIUI/modules/satchel/itemlogic.lua
+++ b/XIUI/modules/satchel/itemlogic.lua
@@ -1,4 +1,5 @@
 local breader = require('bitreader')
+local imgui = require('imgui')
 local TextureManager = require('libs.texturemanager')
 local tooltips = require('modules.satchel.tooltips')
 local satchelfontcore = require('modules.satchel.satchelfontcore')
@@ -190,6 +191,10 @@ local function create_item_logic(ctx)
     local description_text_cache = {}
     local slot_augment_cache = {}
     local tooltip_sections_cache = {}
+    local border_u32_cache = {}
+    local border_u32_cache_gen = -1
+    local equipped_lookup_gen = -1
+    local equipped_lookup = {}
 
     function M.clear_caches()
         satchel.names = {}
@@ -199,6 +204,48 @@ local function create_item_logic(ctx)
         description_text_cache = {}
         slot_augment_cache = {}
         tooltip_sections_cache = {}
+        border_u32_cache = {}
+        border_u32_cache_gen = -1
+        equipped_lookup_gen = -1
+        equipped_lookup = {}
+    end
+
+    function M.ensure_equipped_lookup()
+        local gen = satchel.search.match_inv_gen or 0
+        if equipped_lookup_gen == gen then
+            return
+        end
+
+        equipped_lookup_gen = gen
+        equipped_lookup = {}
+
+        local inv = AshitaCore:GetMemoryManager():GetInventory()
+        if not inv then
+            return
+        end
+
+        for equip_slot = 0, 15 do
+            local equipped = inv:GetEquippedItem(equip_slot)
+            if equipped and equipped.Index then
+                local raw_index = tonumber(equipped.Index) or 0
+                local equipped_index = bit.band(raw_index, 0x00FF)
+                if equipped_index > 0 then
+                    local equipped_container = bit.rshift(bit.band(raw_index, 0xFF00), 8)
+                    equipped_lookup[('%d:%d'):format(equipped_container, equipped_index)] = true
+                end
+            end
+        end
+    end
+
+    local function search_slot_key(slot)
+        if type(slot) ~= 'table' then
+            return nil
+        end
+        return ('%s:%s:%s'):format(
+            tostring(slot.container_id or ''),
+            tostring(slot.slot_index or ''),
+            tostring(slot.id or 0)
+        )
     end
 
     function M.get_item_type(item_id)
@@ -654,31 +701,13 @@ local function create_item_logic(ctx)
             return false
         end
 
-        local inv = AshitaCore:GetMemoryManager():GetInventory()
-        if not inv then
-            return false
-        end
-
         local target_property_index = tonumber(slot.property_index)
         if target_property_index == nil or target_property_index <= 0 then
             return false
         end
 
-        for equip_slot = 0, 15 do
-            local equipped = inv:GetEquippedItem(equip_slot)
-            if equipped and equipped.Index then
-                local raw_index = tonumber(equipped.Index) or 0
-                local equipped_index = bit.band(raw_index, 0x00FF)
-                if equipped_index > 0 then
-                    local equipped_container = bit.rshift(bit.band(raw_index, 0xFF00), 8)
-                    if equipped_container == target_container and equipped_index == target_property_index then
-                        return true
-                    end
-                end
-            end
-        end
-
-        return false
+        M.ensure_equipped_lookup()
+        return equipped_lookup[('%d:%d'):format(target_container, target_property_index)] == true
     end
 
     function M.is_slot_currently_equipped(slot)
@@ -3037,6 +3066,38 @@ local function create_item_logic(ctx)
         return M.get_item_type_border_color(slot)
     end
 
+    function M.get_slot_border_color_u32(slot)
+        if not slot or not slot.id or slot.id <= 0 then
+            return M.get_empty_slot_border_u32()
+        end
+
+        local gen = satchel.search.match_inv_gen or 0
+        if border_u32_cache_gen ~= gen then
+            border_u32_cache = {}
+            border_u32_cache_gen = gen
+        end
+
+        local cache_key = slot_cache_key(slot)
+        local cached = border_u32_cache[cache_key]
+        if cached ~= nil then
+            return cached
+        end
+
+        M.ensure_equipped_lookup()
+        local border_u32 = imgui.GetColorU32(M.get_slot_border_color(slot))
+        border_u32_cache[cache_key] = border_u32
+        return border_u32
+    end
+
+    local empty_slot_border_u32 = nil
+
+    function M.get_empty_slot_border_u32()
+        if empty_slot_border_u32 == nil then
+            empty_slot_border_u32 = imgui.GetColorU32(satchelcolors.get_empty_slot_border())
+        end
+        return empty_slot_border_u32
+    end
+
     function M.get_context_menu_actions(slot)
         if not slot or slot.container_id == nil or not slot.id or slot.id <= 0 then
             return nil
@@ -3430,7 +3491,7 @@ local function create_item_logic(ctx)
         return blob
     end
 
-    function M.matches_search(slot_or_id, query)
+    local function matches_search_impl(slot_or_id, query)
         local slot = type(slot_or_id) == 'table' and slot_or_id or nil
         local item_id = slot and slot.id or slot_or_id
         if not item_id or item_id <= 0 then
@@ -3546,6 +3607,95 @@ local function create_item_logic(ctx)
         end
 
         return false
+    end
+
+    local function empty_search_index(query, inv_gen)
+        return {
+            query = normalize_search_query(query),
+            inv_gen = inv_gen or 0,
+            slot_keys = {},
+            containers = {},
+            slips = {},
+        }
+    end
+
+    function M.build_search_index(query, inv_gen, slots_by_container, slip_ids, slip_items_fn)
+        local normalized = normalize_search_query(query)
+        inv_gen = inv_gen or 0
+        if normalized == '' then
+            return empty_search_index('', inv_gen)
+        end
+
+        local index = empty_search_index(normalized, inv_gen)
+        for container_id, slots in pairs(slots_by_container or {}) do
+            local cid = tonumber(container_id) or container_id
+            for _, slot in ipairs(slots or {}) do
+                if matches_search_impl(slot, normalized) then
+                    local key = search_slot_key(slot)
+                    if key then
+                        index.slot_keys[key] = true
+                    end
+                    index.containers[cid] = true
+                end
+            end
+        end
+
+        for _, slip_id in ipairs(slip_ids or {}) do
+            local stored = slip_items_fn and slip_items_fn(slip_id) or {}
+            for _, entry in ipairs(stored) do
+                local item_id = type(entry) == 'table' and (entry.id or entry.Id or entry.item_id) or entry
+                if matches_search_impl(item_id, normalized) then
+                    index.slips[slip_id] = true
+                    break
+                end
+            end
+        end
+
+        return index
+    end
+
+    function M.build_search_index_for_slots(query, inv_gen, slots)
+        local normalized = normalize_search_query(query)
+        inv_gen = inv_gen or 0
+        if normalized == '' then
+            return empty_search_index('', inv_gen)
+        end
+
+        local index = empty_search_index(normalized, inv_gen)
+        for _, slot in ipairs(slots or {}) do
+            if matches_search_impl(slot, normalized) then
+                local key = search_slot_key(slot)
+                if key then
+                    index.slot_keys[key] = true
+                end
+            end
+        end
+        return index
+    end
+
+    function M.index_matches_slot(index, slot)
+        if not index or index.query == '' then
+            return true
+        end
+        if not slot or not slot.id or slot.id <= 0 then
+            return false
+        end
+        local key = search_slot_key(slot)
+        return key ~= nil and index.slot_keys[key] == true
+    end
+
+    function M.index_has_slip_matches(index)
+        if not index or index.query == '' then
+            return false
+        end
+        for _ in pairs(index.slips or {}) do
+            return true
+        end
+        return false
+    end
+
+    function M.matches_search(slot_or_id, query)
+        return matches_search_impl(slot_or_id, query)
     end
 
     return M

--- a/XIUI/modules/satchel/searchlogic.lua
+++ b/XIUI/modules/satchel/searchlogic.lua
@@ -314,51 +314,42 @@ function M.blob_matches_query(blob, normalized, compact)
     return false
 end
 
--- Animated search match borders (drawn on slot/window draw lists).
+-- Search match highlight (single AddRect per region — no animated dashes).
 local imgui = require('imgui')
 
 local SEARCH_HIGHLIGHT_COLOR = 0xFFD4AA44
+local SEARCH_BORDER_THICKNESS = 2
 
-local last_clock_read = 0
-local cached_anim_offset = 0
+local cached_border_u32 = nil
+local cached_border_opacity = nil
+local cached_inner_dim_u32 = nil
+local cached_inner_dim_coverage = nil
 
-local function get_animation_offset()
-    local now = os.clock()
-    if now ~= last_clock_read then
-        last_clock_read = now
-        cached_anim_offset = (now * 50) % 16
+function M.get_match_border_color_u32(opacity)
+    opacity = opacity or 1
+    if cached_border_u32 ~= nil and cached_border_opacity == opacity then
+        return cached_border_u32
     end
-    return cached_anim_offset
+
+    local color = SEARCH_HIGHLIGHT_COLOR
+    local alpha = math.floor(bit.rshift(bit.band(color, 0xFF000000), 24) * opacity)
+    local r = bit.rshift(bit.band(color, 0x00FF0000), 16) / 255
+    local g = bit.rshift(bit.band(color, 0x0000FF00), 8) / 255
+    local b = bit.band(color, 0x000000FF) / 255
+    cached_border_u32 = imgui.GetColorU32({ r, g, b, alpha / 255 })
+    cached_border_opacity = opacity
+    return cached_border_u32
 end
 
-local function draw_dashed_line(draw_list, x1, y1, x2, y2, color, thickness, dash_len, gap_len, offset)
-    local dx = x2 - x1
-    local dy = y2 - y1
-    local len = math.sqrt(dx * dx + dy * dy)
-    if len == 0 then
-        return
+function M.get_match_inner_dim_u32(coverage)
+    coverage = coverage or 0.7
+    if cached_inner_dim_u32 ~= nil and cached_inner_dim_coverage == coverage then
+        return cached_inner_dim_u32
     end
 
-    local nx = dx / len
-    local ny = dy / len
-    local total_len = dash_len + gap_len
-    local start_offset = offset % total_len
-    local pos = -start_offset
-
-    while pos < len do
-        local dash_start = math.max(0, pos)
-        local dash_end = math.min(len, pos + dash_len)
-
-        if dash_end > dash_start then
-            local sx = x1 + nx * dash_start
-            local sy = y1 + ny * dash_start
-            local ex = x1 + nx * dash_end
-            local ey = y1 + ny * dash_end
-            draw_list:AddLine({ sx, sy }, { ex, ey }, color, thickness)
-        end
-
-        pos = pos + total_len
-    end
+    cached_inner_dim_u32 = imgui.GetColorU32({ 0, 0, 0, 1.0 - coverage })
+    cached_inner_dim_coverage = coverage
+    return cached_inner_dim_u32
 end
 
 function M.draw_match_border_rect(draw_list, x, y, w, h, opacity)
@@ -366,18 +357,7 @@ function M.draw_match_border_rect(draw_list, x, y, w, h, opacity)
         return
     end
 
-    local color = SEARCH_HIGHLIGHT_COLOR
-    local anim_offset = get_animation_offset()
-    local alpha = math.floor(bit.rshift(bit.band(color, 0xFF000000), 24) * (opacity or 1))
-    local r = bit.rshift(bit.band(color, 0x00FF0000), 16) / 255
-    local g = bit.rshift(bit.band(color, 0x0000FF00), 8) / 255
-    local b = bit.band(color, 0x000000FF) / 255
-    local line_color = imgui.GetColorU32({ r, g, b, alpha / 255 })
-
-    local dash_len = 4
-    local gap_len = 4
-    local thickness = 2
-    -- Keep the stroke fully inside the slot so child/window clipping cannot cut it off.
+    local thickness = SEARCH_BORDER_THICKNESS
     local inset = thickness * 0.5
     x = x + inset
     y = y + inset
@@ -387,10 +367,14 @@ function M.draw_match_border_rect(draw_list, x, y, w, h, opacity)
         return
     end
 
-    draw_dashed_line(draw_list, x, y, x + w, y, line_color, thickness, dash_len, gap_len, anim_offset)
-    draw_dashed_line(draw_list, x + w, y, x + w, y + h, line_color, thickness, dash_len, gap_len, anim_offset)
-    draw_dashed_line(draw_list, x + w, y + h, x, y + h, line_color, thickness, dash_len, gap_len, anim_offset)
-    draw_dashed_line(draw_list, x, y + h, x, y, line_color, thickness, dash_len, gap_len, anim_offset)
+    draw_list:AddRect(
+        { x, y },
+        { x + w, y + h },
+        M.get_match_border_color_u32(opacity),
+        0,
+        0,
+        thickness
+    )
 end
 
 function M.draw_match_border(draw_list, x, y, size, opacity)
@@ -399,8 +383,8 @@ end
 
 -- Profile search (lua / xml gear profiles).
 local name_index = nil
-local profile_cache = {} -- path -> { size = n, ids = { [id] = true } }
-local query_cache = {} -- query_key -> ids set
+local profile_cache = {} -- path -> { size, ids }
+local query_cache = {} -- cache_key -> { resolved, path, size, ids }
 
 local function install_path()
     if not AshitaCore or not AshitaCore.GetInstallPath then
@@ -418,6 +402,22 @@ end
 
 local function lower(text)
     return trim(text):lower()
+end
+
+-- Strip trailing dots from partial filenames (e.g. "drg." -> "drg").
+local function normalize_profile_arg(arg)
+    if type(arg) ~= 'string' then
+        return nil
+    end
+    arg = trim(arg)
+    if arg == '' then
+        return nil
+    end
+    arg = arg:gsub('%.+$', '')
+    if arg == '' then
+        return nil
+    end
+    return arg
 end
 
 local function get_player_context()
@@ -485,9 +485,7 @@ function M.parse_query(query)
     if mode ~= 'lua' and mode ~= 'xml' then
         return nil, nil
     end
-    if rest == '' then
-        rest = nil
-    end
+    rest = normalize_profile_arg(rest)
     return mode, rest
 end
 
@@ -545,17 +543,26 @@ local function find_file_ci(dir, filename)
         return direct
     end
 
-    -- Case-insensitive scan of direct children only.
-    local entries = ashita.fs.get_directory(dir, '.*') or list_dirs(dir)
+    local entries = list_dirs(dir)
+    local prefix_match = nil
+    local prefix_len = math.huge
+    local allow_prefix = want:find('%.', 1, true) ~= nil
+
     for _, entry in ipairs(entries) do
-        if lower(entry) == want then
-            local path = dir .. entry
-            if file_exists(path) then
+        local entry_l = lower(entry)
+        local path = dir .. entry
+        if file_exists(path) then
+            if entry_l == want then
                 return path
+            end
+            if allow_prefix and entry_l:sub(1, #want) == want and #entry_l < prefix_len then
+                prefix_match = path
+                prefix_len = #entry_l
             end
         end
     end
-    return nil
+
+    return prefix_match
 end
 
 local function prefer_candidate(candidates)
@@ -873,6 +880,29 @@ local function load_profile_ids(path)
     return ids
 end
 
+local function lookup_query_cache(cache_key)
+    local cached = query_cache[cache_key]
+    if not cached or not cached.resolved then
+        return nil
+    end
+    if not cached.path then
+        return cached.ids or {}
+    end
+    if file_size(cached.path) == cached.size then
+        return cached.ids
+    end
+    return nil
+end
+
+local function store_query_cache(cache_key, path, ids)
+    query_cache[cache_key] = {
+        resolved = true,
+        path = path,
+        size = path and file_size(path) or 0,
+        ids = ids,
+    }
+end
+
 function M.get_match_ids(query)
     local mode, arg = M.parse_query(query)
     if not mode then
@@ -892,13 +922,9 @@ function M.get_match_ids(query)
         player.job_abbr,
     }, '\0')
 
-    local cached = query_cache[cache_key]
-    if cached then
-        -- Re-validate underlying file size cheaply.
-        local path = cached.path
-        if path and file_size(path) == cached.size then
-            return cached.ids
-        end
+    local cached_ids = lookup_query_cache(cache_key)
+    if cached_ids then
+        return cached_ids
     end
 
     local path
@@ -909,11 +935,7 @@ function M.get_match_ids(query)
     end
 
     local ids = load_profile_ids(path)
-    query_cache[cache_key] = {
-        path = path,
-        size = path and file_size(path) or 0,
-        ids = ids,
-    }
+    store_query_cache(cache_key, path, ids)
     return ids
 end
 

--- a/XIUI/modules/satchel/ui.lua
+++ b/XIUI/modules/satchel/ui.lua
@@ -30,6 +30,8 @@ end
 local COLOR_SLOT_BG = { 0.098, 0.090, 0.075, 1.0 }
 local COLOR_SLOT_LOCKED_BG = { 0.055, 0.050, 0.045, 1.0 }
 local DIM_SEARCH = 0.3
+local DIM_SEARCH_MATCH_INNER = 0.7
+local SEARCH_MATCH_INNER_DIM_PX = 2
 local COLOR_QTY = { 0.99, 0.95, 0.75, 1.0 }
 local COLOR_MISSING_ICON = { 0.9, 0.82, 0.50, 1.0 }
 local COLOR_EMPTY_TEXT = { 0.75, 0.75, 0.75, 1.0 }
@@ -190,8 +192,29 @@ end
 
 local function get_content_avail_width()
     local avail = imgui.GetContentRegionAvail()
+    if type(avail) == 'table' then
+        return tonumber(avail[1] or avail.x) or 0
+    end
     if type(avail) == 'number' then
         return avail
+    end
+    return 0
+end
+
+local function get_content_avail_height()
+    local avail = imgui.GetContentRegionAvail()
+    if type(avail) == 'table' then
+        return tonumber(avail[2] or avail.y) or 0
+    end
+    local h = select(2, imgui.GetContentRegionAvail())
+    if type(h) == 'number' then
+        return h
+    end
+
+    local win_h = imgui.GetWindowHeight()
+    local cursor_y = imgui.GetCursorPosY()
+    if type(win_h) == 'number' and type(cursor_y) == 'number' then
+        return math.max(0, win_h - cursor_y - ui.scaled(10, ui.get_global_scale()))
     end
     return 0
 end
@@ -209,19 +232,69 @@ local function center_cursor_for_width(width)
     imgui.SetCursorPosX(math.max(0, (get_full_content_width() - width) * 0.5))
 end
 
-local function get_content_avail_height()
-    local h = select(2, imgui.GetContentRegionAvail())
-    if type(h) == 'number' then
-        return h
-    end
+local function measure_footer_button_height(scale)
+    scale = scale or ui.get_global_scale()
+    ui.push_tab_button_style()
+    local frame_h = imgui.GetFrameHeight()
+    ui.pop_tab_button_style()
+    frame_h = (type(frame_h) == 'number' and frame_h > 0) and frame_h or ui.scaled(22, scale)
+    local style = imgui.GetStyle()
+    local border = (tonumber(style and style.FrameBorderSize) or 0) * 2
+    return frame_h + border
+end
 
-    local win_h = imgui.GetWindowHeight()
-    local cursor_y = imgui.GetCursorPosY()
-    if type(win_h) == 'number' and type(cursor_y) == 'number' then
-        return math.max(0, win_h - cursor_y - ui.scaled(10, ui.get_global_scale()))
-    end
+local function begin_footer_row(scale)
+    scale = scale or ui.get_global_scale()
+    local row_h = ui.get_footer_row_height(scale)
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 })
+    ui.begin_child('##satchel_footer_row', { 0, row_h }, false, ui.NO_SCROLL_CHILD_FLAGS)
 
-    return ui.scaled(100, ui.get_global_scale())
+    local line_h = imgui.GetTextLineHeight()
+    line_h = (type(line_h) == 'number' and line_h > 0) and line_h or ui.scaled(14, scale)
+    local btn_h = measure_footer_button_height(scale)
+    local margin = 2
+    local button_y = math.max(0, row_h - btn_h - margin)
+    local text_y = math.max(0, (row_h - line_h) * 0.5)
+
+    return {
+        text_y = text_y,
+        button_y = button_y,
+        button_h = btn_h,
+        line_h = line_h,
+    }
+end
+
+local function end_footer_row()
+    ui.end_child()
+    imgui.PopStyleVar()
+end
+
+local function set_footer_line_cursor(x, y)
+    if type(x) == 'number' and type(y) == 'number' then
+        imgui.SetCursorPos({ x, y })
+    end
+end
+
+local function footer_sidebar_left_x(sidebar_width, gap)
+    local left_x = imgui.GetCursorPosX()
+    if sidebar_width > 0 then
+        return left_x + sidebar_width + gap
+    end
+    return left_x
+end
+
+local function footer_centered_block_left_x(block_width)
+    if not block_width or block_width <= 0 then
+        return imgui.GetCursorPosX()
+    end
+    return math.max(0, (get_full_content_width() - block_width) * 0.5)
+end
+
+local function footer_align_right_in_block(left_x, block_width, right_width)
+    if block_width and block_width > 0 then
+        return left_x + block_width - right_width
+    end
+    return math.max(0, get_full_content_width() - right_width)
 end
 
 local function blend_slot_background(base_bg, highlight_color, strength)
@@ -277,6 +350,73 @@ local function dim_color(color, factor)
     }
 end
 
+local function color_to_u32(color)
+    if type(color) == 'number' then
+        return color
+    end
+    return imgui.GetColorU32(color)
+end
+
+local function icon_tint_u32(alpha)
+    alpha = alpha or 1
+    return imgui.GetColorU32({ alpha, alpha, alpha, 1.0 })
+end
+
+local idle_grid_chrome = nil
+local search_grid_chrome = nil
+
+local function build_idle_grid_chrome()
+    if idle_grid_chrome then
+        return idle_grid_chrome
+    end
+
+    idle_grid_chrome = {
+        slot_bg_u32 = imgui.GetColorU32(COLOR_SLOT_BG),
+        locked_bg_u32 = imgui.GetColorU32(COLOR_SLOT_LOCKED_BG),
+        locked_border_u32 = imgui.GetColorU32(dim_color(satchelcolors.get_locked_slot_border(), 0.5)),
+        empty_border_u32 = imgui.GetColorU32(satchelcolors.get_empty_slot_border()),
+        icon_full_u32 = icon_tint_u32(1.0),
+        icon_locked_u32 = icon_tint_u32(0.35),
+        qty_u32 = imgui.GetColorU32(COLOR_QTY),
+        missing_icon_u32 = imgui.GetColorU32(COLOR_MISSING_ICON),
+    }
+    return idle_grid_chrome
+end
+
+local function build_search_grid_chrome()
+    if search_grid_chrome then
+        return search_grid_chrome
+    end
+
+    search_grid_chrome = {
+        slot_bg_u32 = imgui.GetColorU32(COLOR_SLOT_BG),
+        locked_bg_u32 = imgui.GetColorU32(COLOR_SLOT_LOCKED_BG),
+        locked_border_u32 = imgui.GetColorU32(dim_color(satchelcolors.get_locked_slot_border(), 0.5)),
+        empty_border_u32 = imgui.GetColorU32(satchelcolors.get_empty_slot_border()),
+        icon_full_u32 = icon_tint_u32(1.0),
+        icon_locked_u32 = icon_tint_u32(0.35),
+        qty_u32 = imgui.GetColorU32(COLOR_QTY),
+        missing_icon_u32 = imgui.GetColorU32(COLOR_MISSING_ICON),
+        search_dim_slot_bg_u32 = imgui.GetColorU32(dim_color(COLOR_SLOT_BG, DIM_SEARCH)),
+        search_dim_locked_bg_u32 = imgui.GetColorU32(dim_color(COLOR_SLOT_LOCKED_BG, DIM_SEARCH)),
+        search_dim_border_u32 = imgui.GetColorU32(dim_color(satchelcolors.get_empty_slot_border(), DIM_SEARCH)),
+        search_dim_locked_border_u32 = imgui.GetColorU32(
+            dim_color(dim_color(satchelcolors.get_locked_slot_border(), 0.5), DIM_SEARCH)
+        ),
+        icon_search_dim_u32 = icon_tint_u32(DIM_SEARCH),
+        icon_locked_search_dim_u32 = icon_tint_u32(0.35 * DIM_SEARCH),
+        qty_search_dim_u32 = imgui.GetColorU32(dim_color(COLOR_QTY, DIM_SEARCH)),
+        missing_icon_search_dim_u32 = imgui.GetColorU32(dim_color(COLOR_MISSING_ICON, DIM_SEARCH)),
+        search_match_border_u32 = searchlogic.get_match_border_color_u32(1.0),
+        search_match_inner_dim_u32 = searchlogic.get_match_inner_dim_u32(DIM_SEARCH_MATCH_INNER),
+    }
+    return search_grid_chrome
+end
+
+local function attach_grid_chrome(ctx)
+    ctx.chrome = ctx.search_active and build_search_grid_chrome() or build_idle_grid_chrome()
+end
+
 local function get_text_width(text, fallback)
     local width = imgui.CalcTextSize(text)
     if type(width) == 'number' then
@@ -298,6 +438,8 @@ end
 
 function ui.push_config_window_style()
     components.PushWindowStyle()
+    -- Let the main window background show through grid/tab/footer child regions.
+    imgui.PushStyleColor(ImGuiCol_ChildBg, { 0, 0, 0, 0 })
     local s = components.TAB_STYLE
     imgui.PushStyleColor(ImGuiCol_ScrollbarBg, s.bgMedium)
     imgui.PushStyleColor(ImGuiCol_ScrollbarGrab, s.bgLight)
@@ -310,6 +452,7 @@ end
 function ui.pop_config_window_style()
     imgui.PopStyleVar(2)
     imgui.PopStyleColor(4)
+    imgui.PopStyleColor(1)
     components.PopWindowStyle()
 end
 
@@ -338,7 +481,7 @@ local function draw_outlined_text(draw_list, x, y, text, color, outline_px)
 
     outline_px = outline_px or 1
     local outline = imgui.GetColorU32({ 0.0, 0.0, 0.0, 1.0 })
-    local fill = imgui.GetColorU32(color or COLOR_QTY)
+    local fill = color_to_u32(color or COLOR_QTY)
 
     for _, offset in ipairs({ { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } }) do
         draw_list:AddText(
@@ -348,27 +491,6 @@ local function draw_outlined_text(draw_list, x, y, text, color, outline_px)
         )
     end
     draw_list:AddText({ x, y }, fill, text)
-end
-
-local function get_window_padding_x()
-    local pad = imgui.GetStyle().WindowPadding
-    if type(pad) == 'table' then
-        return tonumber(pad[1] or pad.x) or 0
-    end
-    return tonumber(pad) or 0
-end
-
-local function get_window_content_right_x()
-    local window_w = tonumber(imgui.GetWindowWidth()) or 0
-    return math.max(0, window_w - get_window_padding_x())
-end
-
-local function get_window_content_left_x()
-    local region_min = imgui.GetWindowContentRegionMin()
-    if type(region_min) == 'table' then
-        return tonumber(region_min[1] or region_min.x) or get_window_padding_x()
-    end
-    return get_window_padding_x()
 end
 
 local function get_layout_columns(settings)
@@ -407,13 +529,6 @@ local function get_slots_for_grid(slots, settings)
         return slots or {}
     end
     return filter_display_slots(slots)
-end
-
-local function normalize_search_query(query)
-    if type(query) ~= 'string' then
-        return ''
-    end
-    return (query:match('^%s*(.-)%s*$') or '')
 end
 
 local function measure_toolbar_button_width(label)
@@ -477,7 +592,7 @@ local function render_toolbar_buttons_right_aligned(buttons, widths, right_x, ga
         local participates = highlight_ids and highlight_ids[button.id] ~= nil
         local is_match = participates and highlight_ids[button.id] == true
         -- Dim from highlight_ids alone so chrome (e.g. slips) can use a different
-        -- query than the toolbar's own Search/Cancel active state.
+        -- query than the toolbar search field state.
         local dim_button = participates and not is_match and not is_dragging
         local btn_size = (width > 0) and { width, 0 } or nil
         local clicked
@@ -546,25 +661,7 @@ function ui.render_toolbar_with_search(search_buffer, scale, id_suffix, buttons,
     id_suffix = tostring(id_suffix or 'main')
 
     local gap = ui.scaled(8, scale)
-    local active_search_text = normalize_search_query(opts.active_search_text or '')
-    local draft_text = (type(search_buffer) == 'table' and search_buffer[1]) or ''
-    local draft_normalized = normalize_search_query(draft_text)
-    local has_active_search = opts.search_active == true or active_search_text ~= ''
-    local draft_differs = draft_normalized ~= active_search_text
-    local show_cancel = has_active_search and active_search_text ~= '' and not draft_differs
-    -- Reserve the wider of Search/Cancel so the field width does not jump on toggle.
-    local action_width = math.max(
-        measure_toolbar_button_width(('Search##satchel_search_go_%s'):format(id_suffix)),
-        measure_toolbar_button_width(('Cancel##satchel_search_go_%s'):format(id_suffix))
-    )
-    local action_button = {
-        id = show_cancel and 'cancel' or 'search',
-        label = show_cancel
-            and ('Cancel##satchel_search_go_%s'):format(id_suffix)
-            or ('Search##satchel_search_go_%s'):format(id_suffix),
-        enabled = show_cancel or draft_text ~= '',
-    }
-    local visible_buttons = { action_button }
+    local visible_buttons = {}
     for _, button in ipairs(buttons) do
         if button.visible ~= false then
             visible_buttons[#visible_buttons + 1] = button
@@ -579,17 +676,14 @@ function ui.render_toolbar_with_search(search_buffer, scale, id_suffix, buttons,
     local line_start_x = imgui.GetCursorPosX()
     local line_y = imgui.GetCursorPosY()
     local buttons_w, button_widths = measure_toolbar_button_group(visible_buttons, gap)
-    button_widths[1] = action_width
-    buttons_w = action_width
-    for index = 2, #visible_buttons do
-        buttons_w = buttons_w + gap + (button_widths[index] or 0)
-    end
     local button_gap = (#visible_buttons > 0) and gap or 0
     local search_w = math.max(ui.scaled(80, scale), align_width - buttons_w - button_gap)
-    local enter_pressed, input_focused = ui.render_search_bar(search_buffer, search_w, scale, id_suffix)
-    if not show_cancel then
-        action_button.enabled = draft_text ~= ''
-    end
+    local input_focused = ui.render_search_bar(
+        search_buffer,
+        search_w,
+        scale,
+        id_suffix
+    )
 
     local clicks = render_toolbar_buttons_right_aligned(
         visible_buttons,
@@ -601,13 +695,6 @@ function ui.render_toolbar_with_search(search_buffer, scale, id_suffix, buttons,
         opts.search_active == true,
         opts.is_dragging == true
     )
-    if enter_pressed then
-        if draft_text ~= '' then
-            clicks.search = true
-        elseif show_cancel then
-            clicks.cancel = true
-        end
-    end
 
     return clicks, input_focused == true
 end
@@ -615,49 +702,34 @@ end
 function ui.render_search_bar(buffer, width, scale, id_suffix)
     scale = scale or ui.get_global_scale()
     if type(buffer) ~= 'table' then
-        return false, false
+        return false
     end
 
     local widget_id = ('##satchel_search_%s'):format(tostring(id_suffix or 'main'))
-    local enter_flag = ImGuiInputTextFlags_EnterReturnsTrue or 0
-    local submitted = false
     imgui.PushStyleColor(ImGuiCol_FrameBg, { 0.067, 0.063, 0.055, 0.95 })
     imgui.PushStyleColor(ImGuiCol_FrameBgHovered, COLOR_HOVER)
     imgui.PushStyleColor(ImGuiCol_FrameBgActive, COLOR_IDLE)
     imgui.PushItemWidth(width or ui.scaled(180, scale))
-    local ok, result = pcall(imgui.InputTextWithHint, widget_id, 'Search items...', buffer, 64, enter_flag)
-    if ok then
-        submitted = result == true
-    else
+    local ok, _ = pcall(imgui.InputTextWithHint, widget_id, 'Search items...', buffer, 64, 0)
+    if not ok then
         local fallback_id = ('Search%s'):format(widget_id)
-        local ok_fallback, fallback_result = pcall(imgui.InputText, fallback_id, buffer, 64, enter_flag)
-        if ok_fallback then
-            submitted = fallback_result == true
-        else
+        local ok_fallback = pcall(imgui.InputText, fallback_id, buffer, 64, 0)
+        if not ok_fallback then
             imgui.InputText(fallback_id, buffer, 64)
         end
     end
     imgui.PopItemWidth()
     imgui.PopStyleColor(3)
 
-    -- Enter deactivates the field in the same frame; treat submit as still focused
-    -- so callers can arm the Enter-block trail before the game sees the key.
-    local input_focused = submitted == true
-    if not input_focused then
-        local active_ok, is_active = pcall(function()
-            return imgui.IsItemActive()
-        end)
-        if active_ok and is_active then
-            input_focused = true
-        else
-            local focused_ok, is_focused = pcall(function()
-                return imgui.IsItemFocused()
-            end)
-            input_focused = focused_ok and is_focused == true
-        end
-    end
+    local active_ok, is_active = pcall(function()
+        return imgui.IsItemActive()
+    end)
+    local focused_ok, is_focused = pcall(function()
+        return imgui.IsItemFocused()
+    end)
+    local field_active = (active_ok and is_active == true) or (focused_ok and is_focused == true)
 
-    return submitted, input_focused
+    return field_active
 end
 
 local function draw_full_badge(max_x, min_y, max_y)
@@ -857,9 +929,8 @@ function ui.get_footer_row_height(scale)
     scale = scale or ui.get_global_scale()
     local text_h = imgui.GetTextLineHeight()
     text_h = type(text_h) == 'number' and text_h or ui.scaled(14, scale)
-    local frame_h = imgui.GetFrameHeight()
-    frame_h = type(frame_h) == 'number' and frame_h or ui.scaled(22, scale)
-    return math.max(text_h, frame_h, ui.scaled(24, scale))
+    local btn_h = measure_footer_button_height(scale)
+    return math.max(text_h, btn_h + 4, ui.scaled(30, scale))
 end
 
 function ui.render_inventory_footer(stat, ctx, opts)
@@ -868,20 +939,22 @@ function ui.render_inventory_footer(stat, ctx, opts)
     local sidebar_width = opts.sidebar_width or 0
     local gap = opts.gap or ui.scaled(8, scale)
 
+    local layout = begin_footer_row(scale)
+
     local used = (stat and stat.used) or 0
     local total = (stat and stat.total) or 0
-
-    if sidebar_width > 0 then
-        imgui.SetCursorPosX(imgui.GetCursorPosX() + sidebar_width + gap)
-    end
+    local left_x = footer_sidebar_left_x(sidebar_width, gap)
+    set_footer_line_cursor(left_x, layout.text_y)
     imgui.TextColored(COLOR_USED_TEXT, ('Used: %d / %d'):format(used, total))
 
     if not ctx or not ctx.get_gil_amount or not ctx.format_gil_text or ctx.hide_gil then
+        end_footer_row()
         return
     end
 
     local gil_amount = ctx.get_gil_amount()
     if gil_amount == nil then
+        end_footer_row()
         return
     end
 
@@ -899,8 +972,9 @@ function ui.render_inventory_footer(stat, ctx, opts)
             or (ctx.tex_ptr and ctx.tex_ptr(gil_icon) or nil)
     end
     local right_width = text_w + (gil_ptr and (icon_size + icon_gap) or 0)
-    local right_x = math.max(0, get_full_content_width() - right_width)
-    imgui.SameLine(right_x)
+    local grid_block_width = tonumber(opts.grid_block_width) or 0
+    local right_x = footer_align_right_in_block(left_x, grid_block_width, right_width)
+    set_footer_line_cursor(right_x, layout.text_y)
 
     if gil_ptr then
         imgui.Image(gil_ptr, { icon_size, icon_size })
@@ -908,88 +982,161 @@ function ui.render_inventory_footer(stat, ctx, opts)
     end
 
     imgui.TextColored(COLOR_GIL_TEXT, gil_text)
+    end_footer_row()
+end
+
+local function render_footer_pagination(page_index, page_count, on_page_change, scale, layout, opts)
+    opts = opts or {}
+    scale = scale or ui.get_global_scale()
+    local page = tonumber(page_index) or 0
+    local total_pages = math.max(1, tonumber(page_count) or 1)
+    local gap = opts.gap or ui.scaled(8, scale)
+    local page_text = ('Page %d / %d'):format(page + 1, total_pages)
+    local grid_width = tonumber(opts.grid_width) or 0
+    local left_x = footer_centered_block_left_x(grid_width)
+    local right_inset = tonumber(opts.right_inset) or ui.scaled(2, scale)
+    local prev_w = measure_toolbar_button_width('Prev##satchel_slip_page')
+    local next_w = measure_toolbar_button_width('Next##satchel_slip_page')
+    local page_w = get_text_width(page_text, 0)
+    local page_text_y = layout.button_y + math.max(0, (layout.button_h - layout.line_h) * 0.5)
+    local btn_size = { 0, layout.button_h }
+    local grid_right = left_x + grid_width
+
+    local x = grid_right - right_inset - next_w
+    btn_size[1] = next_w
+    set_footer_line_cursor(x, layout.button_y)
+    if ui.render_toolbar_button('Next##satchel_slip_page', page < (total_pages - 1), btn_size) and on_page_change then
+        on_page_change(page + 1)
+    end
+
+    x = x - gap - page_w
+    set_footer_line_cursor(x, page_text_y)
+    imgui.TextColored(COLOR_USED_TEXT, page_text)
+
+    x = x - gap - prev_w
+    btn_size[1] = prev_w
+    set_footer_line_cursor(x, layout.button_y)
+    if ui.render_toolbar_button('Prev##satchel_slip_page', page > 0, btn_size) and on_page_change then
+        on_page_change(page - 1)
+    end
 end
 
 function ui.render_slip_window_footer(stored_count, page_index, page_count, on_page_change, scale, opts)
     opts = opts or {}
     scale = scale or ui.get_global_scale()
-    local page = tonumber(page_index) or 0
-    local total_pages = math.max(1, tonumber(page_count) or 1)
-    local can_prev = page > 0
-    local can_next = page < (total_pages - 1)
-    local gap = opts.gap or ui.scaled(8, scale)
     local stored_text = ('Stored: %d Items'):format(tonumber(stored_count) or 0)
-    local page_text = ('Page %d / %d'):format(page + 1, total_pages)
 
-    local grid_width = tonumber(opts.grid_width) or 0
-    local content_width = get_full_content_width()
-    local left_offset = 0
-    if grid_width > 0 then
-        left_offset = math.max(0, (content_width - grid_width) * 0.5)
-        imgui.SetCursorPosX(left_offset)
-    end
+    local layout = begin_footer_row(scale)
+    local left_x = footer_centered_block_left_x(tonumber(opts.grid_width) or 0)
+    set_footer_line_cursor(left_x, layout.text_y)
     imgui.TextColored(COLOR_USED_TEXT, stored_text)
-
-    local prev_w = measure_toolbar_button_width('Prev##satchel_slip_page')
-    local next_w = measure_toolbar_button_width('Next##satchel_slip_page')
-    local page_w = get_text_width(page_text, 0)
-    local right_width = prev_w + gap + page_w + gap + next_w
-    local right_x
-    if grid_width > 0 then
-        right_x = left_offset + grid_width - right_width
-    else
-        right_x = math.max(0, content_width - right_width)
-    end
-    imgui.SameLine(right_x)
-
-    if ui.render_toolbar_button('Prev##satchel_slip_page', can_prev) and on_page_change then
-        on_page_change(page - 1)
-    end
-    imgui.SameLine(0, gap)
-    imgui.TextColored(COLOR_USED_TEXT, page_text)
-    imgui.SameLine(0, gap)
-    if ui.render_toolbar_button('Next##satchel_slip_page', can_next) and on_page_change then
-        on_page_change(page + 1)
-    end
+    render_footer_pagination(page_index, page_count, on_page_change, scale, layout, opts)
+    end_footer_row()
 end
 
-local function draw_slot_icon(draw_list, tex_ptr, screen_x, screen_y, icon_size, icon_alpha)
-    if not draw_list or not tex_ptr or tex_ptr == 0 or icon_alpha <= 0.01 then
+local function grid_slot_screen_bounds(grid_ox, grid_oy, index, columns, slot_size, cell_gap)
+    local zero = index - 1
+    local col = zero % columns
+    local row = math.floor(zero / columns)
+    local cell = slot_size + cell_gap
+    local min_x = grid_ox + (col * cell)
+    local min_y = grid_oy + (row * cell)
+    return min_x, min_y, min_x + slot_size, min_y + slot_size
+end
+
+local function hit_test_grid_slot(mouse_x, mouse_y, grid_ox, grid_oy, columns, slot_size, cell_gap, slot_count)
+    if type(mouse_x) ~= 'number' or type(mouse_y) ~= 'number' then
+        return nil
+    end
+
+    local local_x = mouse_x - grid_ox
+    local local_y = mouse_y - grid_oy
+    if local_x < 0 or local_y < 0 then
+        return nil
+    end
+
+    local cell = slot_size + cell_gap
+    local col = math.floor(local_x / cell)
+    local row = math.floor(local_y / cell)
+    if col < 0 or col >= columns then
+        return nil
+    end
+
+    local in_cell_x = local_x - (col * cell)
+    local in_cell_y = local_y - (row * cell)
+    if in_cell_x > slot_size or in_cell_y > slot_size then
+        return nil
+    end
+
+    local index = (row * columns) + col + 1
+    if index < 1 or index > slot_count then
+        return nil
+    end
+    return index
+end
+
+local function draw_slot_icon(draw_list, tex_ptr, screen_x, screen_y, icon_size, tint_u32)
+    if not draw_list or not tex_ptr or tex_ptr == 0 or not tint_u32 then
         return
     end
 
-    local tint = imgui.GetColorU32({ icon_alpha, icon_alpha, icon_alpha, 1.0 })
     draw_list:AddImage(
         tex_ptr,
         { screen_x, screen_y },
         { screen_x + icon_size, screen_y + icon_size },
         { 0, 0 },
         { 1, 1 },
-        tint
+        tint_u32
     )
 end
 
-local function draw_slot(slot, index, key_prefix, ctx)
+-- Darken only the inner band of an icon so built-in icon borders do not wash out the gold highlight.
+local function draw_search_match_inner_dim(draw_list, x1, y1, x2, y2, band_px, dim_u32)
+    if not draw_list or not dim_u32 or band_px <= 0 then
+        return
+    end
+
+    if (x2 - x1) <= band_px or (y2 - y1) <= band_px then
+        return
+    end
+
+    draw_list:AddRectFilled({ x1, y1 }, { x2, y1 + band_px }, dim_u32)
+    draw_list:AddRectFilled({ x1, y2 - band_px }, { x2, y2 }, dim_u32)
+    draw_list:AddRectFilled({ x1, y1 }, { x1 + band_px, y2 }, dim_u32)
+    draw_list:AddRectFilled({ x2 - band_px, y1 }, { x2, y2 }, dim_u32)
+end
+
+local function draw_slot(slot, index, key_prefix, ctx, layout)
     local slot_size = ctx.slot_size or ctx.settings.slot_size
-    local icon_padding = math.max(1, math.floor(slot_size * 0.05))
-    local icon_size = math.max(20, slot_size - (icon_padding * 2))
+    local icon_padding = ctx.icon_padding or math.max(1, math.floor(slot_size * 0.05))
+    local icon_size = ctx.icon_size or math.max(20, slot_size - (icon_padding * 2))
     local locked = slot.locked == true
     local read_only = slot.read_only == true or ctx.read_only == true
     local allow_visual_drag = ctx.visual_sort_only == true
     local allow_drag = allow_visual_drag and not locked and slot.id and slot.id > 0
-    local search_query = normalize_search_query(ctx.search_query or '')
-    local search_active = search_query ~= ''
+    local is_dragging = ctx.grid_is_dragging == true
+    local search_active = ctx.search_active == true
     local search_match = false
     if search_active and slot.id and slot.id > 0 and ctx.item_matches_search then
-        search_match = ctx.item_matches_search(slot, search_query) == true
+        search_match = ctx.item_matches_search(slot, ctx.search_query) == true
     end
 
-    local border_color = locked and dim_color(satchelcolors.get_locked_slot_border(), 0.5) or ctx.get_slot_border_color(slot)
-    if not locked and (not slot.id or slot.id <= 0) then
-        border_color = satchelcolors.get_empty_slot_border()
+    local chrome = ctx.chrome
+    local border_u32
+    if search_active and search_match then
+        border_u32 = nil
+    elseif search_active and not is_dragging then
+        border_u32 = locked and chrome.search_dim_locked_border_u32 or chrome.search_dim_border_u32
+    elseif locked then
+        border_u32 = chrome.locked_border_u32
+    elseif not slot.id or slot.id <= 0 then
+        border_u32 = chrome.empty_border_u32
+    elseif ctx.get_slot_border_u32 then
+        border_u32 = ctx.get_slot_border_u32(slot)
+    else
+        border_u32 = color_to_u32(ctx.get_slot_border_color(slot))
     end
 
-    local is_dragging = ctx.is_dragging and ctx.is_dragging() == true
     local is_drag_source = is_dragging
         and ctx.is_drag_source
         and ctx.is_drag_source(slot) == true
@@ -1003,96 +1150,123 @@ local function draw_slot(slot, index, key_prefix, ctx)
     -- Dim non-matches while searching, including empty and locked slots.
     -- Suspend dimming during an active drag so the board is fully readable.
     local search_dim = search_active and not search_match and not is_dragging
-    local icon_alpha = 1.0
-    if locked then
-        icon_alpha = search_dim and (0.35 * DIM_SEARCH) or 0.35
-    elseif is_drag_source then
-        icon_alpha = 0.0
+    local icon_tint
+    if is_drag_source then
+        icon_tint = nil
+    elseif locked then
+        icon_tint = search_dim and chrome.icon_locked_search_dim_u32 or chrome.icon_locked_u32
     elseif search_dim then
-        icon_alpha = DIM_SEARCH
-    end
-    if search_dim then
-        border_color = dim_color(border_color, DIM_SEARCH)
+        icon_tint = chrome.icon_search_dim_u32
+    else
+        icon_tint = chrome.icon_full_u32
     end
 
     local tex = nil
-    local slot_id = ('##satchel_slot_%s_%d'):format(tostring(key_prefix or 'all'), index)
-    imgui.InvisibleButton(slot_id, { slot_size, slot_size })
+    local min_x, min_y, max_x, max_y
+    local slot_hovered = false
+    layout = layout or {}
+
+    if layout.min_x ~= nil then
+        min_x = layout.min_x
+        min_y = layout.min_y
+        max_x = layout.max_x
+        max_y = layout.max_y
+        slot_hovered = layout.is_hovered == true
+    else
+        local slot_id = ('##satchel_slot_%s_%d'):format(tostring(key_prefix or 'all'), index)
+        imgui.InvisibleButton(slot_id, { slot_size, slot_size })
+        slot_hovered = is_dragging and imgui.IsItemHovered(DRAG_HOVER_FLAGS) or imgui.IsItemHovered()
+        min_x, min_y = imgui.GetItemRectMin()
+        max_x, max_y = imgui.GetItemRectMax()
+    end
 
     local drag_source_hovered = is_dragging
         and is_drag_source
-        and imgui.IsItemHovered(DRAG_HOVER_FLAGS)
+        and slot_hovered
 
     local drop_target_hovered = is_dragging
         and not is_drag_source
         and (allow_visual_drag or not read_only)
         and not locked
-        and imgui.IsItemHovered(DRAG_HOVER_FLAGS)
+        and slot_hovered
 
-    local min_x, min_y = imgui.GetItemRectMin()
-    local max_x, max_y = imgui.GetItemRectMax()
     local draw_list = imgui.GetWindowDrawList()
-    local slot_bg = locked and COLOR_SLOT_LOCKED_BG or COLOR_SLOT_BG
+    local slot_bg_u32 = locked and chrome.locked_bg_u32 or chrome.slot_bg_u32
     if search_dim then
-        slot_bg = dim_color(slot_bg, DIM_SEARCH)
+        slot_bg_u32 = locked and chrome.search_dim_locked_bg_u32 or chrome.search_dim_slot_bg_u32
     end
 
     if is_drag_source then
-        slot_bg, border_color = apply_drag_slot_colors(slot_bg, false, false)
+        local drag_bg, drag_border = apply_drag_slot_colors(
+            locked and COLOR_SLOT_LOCKED_BG or COLOR_SLOT_BG,
+            false,
+            false
+        )
+        slot_bg_u32 = color_to_u32(drag_bg)
+        border_u32 = color_to_u32(drag_border)
     elseif is_dragging and (allow_visual_drag or not read_only) and not locked and is_empty_slot then
-        slot_bg, border_color = apply_drag_slot_colors(slot_bg, can_accept_drop, false)
+        local drag_bg, drag_border = apply_drag_slot_colors(
+            locked and COLOR_SLOT_LOCKED_BG or COLOR_SLOT_BG,
+            can_accept_drop,
+            false
+        )
+        slot_bg_u32 = color_to_u32(drag_bg)
+        border_u32 = color_to_u32(drag_border)
     end
 
     if drag_source_hovered then
-        slot_bg, border_color = apply_drag_slot_colors(slot_bg, false, true)
+        local drag_bg, drag_border = apply_drag_slot_colors(
+            locked and COLOR_SLOT_LOCKED_BG or COLOR_SLOT_BG,
+            false,
+            true
+        )
+        slot_bg_u32 = color_to_u32(drag_bg)
+        border_u32 = color_to_u32(drag_border)
     elseif drop_target_hovered then
-        slot_bg, border_color = apply_drag_slot_colors(slot_bg, can_accept_drop, true)
+        local drag_bg, drag_border = apply_drag_slot_colors(
+            locked and COLOR_SLOT_LOCKED_BG or COLOR_SLOT_BG,
+            can_accept_drop,
+            true
+        )
+        slot_bg_u32 = color_to_u32(drag_bg)
+        border_u32 = color_to_u32(drag_border)
     end
 
     if is_drag_source then
-        border_color = satchelcolors.get_drag_drop_invalid_highlight_hover()
+        border_u32 = color_to_u32(satchelcolors.get_drag_drop_invalid_highlight_hover())
     end
 
-    if (allow_drag or (not read_only and not locked)) and slot.id and slot.id > 0
-        and imgui.IsItemActive() and imgui.IsMouseDown(MOUSE_LEFT) then
+    if not layout.defer_interaction
+        and (allow_drag or (not read_only and not locked)) and slot.id and slot.id > 0
+        and ((layout.min_x == nil and imgui.IsItemActive()) or slot_hovered)
+        and imgui.IsMouseDown(MOUSE_LEFT) then
         block_window_move = true
     end
 
     if draw_list and type(min_x) == 'number' and type(min_y) == 'number'
         and type(max_x) == 'number' and type(max_y) == 'number' then
-        draw_list:AddRectFilled({ min_x, min_y }, { max_x, max_y }, imgui.GetColorU32(slot_bg))
+        draw_list:AddRectFilled({ min_x, min_y }, { max_x, max_y }, slot_bg_u32)
 
-        -- Search matches use the ant border in place of the solid slot border
-        -- (drawn on the slot's window list so tooltips stay on top).
-        local use_ant_border = search_match and not is_drag_source
-        if use_ant_border then
-            searchlogic.draw_match_border_rect(
-                draw_list,
-                min_x,
-                min_y,
-                max_x - min_x,
-                max_y - min_y,
-                1.0
-            )
-        else
-            draw_list:AddRect({ min_x, min_y }, { max_x, max_y }, imgui.GetColorU32(border_color), 0, 0, 1.0)
+        local use_match_border = search_match and not is_drag_source
+        if not use_match_border and border_u32 then
+            draw_list:AddRect({ min_x, min_y }, { max_x, max_y }, border_u32, 0, 0, 1.0)
         end
 
         if slot.id and slot.id > 0 then
             tex = ctx.load_item_icon(slot.id)
-            if tex then
+            if tex and icon_tint then
                 draw_slot_icon(
                     draw_list,
                     ctx.tex_ptr(tex),
                     min_x + icon_padding,
                     min_y + icon_padding,
                     icon_size,
-                    icon_alpha
+                    icon_tint
                 )
-            else
+            elseif not tex then
                 draw_list:AddText(
                     { min_x + 4, min_y + 8 },
-                    imgui.GetColorU32(dim_color(COLOR_MISSING_ICON, icon_alpha)),
+                    search_dim and chrome.missing_icon_search_dim_u32 or chrome.missing_icon_u32,
                     '?'
                 )
             end
@@ -1111,8 +1285,40 @@ local function draw_slot(slot, index, key_prefix, ctx)
                     qty_x,
                     qty_y,
                     qty_text,
-                    dim_color(COLOR_QTY, icon_alpha),
+                    search_dim and chrome.qty_search_dim_u32 or chrome.qty_u32,
                     outline_px
+                )
+            end
+        end
+
+        if use_match_border and slot.id and slot.id > 0 and chrome.search_match_inner_dim_u32 then
+            local ix = min_x + icon_padding
+            local iy = min_y + icon_padding
+            draw_search_match_inner_dim(
+                draw_list,
+                ix,
+                iy,
+                ix + icon_size,
+                iy + icon_size,
+                SEARCH_MATCH_INNER_DIM_PX,
+                chrome.search_match_inner_dim_u32
+            )
+        end
+
+        -- Search highlight on top of icon so built-in icon borders do not obscure it.
+        if use_match_border and chrome.search_match_border_u32 then
+            local thickness = 2
+            local inset = thickness * 0.5
+            local bx, by = min_x + inset, min_y + inset
+            local bw, bh = (max_x - min_x) - thickness, (max_y - min_y) - thickness
+            if bw > 0 and bh > 0 then
+                draw_list:AddRect(
+                    { bx, by },
+                    { bx + bw, by + bh },
+                    chrome.search_match_border_u32,
+                    0,
+                    0,
+                    thickness
                 )
             end
         end
@@ -1122,7 +1328,10 @@ local function draw_slot(slot, index, key_prefix, ctx)
         ctx.pending_drop_target = slot
     end
 
-    local slot_hovered = is_dragging and imgui.IsItemHovered(DRAG_HOVER_FLAGS) or imgui.IsItemHovered()
+    if layout.defer_interaction then
+        return
+    end
+
     if not locked and slot_hovered and slot.id and slot.id > 0 and ctx.render_item_detail_tooltip then
         local ok, err = pcall(ctx.render_item_detail_tooltip, slot)
         if not ok and ashita and ashita.log and ashita.log.error then
@@ -1142,7 +1351,48 @@ local function draw_slot(slot, index, key_prefix, ctx)
     end
 
     if not read_only and not locked and slot.id and slot.id > 0 and ctx.on_slot_double_click
-        and imgui.IsItemHovered() and imgui.IsMouseDoubleClicked(MOUSE_LEFT) then
+        and slot_hovered and imgui.IsMouseDoubleClicked(MOUSE_LEFT) then
+        ctx.on_slot_double_click(slot)
+    end
+end
+
+local function handle_fast_grid_slot_interactions(slot, ctx, grid_hovered, grid_active, hovered_idx)
+    if not grid_hovered or not hovered_idx or not slot then
+        return
+    end
+
+    local locked = slot.locked == true
+    local read_only = slot.read_only == true or ctx.read_only == true
+    local allow_visual_drag = ctx.visual_sort_only == true
+    local allow_drag = allow_visual_drag and not locked and slot.id and slot.id > 0
+
+    if grid_active
+        and (allow_drag or (not read_only and not locked)) and slot.id and slot.id > 0
+        and imgui.IsMouseDown(MOUSE_LEFT) then
+        block_window_move = true
+    end
+
+    if not locked and slot.id and slot.id > 0 and ctx.render_item_detail_tooltip and not ctx.grid_is_dragging then
+        local ok, err = pcall(ctx.render_item_detail_tooltip, slot)
+        if not ok and ashita and ashita.log and ashita.log.error then
+            ashita.log.error(('[XIUI Satchel] tooltip error: %s'):format(tostring(err)))
+        end
+    end
+
+    if (allow_visual_drag or not read_only) and not locked and slot.id and slot.id > 0
+        and imgui.IsItemClicked(MOUSE_RIGHT) and ctx.on_slot_right_click then
+        ctx.on_slot_right_click(slot)
+    end
+
+    if allow_drag and ctx.on_slot_drag_start and imgui.IsItemClicked(MOUSE_LEFT) then
+        pending_drag = { scope = ctx.drag_scope, slot = slot, item_id = slot.id }
+    elseif not read_only and not locked and slot.id and slot.id > 0 and ctx.on_slot_drag_start
+        and imgui.IsItemClicked(MOUSE_LEFT) then
+        pending_drag = { scope = ctx.drag_scope, slot = slot, item_id = slot.id }
+    end
+
+    if not read_only and not locked and slot.id and slot.id > 0 and ctx.on_slot_double_click
+        and imgui.IsMouseDoubleClicked(MOUSE_LEFT) then
         ctx.on_slot_double_click(slot)
     end
 end
@@ -1216,7 +1466,16 @@ function ui.render_slot_grid(slots, key_prefix, stat, ctx)
     local scale = ctx.scale or ui.get_global_scale()
     ctx.scale = scale
     ctx.slot_size = ui.scaled(ctx.settings.slot_size or ctx.default_slot_size or 40, scale)
+    ctx.icon_padding = math.max(1, math.floor(ctx.slot_size * 0.05))
+    ctx.icon_size = math.max(20, ctx.slot_size - (ctx.icon_padding * 2))
+    ctx.grid_is_dragging = ctx.is_dragging and ctx.is_dragging() == true
     block_window_move = false
+
+    ctx.search_active = ctx.search_active == true
+    attach_grid_chrome(ctx)
+    if ctx.prepare_slot_render then
+        ctx.prepare_slot_render()
+    end
 
     local packed = get_slots_for_grid(slots, ctx.settings)
     local packed_count = #packed
@@ -1236,10 +1495,70 @@ function ui.render_slot_grid(slots, key_prefix, stat, ctx)
         metrics.needs_scroll and 0 or SLOT_CHILD_FLAGS
     )
 
-    for i = 1, packed_count do
-        draw_slot(packed[i], i, tostring(key_prefix), ctx)
-        if i % metrics.columns ~= 0 then
-            imgui.SameLine(0, metrics.cell_gap)
+    local key = tostring(key_prefix)
+    local use_fast_grid = not metrics.needs_scroll and packed_count > 0
+    local grid_ox, grid_oy
+    local hovered_idx = nil
+
+    if use_fast_grid then
+        grid_ox, grid_oy = imgui.GetCursorScreenPos()
+        imgui.InvisibleButton(
+            ('##satchel_grid_hit_%s'):format(key),
+            { metrics.grid_width, metrics.grid_height }
+        )
+        local grid_hovered = imgui.IsItemHovered()
+        local grid_active = imgui.IsItemActive()
+
+        if grid_hovered then
+            local mouse_x, mouse_y = imgui.GetMousePos()
+            hovered_idx = hit_test_grid_slot(
+                mouse_x,
+                mouse_y,
+                grid_ox,
+                grid_oy,
+                metrics.columns,
+                metrics.slot_size,
+                metrics.cell_gap,
+                packed_count
+            )
+        end
+
+        for i = 1, packed_count do
+            local min_x, min_y, max_x, max_y = grid_slot_screen_bounds(
+                grid_ox,
+                grid_oy,
+                i,
+                metrics.columns,
+                metrics.slot_size,
+                metrics.cell_gap
+            )
+            draw_slot(packed[i], i, key, ctx, {
+                min_x = min_x,
+                min_y = min_y,
+                max_x = max_x,
+                max_y = max_y,
+                is_hovered = grid_hovered and hovered_idx == i,
+                defer_interaction = true,
+            })
+        end
+
+        if hovered_idx then
+            handle_fast_grid_slot_interactions(
+                packed[hovered_idx],
+                ctx,
+                grid_hovered,
+                grid_active,
+                hovered_idx
+            )
+        elseif grid_active and imgui.IsMouseDown(MOUSE_LEFT) then
+            block_window_move = true
+        end
+    else
+        for i = 1, packed_count do
+            draw_slot(packed[i], i, key, ctx)
+            if i % metrics.columns ~= 0 then
+                imgui.SameLine(0, metrics.cell_gap)
+            end
         end
     end
 
@@ -1255,8 +1574,7 @@ function ui.render_slot_grid(slots, key_prefix, stat, ctx)
 
     if ctx.pending_drop_target
         and ctx.on_drop_to_slot
-        and ctx.is_dragging
-        and ctx.is_dragging() == true
+        and ctx.grid_is_dragging
         and ctx.can_drop_to_slot
         and ctx.can_drop_to_slot(ctx.pending_drop_target) == true
         and imgui.IsMouseReleased(MOUSE_LEFT) then


### PR DESCRIPTION
Improved Satchel Module Performance And Switched Search To Live Search
- Fixed `lua` and `xml` gear profile searching causing fps slow downs or crashes.
  - Search now cache negative results `(path == nil)` so failed lookups are resolved once.
  - Normalized profile args to strip trailing dots to prevent a failed lookup.
  - Incomplete extensions now get auto-completed (`drg.lu` into `drg.lua`).
- Made search to filter your bags as you type without needing a Search or Cancel button.
- Improved satchel module performance.
  - Improved search speed with caching so open Satchel windows stay smoother while you play.
  - Replaced the animated ant border with a solid gold highlight on matching items to improve performance.
  - Reduced idle slowdown when Satchel windows were open but you were not searching.
- Fixed ESC key to always clear an active search first, and optionally close windows on a second press when Close on ESC is enabled.
- Fixed footer text, gil display, and slip page buttons so they lined up with the item grid.
- Made inventory tabs, grids, and footers show the window background instead of a separate black panel behind them.
- Matched alt character inventory windows to the same sizing and layout as the main Satchel bag.