### PR TITLE
fix: restore XIUI startup parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lua:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install LuaJIT
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes luajit
+
+      - name: Check Lua syntax
+        run: ./scripts/check-lua.sh
+
+      - name: Run fake-host tests
+        run: luajit tests/run.lua

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install LuaJIT
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes luajit
+
+      - name: Check Lua syntax
+        run: ./scripts/check-lua.sh
+
+      - name: Run fake-host tests
+        run: luajit tests/run.lua
+
       - name: Prepare release packages
         run: |
           # Extract version from tag (e.g., v1.3.6 -> 1.3.6)

--- a/XIUI/libs/hp.lua
+++ b/XIUI/libs/hp.lua
@@ -296,7 +296,7 @@ function M.GetHpColors(hpPercent)
     if (hpPercent < .25) then
         hpNameColor = 0xFFFF0000;
         hpGradient = {"#ec3232", "#f16161"};
-    elseif (hpPercent < .50) then;
+    elseif (hpPercent < .50) then
         hpNameColor = 0xFFFFA500;
         hpGradient = {"#ee9c06", "#ecb44e"};
     elseif (hpPercent < .75) then

--- a/scripts/check-lua.sh
+++ b/scripts/check-lua.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -u
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "${temporary_directory}"' EXIT
+
+if ! command -v luajit >/dev/null 2>&1; then
+    echo 'LuaJIT is required to check XIUI Lua files.' >&2
+    exit 2
+fi
+
+mapfile -d '' lua_files < <(find "${repository_root}/XIUI" -type f -name '*.lua' -print0 | sort -z)
+
+failure_count=0
+for lua_file in "${lua_files[@]}"; do
+    if ! luajit -b "${lua_file}" "${temporary_directory}/output.ljbc"; then
+        failure_count=$((failure_count + 1))
+    fi
+done
+
+if (( failure_count > 0 )); then
+    echo "LuaJIT parse failures: ${failure_count}" >&2
+    exit 1
+fi
+
+echo "LuaJIT parsed ${#lua_files[@]} files."

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,0 +1,37 @@
+local source_path = debug.getinfo(1, 'S').source:sub(2);
+local repository_root = source_path:match('^(.*)[/\\]tests[/\\]run%.lua$') or '.';
+
+package.path = table.concat({
+    repository_root .. '/tests/?.lua',
+    repository_root .. '/tests/?/init.lua',
+    repository_root .. '/XIUI/?.lua',
+    repository_root .. '/XIUI/?/init.lua',
+    package.path,
+}, ';');
+
+local suites = {
+    require('startup_test'),
+};
+
+local failures = 0;
+local tests_run = 0;
+
+for _, suite in ipairs(suites) do
+    for _, test_case in ipairs(suite) do
+        tests_run = tests_run + 1;
+        local ok, result = xpcall(test_case.run, debug.traceback);
+        if ok then
+            print('PASS ' .. test_case.name);
+        else
+            failures = failures + 1;
+            io.stderr:write('FAIL ' .. test_case.name .. '\n' .. result .. '\n');
+        end
+    end
+end
+
+if failures > 0 then
+    io.stderr:write(string.format('%d of %d tests failed.\n', failures, tests_run));
+    os.exit(1);
+end
+
+print(string.format('%d tests passed.', tests_run));

--- a/tests/startup_test.lua
+++ b/tests/startup_test.lua
@@ -1,0 +1,12 @@
+local fake_ashita = require('support.fake_ashita');
+
+return {
+    {
+        name = 'normal module graph loads without FFXI',
+        run = function()
+            fake_ashita.install();
+            local modules = require('modules.init');
+            assert(type(modules) == 'table', 'modules.init did not return the module registry');
+        end,
+    },
+};

--- a/tests/support/fake_ashita.lua
+++ b/tests/support/fake_ashita.lua
@@ -1,0 +1,142 @@
+local M = {};
+local AVAILABLE_SIGNATURE_ADDRESS = 0x1000;
+
+local table_methods = {};
+
+function table_methods:all(predicate)
+    for _, value in pairs(self) do
+        if not predicate(value) then
+            return false;
+        end
+    end
+    return true;
+end
+
+local function table_wrapper(value)
+    return setmetatable(value or {}, { __index = table_methods });
+end
+
+local function no_op()
+end
+
+local function zero()
+    return 0;
+end
+
+local function callable_table(default_return)
+    return setmetatable({}, {
+        __index = function(self, key)
+            local value = default_return or no_op;
+            rawset(self, key, value);
+            return value;
+        end,
+    });
+end
+
+local function install_external_modules()
+    package.preload['common'] = function()
+        _G.T = table_wrapper;
+        _G.V = table_wrapper;
+        _G.bit = require('bit');
+        _G.struct = {
+            pack = function()
+                return { totable = function() return {}; end };
+            end,
+        };
+        _G.ARGB = zero;
+        _G.ARGBToImGui = function() return { 0, 0, 0, 0 }; end;
+        _G.ImGuiToARGB = zero;
+        return true;
+    end;
+
+    package.preload['chat'] = function()
+        local message = {};
+        function message:append()
+            return self;
+        end
+        return {
+            header = function() return message; end,
+            message = function(value) return value; end,
+            error = function(value) return value; end,
+        };
+    end;
+
+    package.preload['settings'] = function()
+        return {
+            load = function(defaults) return defaults; end,
+            register = no_op,
+            save = no_op,
+        };
+    end;
+
+    package.preload['imgui'] = function()
+        return callable_table(no_op);
+    end;
+
+    package.preload['d3d8'] = function()
+        return callable_table(no_op);
+    end;
+
+    package.preload['bitreader'] = function()
+        return { new = function() return {}; end };
+    end;
+
+    package.preload['struct'] = function()
+        return _G.struct;
+    end;
+
+    package.preload['win32types'] = function()
+        return true;
+    end;
+
+    package.loaded['ffi'] = {
+        C = callable_table(zero),
+        cdef = no_op,
+        cast = zero,
+        load = function() return callable_table(zero); end,
+        new = function() return {}; end,
+        sizeof = zero,
+        string = function() return ''; end,
+    };
+end
+
+function M.install()
+    install_external_modules();
+
+    _G.addon = {
+        name = 'XIUI',
+        path = './XIUI/',
+    };
+
+    _G.ashita = {
+        bits = callable_table(zero),
+        events = { register = no_op },
+        fs = {
+            exists = function() return false; end,
+            get_dir = function() return {}; end,
+            get_directory = function() return {}; end,
+        },
+        memory = {
+            find = function() return AVAILABLE_SIGNATURE_ADDRESS; end,
+            read_string = function() return ''; end,
+            read_uint8 = zero,
+            read_uint32 = zero,
+            write_uint8 = no_op,
+            write_uint32 = no_op,
+        },
+        misc = { play_sound = no_op },
+    };
+
+    _G.AshitaCore = callable_table(function() return callable_table(zero); end);
+
+    setmetatable(_G, {
+        __index = function(_, key)
+            if type(key) == 'string' and key:match('^ImGui') then
+                return 0;
+            end
+            return nil;
+        end,
+    });
+end
+
+return M;


### PR DESCRIPTION
Fixes GEN-001 by removing the LuaJIT syntax error that prevents the normal XIUI module graph from loading.

**Startup safety**
- Parse every shipped Lua file before pull-request and release packaging.
- Load the real module aggregate under deterministic Ashita, ImGui, D3D8, and native-service fakes.

**Tests**
- Confirmed the original hp.lua failure under both gates.
- Confirmed all 148 Lua files parse and the cold module graph loads without launching FFXI.