### PR TITLE
ci: validate changed Lua syntax

### DIFF
--- a/.github/workflows/lua-syntax.yml
+++ b/.github/workflows/lua-syntax.yml
@@ -1,0 +1,49 @@
+name: Lua syntax
+
+on:
+  pull_request:
+    paths:
+      - '**/*.lua'
+      - '.github/workflows/lua-syntax.yml'
+      - 'tests/lua-syntax/**'
+
+permissions:
+  contents: read
+
+jobs:
+  changed-files:
+    name: Changed Lua files
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      MOONJIT_BIN: ${{ runner.temp }}/moonjit/src/luajit
+      MOONJIT_COMMIT: a2a39ea7184f3c8cab9474c6e41f6541265fb362
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build Ashita-compatible MoonJIT
+        run: |
+          git init --quiet "${RUNNER_TEMP}/moonjit"
+          git -C "${RUNNER_TEMP}/moonjit" remote add origin https://github.com/moonjit/moonjit.git
+          git -C "${RUNNER_TEMP}/moonjit" fetch --quiet --depth=1 origin "${MOONJIT_COMMIT}"
+          git -C "${RUNNER_TEMP}/moonjit" checkout --quiet --detach FETCH_HEAD
+          make -C "${RUNNER_TEMP}/moonjit" -j2 XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
+
+      - name: Test syntax checker
+        run: tests/lua-syntax/check-changed-test.sh "${MOONJIT_BIN}"
+
+      - name: Check changed Lua syntax
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          tests/lua-syntax/check-changed.sh
+          "${MOONJIT_BIN}"
+          "${GITHUB_WORKSPACE}"
+          "${BASE_SHA}"
+          "${HEAD_SHA}"

--- a/.github/workflows/lua-syntax.yml
+++ b/.github/workflows/lua-syntax.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
-      MOONJIT_BIN: ${{ runner.temp }}/moonjit/src/luajit
       MOONJIT_COMMIT: a2a39ea7184f3c8cab9474c6e41f6541265fb362
 
     steps:
@@ -35,7 +34,9 @@ jobs:
           make -C "${RUNNER_TEMP}/moonjit" -j2 XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
 
       - name: Test syntax checker
-        run: tests/lua-syntax/check-changed-test.sh "${MOONJIT_BIN}"
+        run: >-
+          tests/lua-syntax/check-changed-test.sh
+          "${RUNNER_TEMP}/moonjit/src/luajit"
 
       - name: Check changed Lua syntax
         env:
@@ -43,7 +44,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           tests/lua-syntax/check-changed.sh
-          "${MOONJIT_BIN}"
+          "${RUNNER_TEMP}/moonjit/src/luajit"
           "${GITHUB_WORKSPACE}"
           "${BASE_SHA}"
           "${HEAD_SHA}"

