### PR TITLE
Improved Hotbar Action Validation And Cost Display

### DIFF
--- a/XIUI/config/palettemanager.lua
+++ b/XIUI/config/palettemanager.lua
@@ -40,8 +40,7 @@ local modalState = {
 
 -- Get job name from ID (uses libs/jobs.lua)
 local function GetJobName(jobId)
-    if jobId == 0 then return 'Shared'; end
-    return jobs[jobId] or ('Job ' .. jobId);
+    return jobs.GetDisplayName(jobId);
 end
 
 -- Check if using fallback (shared) palettes for the selected type
@@ -59,8 +58,8 @@ end
 function M.Open()
     windowState.isOpen = true;
 
-    -- Always open on the player's CURRENT job, not the last-used selection.
-    windowState.selectedJobId = data.jobId or 1;
+    -- Always open on the player's CURRENT job category (Other for unknown jobs).
+    windowState.selectedJobId = jobs.ResolveJobCategory(data.jobId);
 
     -- Default the subjob selector to the current subjob only if it has its own
     -- palettes; otherwise show the Shared library (subjob 0). This mirrors what's
@@ -114,7 +113,7 @@ local function DrawJobSelector()
     imgui.SameLine();
     imgui.PushItemWidth(80);
     if imgui.BeginCombo('##jobSelector', currentLabel) then
-        for jobId = 1, 22 do
+        for jobId = 1, jobs.STANDARD_MAX do
             local isSelected = (jobId == windowState.selectedJobId);
             if imgui.Selectable(GetJobName(jobId), isSelected) then
                 if jobId ~= windowState.selectedJobId then
@@ -128,6 +127,22 @@ local function DrawJobSelector()
                 imgui.SetItemDefaultFocus();
             end
         end
+
+        imgui.Separator();
+        local otherId = jobs.OTHER_JOB_ID;
+        local otherSelected = (windowState.selectedJobId == otherId);
+        if imgui.Selectable(jobs.OTHER_LABEL, otherSelected) then
+            if windowState.selectedJobId ~= otherId then
+                windowState.selectedJobId = otherId;
+                windowState.selectedSubjobId = 0;
+                windowState.selectedPaletteName = nil;
+                changed = true;
+            end
+        end
+        if otherSelected then
+            imgui.SetItemDefaultFocus();
+        end
+
         imgui.EndCombo();
     end
     imgui.PopItemWidth();
@@ -500,7 +515,7 @@ local function DrawCopyModal()
         imgui.SameLine();
         imgui.PushItemWidth(100);
         if imgui.BeginCombo('##copyJobSelector', GetJobName(modalState.copyTargetJobId)) then
-            for jobId = 1, 22 do
+            for jobId = 1, jobs.STANDARD_MAX do
                 local isSelected = (jobId == modalState.copyTargetJobId);
                 if imgui.Selectable(GetJobName(jobId), isSelected) then
                     modalState.copyTargetJobId = jobId;
@@ -508,6 +523,15 @@ local function DrawCopyModal()
                 if isSelected then
                     imgui.SetItemDefaultFocus();
                 end
+            end
+            imgui.Separator();
+            local otherId = jobs.OTHER_JOB_ID;
+            local otherSelected = (modalState.copyTargetJobId == otherId);
+            if imgui.Selectable(jobs.OTHER_LABEL, otherSelected) then
+                modalState.copyTargetJobId = otherId;
+            end
+            if otherSelected then
+                imgui.SetItemDefaultFocus();
             end
             imgui.EndCombo();
         end

--- a/XIUI/core/settings/migration.lua
+++ b/XIUI/core/settings/migration.lua
@@ -1101,6 +1101,129 @@ function M.MigrateSlotMacroRefs(gConfig)
     return keysAdded, fieldsStripped;
 end
 
+--- Rewrite colliding per-palette macro ids into globally unique ids and
+--- retarget every slotActions / crossbar macroRef that pointed at them.
+--- Idempotent when ids are already unique.
+---@param gConfig table
+---@return number rewrittenMacros
+---@return number rewrittenSlots
+function M.MigrateUniqueMacroIds(gConfig)
+    if not gConfig or not gConfig.macroDB then
+        return 0, 0;
+    end
+
+    local seen = {};
+    local remaps = {}; -- [paletteKey] = { [oldId] = newId }
+    local nextId = gConfig.macroIdSeq or 0;
+    local rewrittenMacros = 0;
+
+    -- First pass: discover max id
+    for _, macros in pairs(gConfig.macroDB) do
+        if type(macros) == 'table' then
+            for _, macro in ipairs(macros) do
+                if macro and macro.id and macro.id > nextId then
+                    nextId = macro.id;
+                end
+            end
+        end
+    end
+
+    -- Second pass: rewrite collisions (same id in multiple palettes)
+    for paletteKey, macros in pairs(gConfig.macroDB) do
+        if type(macros) == 'table' then
+            for _, macro in ipairs(macros) do
+                if macro and macro.id then
+                    local oldId = macro.id;
+                    if seen[oldId] then
+                        nextId = nextId + 1;
+                        if not remaps[paletteKey] then
+                            remaps[paletteKey] = {};
+                        end
+                        remaps[paletteKey][oldId] = nextId;
+                        macro.id = nextId;
+                        rewrittenMacros = rewrittenMacros + 1;
+                        seen[nextId] = true;
+                    else
+                        seen[oldId] = true;
+                    end
+                end
+            end
+        end
+    end
+
+    gConfig.macroIdSeq = nextId;
+
+    if rewrittenMacros == 0 then
+        return 0, 0;
+    end
+
+    local function RemapSlot(slot, contextPaletteHint)
+        if type(slot) ~= 'table' or not slot.macroRef then
+            return false;
+        end
+        local paletteKey = slot.macroPaletteKey or contextPaletteHint;
+        local map = paletteKey and remaps[paletteKey];
+        if map and map[slot.macroRef] then
+            slot.macroRef = map[slot.macroRef];
+            if not slot.macroPaletteKey and paletteKey then
+                slot.macroPaletteKey = paletteKey;
+            end
+            return true;
+        end
+        -- Ambiguous: if only one remap table contains this old id, use it
+        local matchNew, matchCount = nil, 0;
+        for pKey, pMap in pairs(remaps) do
+            if pMap[slot.macroRef] then
+                matchCount = matchCount + 1;
+                matchNew = pMap[slot.macroRef];
+                paletteKey = pKey;
+            end
+        end
+        if matchCount == 1 then
+            slot.macroRef = matchNew;
+            slot.macroPaletteKey = slot.macroPaletteKey or paletteKey;
+            return true;
+        end
+        return false;
+    end
+
+    local rewrittenSlots = 0;
+    for barIdx = 1, 6 do
+        local bar = gConfig['hotbarBar' .. barIdx];
+        if bar and bar.slotActions then
+            for storageKey, slots in pairs(bar.slotActions) do
+                if type(slots) == 'table' then
+                    local jobHint = tonumber(tostring(storageKey):match('^(%d+)'));
+                    for _, slot in pairs(slots) do
+                        if RemapSlot(slot, jobHint) then
+                            rewrittenSlots = rewrittenSlots + 1;
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    if gConfig.hotbarCrossbar and gConfig.hotbarCrossbar.slotActions then
+        for storageKey, combos in pairs(gConfig.hotbarCrossbar.slotActions) do
+            if type(combos) == 'table' then
+                local jobHint = tonumber(tostring(storageKey):match('^(%d+)'));
+                for _, slots in pairs(combos) do
+                    if type(slots) == 'table' then
+                        for _, slot in pairs(slots) do
+                            if RemapSlot(slot, jobHint) then
+                                rewrittenSlots = rewrittenSlots + 1;
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return rewrittenMacros, rewrittenSlots;
+end
+
 -- Run structure migrations (called AFTER settings.load())
 -- These handle migrating old settings structures to new ones
 function M.RunStructureMigrations(gConfig, defaults)
@@ -1117,6 +1240,7 @@ function M.RunStructureMigrations(gConfig, defaults)
     M.MigrateNotificationGroups(gConfig, defaults);
     M.MigrateCrossbarComboModeSettings(gConfig, defaults);
     M.MigrateLegacyPositionFields(gConfig);
+    M.MigrateUniqueMacroIds(gConfig);
     M.MigrateSlotMacroRefs(gConfig);
 end
 

--- a/XIUI/libs/abilityrecast.lua
+++ b/XIUI/libs/abilityrecast.lua
@@ -134,10 +134,21 @@ function M.FindAbilityRecast(abilityId)
     return nil, 0;  -- Not found (ability may be ready or not tracked)
 end
 
--- Get ability recast by ability ID (scans slots to find it)
+-- Get ability recast by ability ID
+-- Uses the ability's RecastTimerId so shared timers (e.g. PUP maneuvers) all show cooldown
 -- Returns: remaining recast time in seconds, or 0 if ready/not found
 -- @param abilityId: The ability ID (not timer ID)
 function M.GetAbilityRecastByAbilityId(abilityId)
+    if abilityId == nil then return 0; end
+
+    local resourceMgr = AshitaCore:GetResourceManager();
+    local ability = resourceMgr and resourceMgr:GetAbilityById(abilityId);
+    -- Timer 0 is the 2-hour ability slot; prefer RecastTimerId for shared pools (maneuvers, etc.)
+    if ability and ability.RecastTimerId and ability.RecastTimerId > 0 then
+        return M.GetAbilityRecastSeconds(ability.RecastTimerId);
+    end
+
+    -- Fallback: scan slots for a matching ability id (covers 2hr / unmapped)
     local timerId, rawTimer = M.FindAbilityRecast(abilityId);
     if rawTimer <= 0 then return 0; end
     return rawTimer / 60;

--- a/XIUI/libs/jobs.lua
+++ b/XIUI/libs/jobs.lua
@@ -1,10 +1,99 @@
-local jobs = {
+--[[
+* XIUI job id helpers
+* Standard adventurer jobs are 1..22. Anything else (Monstrosity monipulators,
+* future unknowns) collapses into the shared "Other" category for macro/palette UI.
+*
+* The returned table keeps numeric keys only so existing `pairs(jobs)` / `jobs[id]`
+* call sites keep working. Helpers live on the metatable.
+]]--
+
+local STANDARD_JOBS = {
     [1]  = 'WAR', [2]  = 'MNK', [3]  = 'WHM', [4]  = 'BLM',
     [5]  = 'RDM', [6]  = 'THF', [7]  = 'PLD', [8]  = 'DRK',
     [9]  = 'BST', [10] = 'BRD', [11] = 'RNG', [12] = 'SAM',
     [13] = 'NIN', [14] = 'DRG', [15] = 'SMN', [16] = 'BLU',
     [17] = 'COR', [18] = 'PUP', [19] = 'DNC', [20] = 'SCH',
-    [21] = 'GEO', [22] = 'RUN'
-}
+    [21] = 'GEO', [22] = 'RUN',
+};
 
-return jobs;
+-- Sentinel for palette / hotbar job:subjob storage when not on a standard job.
+-- MacroDB uses the string key OTHER_MACRO_KEY instead.
+local OTHER_JOB_ID = 23;
+local OTHER_MACRO_KEY = 'other';
+local OTHER_LABEL = 'Other';
+
+local api = {};
+
+api.OTHER_JOB_ID = OTHER_JOB_ID;
+api.OTHER_MACRO_KEY = OTHER_MACRO_KEY;
+api.OTHER_LABEL = OTHER_LABEL;
+api.STANDARD_MAX = 22;
+
+--- Whether jobId is a normal playable job (WAR..RUN)
+---@param jobId number|nil
+---@return boolean
+function api.IsStandardJob(jobId)
+    jobId = tonumber(jobId);
+    return jobId ~= nil and STANDARD_JOBS[jobId] ~= nil;
+end
+
+--- Numeric job id used for hotbar/palette storage (maps unknown -> Other sentinel)
+---@param jobId number|nil
+---@return number
+function api.ResolveJobCategory(jobId)
+    jobId = tonumber(jobId) or 0;
+    if api.IsStandardJob(jobId) then
+        return jobId;
+    end
+    return OTHER_JOB_ID;
+end
+
+--- macroDB palette key for a main job (number, 'global', or 'other')
+---@param jobId number|string|nil
+---@return number|string
+function api.ResolveMacroPaletteKey(jobId)
+    if jobId == 'global' or jobId == OTHER_MACRO_KEY then
+        return jobId;
+    end
+    local numeric = tonumber(jobId);
+    if numeric and api.IsStandardJob(numeric) then
+        return numeric;
+    end
+    if type(jobId) == 'string' then
+        local base = tonumber(jobId:match('^(%d+)'));
+        if base and api.IsStandardJob(base) then
+            return jobId;
+        end
+        if jobId:match('^other') then
+            return jobId;
+        end
+    end
+    return OTHER_MACRO_KEY;
+end
+
+--- Display name for a job id / Other / Shared
+---@param jobId number|string|nil
+---@return string
+function api.GetDisplayName(jobId)
+    if jobId == 0 or jobId == '0' then
+        return 'Shared';
+    end
+    if jobId == OTHER_JOB_ID or jobId == OTHER_MACRO_KEY or jobId == OTHER_LABEL then
+        return OTHER_LABEL;
+    end
+    local numeric = tonumber(jobId);
+    if numeric and STANDARD_JOBS[numeric] then
+        return STANDARD_JOBS[numeric];
+    end
+    if type(jobId) == 'string' and jobId ~= '' then
+        return jobId;
+    end
+    return OTHER_LABEL;
+end
+
+local jobs = {};
+for id, name in pairs(STANDARD_JOBS) do
+    jobs[id] = name;
+end
+
+return setmetatable(jobs, { __index = api });

--- a/XIUI/modules/hotbar/actions.lua
+++ b/XIUI/modules/hotbar/actions.lua
@@ -10,6 +10,7 @@ local horizonSpells = require('modules.hotbar.database.horizonspells');
 local textures = require('modules.hotbar.textures');
 local actiondb = require('modules.hotbar.actiondb');
 local playerdata = require('modules.hotbar.playerdata');
+local recast = require('modules.hotbar.recast');
 local TextureManager = require('libs.texturemanager');
 local macrosLib = require('libs.ffxi.macros');
 package.loaded['libs.target'] = nil;
@@ -428,65 +429,210 @@ local function GetSpellByName(spellName)
     return spellByNameLookup[spellName];
 end
 
--- Ability MP cost cache (static resource data), keyed by ability name
-local abilityMpCostCache = {};
+-- Buff ids used for cost overrides
+local BUFF_MANAFONT = 47;
+local BUFF_MANAWELL = 229;
+local BUFF_TRANCE = 376;
+local BUFF_TABULA_RASA = 377;
 
---- MP cost for a job ability (e.g. SMN Blood Pacts), read from the resource
---- manager so it stays correct for any ability without a curated table.
----@param abilityName string|nil
----@return number|nil mpCost
-local function GetAbilityMpCost(abilityName)
-    if not abilityName or abilityName == '' then return nil; end
+-- Finishing-move count encoded in status ids.
+-- Buff 588 is the client's "5+" icon (JP gifts raise the real cap to 7/9).
+local FINISHING_MOVE_BUFF = {
+    [381] = 1, [382] = 2, [383] = 3, [384] = 4, [385] = 5,
+};
+local BUFF_FINISHING_MOVE_5_PLUS = 588;
 
-    local cached = abilityMpCostCache[abilityName];
-    if cached ~= nil then
-        return cached or nil;
+-- Flourish ability ids -> required finishing moves
+local FLOURISH_FM_COST = {
+    [716] = 1, [717] = 1, [718] = 1, [719] = 1, [720] = 1,
+    [721] = 2, [776] = 1, [825] = 2, [826] = 3,
+};
+
+local function PlayerHasBuff(buffId)
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return false; end
+    local buffs = player:GetBuffs();
+    if not buffs then return false; end
+    for i = 1, 32 do
+        if buffs[i] == buffId then
+            return true;
+        end
+    end
+    return false;
+end
+
+--- @return number count Exact 1-5, or 5 when buff 588 (5+) is active
+--- @return string label "1".."5" or "5+"
+local function GetFinishingMoveDisplay()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return 0, '0'; end
+    local buffs = player:GetBuffs();
+    if not buffs then return 0, '0'; end
+
+    for i = 1, 32 do
+        local buff = buffs[i];
+        if buff == BUFF_FINISHING_MOVE_5_PLUS then
+            return 5, '5+';
+        end
+        local mapped = FINISHING_MOVE_BUFF[buff];
+        if mapped then
+            return mapped, tostring(mapped);
+        end
+    end
+    return 0, '0';
+end
+
+local function GetPartyMp()
+    local party = AshitaCore:GetMemoryManager():GetParty();
+    return party and party:GetMemberMP(0) or 0;
+end
+
+local function GetPartyTp()
+    local party = AshitaCore:GetMemoryManager():GetParty();
+    return party and party:GetMemberTP(0) or 0;
+end
+
+--- Effective spell MP after Manafont / arts-style buffs (simplified SCH arts)
+---@param spellRes table
+---@return number cost
+---@return boolean met
+local function ComputeSpellMpCost(spellRes)
+    local cost = spellRes.ManaCost or 0;
+    if cost < 1 then
+        return 0, true;
+    end
+    if PlayerHasBuff(BUFF_MANAFONT) or PlayerHasBuff(BUFF_MANAWELL) then
+        return 0, true;
     end
 
-    local mpCost = false;
-    local abilityId = actiondb.GetAbilityId(abilityName);
-    if abilityId then
-        local ability = AshitaCore:GetResourceManager():GetAbilityById(abilityId);
-        if ability and ability.ManaCost and ability.ManaCost > 0 then
-            mpCost = ability.ManaCost;
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    local buffs = player and player:GetBuffs();
+    if buffs and cost > 0 then
+        local artsMod, penuryMod;
+        local spellType = spellRes.Type or 0;
+        for i = 1, 32 do
+            local buff = buffs[i];
+            if buff == 255 then
+                break;
+            elseif spellType == 1 then -- white
+                if buff == 358 or buff == 401 then artsMod = 0.9;
+                elseif buff == 359 or buff == 402 then artsMod = 1.2;
+                elseif buff == 360 then penuryMod = 0.5; end
+            elseif spellType == 2 then -- black
+                if buff == 358 or buff == 401 then artsMod = 1.2;
+                elseif buff == 359 or buff == 402 then artsMod = 0.9;
+                elseif buff == 361 then penuryMod = 0.5; end
+            end
+        end
+        if penuryMod then
+            cost = math.ceil(cost * penuryMod);
+        elseif artsMod then
+            cost = math.ceil(cost * artsMod);
         end
     end
 
-    abilityMpCostCache[abilityName] = mpCost;
-    return mpCost or nil;
+    return cost, GetPartyMp() >= cost;
 end
 
---- Get MP cost for an action (magic spells and MP-costing job abilities)
----@param bind table The keybind data with actionType and action fields
----@return number|nil mpCost The MP cost, or nil if not applicable
-function M.GetMPCost(bind)
-    if not bind then return nil; end
+--- Unified cost readout for slot overlays and soft-dimming.
+--- Returns a reused table — read values immediately, do not cache the reference.
+---@param bind table|nil
+---@return table info { kind, amount, met, label }
+local costResult = { kind = 'none', amount = 0, met = true, label = nil };
+local function SetCostResult(kind, amount, met, label)
+    costResult.kind = kind;
+    costResult.amount = amount;
+    costResult.met = met;
+    costResult.label = label;
+    return costResult;
+end
 
-    -- A macro surfaces its recast source's cost; a direct ma/ja bind uses its
-    -- own action.
+function M.GetActionCostInfo(bind)
+    SetCostResult('none', 0, true, nil);
+    if not bind then return costResult; end
+
     local actionType, actionName = bind.actionType, bind.action;
     if bind.actionType == 'macro' then
         actionType, actionName = bind.recastSourceType, bind.recastSourceAction;
     end
+    if not actionType or actionType == 'none' or not actionName then
+        return costResult;
+    end
 
     if actionType == 'ma' then
-        local spell = GetSpellByName(actionName);
-        if spell and spell.mp_cost and spell.mp_cost > 0 then
-            return spell.mp_cost;
+        local spellId = actiondb.GetSpellId(actionName);
+        local spellRes = spellId and AshitaCore:GetResourceManager():GetSpellById(spellId);
+        if not spellRes then
+            local hz = GetSpellByName(actionName);
+            if hz and hz.mp_cost and hz.mp_cost > 0 then
+                local cost = hz.mp_cost;
+                if PlayerHasBuff(BUFF_MANAFONT) or PlayerHasBuff(BUFF_MANAWELL) then
+                    cost = 0;
+                end
+                return SetCostResult('mp', cost, GetPartyMp() >= cost, tostring(cost));
+            end
+            return costResult;
         end
-        return nil;
+        local cost, met = ComputeSpellMpCost(spellRes);
+        if cost < 1 and not (spellRes.ManaCost and spellRes.ManaCost > 0) then
+            return costResult;
+        end
+        return SetCostResult('mp', cost, met, tostring(cost));
     end
 
-    -- Blood Pacts and similar pet commands are abilities behind a /pet prefix.
+    if actionType == 'ws' then
+        local tpCost = M.GetWeaponskillTpCost(actionName);
+        return SetCostResult('tp', tpCost, GetPartyTp() >= tpCost, tostring(tpCost));
+    end
+
     if actionType == 'ja' or actionType == 'pet' then
-        return GetAbilityMpCost(actionName);
+        local abilityId = actiondb.GetAbilityId(actionName);
+        local ability = abilityId and AshitaCore:GetResourceManager():GetAbilityById(abilityId);
+        if not ability then
+            return costResult;
+        end
+
+        local timerId = ability.RecastTimerId;
+
+        if timerId == recast.CHARGE_TIMER.STRATAGEM then
+            if PlayerHasBuff(BUFF_TABULA_RASA) then
+                return SetCostResult('charges', 0, true, '0');
+            end
+            local charges = recast.GetStratagemCharges();
+            return SetCostResult('charges', charges, charges > 0, tostring(charges));
+        elseif timerId == recast.CHARGE_TIMER.READY then
+            local charges = recast.GetReadyCharges();
+            return SetCostResult('charges', charges, charges > 0, tostring(charges));
+        elseif timerId == recast.CHARGE_TIMER.QUICK_DRAW then
+            local charges = recast.GetQuickDrawCharges();
+            return SetCostResult('charges', charges, charges > 0, tostring(charges));
+        end
+
+        local fmNeed = abilityId and FLOURISH_FM_COST[abilityId];
+        if fmNeed then
+            local have, label = GetFinishingMoveDisplay();
+            return SetCostResult('fm', fmNeed, have >= fmNeed, label);
+        end
+
+        local tpCost = ability.TP or 0;
+        if tpCost >= 1 then
+            if PlayerHasBuff(BUFF_TRANCE) then
+                return SetCostResult('tp', 0, true, '0');
+            end
+            return SetCostResult('tp', tpCost, GetPartyTp() >= tpCost, tostring(tpCost));
+        end
+
+        local manaCost = ability.ManaCost or 0;
+        if manaCost > 0 then
+            if PlayerHasBuff(BUFF_MANAFONT) or PlayerHasBuff(BUFF_MANAWELL) then
+                return SetCostResult('mp', 0, true, '0');
+            end
+            return SetCostResult('mp', manaCost, GetPartyMp() >= manaCost, tostring(manaCost));
+        end
     end
 
-    return nil;
+    return costResult;
 end
-
--- TP cost cache for weaponskills (static resource data)
-local wsTpCostCache = {};
 
 -- Action types checked directly for job/gear/inventory availability dimming
 local AVAILABILITY_ACTION_TYPES = {
@@ -519,16 +665,12 @@ end
 function M.NeedsTpCheck(bind)
     if not bind then return false; end
 
-    if bind.actionType == 'ws' then
-        return true;
-    end
-
-    if bind.actionType == 'macro' and bind.recastSourceType == 'ws' and bind.recastSourceAction then
-        return true;
-    end
-
-    return false;
+    local info = M.GetActionCostInfo(bind);
+    return info.kind == 'tp';
 end
+
+-- TP cost cache for weaponskills (static resource data)
+local wsTpCostCache = {};
 
 --- Get TP cost for a weaponskill (clamped to 1000-3000)
 ---@param wsName string
@@ -564,19 +706,19 @@ end
 ---@param bind table
 ---@return boolean hasEnoughTp
 function M.HasEnoughTpForBind(bind)
-    if not M.NeedsTpCheck(bind) then
+    local info = M.GetActionCostInfo(bind);
+    if info.kind ~= 'tp' then
         return true;
     end
+    return info.met == true;
+end
 
-    local wsName = bind.action;
-    if bind.actionType == 'macro' then
-        wsName = bind.recastSourceAction;
-    end
-
-    local tpCost = M.GetWeaponskillTpCost(wsName);
-    local party = AshitaCore:GetMemoryManager():GetParty();
-    local playerTp = party and party:GetMemberTP(0) or 0;
-    return playerTp >= tpCost;
+--- Whether cost requirements are currently met (MP/TP/charges/FM)
+---@param bind table
+---@return boolean
+function M.HasEnoughCostForBind(bind)
+    local info = M.GetActionCostInfo(bind);
+    return info.met ~= false;
 end
 
 --- Resolve macro recast source into a bind suitable for availability checks
@@ -595,23 +737,32 @@ local function ResolveAvailabilityBind(bind)
 end
 
 --- Check if the player currently has a named ability or weaponskill
----@param player table
 ---@param actionName string
 ---@param cacheFallback function|nil Fallback when ability ID lookup fails
 ---@return boolean
-local function PlayerHasNamedAbility(player, actionName, cacheFallback)
+---@return boolean cacheable Negative HasAbility results are volatile post-zone
+local function PlayerHasNamedAbility(actionName, cacheFallback)
     local abilityId = actiondb.GetAbilityId(actionName);
     if abilityId then
-        return player:HasAbility(abilityId);
+        local player = AshitaCore:GetMemoryManager():GetPlayer();
+        if player and player:HasAbility(abilityId) then
+            return true, true;
+        end
+        -- Volatile: HasAbility can read false briefly after zoning
+        return false, false;
     end
-    return cacheFallback and cacheFallback(actionName) or false;
+    if cacheFallback and cacheFallback(actionName) then
+        return true, true;
+    end
+    return false, false;
 end
 
---- Check if an action is currently available to use
---- Takes into account job, level, subjob, and level sync
+--- Check if an action is currently known/available to the player (hard dim)
+--- Cost and recast are handled separately as "ready" soft-dim.
 ---@param bind table The keybind data with actionType and action fields
----@return boolean isAvailable True if the action can be used
----@return string|nil reason Reason if not available (e.g., "Level 50 required", "Wrong job")
+---@return boolean isAvailable True if the action is known
+---@return string|nil reason Reason if not available
+---@return boolean|nil cacheable When false, do not cache this negative
 function M.IsActionAvailable(bind)
     if not bind then return true, nil; end
 
@@ -620,84 +771,60 @@ function M.IsActionAvailable(bind)
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     if not player then return true, nil; end
 
-    local mainJobId = player:GetMainJob();
-    local mainJobLevel = player:GetMainJobLevel();
-    local subJobId = player:GetSubJob();
-    local subJobLevel = player:GetSubJobLevel();
+    local mainJobId = player:GetMainJob() or 0;
+    local mainJobLevel = player:GetMainJobLevel() or 0;
 
     -- Guard: If job data is invalid (e.g., during zoning), assume available
-    -- Don't cache this result - return nil as reason to signal "don't cache"
     if mainJobId == 0 or mainJobLevel == 0 then
-        return true, "pending";  -- "pending" signals not to cache this result
+        return true, "pending";
     end
 
     if bind.actionType == 'macro' then
         return true, nil;
     end
 
-    -- Handle magic spells
     if bind.actionType == 'ma' then
         local spellId = actiondb.GetSpellId(bind.action);
-        if spellId and not player:HasSpell(spellId) then
-            -- Volatile: HasSpell reads false right after zone-in until the spell
-            -- list repopulates; don't cache or it sticks "N/A". See ja/ws.
-            return false, "N/A", false;
-        end
-
-        local spell = GetSpellByName(bind.action);
-        if not spell then return true, nil; end  -- Unknown spell, assume available
-
-        local levels = spell.levels;
-        if not levels then return true, nil; end  -- No level requirements
-
-        -- Check if main job can cast this spell
-        local mainReqLevel = levels[mainJobId];
-        local subReqLevel = subJobId and levels[subJobId] or nil;
-
-        -- Check main job first (Job Point spells report level > 99)
-        if mainReqLevel then
-            if mainJobLevel >= mainReqLevel or mainReqLevel > MAX_JOB_LEVEL then
-                return true, nil;  -- Can cast with main job
+        local spellRes = spellId and AshitaCore:GetResourceManager():GetSpellById(spellId);
+        if spellRes then
+            local canCast, _, reqLevel = playerdata.EvaluateSpellAccess(spellRes, player);
+            if canCast then
+                return true, nil;
             end
-        end
-
-        -- Check subjob
-        if subReqLevel then
-            if subJobLevel >= subReqLevel then
-                return true, nil;  -- Can cast with subjob
+            if not player:HasSpell(spellRes.Index) then
+                return false, "N/A", false;
             end
-        end
-
-        -- Spell exists but can't be cast
-        if mainReqLevel then
-            -- Has the job but not the level
-            return false, string.format("Lv%d", mainReqLevel);
-        elseif subReqLevel then
-            -- Subjob has it but not the level
-            return false, string.format("Lv%d", subReqLevel);
-        else
-            -- Job can't cast this spell at all
+            if reqLevel and reqLevel > 0 and reqLevel < 255 then
+                return false, string.format("Lv%d", reqLevel);
+            end
             return false, "Job";
         end
 
-    -- Handle job abilities (live HasAbility reflects current job/gear state)
-    elseif bind.actionType == 'ja' then
-        if not PlayerHasNamedAbility(player, bind.action, playerdata.IsAbilityInCache) then
-            -- Volatile: HasAbility reads false briefly after zoning until the
-            -- ability list repopulates; don't cache or it sticks "N/A".
+        -- Fallback for horizon-only names
+        if spellId and not player:HasSpell(spellId) then
             return false, "N/A", false;
         end
+        return true, nil;
 
-    -- Handle weapon skills (HasAbility reflects currently equipped weapon types)
-    elseif bind.actionType == 'ws' then
-        if not PlayerHasNamedAbility(player, bind.action, playerdata.IsWeaponskillInCache) then
-            return false, "N/A", false;
+    elseif bind.actionType == 'ja' or bind.actionType == 'ws' then
+        local known, cacheable = PlayerHasNamedAbility(
+            bind.action,
+            bind.actionType == 'ws' and playerdata.IsWeaponskillInCache or playerdata.IsAbilityInCache
+        );
+        if not known then
+            return false, "N/A", cacheable;
         end
 
     elseif bind.actionType == 'pet' then
-        if not playerdata.IsPetCommandAvailable(bind.action) then
-            return false, "N/A";
+        -- Pet bits are volatile across summon/release; never permanently cache.
+        local abilityId = actiondb.GetAbilityId(bind.action);
+        if abilityId and player:HasAbility(abilityId) then
+            return true, nil, false;
         end
+        if not playerdata.IsPetCommandAvailable(bind.action) then
+            return false, "N/A", false;
+        end
+        return true, nil, false;
 
     elseif bind.actionType == 'equip' then
         if not playerdata.IsEquipActionAvailable(bind.equipSlot, bind.action, bind.itemId) then
@@ -1814,7 +1941,7 @@ function M.HandleKey(event)
            if PALETTE_DEBUG_KEYS then
                print('[XIUI Palette Debug] Cycling palettes...');
            end
-           -- DOWN = next (+1), UP = previous (-1) to match tHotBar/in-game macro convention
+           -- DOWN = next (+1), UP = previous (-1) to match in-game macro convention
            local direction = (keyCode == nextKey) and 1 or -1;
            local jobId = data.jobId or 1;
            local subjobId = data.subjobId or 0;

--- a/XIUI/modules/hotbar/data.lua
+++ b/XIUI/modules/hotbar/data.lua
@@ -46,6 +46,7 @@ end
 -- With 197 macros and 72 slots, this reduces from ~14,184 iterations/frame to 72 lookups
 
 local macroIdLookup = {};  -- macroIdLookup[paletteKey][macroId] = macro
+local macroIdGlobalLookup = {}; -- macroId -> macro (unique across all palettes after migration)
 local macroIdLookupDirty = true;
 -- Identity reference of the macroDB the lookup was built against. If gConfig
 -- gets reassigned (profile switch / character swap), this will no longer
@@ -57,6 +58,7 @@ local macroIdLookupSource = nil;
 
 local function RebuildMacroLookup()
     macroIdLookup = {};
+    macroIdGlobalLookup = {};
     macroIdLookupSource = (gConfig and gConfig.macroDB) or nil;
     if gConfig and gConfig.macroDB then
         for paletteKey, macros in pairs(gConfig.macroDB) do
@@ -65,6 +67,8 @@ local function RebuildMacroLookup()
                 for _, macro in ipairs(macros) do
                     if macro.id then
                         macroIdLookup[paletteKey][macro.id] = macro;
+                        -- Last write wins on legacy collisions; migration removes them
+                        macroIdGlobalLookup[macro.id] = macro;
                     end
                 end
             end
@@ -79,9 +83,9 @@ local function GetMacroFromLookup(macroId, paletteKey)
     if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
         RebuildMacroLookup();
     end
-    local paletteLookup = macroIdLookup[paletteKey];
-    if paletteLookup then
-        return paletteLookup[macroId];
+    if paletteKey ~= nil and macroIdLookup[paletteKey] then
+        local macro = macroIdLookup[paletteKey][macroId];
+        if macro then return macro; end
     end
     return nil;
 end
@@ -118,6 +122,7 @@ M.ROW_GAP = 6;
 -- ============================================
 
 M.jobId = nil;
+M.rawJobId = nil;
 M.subjobId = nil;
 
 -- ============================================
@@ -163,7 +168,7 @@ local function getSlotActionsForJob(slotActions, storageKey)
         return result;
     end
     -- Fallback: try base job key (jobId:0) for imported data without subjob
-    -- This handles tHotBar imports which don't track subjobs
+    -- Fallback for imported bindings that omit subjob in the storage key
     local jobId, subjobId, suffix = storageKey:match('^(%d+):(%d+)(.*)$');
     if jobId and subjobId ~= '0' then
         -- Build fallback key with subjob=0, preserving any suffix (palette, avatar, etc.)
@@ -672,7 +677,7 @@ end
 -- Helper to look up a macro from macroDB by id
 -- paletteKey can be a job ID (number) or composite key (string like "15:avatar:ifrit")
 -- OPTIMIZED: Uses O(1) lookup map instead of linear search
--- Falls back to scanning all palettes for legacy slots that don't have macroPaletteKey set
+-- Falls back to global unique-id map, then scanning all palettes for legacy slots
 local function GetMacroById(macroId, paletteKey)
     if not gConfig or not gConfig.macroDB then return nil; end
 
@@ -692,14 +697,22 @@ local function GetMacroById(macroId, paletteKey)
                     return macro;
                 end
             end
+            if paletteKey == 'other' or paletteKey:match('^other') then
+                macro = GetMacroFromLookup(macroId, 'other');
+                if macro then return macro; end
+            end
         end
     end
 
-    -- Fallback for legacy slots missing macroPaletteKey: scan all palettes
-    -- (rebuild lookup if dirty OR if gConfig.macroDB was swapped under us)
+    -- Globally unique ids: O(1) regardless of palette
     if macroIdLookupDirty or macroIdLookupSource ~= (gConfig and gConfig.macroDB) then
         RebuildMacroLookup();
     end
+    if macroIdGlobalLookup[macroId] then
+        return macroIdGlobalLookup[macroId];
+    end
+
+    -- Fallback for legacy slots missing macroPaletteKey: scan all palettes
     for key, paletteLookup in pairs(macroIdLookup) do
         if key ~= paletteKey then
             local macro = paletteLookup[macroId];
@@ -1088,12 +1101,18 @@ function M.SetPlayerJob()
         return false;
     end
 
+    local jobs = require('libs.jobs');
     local player = AshitaCore:GetMemoryManager():GetPlayer()
-    local currentJobId = player:GetMainJob();
-    if currentJobId == 0 then
+    local rawJobId = player:GetMainJob();
+    if rawJobId == 0 then
         return false;
     end
+    local currentJobId = jobs.ResolveJobCategory(rawJobId);
     local currentSubjobId = player:GetSubJob();
+    if currentSubjobId and currentSubjobId ~= 0 then
+        -- Keep real subjob id for display; only main job collapses into Other
+        currentSubjobId = jobs.IsStandardJob(currentSubjobId) and currentSubjobId or 0;
+    end
 
     -- Invalidate caches if job changed
     if M.jobId ~= currentJobId or M.subjobId ~= currentSubjobId then
@@ -1101,6 +1120,7 @@ function M.SetPlayerJob()
     end
 
     M.jobId = currentJobId;
+    M.rawJobId = rawJobId;
     M.subjobId = currentSubjobId;
     return true;
 end

--- a/XIUI/modules/hotbar/init.lua
+++ b/XIUI/modules/hotbar/init.lua
@@ -165,17 +165,21 @@ function M.Initialize(settings)
         -- user toggled petAware off mid-pet. Always run it.
         data.InvalidateStorageKeyCache();
 
+        -- Availability (HasAbility for BPs/maneuvers/etc.) flips with pet state
+        -- even when no bar uses petAware palette swapping. Always invalidate
+        -- so summon→release does not leave stale "available" dims.
+        slotrenderer.ClearAvailabilityCache();
+        macropalette.ClearPetCommandsCache();
+
         if not AnyBarIsPetAware() then return; end
 
-        -- Clear ALL caches when pet changes to force full refresh
+        -- Clear remaining caches when pet-aware bars may swap slot content
         slotrenderer.ClearAllCache();
         display.ClearIconCache();
         actions.ClearNoIconCache();
         if crossbarInitialized then
             crossbar.ClearIconCache();
         end
-        -- Clear macro palette's pet commands cache (for BST ready moves)
-        macropalette.ClearPetCommandsCache();
     end);
 
     -- Register palette change callback to clear caches
@@ -445,6 +449,10 @@ function M.HandleZonePacket()
 end
 
 function M.HandleJobChangePacket(e)
+    -- Persist pending edits before storage keys rematerialize for the new job
+    macropalette.FlushPendingSave();
+    palette.FlushPendingSave();
+
     local function TrySetJob(attempt)
         attempt = attempt or 1;
         local maxAttempts = 20;

--- a/XIUI/modules/hotbar/macropalette.lua
+++ b/XIUI/modules/hotbar/macropalette.lua
@@ -142,12 +142,6 @@ local function ClearAllIconCaches()
     if slotrenderer and slotrenderer.ClearSlotRenderingCache then
         slotrenderer.ClearSlotRenderingCache();
     end
-    -- Edits that change a macro's action leave the old actionType:action entry
-    -- orphaned in mpCostCache / availabilityCache. Functionally fine (the new key
-    -- naturally misses), but bounds memory across many edits.
-    if slotrenderer and slotrenderer.ClearMPCostCache then
-        slotrenderer.ClearMPCostCache();
-    end
     if slotrenderer and slotrenderer.ClearAvailabilityCache then
         slotrenderer.ClearAvailabilityCache();
     end
@@ -829,6 +823,7 @@ local function InvalidateBrowsingIconCache()
 end
 
 -- Build/return pet commands for the macro editor dropdown.
+-- Only includes commands the player currently knows (pet must be out for pet-specific bits).
 local function GetEditorPetCommands()
     if not cachedPetCommands then
         local viewedJobId = selectedPaletteType;
@@ -856,7 +851,17 @@ local function GetEditorPetCommands()
             activePetName = petpalette.GetCurrentPetEntityName();
         end
 
-        cachedPetCommands = GetPetCommandsForJob(viewedJobId, avatarName, activePetName);
+        local allCommands = GetPetCommandsForJob(viewedJobId, avatarName, activePetName);
+        local actiondb = require('modules.hotbar.actiondb');
+        local player = AshitaCore:GetMemoryManager():GetPlayer();
+        local filtered = {};
+        for _, cmd in ipairs(allCommands) do
+            local abilityId = actiondb.GetAbilityId(cmd.name);
+            if not abilityId or (player and player:HasAbility(abilityId)) then
+                filtered[#filtered + 1] = cmd;
+            end
+        end
+        cachedPetCommands = filtered;
     end
 
     return cachedPetCommands or {};
@@ -1386,16 +1391,16 @@ end
 -- ============================================
 
 -- Get current effective type for the palette (selected type or player's current job)
--- Returns GLOBAL_MACRO_KEY for global macros, a job ID, or a composite key like "15:avatar:ifrit"
+-- Returns GLOBAL_MACRO_KEY for global macros, a job ID, 'other', or a composite key like "15:avatar:ifrit"
 local function GetEffectivePaletteType()
     if selectedPaletteType then
-        -- If Global is selected, return the global key
         if selectedPaletteType == GLOBAL_MACRO_KEY then
             return GLOBAL_MACRO_KEY;
         end
-        -- If a valid job ID is selected
+        if selectedPaletteType == jobs.OTHER_MACRO_KEY or selectedPaletteType == jobs.OTHER_JOB_ID then
+            return jobs.OTHER_MACRO_KEY;
+        end
         if type(selectedPaletteType) == 'number' and selectedPaletteType > 0 then
-            -- Check for SMN avatar-specific palette
             if selectedPaletteType == petregistry.JOB_SMN and selectedAvatarPalette then
                 local avatarKey = petregistry.avatars[selectedAvatarPalette];
                 if avatarKey then
@@ -1405,8 +1410,7 @@ local function GetEffectivePaletteType()
             return selectedPaletteType;
         end
     end
-    -- Default to current player job
-    return data.jobId or 1;
+    return jobs.ResolveMacroPaletteKey(data.jobId);
 end
 
 -- Get display name for a palette type key
@@ -1414,14 +1418,15 @@ local function GetPaletteDisplayName(typeKey)
     if typeKey == GLOBAL_MACRO_KEY then
         return 'Global';
     end
-    if type(typeKey) == 'number' then
-        return jobs[typeKey] or 'Unknown';
+    if typeKey == jobs.OTHER_MACRO_KEY or typeKey == jobs.OTHER_JOB_ID then
+        return jobs.OTHER_LABEL;
     end
-    -- Composite key like "15:avatar:ifrit"
+    if type(typeKey) == 'number' then
+        return jobs.GetDisplayName(typeKey);
+    end
     if type(typeKey) == 'string' then
         local jobId, petType, petId = typeKey:match('^(%d+):([^:]+):(.+)$');
         if jobId and petType == 'avatar' and petId then
-            -- Find avatar display name
             for name, key in pairs(petregistry.avatars) do
                 if key == petId then
                     return string.format('%s (%s)', jobs[tonumber(jobId)] or 'SMN', name);
@@ -1434,29 +1439,50 @@ end
 
 -- Sync palette to current player job (call on job change)
 function M.SyncToCurrentJob()
-    -- Only sync if not viewing Global - preserve Global selection across job changes
     if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+        selectedPaletteType = jobs.ResolveMacroPaletteKey(data.jobId);
     end
-    -- Clear spell/ability/item caches so they rebuild for new job
     playerdata.ClearCache();
     InvalidateBrowsingIconCache();
     cachedPetCommands = nil;
     petAvatarFilter = 1;
     selectedAvatarPalette = nil;
-    -- Close editor window if open (spells/abilities are job-specific)
     if editingMacro then
         editingMacro = nil;
         isCreatingNew = false;
         searchFilter[1] = '';
         iconPickerOpen = false;
     end
-    -- Clear macro selection (macros are per-type)
     selectedMacroIndex = nil;
-    -- If palette is open, immediately refresh the caches
     if paletteOpen then
         RefreshCachedLists();
     end
+end
+
+--- Allocate a macro id unique across the entire macroDB
+---@return number
+local function AllocateUniqueMacroId()
+    if not gConfig then
+        return 1;
+    end
+    local nextId = (gConfig.macroIdSeq or 0) + 1;
+    if gConfig.macroDB then
+        local used = {};
+        for _, macros in pairs(gConfig.macroDB) do
+            if type(macros) == 'table' then
+                for _, macro in ipairs(macros) do
+                    if macro and macro.id then
+                        used[macro.id] = true;
+                    end
+                end
+            end
+        end
+        while used[nextId] do
+            nextId = nextId + 1;
+        end
+    end
+    gConfig.macroIdSeq = nextId;
+    return nextId;
 end
 
 -- Clear pet commands cache (call on pet change for BST)
@@ -1483,15 +1509,7 @@ end
 function M.AddMacro(macroData)
     local db, _ = M.GetMacroDatabase();
 
-    -- Generate unique ID
-    local maxId = 0;
-    for _, macro in ipairs(db) do
-        if macro.id and macro.id > maxId then
-            maxId = macro.id;
-        end
-    end
-
-    macroData.id = maxId + 1;
+    macroData.id = AllocateUniqueMacroId();
     table.insert(db, macroData);
     MarkHotbarDirty();
     data.MarkMacroLookupDirty();
@@ -1531,15 +1549,8 @@ local function AddMacroToTypeKey(typeKey, macroData)
     end
 
     local db = gConfig.macroDB[typeKey];
-    local maxId = 0;
-    for _, macro in ipairs(db) do
-        if macro.id and macro.id > maxId then
-            maxId = macro.id;
-        end
-    end
-
     local copy = deep_copy_table(macroData);
-    copy.id = maxId + 1;
+    copy.id = AllocateUniqueMacroId();
     table.insert(db, copy);
     SaveSettingsToDisk();
     data.MarkMacroLookupDirty();
@@ -1815,7 +1826,7 @@ function M.OpenPalette()
 
     -- Sync to current player job when opening (unless Global was selected)
     if selectedPaletteType ~= GLOBAL_MACRO_KEY then
-        selectedPaletteType = data.jobId or 1;
+        selectedPaletteType = jobs.ResolveMacroPaletteKey(data.jobId);
     end
 
     -- Refresh spell/ability/weaponskill caches
@@ -1956,13 +1967,16 @@ end
 local PushWindowStyle = components.PushWindowStyle;
 local PopWindowStyle = components.PopWindowStyle;
 
--- Build job list for dropdown
+-- Build job list for dropdown (standard jobs + Other catch-all)
 local JOB_LIST = {};
 local JOB_ID_MAP = {};
 for jobId, jobName in pairs(jobs) do
-    table.insert(JOB_LIST, { id = jobId, name = jobName });
+    if type(jobId) == 'number' then
+        table.insert(JOB_LIST, { id = jobId, name = jobName });
+    end
 end
 table.sort(JOB_LIST, function(a, b) return a.id < b.id; end);
+table.insert(JOB_LIST, { id = jobs.OTHER_MACRO_KEY, name = jobs.OTHER_LABEL });
 for i, job in ipairs(JOB_LIST) do
     JOB_ID_MAP[job.id] = i;
 end
@@ -2077,16 +2091,22 @@ function M.DrawPalette()
 
     -- Initialize selectedPaletteType to current job if not set
     if not selectedPaletteType then
-        selectedPaletteType = data.jobId or 1;
+        selectedPaletteType = jobs.ResolveMacroPaletteKey(data.jobId);
     end
 
     local db, typeKey = M.GetMacroDatabase();
     local isGlobal = (typeKey == GLOBAL_MACRO_KEY);
+    local isOther = (typeKey == jobs.OTHER_MACRO_KEY);
     local typeName = GetPaletteDisplayName(typeKey);
     local currentPlayerJob = data.jobId or 1;
+    local currentMacroKey = jobs.ResolveMacroPaletteKey(currentPlayerJob);
     -- For SMN with avatar selected, check base job ID
     local baseJobId = type(typeKey) == 'number' and typeKey or tonumber(tostring(typeKey):match('^(%d+)'));
-    local isViewingCurrentJob = (not isGlobal and baseJobId == currentPlayerJob);
+    local isViewingCurrentJob = (not isGlobal) and (
+        (isOther and currentMacroKey == jobs.OTHER_MACRO_KEY)
+        or (baseJobId ~= nil and baseJobId == currentPlayerJob)
+        or (typeKey == currentMacroKey)
+    );
 
     -- Calculate pagination
     local totalMacros = #db;
@@ -2186,7 +2206,10 @@ function M.DrawPalette()
 
             -- Job options
             for i, job in ipairs(JOB_LIST) do
-                local isSelected = (not isGlobal and job.id == typeKey);
+                local isSelected = (not isGlobal and (
+                    job.id == typeKey
+                    or (job.id == jobs.OTHER_MACRO_KEY and typeKey == jobs.OTHER_MACRO_KEY)
+                ));
                 local jobMacroCount = getMacroCount(job.id);
 
                 -- Build label with indicators
@@ -2198,12 +2221,12 @@ function M.DrawPalette()
                 end
 
                 -- Add main job indicator
-                if job.id == currentPlayerJob then
+                if job.id == currentMacroKey or (job.id == currentPlayerJob) then
                     label = label .. '  *';
                 end
 
-                -- Add subjob indicator
-                if job.id == data.subjobId then
+                -- Add subjob indicator (standard jobs only)
+                if type(job.id) == 'number' and job.id == data.subjobId then
                     label = label .. '  /sub';
                 end
 

--- a/XIUI/modules/hotbar/playerdata.lua
+++ b/XIUI/modules/hotbar/playerdata.lua
@@ -19,11 +19,73 @@ local cachedItems = nil;
 local cacheJobId = nil;
 local cacheSubJobId = nil;
 
-local MAX_JOB_LEVEL = 99;
+local JOB_CAP = 99;
 
 -- ============================================
--- Container Definitions
+-- Spell / ability access rules (Ashita APIs)
 -- ============================================
+
+local function GetSpentJobPoints(player, jobId)
+    if not player or not jobId or jobId <= 0 then return 0; end
+    local ok, spent = pcall(function()
+        return player:GetJobPointsSpent(jobId);
+    end);
+    if ok and type(spent) == 'number' then
+        return spent;
+    end
+    return 0;
+end
+
+--- Whether the player can cast a spell on main or sub (HasSpell + level/JP gates)
+---@param spell table Resource spell
+---@param player table|nil Optional player; fetched if nil
+---@return boolean ok
+---@return string|nil source 'main'|'sub'
+---@return number|nil requirement
+function M.EvaluateSpellAccess(spell, player)
+    if not spell or not spell.Index then
+        return false, nil, nil;
+    end
+
+    player = player or AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return false, nil, nil; end
+
+    if not player:HasSpell(spell.Index) then
+        return false, nil, nil;
+    end
+
+    local levels = spell.LevelRequired;
+    if not levels then
+        return true, 'main', 0;
+    end
+
+    local mainJob = player:GetMainJob() or 0;
+    local mainLevel = player:GetMainJobLevel() or 0;
+    local subJob = player:GetSubJob() or 0;
+    local subLevel = player:GetSubJobLevel() or 0;
+    local jpMask = spell.JobPointMask or 0;
+
+    local mainReq = levels[mainJob + 1];
+    if mainReq and mainReq ~= -1 then
+        local jpGated = bit.band(bit.rshift(jpMask, mainJob), 1) == 1;
+        if jpGated then
+            if mainLevel >= JOB_CAP and GetSpentJobPoints(player, mainJob) >= mainReq then
+                return true, 'main', mainReq;
+            end
+        elseif mainReq > 0 and mainReq < 255 and mainLevel >= mainReq then
+            return true, 'main', mainReq;
+        end
+    end
+
+    if subJob > 0 and bit.band(bit.rshift(jpMask, subJob), 1) == 0 then
+        local subReq = levels[subJob + 1];
+        if subReq and subReq ~= -1 and subReq > 0 and subReq < 255 and subLevel >= subReq then
+            return true, 'sub', subReq;
+        end
+    end
+
+    return false, nil, mainReq;
+end
 
 local CONTAINERS = {
     { id = 0, name = 'Inventory' },
@@ -168,56 +230,32 @@ end
 -- ============================================
 
 --- Get player's known spells for current job (excludes trusts and garbage entries)
---- Supports both main job and subjob spell access
+--- Supports both main job and subjob spell access, including JP-gated spells.
 ---@return table Array of {id, name, level, source} where source is 'main' or 'sub'
 function M.GetPlayerSpells()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     if not player then return {}; end
 
-    local mainJobId = player:GetMainJob();
-    local mainJobLevel = player:GetMainJobLevel();
-    local subJobId = player:GetSubJob();
-    local subJobLevel = player:GetSubJobLevel();
     local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then return {}; end
 
     local spells = {};
-    local addedSpells = {};  -- Track by spell ID to avoid duplicates
+    local addedSpells = {};
 
-    for spellId = 1, 1024 do
+    for spellId = 1, 0x400 do
         if player:HasSpell(spellId) then
             local spell = resMgr:GetSpellById(spellId);
-            -- Skip trusts by magic type, not ID range (the old ID-896 cutoff also
-            -- hid real spells above it, e.g. Death = 904).
             if spell and spell.Name and spell.Name[1] and spell.Name[1] ~= ''
                 and (spell.Type or 0) ~= MAGIC_TYPE_TRUST then
                 local spellName = spell.Name[1];
-
-                -- Skip garbage/test spell names
                 if not IsGarbageSpellName(spellName) then
-                    -- LevelRequired array uses jobId + 1 offset
-                    -- WHM (jobId=3) -> LevelRequired[4], BLM (jobId=4) -> LevelRequired[5]
-                    local mainReqLevel = spell.LevelRequired[mainJobId + 1] or 0;
-                    local subReqLevel = subJobId > 0 and (spell.LevelRequired[subJobId + 1] or 0) or 0;
-
-                    -- Filter invalid level values (0 = can't learn, 255 = can't learn)
-                    local validMainReq = mainReqLevel > 0 and mainReqLevel < 255;
-                    local validSubReq = subReqLevel > 0 and subReqLevel < 255;
-
-                    -- Check if castable by main job (Job Point spells report level > 99)
-                    local canCastMain = validMainReq and (mainReqLevel <= mainJobLevel or mainReqLevel > MAX_JOB_LEVEL);
-                    -- Check if castable by sub job
-                    local canCastSub = validSubReq and subReqLevel <= subJobLevel;
-
-                    if (canCastMain or canCastSub) and not addedSpells[spellId] then
-                        -- Use main job level if castable, otherwise sub job level
-                        local displayLevel = canCastMain and mainReqLevel or subReqLevel;
-                        local source = canCastMain and 'main' or 'sub';
-
+                    local canCast, source, reqLevel = M.EvaluateSpellAccess(spell, player);
+                    if canCast and not addedSpells[spellId] then
                         table.insert(spells, {
                             id = spellId,
                             name = spellName,
-                            level = displayLevel,
-                            source = source,
+                            level = reqLevel or 0,
+                            source = source or 'main',
                         });
                         addedSpells[spellId] = true;
                     end
@@ -263,6 +301,27 @@ local ABILITY_TYPE = {
     RuneEffusion      = 23,
 };
 
+-- Menu subcategory headers (not executable actions)
+local CATEGORY_STUB_IDS = {
+    [567] = true, -- Pet Commands
+    [603] = true, -- Blood Pact: Rage
+    [609] = true, -- Phantom Roll
+    [636] = true, -- Quick Draw
+    [684] = true, -- Blood Pact: Ward
+    [694] = true, -- Sambas
+    [695] = true, -- Waltzes
+    [710] = true, -- Jigs
+    [711] = true, -- Steps
+    [712] = true, -- Flourishes I
+    [725] = true, -- Flourishes II
+    [735] = true, -- Stratagems
+    [763] = true, -- Ready
+    [775] = true, -- Flourishes III
+    [869] = true, -- Rune Enchantment
+    [891] = true, -- Ward
+    [892] = true, -- Effusion
+};
+
 -- Pet commands to filter out from ability list (these belong in Pet Command section)
 local PET_COMMAND_NAMES = {
     ['Assault'] = true,
@@ -274,90 +333,63 @@ local PET_COMMAND_NAMES = {
     ['Fight'] = true,
     ['Sic'] = true,
     ['Ready'] = true,
-    -- SMN commands
     ['Avatar\'s Favor'] = true,
-    -- DRG commands
     ['Steady Wing'] = true,
-    -- PUP commands
     ['Deploy'] = true,
     ['Retrieve'] = true,
     ['Activate'] = true,
     ['Deactivate'] = true,
 };
 
--- FFXI macro-maker subcategory headers ("Sambas", "Waltzes", etc.) are present
--- as ability entries in the resource manager and HasAbility() returns true for
--- them, but they aren't executable. Filter them out of the JA dropdown.
-local CATEGORY_PLACEHOLDER_NAMES = {
-    ['Sambas']         = true,
-    ['Waltzes']        = true,
-    ['Steps']          = true,
-    ['Jigs']           = true,
-    ['Flourishes I']   = true,
-    ['Flourishes II']  = true,
-    ['Flourishes III'] = true,
-};
-
 --- Get player's available job abilities (includes both main job and subjob abilities)
---- Filters out weapon skills (Type 3) and pet commands
+--- Filters out weapon skills (Type 3), traits, pet commands, and menu stubs
 ---@return table Array of {id, name, source} where source is 'main' or 'sub'
 function M.GetPlayerAbilities()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     if not player then return {}; end
 
-    local mainJobId = player:GetMainJob();
-    local mainJobLevel = player:GetMainJobLevel();
-    local subJobId = player:GetSubJob();
-    local subJobLevel = player:GetSubJobLevel();
     local resMgr = AshitaCore:GetResourceManager();
+    if not resMgr then return {}; end
+
+    local mainJobId = player:GetMainJob() or 0;
+    local mainJobLevel = player:GetMainJobLevel() or 0;
+    local subJobId = player:GetSubJob() or 0;
+    local subJobLevel = player:GetSubJobLevel() or 0;
 
     local abilities = {};
-    local addedAbilities = {};  -- Track by ability ID to avoid duplicates
+    local addedAbilities = {};
 
-    -- Scan ability IDs 1-1024 (job abilities can be in higher ranges like 500+)
-    for abilityId = 1, 1024 do
-        if player:HasAbility(abilityId) then
+    -- Job ability resource ids live in 0x200..0x600
+    for abilityId = 0x200, 0x600 do
+        if not CATEGORY_STUB_IDS[abilityId] and player:HasAbility(abilityId) then
             local ability = resMgr:GetAbilityById(abilityId);
             if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
                 local abilityType = ability.Type or 0;
                 local abilityName = ability.Name[1];
-
-                -- Exclude: weapon skills (separate dropdown), passive traits (not
-                -- macroable), pet commands (separate section), and subcategory
-                -- header placeholders ("Sambas", "Waltzes", etc.).
                 local isWeaponSkill = abilityType == ABILITY_TYPE.WeaponSkill;
-                local isTrait       = abilityType == ABILITY_TYPE.Trait;
+                local isTrait = abilityType == ABILITY_TYPE.Trait;
                 if not isWeaponSkill
                     and not isTrait
                     and not PET_COMMAND_NAMES[abilityName]
-                    and not CATEGORY_PLACEHOLDER_NAMES[abilityName]
+                    and not addedAbilities[abilityId]
                 then
-
-                    if not addedAbilities[abilityId] then
-                        local source = 'main';
-
-                        if ability.Level then
-                            local mainReqLevel = ability.Level[mainJobId + 1] or 0;
-                            local subReqLevel = subJobId > 0 and (ability.Level[subJobId + 1] or 0) or 0;
-
-                            local validMainReq = mainReqLevel > 0 and mainReqLevel < 255;
-                            local validSubReq = subReqLevel > 0 and subReqLevel < 255;
-
-                            local canUseMain = validMainReq and mainReqLevel <= mainJobLevel;
-                            local canUseSub = validSubReq and subReqLevel <= subJobLevel;
-
-                            if canUseSub and not canUseMain then
-                                source = 'sub';
-                            end
+                    local source = 'main';
+                    if ability.Level then
+                        local mainReqLevel = ability.Level[mainJobId + 1] or 0;
+                        local subReqLevel = subJobId > 0 and (ability.Level[subJobId + 1] or 0) or 0;
+                        local canUseMain = mainReqLevel > 0 and mainReqLevel < 255 and mainReqLevel <= mainJobLevel;
+                        local canUseSub = subReqLevel > 0 and subReqLevel < 255 and subReqLevel <= subJobLevel;
+                        if canUseSub and not canUseMain then
+                            source = 'sub';
                         end
-
-                        table.insert(abilities, {
-                            id = abilityId,
-                            name = abilityName,
-                            source = source,
-                        });
-                        addedAbilities[abilityId] = true;
                     end
+
+                    table.insert(abilities, {
+                        id = abilityId,
+                        name = abilityName,
+                        source = source,
+                    });
+                    addedAbilities[abilityId] = true;
                 end
             end
         end
@@ -371,18 +403,18 @@ function M.GetPlayerAbilities()
 end
 
 --- Get player's available weaponskills
---- Uses HasAbility and filters by Type 3 (weapon skills)
 ---@return table Array of {id, name}
 function M.GetPlayerWeaponskills()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     if not player then return {}; end
 
     local resMgr = AshitaCore:GetResourceManager();
-    local weaponskills = {};
-    local addedWeaponskills = {};  -- Track by name to avoid duplicates
+    if not resMgr then return {}; end
 
-    -- Scan HasAbility and filter by Type == WeaponSkill (3)
-    for abilityId = 1, 1024 do
+    local weaponskills = {};
+    local addedWeaponskills = {};
+
+    for abilityId = 1, 0x200 do
         if player:HasAbility(abilityId) then
             local ability = resMgr:GetAbilityById(abilityId);
             if ability and ability.Name and ability.Name[1] and ability.Name[1] ~= '' then
@@ -736,22 +768,29 @@ function M.IsPetCommandAvailable(commandName)
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     if not player then return true; end
 
+    local actiondb = require('modules.hotbar.actiondb');
+    local abilityId = actiondb.GetAbilityId(commandName);
+
+    -- HasAbility is the authoritative source: pet-specific bits appear after summon
+    if abilityId then
+        return player:HasAbility(abilityId) == true;
+    end
+
+    -- Unresolved name: fall back to the static command list for the pet job
     local petregistry = require('modules.hotbar.petregistry');
     local petpalette = require('modules.hotbar.petpalette');
 
-    -- Resolve the pet job from main OR subjob (e.g. WAR/BST grants Fight/Sic/etc.).
     local jobId = petregistry.ResolvePetJob(player:GetMainJob(), player:GetSubJob());
     if not jobId then
         return false;
     end
 
-    local avatarName = nil;
     local activePetName = nil;
     if jobId == petregistry.JOB_BST then
         activePetName = petpalette.GetCurrentPetEntityName();
     end
 
-    local commands = petregistry.GetPetCommandsForJob(jobId, avatarName, activePetName);
+    local commands = petregistry.GetPetCommandsForJob(jobId, nil, activePetName);
     for _, cmd in ipairs(commands) do
         if cmd.name == commandName then
             return true;

--- a/XIUI/modules/hotbar/recast.lua
+++ b/XIUI/modules/hotbar/recast.lua
@@ -119,6 +119,85 @@ function M.GetAbilityRecast(abilityId)
     return abilityRecastCache[abilityId] or 0;
 end
 
+-- Shared timer-id lookup (PUP maneuvers, etc. share one RecastTimerId)
+---@param timerId number
+---@return number remainingSeconds
+function M.GetRecastByTimerId(timerId)
+    if not timerId then return 0; end
+    return abilityRecast.GetAbilityRecastSeconds(timerId) or 0;
+end
+
+-- Charge-based ability pools keyed by RecastTimerId
+local CHARGE_TIMER = {
+    READY = 102,
+    QUICK_DRAW = 195,
+    STRATAGEM = 231,
+};
+
+local function RecastRawToDisplaySeconds(raw)
+    if not raw or raw <= 0 then return 0; end
+    return raw / 60;
+end
+
+--- Remaining charges + seconds until next charge for a charge pool
+---@param timerId number
+---@param maxCharges number
+---@param baseSeconds number Base full-pool recast in seconds (before modifier)
+---@return number charges
+---@return number nextChargeSeconds
+local function GetChargePool(timerId, maxCharges, baseSeconds)
+    if maxCharges <= 0 then
+        return 0, 0;
+    end
+    local data = abilityRecast.GetAbilityTimerDataByTimerId(timerId);
+    if not data or not data.Recast or data.Recast == 0 then
+        return maxCharges, 0;
+    end
+    local baseRecast = 60 * (baseSeconds + (data.Modifier or 0));
+    if baseRecast <= 0 then
+        return 0, RecastRawToDisplaySeconds(data.Recast);
+    end
+    local chargeValue = baseRecast / maxCharges;
+    local remainingCharges = math.floor((baseRecast - data.Recast) / chargeValue);
+    local timeUntilNext = math.fmod(data.Recast, chargeValue);
+    if remainingCharges < 0 then remainingCharges = 0; end
+    if remainingCharges > maxCharges then remainingCharges = maxCharges; end
+    return remainingCharges, RecastRawToDisplaySeconds(timeUntilNext);
+end
+
+function M.GetReadyCharges()
+    return GetChargePool(CHARGE_TIMER.READY, 3, 90);
+end
+
+function M.GetQuickDrawCharges()
+    return GetChargePool(CHARGE_TIMER.QUICK_DRAW, 2, 120);
+end
+
+--- SCH stratagem charges (level-scaled max)
+---@return number charges
+---@return number nextChargeSeconds
+---@return number maxCharges
+function M.GetStratagemCharges()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if not player then return 0, 0, 0; end
+
+    local lvl = 0;
+    if player:GetMainJob() == 20 then
+        lvl = player:GetMainJobLevel();
+    elseif player:GetSubJob() == 20 then
+        lvl = player:GetSubJobLevel();
+    else
+        return 0, 0, 0;
+    end
+
+    local maxCharges = math.floor((lvl - 10) / 20) + 1;
+    if maxCharges < 1 then maxCharges = 0; end
+    local charges, nextCharge = GetChargePool(CHARGE_TIMER.STRATAGEM, maxCharges, 240);
+    return charges, nextCharge, maxCharges;
+end
+
+M.CHARGE_TIMER = CHARGE_TIMER;
+
 -- Get item/equipment recast by item ID
 -- Uses itemrecast.lua which reads from item.Extra data
 -- Returns: remaining seconds, or 0 if ready

--- a/XIUI/modules/hotbar/slotrenderer.lua
+++ b/XIUI/modules/hotbar/slotrenderer.lua
@@ -12,6 +12,7 @@ local imgui = require('imgui');
 local recast = require('modules.hotbar.recast');
 local actions = require('modules.hotbar.actions');
 local playerdata = require('modules.hotbar.playerdata');
+local petpalette = require('modules.hotbar.petpalette');
 local dragdrop = require('libs.dragdrop');
 local textures = require('modules.hotbar.textures');
 local skillchain = require('modules.hotbar.skillchain');
@@ -40,11 +41,11 @@ local DIM_UNAVAILABLE_ALPHA = 0.7;
 
 ---@return number colorMult
 ---@return boolean applyGreyTint
-local function GetSlotColorMult(isUnavailable, isOnCooldown, notEnoughMp, notEnoughTp)
+local function GetSlotColorMult(isUnavailable, isOnCooldown, notEnoughCost)
     if isUnavailable then
         return DIM_UNAVAILABLE, true;
     end
-    if isOnCooldown or notEnoughMp or notEnoughTp then
+    if isOnCooldown or notEnoughCost then
         return DIM_RESTRICTED, false;
     end
     return 1.0, false;
@@ -54,9 +55,6 @@ local ACTION_TYPE_LABELS = {
     ma = 'Spell (ma)', ja = 'Ability (ja)', ws = 'Weaponskill (ws)',
     item = 'Item', equip = 'Equip', macro = 'Macro', pet = 'Pet Command',
 };
-
--- Cache for MP cost lookups (keyed by action key string)
-local mpCostCache = {};
 
 -- Cache for action availability checks (keyed by action key string)
 -- Structure: { isAvailable = bool, reason = string|nil }
@@ -393,7 +391,6 @@ end
 function M.ClearAllCache()
     availabilityCache = {};
     availabilityStateMemo = {};
-    mpCostCache = {};
     equipmentCheckCache = {};
     ninjutsuCache = {};
     itemQuantityCache = {};
@@ -403,8 +400,7 @@ function M.ClearAllCache()
 end
 
 -- Clear slot texture pointer cache
--- Does NOT clear availability, MP cost, or item quantity caches
--- OPTIMIZED: Use this for palette changes to avoid unnecessary recalculation cascade
+-- Does NOT clear availability or item quantity caches
 function M.ClearSlotRenderingCache()
     texturePtrCache = {};
 end
@@ -413,13 +409,6 @@ end
 function M.ClearAvailabilityCache()
     availabilityCache = {};
     availabilityStateMemo = {};
-end
-
--- Clear MP cost cache (call when a slot's action/spell may have changed, e.g. macro edits).
--- Without this, edited macros keep showing the old action's MP cost / no-MP indicator
--- until the addon reloads.
-function M.ClearMPCostCache()
-    mpCostCache = {};
 end
 
 -- Clear item quantity cache (call on inventory changes)
@@ -459,7 +448,9 @@ local function BuildAvailabilityCacheKey(bind, bindKey)
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     local jobId = player and player:GetMainJob() or 0;
     local subjobId = player and player:GetSubJob() or 0;
-    return key .. ':' .. jobId .. ':' .. subjobId .. ':' .. playerdata.GetEquipmentSignature();
+    -- Pet presence affects HasAbility for BPs, maneuvers, ready moves, etc.
+    local petKey = petpalette.GetCurrentPetKey() or 'none';
+    return key .. ':' .. jobId .. ':' .. subjobId .. ':' .. petKey .. ':' .. playerdata.GetEquipmentSignature();
 end
 
 local function GetAvailabilityState(bind, bindKey)
@@ -767,27 +758,15 @@ function M.DrawSlot(params)
     local isOnCooldown = cooldown.isOnCooldown;
     local recastText = cooldown.recastText;
 
-    -- Check if player has enough MP for spells (also includes macros whose
-    -- recast source is a spell — they show the source spell's MP cost).
-    local notEnoughMp = false;
+    -- Check resource cost (MP / TP / charges / finishing moves).
+    -- Not cached across frames: charges/TP/buffs change continuously.
+    local notEnoughCost = false;
+    local costInfo = nil;
     local bindKey = bind and ((bind.actionType or '') .. ':' .. (bind.action or '')) or '';
-    local hasMpCost = bind and (
-        bind.actionType == 'ma'
-        or bind.actionType == 'ja'
-        or (bind.actionType == 'macro'
-            and (bind.recastSourceType == 'ma' or bind.recastSourceType == 'ja')
-            and bind.recastSourceAction)
-    );
-    if hasMpCost then
-        local mpCost = mpCostCache[bindKey];
-        if mpCost == nil then
-            mpCost = actions.GetMPCost(bind) or false;
-            mpCostCache[bindKey] = mpCost;
-        end
-        if mpCost and mpCost ~= false then
-            local party = AshitaCore:GetMemoryManager():GetParty();
-            local playerMp = party and party:GetMemberMP(0) or 0;
-            notEnoughMp = playerMp < mpCost;
+    if bind then
+        costInfo = actions.GetActionCostInfo(bind);
+        if costInfo and costInfo.kind ~= 'none' then
+            notEnoughCost = costInfo.met == false;
         end
     end
 
@@ -795,12 +774,6 @@ function M.DrawSlot(params)
     local isUnavailable = false;
     if bind then
         isUnavailable = select(1, GetAvailabilityState(bind, bindKey));
-    end
-
-    -- Weaponskills (and WS recast-source macros) dim when TP is below the WS cost
-    local notEnoughTp = false;
-    if bind and actions.NeedsTpCheck(bind) and not isUnavailable then
-        notEnoughTp = not actions.HasEnoughTpForBind(bind);
     end
 
     -- ========================================
@@ -825,7 +798,7 @@ function M.DrawSlot(params)
 
             -- Calculate color: unavailable/cooldown/noMP darkening + dim factor + animation opacity
             local colorMult, applyGreyTint = GetSlotColorMult(
-                isUnavailable, isOnCooldown, notEnoughMp, notEnoughTp
+                isUnavailable, isOnCooldown, notEnoughCost
             );
             colorMult = colorMult * dimFactor;
 
@@ -893,7 +866,7 @@ function M.DrawSlot(params)
             abbrW = imtext.Measure(abbr, 12);
         end
 
-        local colorMult = select(1, GetSlotColorMult(isUnavailable, isOnCooldown, notEnoughMp, notEnoughTp));
+        local colorMult = select(1, GetSlotColorMult(isUnavailable, isOnCooldown, notEnoughCost));
         colorMult = colorMult * dimFactor;
         -- Gold base: R=244, G=218, B=151 (0xF4DA97)
         local r = math.floor(244 * colorMult);
@@ -949,12 +922,12 @@ function M.DrawSlot(params)
     if params.showLabel and params.labelText and params.labelText ~= '' and animOpacity > 0.5 and drawList then
         local lblFontSize = params.labelFontSize or 10;
         local labelColor = params.labelFontColor or 0xFFFFFFFF;
-        -- Priority: Unavailable (grey) > Cooldown (grey) > Not enough MP/TP (red) > Normal
+        -- Priority: Unavailable (grey) > Cooldown (grey) > Not enough cost (red) > Normal
         if isUnavailable then
             labelColor = 0xFF888888;
         elseif isOnCooldown then
             labelColor = params.labelCooldownColor or 0xFF888888;
-        elseif notEnoughMp or notEnoughTp then
+        elseif notEnoughCost then
             labelColor = params.labelNoMpColor or 0xFFFF4444;
         end
         local lblW = imtext.Measure(params.labelText, lblFontSize);
@@ -964,8 +937,8 @@ function M.DrawSlot(params)
     end
 
     -- ========================================
-    -- 10. MP Cost Text (anchored position)
-    -- Shows "X" when action is unavailable, otherwise shows MP cost
+    -- 10. Cost Text (MP / TP / charges / finishing moves)
+    -- Shows "X" when action is unavailable, otherwise shows cost amount
     -- ========================================
     do
         local showMpCost = params.showMpCost ~= false;
@@ -984,15 +957,19 @@ function M.DrawSlot(params)
                 end
                 imtext.Draw(drawList, xText, mpX, mpY, xColor, mpFontSize);
             else
-                local mpCost = mpCostCache[bindKey];
-                if mpCost == nil then
-                    mpCost = actions.GetMPCost(bind) or false;
-                    mpCostCache[bindKey] = mpCost;
+                local info = costInfo;
+                if info == nil then
+                    info = actions.GetActionCostInfo(bind);
                 end
-                if mpCost and mpCost ~= false then
-                    local mpText = tostring(mpCost);
+                if info and info.kind ~= 'none' and info.label then
+                    local mpText = info.label;
                     local mpCostColor = params.mpCostFontColor or 0xFFD4FF97;
-                    if notEnoughMp then
+                    if info.kind == 'tp' then
+                        mpCostColor = params.mpCostFontColor or 0xFF97D4FF;
+                    elseif info.kind == 'charges' or info.kind == 'fm' then
+                        mpCostColor = params.mpCostFontColor or 0xFFFFE097;
+                    end
+                    if notEnoughCost then
                         mpCostColor = params.mpCostNoMpColor or 0xFFFF4444;
                     end
                     if mpAnchor == 'topRight' or mpAnchor == 'bottomRight' then


### PR DESCRIPTION
Improved Hotbar Action Validation And Cost Display
- Improved spell and ability checks so known actions are not marked unavailable
- Made every macro use a unique id so slots always point to the right macro
- Saved pending palette and macro edits before job changes so bars stay intact
- Fixed pet abilities and maneuvers staying lit up after the pet was dismissed
- Fixed shared cooldowns so Puppetmaster maneuvers all show the same timer
- Added cost display for MP, TP, charges, and finishing moves on hotbar slots
- Added Scholar stratagem charges and Dancer finishing move counts including 5+ from Job Points
- Zeroed costs correctly during Trance, Tabula Rasa, Manafont, and Manawell
- Added an Other job category for non standard jobs like Monstrosity