--- a/tests/lua-syntax/check-changed-test.sh
+++ b/tests/lua-syntax/check-changed-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MOONJIT_BIN=${1:?Usage: check-changed-test.sh /path/to/moonjit}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CHECKER="$SCRIPT_DIR/check-changed.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+REPOSITORY="$TEST_ROOT/repository"
+mkdir -p "$REPOSITORY/source"
+git -C "$REPOSITORY" init --quiet
+git -C "$REPOSITORY" config user.email tests@example.invalid
+git -C "$REPOSITORY" config user.name "Lua Syntax Tests"
+
+printf 'if true then; return true; end\n' > "$REPOSITORY/source/existing.lua"
+printf 'local value =\n' > "$REPOSITORY/source/unchanged-invalid.lua"
+ln -s existing.lua "$REPOSITORY/source/type-change.lua"
+git -C "$REPOSITORY" add .
+git -C "$REPOSITORY" commit --quiet -m base
+BASE_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+printf 'if true then; return true; end\n' > "$REPOSITORY/source/added.lua"
+git -C "$REPOSITORY" add .
+git -C "$REPOSITORY" commit --quiet -m valid
+VALID_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+VALID_OUTPUT=$("$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" "$BASE_SHA" "$VALID_SHA")
+[[ "$VALID_OUTPUT" == 'MoonJIT parsed 1 changed Lua file.' ]]
+
+if "$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" missing-base "$VALID_SHA" \
+    > "$TEST_ROOT/missing-base.log" 2>&1; then
+    printf 'Expected an unavailable base revision to fail.\n' >&2
+    exit 1
+fi
+
+unlink "$REPOSITORY/source/type-change.lua"
+printf 'local changed_type =\n' > "$REPOSITORY/source/type-change.lua"
+git -C "$REPOSITORY" add .
+git -C "$REPOSITORY" commit --quiet -m type-change
+TYPE_CHANGE_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+if TYPE_CHANGE_OUTPUT=$("$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" \
+    "$VALID_SHA" "$TYPE_CHANGE_SHA" 2>&1); then
+    printf 'Expected an invalid Lua type change to fail.\n' >&2
+    exit 1
+fi
+[[ "$TYPE_CHANGE_OUTPUT" == *'source/type-change.lua'* ]]
+
+BYTECODE_PATH="$REPOSITORY/source/bytecode.lua"
+XIUI_BYTECODE_PATH="$BYTECODE_PATH" "$MOONJIT_BIN" -e \
+    "local path = os.getenv('XIUI_BYTECODE_PATH'); local output = assert(io.open(path, 'wb')); output:write(string.dump(function () return true end)); assert(output:close())"
+git -C "$REPOSITORY" add .
+git -C "$REPOSITORY" commit --quiet -m bytecode
+BYTECODE_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+if "$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" "$TYPE_CHANGE_SHA" "$BYTECODE_SHA" \
+    > "$TEST_ROOT/bytecode.log" 2>&1; then
+    printf 'Expected Lua bytecode disguised as source to fail.\n' >&2
+    exit 1
+fi
+
+printf 'local first =\n' > "$REPOSITORY/source/a-first-invalid.lua"
+printf 'local second =\n' > "$REPOSITORY/source/z-second-invalid.lua"
+git -C "$REPOSITORY" add .
+git -C "$REPOSITORY" commit --quiet -m invalid
+INVALID_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+if INVALID_OUTPUT=$("$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" \
+    "$BYTECODE_SHA" "$INVALID_SHA" 2>&1); then
+    printf 'Expected changed invalid Lua to fail.\n' >&2
+    exit 1
+fi
+[[ "$INVALID_OUTPUT" == *'source/a-first-invalid.lua'* ]]
+[[ "$INVALID_OUTPUT" != *'source/z-second-invalid.lua'* ]]
+
+git -C "$REPOSITORY" mv source/existing.lua source/renamed.lua
+git -C "$REPOSITORY" commit --quiet -m renamed
+RENAMED_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+RENAMED_OUTPUT=$("$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" \
+    "$INVALID_SHA" "$RENAMED_SHA")
+[[ "$RENAMED_OUTPUT" == 'MoonJIT parsed 1 changed Lua file.' ]]
+
+printf 'documentation only\n' > "$REPOSITORY/README.md"
+git -C "$REPOSITORY" add README.md
+git -C "$REPOSITORY" commit --quiet -m documentation
+DOCUMENTATION_SHA=$(git -C "$REPOSITORY" rev-parse HEAD)
+
+DOCUMENTATION_OUTPUT=$("$CHECKER" "$MOONJIT_BIN" "$REPOSITORY" \
+    "$RENAMED_SHA" "$DOCUMENTATION_SHA")
+[[ "$DOCUMENTATION_OUTPUT" == 'No changed Lua files to check.' ]]
+
+printf 'All changed-Lua selector tests passed.\n'

--- a/tests/lua-syntax/check-changed.sh
+++ b/tests/lua-syntax/check-changed.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MOONJIT_BIN=${1:?Usage: check-changed.sh /path/to/moonjit repository base-sha head-sha}
+REPOSITORY=${2:?Usage: check-changed.sh /path/to/moonjit repository base-sha head-sha}
+BASE_SHA=${3:?Usage: check-changed.sh /path/to/moonjit repository base-sha head-sha}
+HEAD_SHA=${4:?Usage: check-changed.sh /path/to/moonjit repository base-sha head-sha}
+
+CHANGED_FILES=$(mktemp)
+trap 'rm -f "$CHANGED_FILES"' EXIT
+git -C "$REPOSITORY" diff --find-renames --diff-filter=ACMRT \
+    --name-only -z "$BASE_SHA...$HEAD_SHA" -- '*.lua' > "$CHANGED_FILES"
+
+count=0
+while IFS= read -r -d '' lua_file; do
+    XIUI_LUA_FILE="$REPOSITORY/$lua_file" "$MOONJIT_BIN" -e \
+        "local path = os.getenv('XIUI_LUA_FILE'); local chunk, err = loadfile(path, 't'); assert(chunk, err)"
+    count=$((count + 1))
+done < "$CHANGED_FILES"
+
+if ((count == 0)); then
+    printf 'No changed Lua files to check.\n'
+elif ((count == 1)); then
+    printf 'MoonJIT parsed 1 changed Lua file.\n'
+else
+    printf 'MoonJIT parsed %d changed Lua files.\n' "$count"
+fi


### PR DESCRIPTION
Build a pinned MoonJIT parser with Ashita-compatible Lua 5.2 syntax support. Check only Lua files changed relative to the pull request base and fail on the first syntax error. Keep the checker and its behavioral tests outside the release tree.