### PR TITLE
Add Phantom Roll Tracker

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -84,6 +84,7 @@ local hotbar = uiMods.hotbar;
 local readyCheck = uiMods.readycheck;
 local satchelModule = uiMods.satchel;
 local magicBurst = uiMods.magicburst;
+local phantomRoll = uiMods.phantomroll;
 local macropalette = require('modules.hotbar.macropalette');
 local palette = require('modules.hotbar.palette');
 local skillchainModule = require('modules.hotbar.skillchain');
@@ -194,6 +195,14 @@ uiModules.Register('magicBurst', {
     settingsKey = 'magicBurstSettings',
     configKey = 'magicBurstEnabled',
     hideOnEventKey = 'hideDuringEvents',
+    hasSetHidden = true,
+});
+uiModules.Register('phantomRoll', {
+    module = phantomRoll,
+    settingsKey = 'phantomRollSettings',
+    configKey = 'showPhantomRoll',
+    hideOnMenuFocusKey = 'phantomRollHideOnMenuFocus',
+    hideMacroPaletteKey = 'phantomRollHideMacroPalette',
     hasSetHidden = true,
 });
 uiModules.Register('gilTracker', {
@@ -552,6 +561,7 @@ local function GetDefaultWindowPositions()
     local elx, ely = defPos.GetEnemyListPosition();
     local ccx, ccy = defPos.GetCastCostPosition();
     local mbx, mby = defPos.GetMagicBurstPosition();
+    local prx, pry = defPos.GetPhantomRollPosition();
 
     local staggerY = 35;
     return {
@@ -570,6 +580,7 @@ local function GetDefaultWindowPositions()
         EnemyList = { x = elx, y = ely },
         CastCost = { x = ccx, y = ccy },
         MagicBurst = { x = mbx, y = mby },
+        PhantomRoll = { x = prx, y = pry },
         InventoryTracker = { x = ix, y = iy },
         Satchel = { x = sx, y = sy },
         SatchelTracker = { x = ix, y = iy + staggerY },
@@ -1845,6 +1856,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
             petBuffHandler.HandleActionPacket(actionPacket);
             actionTracker.HandleActionPacket(actionPacket);
             if gConfig.showNotifications then notifications.HandleActionPacket(actionPacket); end
+            if gConfig.showPhantomRoll then phantomRoll.HandleActionPacket(actionPacket); end
             if skillchainTrackingEnabled() then
                 skillchainModule.HandleActionPacket(actionPacket);
             end
@@ -1863,6 +1875,7 @@ ashita.events.register('packet_in', 'packet_in_cb', function (e)
         debuffHandler.HandleZonePacket(e);
         petBuffHandler.HandleZonePacket();
         actionTracker.HandleZonePacket();
+        phantomRoll.HandleZonePacket();
         mobInfo.data.HandleZonePacket(e);
         statusHandler.clear_zone_cache();  -- Clear status icon cache to prevent accumulation
         gilTracker.HandleZoneInPacket(e);  -- Only reset on fresh login, not zone changes (issue #111)

--- a/XIUI/config.lua
+++ b/XIUI/config.lua
@@ -27,6 +27,7 @@ local notificationsModule = require('config.notifications');
 local treasurepoolModule = require('config.treasurepool');
 local hotbarModule = require('config.hotbar');
 local readycheckModule = require('config.readycheck');
+local phantomrollModule = require('config.phantomroll');
 
 local treasurePool = require('modules.treasurepool.init');
 local tooltipfonts = require('modules.satchel.tooltips');
@@ -333,6 +334,7 @@ local categories = {
     { name = 'castBar', label = 'Cast Bar' },
     { name = 'castCost', label = 'Cast Cost' },
     { name = 'petBar', label = 'Pet Bar' },
+    { name = 'phantomRoll', label = 'Phantom Roll' },
     { name = 'notifications', label = 'Notifications' },
     { name = 'treasurePool', label = 'Treasure Pool' },
     { name = 'hotbar', label = 'Hotbar' },
@@ -572,6 +574,10 @@ local function DrawPetBarSettings()
     applySettingsState(newState);
 end
 
+local function DrawPhantomRollSettings()
+    phantomrollModule.DrawSettings();
+end
+
 local function DrawNotificationsSettings()
     notificationsModule.DrawSettings();
 end
@@ -642,6 +648,10 @@ local function DrawPetBarColorSettings()
     applyColorState(newState);
 end
 
+local function DrawPhantomRollColorSettings()
+    phantomrollModule.DrawColorSettings();
+end
+
 local function DrawNotificationsColorSettings()
     notificationsModule.DrawColorSettings();
 end
@@ -673,6 +683,7 @@ local settingsDrawFunctions = {
     DrawCastBarSettings,
     DrawCastCostSettings,
     DrawPetBarSettings,
+    DrawPhantomRollSettings,
     DrawNotificationsSettings,
     DrawTreasurePoolSettings,
     DrawHotbarSettings,
@@ -692,6 +703,7 @@ local colorSettingsDrawFunctions = {
     DrawCastBarColorSettings,
     DrawCastCostColorSettings,
     DrawPetBarColorSettings,
+    DrawPhantomRollColorSettings,
     DrawNotificationsColorSettings,
     DrawTreasurePoolColorSettings,
     DrawHotbarColorSettings,

--- a/XIUI/config/phantomroll.lua
+++ b/XIUI/config/phantomroll.lua
@@ -25,8 +25,7 @@ function M.DrawSettings()
 end
 
 function M.DrawColorSettings()
-    imgui.TextDisabled('The dice colour themselves: gold on a lucky number or 11,');
-    imgui.TextDisabled('ice blue on the unlucky number, and red on a bust.');
+    imgui.TextDisabled('No color settings for Phantom Roll.');
 end
 
 return M;

--- a/XIUI/config/phantomroll.lua
+++ b/XIUI/config/phantomroll.lua
@@ -16,7 +16,7 @@ function M.DrawSettings()
 
     if components.CollapsingSection('Display Options##phantomRoll') then
         components.DrawCheckbox('Horizon Mode', 'phantomRollHorizonMode', UpdateUserSettings);
-        imgui.ShowHelp('Use HorizonXI values, where some rolls grant a flat bonus instead of a percentage. Chaos becomes flat attack that scales with your level.');
+        imgui.ShowHelp('Use HorizonXI values: Chaos is flat ATK that scales with level, Gallant\'s is flat DEF, and Healer\'s is hMP. Party-job bonuses are off.');
     end
 
     if components.CollapsingSection('Scale & Position##phantomRoll') then

--- a/XIUI/config/phantomroll.lua
+++ b/XIUI/config/phantomroll.lua
@@ -1,0 +1,32 @@
+--[[
+* XIUI Config Menu - Phantom Roll Settings
+]]--
+
+require('common');
+require('handlers.helpers');
+local components = require('config.components');
+local imgui = require('imgui');
+
+local M = {};
+
+function M.DrawSettings()
+    components.DrawCheckbox('Enabled', 'showPhantomRoll', CheckVisibility);
+    imgui.ShowHelp('Show your two active Corsair Phantom Rolls as dice, with potency, time left and bust odds.');
+    components.DrawHideWhenMenuOpenOptions('phantomRollHideOnMenuFocus', 'phantomRollHideMacroPalette');
+
+    if components.CollapsingSection('Display Options##phantomRoll') then
+        components.DrawCheckbox('Horizon Mode', 'phantomRollHorizonMode', UpdateUserSettings);
+        imgui.ShowHelp('Use HorizonXI values, where some rolls grant a flat bonus instead of a percentage. Chaos becomes flat attack that scales with your level.');
+    end
+
+    if components.CollapsingSection('Scale & Position##phantomRoll') then
+        components.DrawSlider('Scale', 'phantomRollScale', 0.5, 3.0, '%.1f');
+    end
+end
+
+function M.DrawColorSettings()
+    imgui.TextDisabled('The dice colour themselves: gold on a lucky number or 11,');
+    imgui.TextDisabled('ice blue on the unlucky number, and red on a bust.');
+end
+
+return M;

--- a/XIUI/core/settings/modules.lua
+++ b/XIUI/core/settings/modules.lua
@@ -252,6 +252,23 @@ function M.createModuleDefaults()
             },
         },
 
+        phantomRollSettings = T{
+            dieSize = 54,
+            nameSize = 18,
+            potencySize = 15,
+            oddsSize = 12,
+            barHeight = 14,
+            horizonMode = false,
+            font_settings = T{
+                font_family = 'Tahoma',
+                font_height = 15,
+                font_color = 0xFFFFFFFF,
+                font_flags = fontconst.FLAG_BOLD,
+                outline_color = 0xFF000000,
+                outline_width = 1,
+            },
+        },
+
         inventoryTrackerSettings = T{
             columnCount = 5,
             rowCount = 6,

--- a/XIUI/core/settings/modules.lua
+++ b/XIUI/core/settings/modules.lua
@@ -258,7 +258,7 @@ function M.createModuleDefaults()
             potencySize = 15,
             oddsSize = 12,
             barHeight = 14,
-            horizonMode = false,
+            horizonMode = HzLimitedMode == true,
             font_settings = T{
                 font_family = 'Tahoma',
                 font_height = 15,

--- a/XIUI/core/settings/updater.lua
+++ b/XIUI/core/settings/updater.lua
@@ -309,6 +309,16 @@ function M.UpdateUserSettings(gAdjustedSettings, default_settings, gConfig)
     gAdjustedSettings.magicBurstSettings.font_settings.font_height = ds.magicBurstSettings.font_settings.font_height * magicBurstScale;
     gAdjustedSettings.magicBurstSettings.showTimer = us.magicBurstShowTimer ~= false;
 
+    -- Phantom Roll
+    applyGlobalFontSettings(gAdjustedSettings.phantomRollSettings.font_settings, us.fontFamily, fontWeightFlags, us.fontOutlineWidth);
+    local phantomRollScale = (us.phantomRollScale or 1.0) * gs;
+    gAdjustedSettings.phantomRollSettings.dieSize = ds.phantomRollSettings.dieSize * phantomRollScale;
+    gAdjustedSettings.phantomRollSettings.nameSize = ds.phantomRollSettings.nameSize * phantomRollScale;
+    gAdjustedSettings.phantomRollSettings.potencySize = ds.phantomRollSettings.potencySize * phantomRollScale;
+    gAdjustedSettings.phantomRollSettings.oddsSize = ds.phantomRollSettings.oddsSize * phantomRollScale;
+    gAdjustedSettings.phantomRollSettings.barHeight = ds.phantomRollSettings.barHeight * phantomRollScale;
+    gAdjustedSettings.phantomRollSettings.horizonMode = us.phantomRollHorizonMode == true;
+
     -- Inventory Tracker
     gAdjustedSettings.inventoryTrackerSettings.dotRadius = ds.inventoryTrackerSettings.dotRadius * us.inventoryTrackerScale * gs;
     gAdjustedSettings.inventoryTrackerSettings.dotSpacing = ds.inventoryTrackerSettings.dotSpacing * us.inventoryTrackerScale * gs;

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -38,7 +38,7 @@ function M.createUserSettingsDefaults()
         -- Corsair Phantom Roll tracker
         showPhantomRoll = false,
         phantomRollScale = 1.0,
-        phantomRollHorizonMode = false,
+        phantomRollHorizonMode = HzLimitedMode == true,
         phantomRollHideOnMenuFocus = false,
         phantomRollHideMacroPalette = false,
 

--- a/XIUI/core/settings/user.lua
+++ b/XIUI/core/settings/user.lua
@@ -35,6 +35,13 @@ function M.createUserSettingsDefaults()
         magicBurstScale = 1.0,
         magicBurstShowTimer = true,
 
+        -- Corsair Phantom Roll tracker
+        showPhantomRoll = false,
+        phantomRollScale = 1.0,
+        phantomRollHorizonMode = false,
+        phantomRollHideOnMenuFocus = false,
+        phantomRollHideMacroPalette = false,
+
         -- Ready Check module settings (per profile)
         readyCheckSoundFile = 'ffxiv-notification.wav',
         readyCheckSoundOnChecker = true,

--- a/XIUI/core/ui_recovery.lua
+++ b/XIUI/core/ui_recovery.lua
@@ -68,6 +68,7 @@ local MODULE_REGISTRY = {
     { key = 'castBar', aliases = { 'castbar' }, keys = { 'CastBar' } },
     { key = 'castCost', aliases = { 'castcost' }, keys = { 'CastCost' } },
     { key = 'petBar', aliases = { 'petbar' }, keys = { 'PetBar', 'PetBarTarget' } },
+    { key = 'phantomRoll', aliases = { 'phantomroll' }, keys = { 'PhantomRoll' } },
     { key = 'notifications', aliases = { 'notifications' }, patterns = { '^Notifications_' } },
     { key = 'treasurePool', aliases = { 'treasurepool' }, keys = { 'TreasurePool' } },
     {

--- a/XIUI/libs/defaultpositions.lua
+++ b/XIUI/libs/defaultpositions.lua
@@ -65,6 +65,14 @@ function M.GetMagicBurstPosition()
     return x, y;
 end
 
+-- Phantom Roll: above the pet bar, left of the player bar
+function M.GetPhantomRollPosition()
+    local px, py = M.GetPlayerBarPosition();
+    local x = px - 250;
+    local y = py - 230;
+    return x, y;
+end
+
 function M.GetCastCostPosition()
     local sw, sh = M.GetScreenSize();
     local x = 50;

--- a/XIUI/libs/itemrecast.lua
+++ b/XIUI/libs/itemrecast.lua
@@ -8,13 +8,10 @@
 * - Offset 9: Equip timestamp (for items with Flags == 5)
 ]]--
 
-local ffi = require('ffi');
 local struct = require('struct');
+local vanatime = require('libs.vanatime');
 
 local M = {};
-
--- Memory pointer for UTC time (initialized on first use)
-local TimePointer = nil;
 
 -- VanaOffset constant for timestamp conversion
 local VANA_OFFSET = 0x3C307D70;
@@ -25,33 +22,8 @@ local EQUIPMENT_CONTAINERS = { 0, 8, 10, 11, 12, 13, 14, 15, 16 };  -- Inventory
 -- Container IDs to scan for consumable items
 local ITEM_CONTAINERS = { 0, 3 };  -- Inventory, Temp items
 
--- Initialize the UTC time pointer by scanning memory
-local function InitTimePointer()
-    if TimePointer ~= nil then return true; end
-
-    -- Memory pattern from tCrossBar
-    local pointer = ashita.memory.find('FFXiMain.dll', 0,
-        '8B0D????????8B410C8B49108D04808D04808D04808D04C1C3', 0x02, 0);
-
-    if pointer == 0 then
-        return false;
-    end
-
-    -- Dereference twice to get actual time pointer
-    local ptr = ashita.memory.read_uint32(pointer);
-    if ptr == 0 then return false; end
-
-    ptr = ashita.memory.read_uint32(ptr);
-    if ptr == 0 then return false; end
-
-    TimePointer = ptr;
-    return true;
-end
-
--- Get current UTC time from memory
 local function GetCurrentTime()
-    if not InitTimePointer() then return 0; end
-    return ashita.memory.read_uint32(TimePointer + 0x0C);
+    return vanatime.Utc() or 0;
 end
 
 -- Parse 4-byte unsigned int from item.Extra at given offset (1-indexed)
@@ -192,9 +164,9 @@ function M.FormatRecast(seconds)
     end
 end
 
--- Check if memory pointer is initialized (for debugging)
+-- Check if the shared game-clock pointer resolved (for debugging)
 function M.IsInitialized()
-    return TimePointer ~= nil;
+    return vanatime.Utc() ~= nil;
 end
 
 return M;

--- a/XIUI/libs/vanatime.lua
+++ b/XIUI/libs/vanatime.lua
@@ -54,7 +54,8 @@ M.StatusSeconds = function(raw, stamp)
         remaining = remaining + 0x100000000;
     end
 
-    return (remaining < 1) and 0 or math.ceil(remaining / 60);
+    if remaining < 0 then return 0; end
+    return remaining / 60;
 end
 
 return M;

--- a/XIUI/libs/vanatime.lua
+++ b/XIUI/libs/vanatime.lua
@@ -51,7 +51,7 @@ M.StatusSeconds = function(raw, stamp)
 
     local remaining = raw - ((stamp - VANA_BASE) * 60);
     while remaining < -2147483648 do
-        remaining = remaining + 0xFFFFFFFF;
+        remaining = remaining + 0x100000000;
     end
 
     return (remaining < 1) and 0 or math.ceil(remaining / 60);

--- a/XIUI/libs/vanatime.lua
+++ b/XIUI/libs/vanatime.lua
@@ -1,0 +1,60 @@
+--[[
+* Game UTC clock for decoding Vana'diel status / item timestamps.
+]]--
+
+local M = {};
+
+local TIME_PATTERN = '8B0D????????8B410C8B49108D04808D04808D04808D04C1C3';
+local VANA_BASE = 0x3C307D70;
+local INFINITE = 0x7FFFFFFF;
+
+local timeStruct = nil;  -- struct whose +0x0C field is the live UTC stamp
+
+local function Ensure()
+    if timeStruct ~= nil then return timeStruct ~= 0; end
+
+    local pointer = ashita.memory.find('FFXiMain.dll', 0, TIME_PATTERN, 2, 0);
+    if pointer == nil or pointer == 0 then
+        timeStruct = 0;
+        return false;
+    end
+
+    local ptr = ashita.memory.read_uint32(pointer);
+    if ptr == nil or ptr == 0 then
+        timeStruct = 0;
+        return false;
+    end
+
+    ptr = ashita.memory.read_uint32(ptr);
+    if ptr == nil or ptr == 0 then
+        timeStruct = 0;
+        return false;
+    end
+
+    timeStruct = ptr;
+    return true;
+end
+
+M.Utc = function()
+    if not Ensure() then return nil; end
+    return ashita.memory.read_uint32(timeStruct + 0x0C);
+end
+
+-- GetStatusTimers raw value -> earth seconds, or -1 if it never expires.
+-- Pass stamp from Utc() when converting several timers in one pass.
+M.StatusSeconds = function(raw, stamp)
+    if raw == nil then return nil; end
+    if raw == INFINITE then return -1; end
+
+    stamp = stamp or M.Utc();
+    if stamp == nil then return nil; end
+
+    local remaining = raw - ((stamp - VANA_BASE) * 60);
+    while remaining < -2147483648 do
+        remaining = remaining + 0xFFFFFFFF;
+    end
+
+    return (remaining < 1) and 0 or math.ceil(remaining / 60);
+end
+
+return M;

--- a/XIUI/modules/init.lua
+++ b/XIUI/modules/init.lua
@@ -22,5 +22,6 @@ modules.hotbar = require('modules.hotbar.init');
 modules.readycheck = require('modules.readycheck.init');
 modules.satchel = require('modules.satchel.init');
 modules.magicburst = require('modules.magicburst');
+modules.phantomroll = require('modules.phantomroll.init');
 
 return modules;

--- a/XIUI/modules/phantomroll/data.lua
+++ b/XIUI/modules/phantomroll/data.lua
@@ -1,0 +1,257 @@
+--[[
+* Phantom Roll potency tables (mirrors LSB corsair.lua).
+]]--
+
+local M = {};
+
+local PCT, FLAT = 'pct', 'flat';
+
+M.MAX_TOTAL = 11;
+M.BUST_TOTAL = 12;
+M.BASE_DURATION = 300;
+M.JOB_ABILITY_CATEGORY = 6;
+M.BUST_STATUS = 309;       -- occupies a roll seat after a bust
+M.DOUBLE_UP_STATUS = 308;  -- window to Double-Up the last roll
+
+-- powers[1..11] + bust; step = Phantom Roll+1; bonus = party job boost; scale for Gallant's.
+local ROLLS = {
+    { name = "Fighter's",     ability =  98, status = 310, lucky = 5, unlucky =  9, job =  1, stat = 'Double Atk.', unit = PCT,  step =   1, bonus =   6,
+      powers = {   2,   2,    3,   4,   12,    5,   6,    7,    1,    9,   18,   6 } },
+    { name = "Monk's",        ability =  99, status = 311, lucky = 3, unlucky =  7, job =  2, stat = 'Subtle Blow', unit = PCT,  step =   4, bonus =  10,
+      powers = {   8,  10,   32,  12,   14,   16,   4,   20,   22,   24,   40,  11 } },
+    { name = "Healer's",      ability = 100, status = 312, lucky = 3, unlucky =  7, job =  3, stat = 'Cure Pot.',   unit = PCT,  step =   3, bonus =   4,
+      powers = {   3,   4,   12,   5,    6,    7,   1,    8,    9,   10,   16,   4 } },
+    { name = "Wizard's",      ability = 101, status = 313, lucky = 5, unlucky =  9, job =  4, stat = 'MAB',         unit = FLAT, step =   2, bonus =  10,
+      powers = {   4,   6,    8,  10,   25,   12,  14,   17,    2,   20,   30,  10 } },
+    { name = "Warlock's",     ability = 102, status = 314, lucky = 4, unlucky =  8, job =  5, stat = 'MACC',        unit = FLAT, step =   1, bonus =   5,
+      powers = {   2,   3,    4,  12,    5,    6,   7,    1,    8,    9,   15,   5 } },
+    { name = "Rogue's",       ability = 103, status = 315, lucky = 5, unlucky =  9, job =  6, stat = 'Crit Rate',   unit = PCT,  step =   1, bonus =   6,
+      powers = {   2,   2,    3,   4,   12,    5,   6,    6,    1,    8,   19,   6 } },
+    { name = "Gallant's",     ability = 104, status = 316, lucky = 3, unlucky =  7, job =  7, stat = 'Dmg Taken',   unit = PCT,  step = 234, bonus = 500, scale = 100,
+      powers = { 600, 800, 2400, 900, 1100, 1200, 300, 1500, 1700, 1800, 3000, 500 } },
+    { name = 'Chaos',         ability = 105, status = 317, lucky = 4, unlucky =  8, job =  8, stat = 'ATK',         unit = PCT,  step =   3, bonus =  10,
+      powers = {   6,   8,    9,  25,   11,   13,  16,    3,   17,   19,   31,  10 } },
+    { name = 'Beast',         ability = 106, status = 318, lucky = 4, unlucky =  8, job =  9, stat = 'Pet ATK',     unit = PCT,  step =   3, bonus =  10,
+      powers = {   4,   5,    7,  19,    8,    9,  11,    2,   13,   14,   23,   7 } },
+    { name = 'Choral',        ability = 107, status = 319, lucky = 2, unlucky =  6, job = 10, stat = 'Spell Intr.', unit = PCT,  step =   4, bonus =  25,
+      powers = {  13,  55,   17,  20,   25,    8,  30,   35,   40,   45,   65,  25 } },
+    { name = "Hunter's",      ability = 108, status = 320, lucky = 4, unlucky =  8, job = 11, stat = 'ACC',         unit = FLAT, step =   5, bonus =  15,
+      powers = {  10,  13,   15,  40,   18,   20,  25,    5,   27,   30,   50,   5 } },
+    { name = 'Samurai',       ability = 109, status = 321, lucky = 2, unlucky =  6, job = 12, stat = 'Store TP',    unit = FLAT, step =   4, bonus =  10,
+      powers = {   8,  32,   10,  12,   14,    4,  16,   20,   22,   24,   40,   5 } },
+    { name = 'Ninja',         ability = 110, status = 322, lucky = 4, unlucky =  8, job = 13, stat = 'EVA',         unit = FLAT, step =   2, bonus =   6,
+      powers = {   4,   5,    5,  14,    6,    7,   9,    2,   10,   11,   18,   6 } },
+    { name = 'Drachen',       ability = 111, status = 323, lucky = 4, unlucky =  8, job = 14, stat = 'Pet ACC',     unit = FLAT, step =   5, bonus =  15,
+      powers = {  10,  13,   15,  40,   18,   20,  25,    5,   28,   30,   50,  15 } },
+    { name = "Evoker's",      ability = 112, status = 324, lucky = 5, unlucky =  9, job = 15, stat = 'Refresh',     unit = FLAT, step =   1, bonus =   1,
+      powers = {   1,   1,    1,   1,    3,    2,   2,    2,    1,    3,    4,   1 } },
+    { name = "Magus's",       ability = 113, status = 325, lucky = 2, unlucky =  6, job = 16, stat = 'MDB',         unit = FLAT, step =   2, bonus =   8,
+      powers = {   5,  20,    6,   8,    9,    3,  10,   13,   14,   15,   25,   5 } },
+    { name = "Corsair's",     ability = 114, status = 326, lucky = 5, unlucky =  9, job = 17, stat = 'EXP',         unit = PCT,  step =   2, bonus =   0,
+      powers = {  10,  11,   11,  12,   20,   13,  15,   16,    8,   17,   24,   6 } },
+    { name = 'Puppet',        ability = 115, status = 327, lucky = 3, unlucky =  7, job = 18, stat = 'Pet MAB',     unit = FLAT, step =   3, bonus =   8,
+      powers = {   4,   5,   18,   7,    9,   10,   2,   11,   13,   15,   22,   8 } },
+    { name = "Dancer's",      ability = 116, status = 328, lucky = 3, unlucky =  7, job = 19, stat = 'Regen',       unit = FLAT, step =   2, bonus =   4,
+      powers = {   3,   4,   12,   5,    6,    7,   1,    8,    9,   10,   16,   4 } },
+    { name = "Scholar's",     ability = 117, status = 329, lucky = 2, unlucky =  6, job = 20, stat = 'Conserve MP', unit = FLAT, step =   1, bonus =   4,
+      powers = {   2,   9,    3,   4,    5,    2,   6,    6,    7,    9,   14,   4 } },
+    { name = "Bolter's",      ability = 118, status = 330, lucky = 3, unlucky =  9, job =  0, stat = 'Move Speed',  unit = PCT,  step =   4, bonus =   0,
+      powers = {   6,   6,   16,   8,    8,   10,  10,   12,    4,   14,   20,   0 } },
+    { name = "Caster's",      ability = 119, status = 331, lucky = 2, unlucky =  7, job =  0, stat = 'Fast Cast',   unit = PCT,  step =   3, bonus =  10,
+      powers = {   6,  15,    7,   8,    9,   10,   5,   11,   12,   13,   20, -10 } },
+    { name = "Courser's",     ability = 120, status = 332, lucky = 3, unlucky =  9, job =  0, stat = 'Snapshot',    unit = PCT,  step =   1, bonus =   3,
+      powers = {   2,   3,   11,   4,    5,    6,   7,    8,    1,   10,   12,  -5 } },
+    { name = "Blitzer's",     ability = 121, status = 333, lucky = 4, unlucky =  9, job =  0, stat = 'Atk Delay',   unit = PCT,  step =  -1, bonus =  -3,
+      powers = {  -2,  -3,   -4, -11,   -5,   -6,  -7,   -8,   -1,  -10,  -12,   3 } },
+    { name = "Tactician's",   ability = 122, status = 334, lucky = 5, unlucky =  8, job =  0, stat = 'Regain',      unit = FLAT, step =   2, bonus =  10,
+      powers = {  10,  10,   10,  10,   30,   10,  10,    0,   20,   20,   40, -10 } },
+    { name = "Allies'",       ability = 302, status = 335, lucky = 3, unlucky = 10, job =  0, stat = 'SC Dmg',      unit = PCT,  step =   1, bonus =   5,
+      powers = {   2,   3,   20,   5,    7,    9,  11,   13,   15,    1,   25,  -5 } },
+    { name = "Miser's",       ability = 303, status = 336, lucky = 5, unlucky =  7, job =  0, stat = 'Save TP',     unit = FLAT, step =  15, bonus =   0,
+      powers = {  30,  50,   70,  90,  200,  110,  20,  130,  150,  170,  250,   0 } },
+    { name = "Companion's",   ability = 304, status = 337, lucky = 2, unlucky = 10, job =  0, stat = 'Pet Regen',   unit = FLAT, step =  10, bonus =   0, unknown = true,
+      powers = {   1,   2,    3,   4,    5,    6,   7,    8,    9,   10,   11,   0 } },
+    { name = "Avenger's",     ability = 305, status = 338, lucky = 4, unlucky =  8, job =  0, stat = 'Counter',     unit = PCT,  step =   1, bonus =   0,
+      powers = {   2,   2,    3,  12,    4,    5,   6,    1,    7,    9,   18,   6 } },
+    { name = "Naturalist's",  ability = 390, status = 339, lucky = 3, unlucky =  7, job = 21, stat = 'Enh. Dur.',   unit = PCT,  step =   1, bonus =   5,
+      powers = {   6,   7,   15,   8,    9,   10,   5,   11,   12,   13,   20,  -5 } },
+    { name = "Runeist's",     ability = 391, status = 600, lucky = 4, unlucky =  8, job = 22, stat = 'MEVA',        unit = FLAT, step =   2, bonus =   7,
+      powers = {   4,   6,    8,  25,   10,   12,  14,    2,   17,   20,   30, -10 } },
+};
+
+--[[
+* Horizon overrides. Chaos: flat ATK via round(power * level * 3 / 70); powers
+* already include +1 Phantom Roll step; bust is flat -15. Gear ids differ on retail.
+]]--
+local HORIZON = {
+    rolls = {
+        ['Chaos'] = { unit = FLAT, perLevel = true,
+          powers = { 9, 11, 12, 28, 14, 16, 19, 6, 20, 22, 34, -15 } },
+    },
+    gear = {
+        [15601] = 1,  -- Corsair's Culottes
+        [16348] = 1,  -- Cor. Culottes +1
+        [26114] = 1,  -- Luzaf's Fang (right ear)
+        [26115] = 1,  -- Luzaf's Fang +1 (right ear)
+    },
+};
+
+-- Highest equipped Phantom Roll+ rank wins (not summed).
+local ROLL_BONUS_GEAR = {
+    [26038] = 7,
+    [28548] = 5,
+    [28547] = 3,
+};
+
+local BONUS_GEAR_SLOTS = { 7, 9, 12, 13, 14 };  -- legs, neck, r.ear, rings
+
+local function BuildIndex(useHorizon)
+    local byAbility, byStatus = {}, {};
+
+    for _, base in ipairs(ROLLS) do
+        local def = base;
+        local override = useHorizon and HORIZON.rolls[base.name];
+
+        if override then
+            def = {};
+            for key, value in pairs(base) do def[key] = value; end
+            for key, value in pairs(override) do def[key] = value; end
+        end
+
+        byAbility[base.ability] = def;
+        byStatus[base.status] = def;
+    end
+
+    return { byAbility = byAbility, byStatus = byStatus };
+end
+
+local INDEX = { [false] = BuildIndex(false), [true] = BuildIndex(true) };
+
+local function Index(horizonMode)
+    return INDEX[horizonMode == true];
+end
+
+M.ByAbility = function(abilityId, horizonMode)
+    return Index(horizonMode).byAbility[abilityId];
+end
+
+M.ByStatus = function(statusId, horizonMode)
+    return Index(horizonMode).byStatus[statusId];
+end
+
+M.IsRollStatus = function(statusId)
+    return INDEX[false].byStatus[statusId] ~= nil;
+end
+
+M.IsTrackedStatus = function(statusId)
+    return M.IsRollStatus(statusId)
+        or statusId == M.BUST_STATUS
+        or statusId == M.DOUBLE_UP_STATUS;
+end
+
+local function EquippedRollBonus(horizonMode)
+    local inventory = AshitaCore:GetMemoryManager():GetInventory();
+    if inventory == nil then return 0; end
+
+    local best = 0;
+    for _, slot in ipairs(BONUS_GEAR_SLOTS) do
+        local equipped = inventory:GetEquippedItem(slot);
+        local index = equipped and bit.band(equipped.Index, 0x00FF) or 0;
+
+        if index ~= 0 then
+            local container = bit.rshift(bit.band(equipped.Index, 0xFF00), 8);
+            local item = inventory:GetContainerItem(container, index);
+            local bonus = item and item.Id ~= 0 and ROLL_BONUS_GEAR[item.Id];
+            if bonus == nil and horizonMode and item and item.Id ~= 0 then
+                bonus = HORIZON.gear[item.Id];
+            end
+            if bonus and bonus > best then best = bonus; end
+        end
+    end
+
+    return best;
+end
+
+local function PartyJobs()
+    local party = AshitaCore:GetMemoryManager():GetParty();
+    if party == nil then return {}; end
+
+    local present = {};
+    for i = 0, 5 do
+        if party:GetMemberIsActive(i) == 1 then
+            present[party:GetMemberMainJob(i)] = true;
+        end
+    end
+    return present;
+end
+
+local function PlayerLevel()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    return player and player:GetMainJobLevel() or 0;
+end
+
+M.Context = function(horizonMode)
+    return {
+        gear = EquippedRollBonus(horizonMode == true),
+        partyJobs = PartyJobs(),
+        level = PlayerLevel(),
+    };
+end
+
+M.Potency = function(def, total, context)
+    if def == nil or def.unknown or total == nil then return nil; end
+    context = context or {};
+
+    local power = def.powers[total];
+    if power == nil then return nil; end
+
+    if total <= M.MAX_TOTAL then
+        local partyJobs = context.partyJobs or {};
+        if partyJobs[def.job] then power = power + def.bonus; end
+        power = power + def.step * (context.gear or 0);
+
+        if def.perLevel then
+            local level = context.level or 0;
+            if level <= 0 then return nil; end
+            power = math.floor(power * level * 3 / 70 + 0.5);
+        end
+    end
+
+    return power / (def.scale or 1);
+end
+
+local function FormatValue(value)
+    if math.abs(value % 1) < 0.05 then
+        return string.format('%d', math.floor(math.abs(value) + 0.5));
+    end
+    return string.format('%.1f', math.abs(value));
+end
+
+M.PotencyText = function(def, total, context)
+    local value = M.Potency(def, total, context);
+    if value == nil or def == nil then return ''; end
+
+    local sign = (value < 0) and '-' or '+';
+    local unit = (def.unit == PCT) and '%' or '';
+    return string.format('%s%s%s %s', sign, FormatValue(value), unit, def.stat);
+end
+
+M.BustChance = function(total)
+    if total == nil or total < 1 or total > M.MAX_TOTAL then return 0; end
+
+    local busts = 0;
+    for face = 1, 6 do
+        if total + face > M.MAX_TOTAL then busts = busts + 1; end
+    end
+    return busts / 6;
+end
+
+M.IsLucky = function(def, total)
+    return def ~= nil and total ~= nil and (total == M.MAX_TOTAL or total == def.lucky);
+end
+
+M.IsUnlucky = function(def, total)
+    return def ~= nil and total ~= nil and total == def.unlucky;
+end
+
+return M;

--- a/XIUI/modules/phantomroll/data.lua
+++ b/XIUI/modules/phantomroll/data.lua
@@ -80,13 +80,17 @@ local ROLLS = {
 };
 
 --[[
-* Horizon overrides. Chaos: flat ATK via round(power * level * 3 / 70); powers
-* already include +1 Phantom Roll step; bust is flat -15. Gear ids differ on retail.
+* Horizon: no party-job bonus. Chaos ATK is floor(lv75 * level / 75);
+* bust is flat -15. Gallant's is flat DEF; Healer's is hMP.
 ]]--
 local HORIZON = {
     rolls = {
         ['Chaos'] = { unit = FLAT, perLevel = true,
-          powers = { 9, 11, 12, 28, 14, 16, 19, 6, 20, 22, 34, -15 } },
+          powers = { 29, 36, 39, 92, 45, 54, 61, 21, 64, 71, 111, -15 } },
+        ["Gallant's"] = { unit = FLAT, stat = 'DEF', scale = 1, step = 4,
+          powers = { 48, 60, 200, 72, 88, 104, 32, 120, 140, 160, 240, -120 } },
+        ["Healer's"] = { unit = FLAT, stat = 'hMP',
+          powers = { 2, 3, 10, 4, 4, 5, 1, 6, 6, 7, 12, -3 } },
     },
     gear = {
         [15601] = 1,  -- Corsair's Culottes
@@ -112,10 +116,13 @@ local function BuildIndex(useHorizon)
         local def = base;
         local override = useHorizon and HORIZON.rolls[base.name];
 
-        if override then
+        if useHorizon or override then
             def = {};
             for key, value in pairs(base) do def[key] = value; end
-            for key, value in pairs(override) do def[key] = value; end
+            if override then
+                for key, value in pairs(override) do def[key] = value; end
+            end
+            if useHorizon then def.bonus = 0; end
         end
 
         byAbility[base.ability] = def;
@@ -191,9 +198,10 @@ local function PlayerLevel()
 end
 
 M.Context = function(horizonMode)
+    local horizon = horizonMode == true;
     return {
-        gear = EquippedRollBonus(horizonMode == true),
-        partyJobs = PartyJobs(),
+        gear = EquippedRollBonus(horizon),
+        partyJobs = (not horizon) and PartyJobs() or nil,
         level = PlayerLevel(),
     };
 end
@@ -213,7 +221,7 @@ M.Potency = function(def, total, context)
         if def.perLevel then
             local level = context.level or 0;
             if level <= 0 then return nil; end
-            power = math.floor(power * level * 3 / 70 + 0.5);
+            power = math.floor(power * level / 75);
         end
     end
 

--- a/XIUI/modules/phantomroll/data.lua
+++ b/XIUI/modules/phantomroll/data.lua
@@ -211,7 +211,7 @@ M.Potency = function(roll, total, context)
 
         if roll.perLevel then
             local level = context.level or 0;
-            if level <= 0 then return nil; end
+            if level < 1 then level = 75; end
             power = math.floor(power * level / 75);
         end
     end

--- a/XIUI/modules/phantomroll/data.lua
+++ b/XIUI/modules/phantomroll/data.lua
@@ -12,6 +12,7 @@ M.BASE_DURATION = 300;
 M.JOB_ABILITY_CATEGORY = 6;
 M.BUST_STATUS = 309;       -- occupies a roll seat after a bust
 M.DOUBLE_UP_STATUS = 308;  -- window to Double-Up the last roll
+M.DOUBLE_UP_DURATION = 45;
 
 -- powers[1..11] + bust; step = Phantom Roll+1; bonus = party job boost; scale for Gallant's.
 local ROLLS = {
@@ -110,7 +111,7 @@ local ROLL_BONUS_GEAR = {
 local BONUS_GEAR_SLOTS = { 7, 9, 12, 13, 14 };  -- legs, neck, r.ear, rings
 
 local function BuildIndex(useHorizon)
-    local byAbility, byStatus = {}, {};
+    local byAbility = {};
 
     for _, base in ipairs(ROLLS) do
         local def = base;
@@ -123,34 +124,27 @@ local function BuildIndex(useHorizon)
         end
 
         byAbility[base.ability] = def;
-        byStatus[base.status] = def;
     end
 
-    return { byAbility = byAbility, byStatus = byStatus };
+    return byAbility;
 end
 
 local INDEX = { [false] = BuildIndex(false), [true] = BuildIndex(true) };
 
-local function Index(horizonMode)
-    return INDEX[horizonMode == true];
+local TRACKED_STATUS = {
+    [M.BUST_STATUS] = true,
+    [M.DOUBLE_UP_STATUS] = true,
+};
+for i = 1, #ROLLS do
+    TRACKED_STATUS[ROLLS[i].status] = true;
 end
 
 M.ByAbility = function(abilityId, horizonMode)
-    return Index(horizonMode).byAbility[abilityId];
-end
-
-M.ByStatus = function(statusId, horizonMode)
-    return Index(horizonMode).byStatus[statusId];
-end
-
-M.IsRollStatus = function(statusId)
-    return INDEX[false].byStatus[statusId] ~= nil;
+    return INDEX[horizonMode == true][abilityId];
 end
 
 M.IsTrackedStatus = function(statusId)
-    return M.IsRollStatus(statusId)
-        or statusId == M.BUST_STATUS
-        or statusId == M.DOUBLE_UP_STATUS;
+    return TRACKED_STATUS[statusId] == true;
 end
 
 local function EquippedRollBonus(horizonMode)
@@ -243,12 +237,7 @@ end
 
 M.BustChance = function(total)
     if total == nil or total < 1 or total > M.MAX_TOTAL then return 0; end
-
-    local busts = 0;
-    for face = 1, 6 do
-        if total + face > M.MAX_TOTAL then busts = busts + 1; end
-    end
-    return busts / 6;
+    return math.max(0, total - 5) / 6;
 end
 
 M.IsLucky = function(def, total)

--- a/XIUI/modules/phantomroll/data.lua
+++ b/XIUI/modules/phantomroll/data.lua
@@ -114,16 +114,16 @@ local function BuildIndex(useHorizon)
     local byAbility = {};
 
     for _, base in ipairs(ROLLS) do
-        local def = base;
+        local roll = base;
         local override = useHorizon and HORIZON.rolls[base.name];
 
         if override then
-            def = {};
-            for key, value in pairs(base) do def[key] = value; end
-            for key, value in pairs(override) do def[key] = value; end
+            roll = {};
+            for key, value in pairs(base) do roll[key] = value; end
+            for key, value in pairs(override) do roll[key] = value; end
         end
 
-        byAbility[base.ability] = def;
+        byAbility[base.ability] = roll;
     end
 
     return byAbility;
@@ -197,26 +197,26 @@ M.Context = function(horizonMode)
     };
 end
 
-M.Potency = function(def, total, context)
-    if def == nil or def.unknown or total == nil then return nil; end
+M.Potency = function(roll, total, context)
+    if roll == nil or roll.unknown or total == nil then return nil; end
     context = context or {};
 
-    local power = def.powers[total];
+    local power = roll.powers[total];
     if power == nil then return nil; end
 
     if total <= M.MAX_TOTAL then
         local partyJobs = context.partyJobs or {};
-        if partyJobs[def.job] then power = power + def.bonus; end
-        power = power + def.step * (context.gear or 0);
+        if partyJobs[roll.job] then power = power + roll.bonus; end
+        power = power + roll.step * (context.gear or 0);
 
-        if def.perLevel then
+        if roll.perLevel then
             local level = context.level or 0;
             if level <= 0 then return nil; end
             power = math.floor(power * level / 75);
         end
     end
 
-    return power / (def.scale or 1);
+    return power / (roll.scale or 1);
 end
 
 local function FormatValue(value)
@@ -226,13 +226,13 @@ local function FormatValue(value)
     return string.format('%.1f', math.abs(value));
 end
 
-M.PotencyText = function(def, total, context)
-    local value = M.Potency(def, total, context);
-    if value == nil or def == nil then return ''; end
+M.PotencyText = function(roll, total, context)
+    local value = M.Potency(roll, total, context);
+    if value == nil or roll == nil then return ''; end
 
     local sign = (value < 0) and '-' or '+';
-    local unit = (def.unit == PCT) and '%' or '';
-    return string.format('%s%s%s %s', sign, FormatValue(value), unit, def.stat);
+    local unit = (roll.unit == PCT) and '%' or '';
+    return string.format('%s%s%s %s', sign, FormatValue(value), unit, roll.stat);
 end
 
 M.BustChance = function(total)
@@ -240,12 +240,12 @@ M.BustChance = function(total)
     return math.max(0, total - 5) / 6;
 end
 
-M.IsLucky = function(def, total)
-    return def ~= nil and total ~= nil and (total == M.MAX_TOTAL or total == def.lucky);
+M.IsLucky = function(roll, total)
+    return roll ~= nil and total ~= nil and (total == M.MAX_TOTAL or total == roll.lucky);
 end
 
-M.IsUnlucky = function(def, total)
-    return def ~= nil and total ~= nil and total == def.unlucky;
+M.IsUnlucky = function(roll, total)
+    return roll ~= nil and total ~= nil and total == roll.unlucky;
 end
 
 return M;

--- a/XIUI/modules/phantomroll/data.lua
+++ b/XIUI/modules/phantomroll/data.lua
@@ -116,13 +116,10 @@ local function BuildIndex(useHorizon)
         local def = base;
         local override = useHorizon and HORIZON.rolls[base.name];
 
-        if useHorizon or override then
+        if override then
             def = {};
             for key, value in pairs(base) do def[key] = value; end
-            if override then
-                for key, value in pairs(override) do def[key] = value; end
-            end
-            if useHorizon then def.bonus = 0; end
+            for key, value in pairs(override) do def[key] = value; end
         end
 
         byAbility[base.ability] = def;

--- a/XIUI/modules/phantomroll/dice.lua
+++ b/XIUI/modules/phantomroll/dice.lua
@@ -51,11 +51,14 @@ M.CenteredText = function(drawList, text, centerX, centerY, size, argbColor)
 end
 
 -- Face already has contrast; global bold/outline turns the numeral into a blob.
-local function DrawNumeral(drawList, text, centerX, centerY, size, argbColor, fontSettings)
+local function DrawNumeral(drawList, text, boxX, boxY, boxSize, fontSize, argbColor, fontSettings)
     imtext.SetConfig(fontSettings.font_family or 'Tahoma', false, 0);
 
-    local width, height = imtext.Measure(text, size);
-    imtext.DrawSimple(drawList, text, centerX - width / 2, centerY - height / 2, argbColor, size);
+    local width, height = imtext.Measure(text, fontSize);
+    imtext.DrawSimple(drawList, text,
+        boxX + math.floor((boxSize - width) / 2 + 0.5),
+        boxY + math.floor(boxSize * 0.45 - height / 2 + 0.5),
+        argbColor, fontSize);
 
     imtext.SetConfigFromSettings(fontSettings);
 end
@@ -134,6 +137,10 @@ local function DrawShadow(drawList, x, y, size, rounding)
 end
 
 M.Draw = function(drawList, x, y, size, state, clock, fontSettings)
+    -- Snap once; face, numeral, and effects all sit in this pixel box.
+    x = math.floor(x + 0.5);
+    y = math.floor(y + 0.5);
+    size = math.floor(size + 0.5);
     local rounding = size * 0.18;
     local pulse = (math.sin(clock * 3.2) + 1) / 2;
     local styleKey = state.style or 'normal';
@@ -156,7 +163,7 @@ M.Draw = function(drawList, x, y, size, state, clock, fontSettings)
         M.Color(PALETTE[style.edge], edgeAlpha), rounding, 0, size * 0.035);
 
     local text, textScale = FaceText(state);
-    DrawNumeral(drawList, text, x + size / 2, y + size * 0.45, size * textScale,
+    DrawNumeral(drawList, text, x, y, size, size * textScale,
         NUMERAL[style.numeral], fontSettings or {});
 
     local effect = EFFECTS[styleKey];

--- a/XIUI/modules/phantomroll/dice.lua
+++ b/XIUI/modules/phantomroll/dice.lua
@@ -1,0 +1,168 @@
+--[[
+* Procedural die: total numeral, flames on lucky/11, icicles on unlucky.
+]]--
+
+local imgui = require('imgui');
+local imtext = require('libs.imtext');
+
+local M = {};
+
+local PALETTE = {
+    shadow      = { 0.02, 0.03, 0.04, 0.22 },
+    face        = { 0.949, 0.945, 0.925, 1.00 },
+    faceLow     = { 0.808, 0.796, 0.769, 1.00 },
+    faceHot     = { 1.000, 0.945, 0.855, 1.00 },
+    faceHotLow  = { 0.898, 0.812, 0.671, 1.00 },
+    faceCold    = { 0.878, 0.937, 0.988, 1.00 },
+    faceColdLow = { 0.706, 0.804, 0.882, 1.00 },
+    faceBust    = { 0.361, 0.114, 0.129, 0.95 },
+    faceBustLow = { 0.239, 0.070, 0.082, 0.95 },
+    edge        = { 0.290, 0.310, 0.330, 0.80 },
+    edgeHot     = { 1.000, 0.620, 0.180, 0.95 },
+    edgeCold    = { 0.451, 0.765, 0.976, 0.95 },
+    glowHot     = { 1.000, 0.500, 0.120, 0.13 },
+    glowCold    = { 0.300, 0.650, 1.000, 0.13 },
+    flameOut    = { 0.980, 0.400, 0.075, 0.70 },
+    flameIn     = { 1.000, 0.855, 0.330, 0.90 },
+    iceOut      = { 0.451, 0.749, 0.949, 0.80 },
+    iceIn       = { 0.898, 0.973, 1.000, 0.92 },
+};
+
+local NUMERAL = {
+    normal = 0xFF143441,
+    bust   = 0xFFFFC7C2,
+};
+
+local STYLES = {
+    bust   = { face = 'faceBust',  shade = 'faceBustLow', numeral = 'bust',   edge = 'edge' },
+    hot    = { face = 'faceHot',   shade = 'faceHotLow',  numeral = 'normal', edge = 'edgeHot',  glow = 'glowHot' },
+    cold   = { face = 'faceCold',  shade = 'faceColdLow', numeral = 'normal', edge = 'edgeCold', glow = 'glowCold' },
+    normal = { face = 'face',      shade = 'faceLow',     numeral = 'normal', edge = 'edge' },
+};
+
+M.Color = function(entry, alphaScale)
+    return imgui.GetColorU32({ entry[1], entry[2], entry[3], entry[4] * (alphaScale or 1) });
+end
+
+M.CenteredText = function(drawList, text, centerX, centerY, size, argbColor)
+    if text == nil or text == '' then return; end
+    local width, height = imtext.Measure(text, size);
+    imtext.Draw(drawList, text, centerX - width / 2, centerY - height / 2, argbColor, size);
+end
+
+-- Face already has contrast; global bold/outline turns the numeral into a blob.
+local function DrawNumeral(drawList, text, centerX, centerY, size, argbColor, fontSettings)
+    imtext.SetConfig(fontSettings.font_family or 'Tahoma', false, 0);
+
+    local width, height = imtext.Measure(text, size);
+    imtext.DrawSimple(drawList, text, centerX - width / 2, centerY - height / 2, argbColor, size);
+
+    imtext.SetConfigFromSettings(fontSettings);
+end
+
+local function FaceText(state)
+    if state.total == nil then return '?', 0.50; end
+
+    local text = tostring(state.total);
+    return text, (#text > 1) and 0.47 or 0.58;
+end
+
+local function DrawGlow(drawList, x, y, size, colorKey, pulse)
+    local centerX, centerY = x + size / 2, y + size / 2;
+    for ring = 1, 4 do
+        local radius = size * (0.62 + ring * 0.11) * (0.97 + pulse * 0.06);
+        drawList:AddCircleFilled({ centerX, centerY }, radius, M.Color(PALETTE[colorKey], 1 - ring * 0.18), 24);
+    end
+end
+
+local function DrawFlames(drawList, x, y, size, clock)
+    local baseY = y + size * 0.10;
+    for i = 1, 5 do
+        local phase = clock * 5.5 + i * 1.9;
+        local flicker = math.sin(phase);
+        local flameX = x + size * (0.16 + 0.17 * (i - 1));
+        local width = size * (0.11 + 0.02 * math.cos(phase * 1.3));
+        local height = size * (0.28 + 0.10 * flicker);  -- keep tips under the roll name
+        local tipX = flameX + flicker * width * 0.5;
+
+        drawList:AddTriangleFilled(
+            { flameX - width, baseY }, { flameX + width, baseY }, { tipX, baseY - height },
+            M.Color(PALETTE.flameOut));
+        drawList:AddTriangleFilled(
+            { flameX - width * 0.5, baseY }, { flameX + width * 0.5, baseY }, { tipX, baseY - height * 0.55 },
+            M.Color(PALETTE.flameIn));
+    end
+end
+
+local function DrawIcicles(drawList, x, y, size, clock)
+    local baseY = y + size * 0.93;
+    local lengths = { 0.26, 0.17, 0.30, 0.15, 0.23 };
+
+    for i = 1, 5 do
+        local phase = clock * 1.5 + i * 2.3;
+        local shimmer = math.sin(phase);
+        local iceX = x + size * (0.17 + 0.165 * (i - 1));
+        local width = size * (0.072 + 0.010 * math.cos(phase));
+        local length = size * (lengths[i] + 0.02 * shimmer);
+
+        drawList:AddTriangleFilled(
+            { iceX - width, baseY }, { iceX + width, baseY }, { iceX, baseY + length },
+            M.Color(PALETTE.iceOut));
+        drawList:AddTriangleFilled(
+            { iceX - width * 0.42, baseY }, { iceX + width * 0.42, baseY }, { iceX, baseY + length * 0.62 },
+            M.Color(PALETTE.iceIn, 0.75 + shimmer * 0.2));
+    end
+end
+
+local EFFECTS = { hot = DrawFlames, cold = DrawIcicles };
+
+-- Stacked layers read as a soft drop; one hard offset looks like a smear.
+local SHADOW_LAYERS = {
+    { offset = 0.030, spread = 0.005, alpha = 0.90 },
+    { offset = 0.055, spread = 0.018, alpha = 0.50 },
+    { offset = 0.085, spread = 0.032, alpha = 0.24 },
+};
+
+local function DrawShadow(drawList, x, y, size, rounding)
+    for _, layer in ipairs(SHADOW_LAYERS) do
+        local drop, spread = size * layer.offset, size * layer.spread;
+        drawList:AddRectFilled(
+            { x - spread, y + drop - spread },
+            { x + size + spread, y + size + drop + spread },
+            M.Color(PALETTE.shadow, layer.alpha), rounding + spread);
+    end
+end
+
+M.Draw = function(drawList, x, y, size, state, clock, fontSettings)
+    local rounding = size * 0.18;
+    local pulse = (math.sin(clock * 3.2) + 1) / 2;
+    local styleKey = state.style or 'normal';
+    local style = STYLES[styleKey] or STYLES.normal;
+
+    if style.glow ~= nil then
+        DrawGlow(drawList, x, y, size, style.glow, pulse);
+    end
+
+    DrawShadow(drawList, x, y, size, rounding);
+
+    -- Shade full face, then inset lit face so the edge stays inside the rounding.
+    drawList:AddRectFilled({ x, y }, { x + size, y + size },
+        M.Color(PALETTE[style.shade]), rounding);
+    drawList:AddRectFilled({ x, y }, { x + size, y + size * 0.88 },
+        M.Color(PALETTE[style.face]), rounding);
+
+    local edgeAlpha = (style.glow ~= nil) and (0.6 + pulse * 0.4) or 1;
+    drawList:AddRect({ x, y }, { x + size, y + size },
+        M.Color(PALETTE[style.edge], edgeAlpha), rounding, 0, size * 0.035);
+
+    local text, textScale = FaceText(state);
+    DrawNumeral(drawList, text, x + size / 2, y + size * 0.45, size * textScale,
+        NUMERAL[style.numeral], fontSettings or {});
+
+    local effect = EFFECTS[styleKey];
+    if effect ~= nil then
+        effect(drawList, x, y, size, clock);
+    end
+end
+
+return M;

--- a/XIUI/modules/phantomroll/display.lua
+++ b/XIUI/modules/phantomroll/display.lua
@@ -99,7 +99,7 @@ local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
 
     return {
         name = (roll and roll.name or (entry.busted and 'Bust' or '?')):upper(),
-        potency = data.PotencyText(roll, entry.total, entry.context),
+        potency = data.PotencyText(roll, entry.total, entry.context or data.Context(horizonMode)),
         odds = oddsText,
         oddsTimer = oddsTimer,
         clock = FormatClock(seconds),

--- a/XIUI/modules/phantomroll/display.lua
+++ b/XIUI/modules/phantomroll/display.lua
@@ -39,20 +39,17 @@ local BAR_FILL = {
 local BAR_BACKDROP = { 0.10, 0.11, 0.13, 0.80 };
 local BAR_BORDER = { 0, 0, 0, 1 };
 
--- Cached so we do not re-measure "Bust 100%" every frame.
-local oddsReserve = { oddsSize = nil, width = 0 };
-
 local function FormatClock(seconds)
     if seconds == nil then return ''; end
     if seconds < 0 then return '--:--'; end
 
-    local whole = math.floor(seconds + 0.5);
+    local whole = math.floor(seconds);
     return string.format('%d:%02d', math.floor(whole / 60), whole % 60);
 end
 
 local function FormatSeconds(seconds)
     if seconds == nil or seconds < 0 then return ''; end
-    return tostring(math.floor(seconds + 0.5));
+    return tostring(math.floor(seconds));
 end
 
 local function BarFill(seconds)
@@ -97,13 +94,16 @@ local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
         nameColor, potencyColor = TEXT.labelCold, TEXT.potencyCold;
     end
 
+    local duration = math.max(entry.duration or data.BASE_DURATION, 1);
+    local fraction = (seconds ~= nil) and math.min(1, math.max(0, seconds / duration)) or 0;
+
     return {
         name = (def and def.name or (entry.busted and 'Bust' or '?')):upper(),
         potency = data.PotencyText(def, entry.total, entry.context),
         odds = oddsText,
         oddsTimer = oddsTimer,
         clock = FormatClock(seconds),
-        fraction = tracker.Fraction(entry),
+        fraction = fraction,
         state = { total = entry.total, style = style },
         nameColor = nameColor,
         potencyColor = potencyColor,
@@ -118,9 +118,14 @@ local function DrawBar(drawList, x, y, width, height, column)
         dice.Color(BAR_BACKDROP), rounding);
 
     if column.fraction > 0 then
-        local fillWidth = math.max(rounding, width * column.fraction);
-        drawList:AddRectFilled({ x, y }, { x + fillWidth, y + height },
-            dice.Color(column.fill), rounding);
+        -- Inset fill so AA stays in the track (bar 2's left sits in the gap).
+        local inset = 1;
+        local innerRounding = math.max(0, rounding - inset);
+        local fillRight = x + math.max(inset, width * column.fraction - inset);
+        drawList:PushClipRect({ x + inset, y + inset }, { fillRight, y + height - inset }, true);
+        drawList:AddRectFilled({ x + inset, y + inset }, { x + width - inset, y + height - inset },
+            dice.Color(column.fill), innerRounding);
+        drawList:PopClipRect();
     end
 
     -- Same idea as player/target bars: a thin stroke around the fill.
@@ -133,36 +138,24 @@ end
 
 M.DrawWindow = function(settings)
     local dieSize = settings.dieSize;
-    local gap = dieSize * 0.26;
+    local gap = dieSize * 0.50;
     local rowGap = dieSize * 0.09;
     local nameGap = dieSize * 0.30;      -- clears flame tips above the die
     local iceHeadroom = dieSize * 0.32;  -- room for icicles below
 
     imtext.SetConfigFromSettings(settings.font_settings);
 
-    local slots, slotCount = tracker.Slots();
-    local doubleUpIndex = tracker.DoubleUpIndex();
-    local doubleUpSeconds = tracker.DoubleUpSeconds();
+    local slots = tracker.Slots();
+    local doubleUpIndex, doubleUpSeconds = tracker.DoubleUp();
 
     local columns = {};
     local columnWidth = dieSize * 1.35;
     local oddsGap = settings.oddsSize * 0.45;
-    if oddsReserve.oddsSize ~= settings.oddsSize then
-        local w = imtext.Measure('Bust 100%', settings.oddsSize);
-        local t = imtext.Measure('45', settings.oddsSize);
-        oddsReserve.oddsSize = settings.oddsSize;
-        oddsReserve.width = w + oddsGap + t;
-    end
-    columnWidth = math.max(columnWidth, oddsReserve.width);
 
-    for i = 1, slotCount do
+    for i = 1, 2 do
         if slots[i] ~= nil then
-            local column = BuildColumn(
+            columns[#columns + 1] = BuildColumn(
                 slots[i], settings.horizonMode, i == doubleUpIndex, doubleUpSeconds);
-            columns[#columns + 1] = column;
-            columnWidth = math.max(columnWidth,
-                imtext.Measure(column.name, settings.nameSize),
-                imtext.Measure(column.potency, settings.potencySize));
         end
     end
 

--- a/XIUI/modules/phantomroll/display.lua
+++ b/XIUI/modules/phantomroll/display.lua
@@ -71,16 +71,16 @@ local function OddsText(entry, canDoubleUp)
         (bust >= 0.5) and TEXT.risk or TEXT.warn;
 end
 
-local function DieStyle(entry, def)
+local function DieStyle(entry, roll)
     if entry.busted then return 'bust'; end
-    if data.IsLucky(def, entry.total) then return 'hot'; end
-    if data.IsUnlucky(def, entry.total) then return 'cold'; end
+    if data.IsLucky(roll, entry.total) then return 'hot'; end
+    if data.IsUnlucky(roll, entry.total) then return 'cold'; end
     return 'normal';
 end
 
 local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
-    local def = data.ByAbility(entry.ability, horizonMode);
-    local style = DieStyle(entry, def);
+    local roll = data.ByAbility(entry.ability, horizonMode);
+    local style = DieStyle(entry, roll);
     local seconds = tracker.SecondsLeft(entry);
     local oddsText, oddsColor = OddsText(entry, canDoubleUp);
     local oddsTimer = (canDoubleUp and oddsText ~= '') and FormatSeconds(doubleUpSeconds) or '';
@@ -98,8 +98,8 @@ local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
     local fraction = (seconds ~= nil) and math.min(1, math.max(0, seconds / duration)) or 0;
 
     return {
-        name = (def and def.name or (entry.busted and 'Bust' or '?')):upper(),
-        potency = data.PotencyText(def, entry.total, entry.context),
+        name = (roll and roll.name or (entry.busted and 'Bust' or '?')):upper(),
+        potency = data.PotencyText(roll, entry.total, entry.context),
         odds = oddsText,
         oddsTimer = oddsTimer,
         clock = FormatClock(seconds),

--- a/XIUI/modules/phantomroll/display.lua
+++ b/XIUI/modules/phantomroll/display.lua
@@ -1,0 +1,238 @@
+--[[
+* Phantom Roll window: die, potency, duration bar, and Double-Up odds.
+]]--
+
+require('common');
+require('handlers.helpers');
+local imgui = require('imgui');
+local imtext = require('libs.imtext');
+local data = require('modules.phantomroll.data');
+local dice = require('modules.phantomroll.dice');
+local tracker = require('modules.phantomroll.tracker');
+
+local M = {};
+
+local WINDOW_NAME = 'PhantomRoll';
+
+local TEXT = {
+    label       = 0xFFC7CCD4,
+    labelHot    = 0xFFFFD159,
+    labelCold   = 0xFF9ED9FF,
+    potency     = 0xFFF5F7FA,
+    potencyHot  = 0xFFFFDB66,
+    potencyCold = 0xFFB3E3FF,
+    potencyBust = 0xFFFF736B,
+    muted       = 0xFF8C949E,
+    clock       = 0xFFFAFCFF,
+    risk        = 0xFFFF7A73,
+    warn        = 0xFFF7C75C,
+    safe        = 0xFF8CD99E,
+};
+
+local BAR_FILL = {
+    normal = { 0.36, 0.72, 0.52, 0.95 },
+    warn   = { 0.88, 0.70, 0.24, 0.95 },
+    low    = { 0.88, 0.36, 0.32, 0.95 },
+    bust   = { 0.75, 0.36, 0.32, 0.95 },
+};
+
+local BAR_BACKDROP = { 0.10, 0.11, 0.13, 0.80 };
+
+-- Cached so we do not re-measure "Bust 100%" every frame.
+local oddsReserve = { oddsSize = nil, width = 0 };
+
+local function FormatClock(seconds)
+    if seconds == nil then return ''; end
+    if seconds < 0 then return '--:--'; end
+
+    local whole = math.floor(seconds + 0.5);
+    return string.format('%d:%02d', math.floor(whole / 60), whole % 60);
+end
+
+local function FormatSeconds(seconds)
+    if seconds == nil or seconds < 0 then return ''; end
+    return tostring(math.floor(seconds + 0.5));
+end
+
+local function BarFill(seconds)
+    if seconds == nil or seconds < 0 then return BAR_FILL.normal; end
+    if seconds <= 30 then return BAR_FILL.low; end
+    if seconds <= 60 then return BAR_FILL.warn; end
+    return BAR_FILL.normal;
+end
+
+-- Bust % only while Double-Up is up; unlucky is visible on the die itself.
+local function OddsText(entry, canDoubleUp)
+    if entry.busted then return 'BUSTED', TEXT.risk; end
+    if not canDoubleUp or entry.total == nil then return '', TEXT.muted; end
+
+    local bust = data.BustChance(entry.total);
+    if bust <= 0 then return 'Safe', TEXT.safe; end
+
+    return string.format('Bust %d%%', math.floor(bust * 100 + 0.5)),
+        (bust >= 0.5) and TEXT.risk or TEXT.warn;
+end
+
+local function DieStyle(entry, def)
+    if entry.busted then return 'bust'; end
+    if data.IsLucky(def, entry.total) then return 'hot'; end
+    if data.IsUnlucky(def, entry.total) then return 'cold'; end
+    return 'normal';
+end
+
+local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
+    local def = data.ByAbility(entry.ability, horizonMode);
+    local style = DieStyle(entry, def);
+    local seconds = tracker.SecondsLeft(entry);
+    local oddsText, oddsColor = OddsText(entry, canDoubleUp);
+    local oddsTimer = (canDoubleUp and oddsText ~= '') and FormatSeconds(doubleUpSeconds) or '';
+
+    local nameColor, potencyColor = TEXT.label, TEXT.potency;
+    if style == 'bust' then
+        potencyColor = TEXT.potencyBust;
+    elseif style == 'hot' then
+        nameColor, potencyColor = TEXT.labelHot, TEXT.potencyHot;
+    elseif style == 'cold' then
+        nameColor, potencyColor = TEXT.labelCold, TEXT.potencyCold;
+    end
+
+    return {
+        name = (def and def.name or '?'):upper(),
+        potency = data.PotencyText(def, entry.total, entry.context),
+        odds = oddsText,
+        oddsTimer = oddsTimer,
+        clock = FormatClock(seconds),
+        fraction = tracker.Fraction(entry),
+        state = { total = entry.total, style = style },
+        nameColor = nameColor,
+        potencyColor = potencyColor,
+        oddsColor = oddsColor,
+        fill = (style == 'bust') and BAR_FILL.bust or BarFill(seconds),
+    };
+end
+
+local function DrawBar(drawList, x, y, width, height, column)
+    drawList:AddRectFilled({ x, y }, { x + width, y + height },
+        dice.Color(BAR_BACKDROP), height * 0.45);
+
+    if column.fraction > 0 then
+        local fillWidth = math.max(height * 0.45, width * column.fraction);
+        drawList:AddRectFilled({ x, y }, { x + fillWidth, y + height },
+            dice.Color(column.fill), height * 0.45);
+    end
+
+    dice.CenteredText(drawList, column.clock, x + width / 2, y + height / 2,
+        height * 0.86, TEXT.clock);
+end
+
+M.DrawWindow = function(settings)
+    local dieSize = settings.dieSize;
+    local gap = dieSize * 0.26;
+    local rowGap = dieSize * 0.09;
+    local nameGap = dieSize * 0.30;      -- clears flame tips above the die
+    local iceHeadroom = dieSize * 0.32;  -- room for icicles below
+
+    imtext.SetConfigFromSettings(settings.font_settings);
+
+    local slots, slotCount = tracker.Slots();
+    local doubleUpIndex = tracker.DoubleUpIndex();
+    local doubleUpSeconds = tracker.DoubleUpSeconds();
+
+    local columns = {};
+    local columnWidth = dieSize * 1.35;
+    local oddsGap = settings.oddsSize * 0.45;
+    if oddsReserve.oddsSize ~= settings.oddsSize then
+        local w = imtext.Measure('Bust 100%', settings.oddsSize);
+        local t = imtext.Measure('45', settings.oddsSize);
+        oddsReserve.oddsSize = settings.oddsSize;
+        oddsReserve.width = w + oddsGap + t;
+    end
+    columnWidth = math.max(columnWidth, oddsReserve.width);
+
+    for i = 1, slotCount do
+        if slots[i] ~= nil then
+            local column = BuildColumn(
+                slots[i], settings.horizonMode, i == doubleUpIndex, doubleUpSeconds);
+            columns[#columns + 1] = column;
+            columnWidth = math.max(columnWidth,
+                imtext.Measure(column.name, settings.nameSize),
+                imtext.Measure(column.potency, settings.potencySize));
+        end
+    end
+
+    local count = #columns;
+    if count == 0 then return; end
+
+    local contentWidth = columnWidth * count + gap * (count - 1);
+    local contentHeight = settings.nameSize + nameGap + dieSize + iceHeadroom
+        + rowGap + settings.potencySize + rowGap + settings.barHeight + rowGap + settings.oddsSize;
+
+    imgui.SetNextWindowSize({ -1, -1 }, ImGuiCond_Always);
+    imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
+
+    ApplyWindowPosition(WINDOW_NAME);
+    if imgui.Begin(WINDOW_NAME, true, GetBaseWindowFlags(gConfig.lockPositions)) then
+        SaveWindowPosition(WINDOW_NAME);
+
+        local originX, originY = imgui.GetCursorScreenPos();
+        imgui.Dummy({ contentWidth, contentHeight });
+
+        local drawList = GetUIDrawList();
+        local clock = os.clock();
+
+        for i = 1, count do
+            local column = columns[i];
+            local centerX = originX + (i - 1) * (columnWidth + gap) + columnWidth / 2;
+            local y = originY;
+
+            dice.CenteredText(drawList, column.name, centerX, y + settings.nameSize / 2,
+                settings.nameSize, column.nameColor);
+            y = y + settings.nameSize + nameGap;
+
+            dice.Draw(drawList, centerX - dieSize / 2, y, dieSize, column.state, clock,
+                settings.font_settings);
+            y = y + dieSize + iceHeadroom + rowGap;
+
+            dice.CenteredText(drawList, column.potency, centerX, y + settings.potencySize / 2,
+                settings.potencySize, column.potencyColor);
+            y = y + settings.potencySize + rowGap;
+
+            DrawBar(drawList, centerX - columnWidth / 2, y, columnWidth, settings.barHeight, column);
+            y = y + settings.barHeight + rowGap;
+
+            if column.odds ~= '' then
+                local oddsY = y + settings.oddsSize / 2;
+                if column.oddsTimer ~= '' then
+                    local oddsW = imtext.Measure(column.odds, settings.oddsSize);
+                    local timerW = imtext.Measure(column.oddsTimer, settings.oddsSize);
+                    local totalW = oddsW + oddsGap + timerW;
+                    local left = centerX - totalW / 2;
+                    dice.CenteredText(drawList, column.odds, left + oddsW / 2, oddsY,
+                        settings.oddsSize, column.oddsColor);
+                    dice.CenteredText(drawList, column.oddsTimer, left + oddsW + oddsGap + timerW / 2,
+                        oddsY, settings.oddsSize, TEXT.muted);
+                else
+                    dice.CenteredText(drawList, column.odds, centerX, oddsY,
+                        settings.oddsSize, column.oddsColor);
+                end
+            end
+        end
+    end
+    imgui.End();
+
+    imgui.PopStyleVar();
+end
+
+M.ResetPositions = function()
+    local defaultPositions = require('libs.defaultpositions');
+    local x, y = defaultPositions.GetPhantomRollPosition();
+
+    if gConfig and gConfig.windowPositions then
+        gConfig.windowPositions[WINDOW_NAME] = { x = x, y = y };
+        if gConfig.appliedPositions then
+            gConfig.appliedPositions[WINDOW_NAME] = nil;
+        end
+    end
+end
+
+return M;

--- a/XIUI/modules/phantomroll/display.lua
+++ b/XIUI/modules/phantomroll/display.lua
@@ -37,6 +37,7 @@ local BAR_FILL = {
 };
 
 local BAR_BACKDROP = { 0.10, 0.11, 0.13, 0.80 };
+local BAR_BORDER = { 0, 0, 0, 1 };
 
 -- Cached so we do not re-measure "Bust 100%" every frame.
 local oddsReserve = { oddsSize = nil, width = 0 };
@@ -97,7 +98,7 @@ local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
     end
 
     return {
-        name = (def and def.name or '?'):upper(),
+        name = (def and def.name or (entry.busted and 'Bust' or '?')):upper(),
         potency = data.PotencyText(def, entry.total, entry.context),
         odds = oddsText,
         oddsTimer = oddsTimer,
@@ -112,14 +113,19 @@ local function BuildColumn(entry, horizonMode, canDoubleUp, doubleUpSeconds)
 end
 
 local function DrawBar(drawList, x, y, width, height, column)
+    local rounding = height * 0.45;
     drawList:AddRectFilled({ x, y }, { x + width, y + height },
-        dice.Color(BAR_BACKDROP), height * 0.45);
+        dice.Color(BAR_BACKDROP), rounding);
 
     if column.fraction > 0 then
-        local fillWidth = math.max(height * 0.45, width * column.fraction);
+        local fillWidth = math.max(rounding, width * column.fraction);
         drawList:AddRectFilled({ x, y }, { x + fillWidth, y + height },
-            dice.Color(column.fill), height * 0.45);
+            dice.Color(column.fill), rounding);
     end
+
+    -- Same idea as player/target bars: a thin stroke around the fill.
+    drawList:AddRect({ x, y }, { x + width, y + height },
+        dice.Color(BAR_BORDER), rounding, 15, 1.0);
 
     dice.CenteredText(drawList, column.clock, x + width / 2, y + height / 2,
         height * 0.86, TEXT.clock);

--- a/XIUI/modules/phantomroll/init.lua
+++ b/XIUI/modules/phantomroll/init.lua
@@ -34,7 +34,7 @@ M.DrawWindow = function(settings)
     if hidden or settings == nil then return; end
 
     if not UpdatePreview() then
-        -- No seats: nothing to sync (packets create seats; Sync only refreshes/clears).
+        -- No seats: nothing to sync (packets create seats; Sync only snaps/clears).
         if not tracker.HasAny() then return; end
         tracker.Sync();
         if not tracker.HasAny() then return; end

--- a/XIUI/modules/phantomroll/init.lua
+++ b/XIUI/modules/phantomroll/init.lua
@@ -1,0 +1,67 @@
+--[[
+* Phantom Roll module for XIUI.
+]]--
+
+local tracker = require('modules.phantomroll.tracker');
+local display = require('modules.phantomroll.display');
+
+local M = {};
+
+local hidden = false;
+local previewActive = false;
+
+-- Demo dice only when config is open and no real rolls are up.
+local function UpdatePreview()
+    local configOpen = showConfig ~= nil and showConfig[1];
+
+    if configOpen and not previewActive and not tracker.HasAny() then
+        tracker.Demo();
+        previewActive = true;
+    elseif not configOpen and previewActive then
+        tracker.Clear();
+        previewActive = false;
+    end
+
+    return previewActive;
+end
+
+M.Initialize = function(settings)
+    hidden = false;
+    previewActive = false;
+end
+
+M.DrawWindow = function(settings)
+    if hidden or settings == nil then return; end
+
+    if not UpdatePreview() then
+        -- No seats: nothing to sync (packets create seats; Sync only refreshes/clears).
+        if not tracker.HasAny() then return; end
+        tracker.Sync();
+        if not tracker.HasAny() then return; end
+    end
+
+    display.DrawWindow(settings);
+end
+
+M.HandleActionPacket = function(actionPacket)
+    tracker.HandleActionPacket(actionPacket);
+end
+
+M.HandleZonePacket = function()
+    tracker.Clear();
+    previewActive = false;
+end
+
+M.SetHidden = function(isHidden)
+    hidden = isHidden == true;
+end
+
+M.Cleanup = function()
+    hidden = false;
+    previewActive = false;
+    tracker.Clear();
+end
+
+M.ResetPositions = display.ResetPositions;
+
+return M;

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -244,10 +244,10 @@ M.Clear = function()
 end
 
 M.Demo = function()
-    local hunters = data.ByAbility(108);
-    local chaos = data.ByAbility(105);
+    local horizon = HorizonMode();
+    local hunters = data.ByAbility(108, horizon);
+    local chaos = data.ByAbility(105, horizon);
     local now = os.clock();
-    local context = data.Context(HorizonMode());
 
     local function DemoSeat(roll, total, left, sequence)
         return {
@@ -258,7 +258,6 @@ M.Demo = function()
             busted = false,
             expiresAt = now + left,
             duration = data.BASE_DURATION,
-            context = context,
         };
     end
 

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -17,18 +17,13 @@ local rollSequence = 0;
 local doubleUpExpiresAt = nil;
 local lastSyncAt = 0;
 
--- Reused across Sync calls so we do not allocate every frame.
-local presentBuf, timersBuf = {}, {};
-local bustTimesBuf = {};
+-- Reused across Sync calls so we do not allocate every poll.
+local presentBuf, timersBuf, bustTimesBuf = {}, {}, {};
 local bustTimesN = 0;
 
-local function Now()
-    return os.clock();
-end
-
-local function Left(expiresAt)
+local function Remaining(expiresAt)
     if expiresAt == nil then return 0; end
-    return math.max(0, expiresAt - Now());
+    return math.max(0, expiresAt - os.clock());
 end
 
 local function ClearMap(map)
@@ -42,19 +37,25 @@ end
 
 -- Seed a packet-time countdown; Sync replaces it once the buff is readable.
 local function ArmCountdown(entry)
-    local now = Now();
+    local now = os.clock();
     entry.expiresAt = now + data.BASE_DURATION;
     entry.duration = data.BASE_DURATION;
-    entry.pending = true;  -- do not clear until the buff has been seen once
+    entry.pending = true;
+end
+
+local function ApplyTimer(entry, seconds, now)
+    if seconds == nil or seconds < 0 then return; end
+    entry.expiresAt = now + seconds;
+    entry.duration = math.max(entry.duration or seconds, seconds);
 end
 
 -- Split presence from readable timers so an unreadable stamp is not "missing".
 local function ReadRollBuffs()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
-    if player == nil then return nil, nil; end
+    if player == nil then return false; end
 
     local buffs = player:GetBuffs();
-    if buffs == nil then return nil, nil; end
+    if buffs == nil then return false; end
     local statusTimers = player:GetStatusTimers();
     local stamp = vanatime.Utc();
 
@@ -77,63 +78,34 @@ local function ReadRollBuffs()
             end
         end
     end
-    return presentBuf, timersBuf;
+    return true;
 end
 
--- Live rolls only; a busted seat keeps the old status id and must not be reused.
-local function FindSlot(statusId)
+-- Matching live roll, else a free seat, else the soonest-expiring live roll.
+-- Never evicts a bust (Hunter replacing Chaos must leave a busted seat).
+local function ClaimSlot(statusId)
+    local empty, victim, shortest = nil, nil, math.huge;
     for i = 1, MAX_SLOTS do
         local entry = slots[i];
-        if entry ~= nil and not entry.busted and entry.status == statusId then
+        if entry == nil then
+            empty = empty or i;
+        elseif not entry.busted and entry.status == statusId then
             return i;
-        end
-    end
-    return nil;
-end
-
-local function NewEntry(def, total)
-    local entry = {
-        ability = def.ability,
-        status = def.status,
-        total = total,
-        sequence = 0,  -- 0: never saw this roll, so it cannot be doubled up
-        busted = false,
-    };
-    ArmCountdown(entry);
-    return entry;
-end
-
--- Free seat, else soonest-expiring live roll. Never evicts a bust.
-local function ReplacementSlot()
-    for i = 1, MAX_SLOTS do
-        if slots[i] == nil then return i; end
-    end
-
-    local victim, shortest = nil, math.huge;
-    for i = 1, MAX_SLOTS do
-        local entry = slots[i];
-        if entry ~= nil and not entry.busted then
-            local remaining = M.SecondsLeft(entry) or 0;
-            if remaining < shortest then
-                victim, shortest = i, remaining;
+        elseif not entry.busted then
+            local left = Remaining(entry.expiresAt);
+            if left < shortest then
+                victim, shortest = i, left;
             end
         end
     end
-    return victim;
+    return empty or victim;
 end
 
-local function Place(def, total)
-    local index = FindSlot(def.status);
-    if index ~= nil then
-        return index, slots[index];
+local function EmptySlot()
+    for i = 1, MAX_SLOTS do
+        if slots[i] == nil then return i; end
     end
-
-    index = ReplacementSlot();
-    if index == nil then return nil, nil; end
-
-    local entry = NewEntry(def, total);
-    slots[index] = entry;
-    return index, entry;
+    return nil;
 end
 
 local function RollTotal(actionPacket, serverId)
@@ -150,12 +122,6 @@ local function RollTotal(actionPacket, serverId)
     return fallback;
 end
 
-local function ApplyTimer(entry, seconds, now)
-    if seconds == nil or seconds < 0 then return; end
-    entry.expiresAt = now + seconds;
-    entry.duration = math.max(entry.duration or seconds, seconds);
-end
-
 M.HandleActionPacket = function(actionPacket)
     if actionPacket == nil or actionPacket.Type ~= data.JOB_ABILITY_CATEGORY then return; end
 
@@ -169,29 +135,27 @@ M.HandleActionPacket = function(actionPacket)
     local total = RollTotal(actionPacket, serverId);
     if total == nil then return; end
 
-    local index, entry = Place(def, total);
-    if entry == nil then return; end
+    local index = ClaimSlot(def.status);
+    if index == nil then return; end
 
-    rollSequence = rollSequence + 1;
-    entry.sequence = rollSequence;
-    entry.total = total;
-
-    if total > data.MAX_TOTAL then
-        entry.busted = true;
-        ArmCountdown(entry);
-        doubleUpExpiresAt = nil;
-    else
-        entry.busted = false;
-        ArmCountdown(entry);
+    local entry = slots[index];
+    if entry == nil or entry.busted or entry.status ~= def.status then
+        entry = { ability = def.ability, status = def.status, sequence = 0 };
+        slots[index] = entry;
     end
 
-    -- Potency is fixed when the roll lands; snapshot gear/party/level here.
+    rollSequence = rollSequence + 1;
+    entry.total = total;
+    entry.sequence = rollSequence;
+    entry.busted = total > data.MAX_TOTAL;
     entry.context = data.Context(HorizonMode());
-    lastSyncAt = 0;  -- pick the new buff up on the next draw
+    ArmCountdown(entry);
+    if entry.busted then doubleUpExpiresAt = nil; end
+    lastSyncAt = 0;
 end
 
 M.DoubleUpIndex = function()
-    if Left(doubleUpExpiresAt) <= 0 then return nil; end
+    if Remaining(doubleUpExpiresAt) <= 0 then return nil; end
 
     local best, bestSequence = nil, 0;
     for i = 1, MAX_SLOTS do
@@ -206,78 +170,65 @@ M.DoubleUpIndex = function()
 end
 
 M.DoubleUpSeconds = function()
-    return Left(doubleUpExpiresAt);
+    return Remaining(doubleUpExpiresAt);
 end
 
--- Bust dice follow copies of status 309 (you can have two).
-local function SyncBusts(now)
-    local seen = 0;
+M.Sync = function()
+    local now = os.clock();
+    if (now - lastSyncAt) < SYNC_INTERVAL then return; end
+    lastSyncAt = now;
+    if not ReadRollBuffs() then return; end
+
+    local bustSeen = 0;
     for i = 1, MAX_SLOTS do
         local entry = slots[i];
-        if entry ~= nil and entry.busted then
-            seen = seen + 1;
-            if seen > bustTimesN and not entry.pending then
-                slots[i] = nil;
+        if entry ~= nil then
+            if entry.busted then
+                bustSeen = bustSeen + 1;
+                if bustSeen > bustTimesN and not entry.pending then
+                    slots[i] = nil;
+                else
+                    if bustTimesN > 0 then entry.pending = false; end
+                    ApplyTimer(entry, bustTimesBuf[bustSeen], now);
+                end
+            elseif not presentBuf[entry.status] then
+                if not entry.pending then slots[i] = nil; end
             else
-                if bustTimesN > 0 then entry.pending = false; end
-                ApplyTimer(entry, bustTimesBuf[seen], now);
+                entry.pending = false;
+                ApplyTimer(entry, timersBuf[entry.status], now);
             end
         end
     end
 
-    for i = seen + 1, bustTimesN do
-        local seat = nil;
-        for s = 1, MAX_SLOTS do
-            if slots[s] == nil then seat = s; break; end
-        end
+    -- Extra 309s with no packet seat (e.g. bust before we saw the roll).
+    for n = bustSeen + 1, bustTimesN do
+        local seat = EmptySlot();
         if seat == nil then break; end
-        slots[seat] = {
-            ability = nil,
+        local entry = {
             status = data.BUST_STATUS,
             total = data.BUST_TOTAL,
             sequence = 0,
             busted = true,
             pending = false,
         };
-        ApplyTimer(slots[seat], bustTimesBuf[i], now);
-    end
-end
-
-M.Sync = function()
-    local now = Now();
-    if (now - lastSyncAt) < SYNC_INTERVAL then return; end
-    lastSyncAt = now;
-
-    local present, timers = ReadRollBuffs();
-    if present == nil then return; end
-
-    for i = 1, MAX_SLOTS do
-        local entry = slots[i];
-        if entry ~= nil and not entry.busted then
-            if not present[entry.status] then
-                if not entry.pending then slots[i] = nil; end
-            else
-                entry.pending = false;
-                ApplyTimer(entry, timers[entry.status], now);
-            end
-        end
+        ApplyTimer(entry, bustTimesBuf[n], now);
+        slots[seat] = entry;
     end
 
-    SyncBusts(now);
-
-    if not present[data.DOUBLE_UP_STATUS] then
+    if not presentBuf[data.DOUBLE_UP_STATUS] then
         doubleUpExpiresAt = nil;
-    else
-        local seconds = timers[data.DOUBLE_UP_STATUS];
-        if seconds ~= nil and seconds >= 0 then
-            doubleUpExpiresAt = now + seconds;
-        end
+        return;
+    end
+
+    local seconds = timersBuf[data.DOUBLE_UP_STATUS];
+    if seconds ~= nil and seconds >= 0 then
+        doubleUpExpiresAt = now + seconds;
     end
 end
 
 M.SecondsLeft = function(entry)
     if entry == nil or entry.expiresAt == nil then return nil; end
-    return Left(entry.expiresAt);
+    return Remaining(entry.expiresAt);
 end
 
 M.Fraction = function(entry)
@@ -295,10 +246,7 @@ M.Slots = function()
 end
 
 M.HasAny = function()
-    for i = 1, MAX_SLOTS do
-        if slots[i] ~= nil then return true; end
-    end
-    return false;
+    return slots[1] ~= nil or slots[2] ~= nil;
 end
 
 M.Clear = function()
@@ -311,21 +259,27 @@ end
 M.Demo = function()
     local hunters = data.ByAbility(108);
     local chaos = data.ByAbility(105);
-    local now = Now();
+    local now = os.clock();
     local context = data.Context(HorizonMode());
 
-    slots = {};
-    slots[1] = NewEntry(hunters, hunters.lucky);
-    slots[1].expiresAt, slots[1].duration, slots[1].sequence = now + 268, 300, 1;
-    slots[1].pending = false;
-    slots[1].context = context;
+    local function DemoSeat(def, total, left, sequence)
+        return {
+            ability = def.ability,
+            status = def.status,
+            total = total,
+            sequence = sequence,
+            busted = false,
+            pending = false,
+            expiresAt = now + left,
+            duration = data.BASE_DURATION,
+            context = context,
+        };
+    end
 
-    -- Lucky + unlucky pair; right die rolled last so it shows bust odds.
-    slots[2] = NewEntry(chaos, chaos.unlucky);
-    slots[2].expiresAt, slots[2].duration, slots[2].sequence = now + 154, 300, 2;
-    slots[2].pending = false;
-    slots[2].context = context;
-
+    slots = {
+        DemoSeat(hunters, hunters.lucky, 268, 1),
+        DemoSeat(chaos, chaos.unlucky, 154, 2),
+    };
     rollSequence = 2;
     doubleUpExpiresAt = now + 32;
 end

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -136,12 +136,6 @@ local function Place(def, total)
     return index, entry;
 end
 
--- Keep the same seat; a second bust occupies the other die instead of replacing this one.
-local function MarkBusted(entry)
-    entry.busted = true;
-    ArmCountdown(entry);
-end
-
 local function RollTotal(actionPacket, serverId)
     if actionPacket.Targets == nil then return nil; end
 
@@ -183,7 +177,8 @@ M.HandleActionPacket = function(actionPacket)
     entry.total = total;
 
     if total > data.MAX_TOTAL then
-        MarkBusted(entry);
+        entry.busted = true;
+        ArmCountdown(entry);
         doubleUpExpiresAt = nil;
     else
         entry.busted = false;
@@ -317,7 +312,7 @@ M.Demo = function()
     local hunters = data.ByAbility(108);
     local chaos = data.ByAbility(105);
     local now = Now();
-    local context = data.Context(false);
+    local context = data.Context(HorizonMode());
 
     slots = {};
     slots[1] = NewEntry(hunters, hunters.lucky);

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -9,7 +9,7 @@ local vanatime = require('libs.vanatime');
 local M = {};
 
 local MAX_SLOTS = 2;
--- Bars interpolate from expiresAt; poll buffs a few times a second to refresh/clear.
+-- Bars countdown from expiresAt; poll buffs a few times a second to snap/clear.
 local SYNC_INTERVAL = 0.15;
 
 local slots = {};
@@ -53,7 +53,7 @@ local function SnapTimer(entry, seconds, now)
     entry.pending = false;
 end
 
--- Split presence from readable timers so an unreadable stamp is not "missing".
+-- Presence and remaining are separate: a live buff can have no readable stamp yet.
 local function ReadRollBuffs()
     local player = AshitaCore:GetMemoryManager():GetPlayer();
     if player == nil then return false; end
@@ -121,8 +121,8 @@ end
 M.HandleActionPacket = function(actionPacket)
     if actionPacket == nil or actionPacket.Type ~= data.JOB_ABILITY_CATEGORY then return; end
 
-    local def = data.ByAbility(actionPacket.Param);
-    if def == nil then return; end
+    local roll = data.ByAbility(actionPacket.Param);
+    if roll == nil then return; end
 
     local party = AshitaCore:GetMemoryManager():GetParty();
     local serverId = party and party:GetMemberServerId(0);
@@ -131,13 +131,13 @@ M.HandleActionPacket = function(actionPacket)
     local total = RollTotal(actionPacket, serverId);
     if total == nil then return; end
 
-    local index = ClaimSlot(def.status);
+    local index = ClaimSlot(roll.status);
     if index == nil then return; end
 
     local entry = slots[index];
-    local reuse = entry ~= nil and entry.status == def.status;
+    local reuse = entry ~= nil and entry.status == roll.status;
     if not reuse then
-        entry = { ability = def.ability, status = def.status, sequence = 0 };
+        entry = { ability = roll.ability, status = roll.status, sequence = 0 };
         slots[index] = entry;
     end
     -- This server resets roll duration on Double-Up as well as a new roll.
@@ -249,10 +249,10 @@ M.Demo = function()
     local now = os.clock();
     local context = data.Context(HorizonMode());
 
-    local function DemoSeat(def, total, left, sequence)
+    local function DemoSeat(roll, total, left, sequence)
         return {
-            ability = def.ability,
-            status = def.status,
+            ability = roll.ability,
+            status = roll.status,
             total = total,
             sequence = sequence,
             busted = false,

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -14,7 +14,7 @@ local SYNC_INTERVAL = 0.15;
 
 local slots = {};
 local rollSequence = 0;
-local doubleUpExpiresAt = nil;
+local doubleUp = nil;
 local lastSyncAt = 0;
 
 -- Reused across Sync calls so we do not allocate every poll.
@@ -35,18 +35,22 @@ local function HorizonMode()
     return settings ~= nil and settings.horizonMode == true;
 end
 
--- Seed a packet-time countdown; Sync replaces it once the buff is readable.
-local function ArmCountdown(entry)
+local function ArmTimer(entry, duration)
     local now = os.clock();
-    entry.expiresAt = now + data.BASE_DURATION;
-    entry.duration = data.BASE_DURATION;
+    entry.expiresAt = now + duration;
+    entry.duration = duration;
     entry.pending = true;
 end
 
-local function ApplyTimer(entry, seconds, now)
+-- Packet is after animation; adopt a readable status timer once, then coast.
+local function SnapTimer(entry, seconds, now)
+    if entry == nil or not entry.pending then return; end
     if seconds == nil or seconds < 0 then return; end
     entry.expiresAt = now + seconds;
-    entry.duration = math.max(entry.duration or seconds, seconds);
+    if seconds > 0 then
+        entry.duration = math.max(entry.duration or seconds, seconds);
+    end
+    entry.pending = false;
 end
 
 -- Split presence from readable timers so an unreadable stamp is not "missing".
@@ -81,31 +85,23 @@ local function ReadRollBuffs()
     return true;
 end
 
--- Matching live roll, else a free seat, else the soonest-expiring live roll.
+-- Reuse this roll, else an empty seat, else the live roll that expires first.
 -- Never evicts a bust (Hunter replacing Chaos must leave a busted seat).
 local function ClaimSlot(statusId)
-    local empty, victim, shortest = nil, nil, math.huge;
+    local empty, oldest, shortest = nil, nil, math.huge;
     for i = 1, MAX_SLOTS do
         local entry = slots[i];
         if entry == nil then
             empty = empty or i;
-        elseif not entry.busted and entry.status == statusId then
-            return i;
         elseif not entry.busted then
+            if entry.status == statusId then return i; end
             local left = Remaining(entry.expiresAt);
             if left < shortest then
-                victim, shortest = i, left;
+                oldest, shortest = i, left;
             end
         end
     end
-    return empty or victim;
-end
-
-local function EmptySlot()
-    for i = 1, MAX_SLOTS do
-        if slots[i] == nil then return i; end
-    end
-    return nil;
+    return empty or oldest;
 end
 
 local function RollTotal(actionPacket, serverId)
@@ -139,38 +135,41 @@ M.HandleActionPacket = function(actionPacket)
     if index == nil then return; end
 
     local entry = slots[index];
-    if entry == nil or entry.busted or entry.status ~= def.status then
+    local reuse = entry ~= nil and entry.status == def.status;
+    if not reuse then
         entry = { ability = def.ability, status = def.status, sequence = 0 };
         slots[index] = entry;
     end
+    -- This server resets roll duration on Double-Up as well as a new roll.
+    ArmTimer(entry, data.BASE_DURATION);
 
     rollSequence = rollSequence + 1;
     entry.total = total;
     entry.sequence = rollSequence;
     entry.busted = total > data.MAX_TOTAL;
     entry.context = data.Context(HorizonMode());
-    ArmCountdown(entry);
-    if entry.busted then doubleUpExpiresAt = nil; end
+    if entry.busted then
+        doubleUp = nil;
+    elseif not reuse then
+        doubleUp = {};
+        ArmTimer(doubleUp, data.DOUBLE_UP_DURATION);
+    end
     lastSyncAt = 0;
 end
 
-M.DoubleUpIndex = function()
-    if Remaining(doubleUpExpiresAt) <= 0 then return nil; end
+M.DoubleUp = function()
+    local seconds = Remaining(doubleUp and doubleUp.expiresAt);
+    if seconds <= 0 then return nil, 0; end
 
-    local best, bestSequence = nil, 0;
+    local best = nil;
     for i = 1, MAX_SLOTS do
         local entry = slots[i];
-        if entry ~= nil and entry.sequence > bestSequence then
-            best, bestSequence = i, entry.sequence;
+        if entry ~= nil and (best == nil or entry.sequence > slots[best].sequence) then
+            best = i;
         end
     end
-
-    if best ~= nil and slots[best].busted then return nil; end
-    return best;
-end
-
-M.DoubleUpSeconds = function()
-    return Remaining(doubleUpExpiresAt);
+    if best == nil or slots[best].busted then return nil, seconds; end
+    return best, seconds;
 end
 
 M.Sync = function()
@@ -185,44 +184,42 @@ M.Sync = function()
         if entry ~= nil then
             if entry.busted then
                 bustSeen = bustSeen + 1;
-                if bustSeen > bustTimesN and not entry.pending then
-                    slots[i] = nil;
+                if bustSeen > bustTimesN then
+                    if not entry.pending then slots[i] = nil; end
                 else
-                    if bustTimesN > 0 then entry.pending = false; end
-                    ApplyTimer(entry, bustTimesBuf[bustSeen], now);
+                    SnapTimer(entry, bustTimesBuf[bustSeen], now);
                 end
             elseif not presentBuf[entry.status] then
                 if not entry.pending then slots[i] = nil; end
             else
-                entry.pending = false;
-                ApplyTimer(entry, timersBuf[entry.status], now);
+                SnapTimer(entry, timersBuf[entry.status], now);
             end
         end
     end
 
-    -- Extra 309s with no packet seat (e.g. bust before we saw the roll).
-    for n = bustSeen + 1, bustTimesN do
-        local seat = EmptySlot();
-        if seat == nil then break; end
-        local entry = {
-            status = data.BUST_STATUS,
-            total = data.BUST_TOTAL,
-            sequence = 0,
-            busted = true,
-            pending = false,
-        };
-        ApplyTimer(entry, bustTimesBuf[n], now);
-        slots[seat] = entry;
+    -- Leftover 309s with no packet seat go in empty slots.
+    for i = 1, MAX_SLOTS do
+        if slots[i] == nil and bustSeen < bustTimesN then
+            bustSeen = bustSeen + 1;
+            local seconds = bustTimesBuf[bustSeen] or 0;
+            slots[i] = {
+                status = data.BUST_STATUS,
+                total = data.BUST_TOTAL,
+                sequence = 0,
+                busted = true,
+                pending = false,
+                expiresAt = now + seconds,
+                duration = math.max(seconds, 1),
+            };
+        end
     end
 
-    if not presentBuf[data.DOUBLE_UP_STATUS] then
-        doubleUpExpiresAt = nil;
-        return;
-    end
+    if doubleUp == nil then return; end
 
-    local seconds = timersBuf[data.DOUBLE_UP_STATUS];
-    if seconds ~= nil and seconds >= 0 then
-        doubleUpExpiresAt = now + seconds;
+    if presentBuf[data.DOUBLE_UP_STATUS] then
+        SnapTimer(doubleUp, timersBuf[data.DOUBLE_UP_STATUS], now);
+    elseif not doubleUp.pending then
+        doubleUp = nil;
     end
 end
 
@@ -231,18 +228,8 @@ M.SecondsLeft = function(entry)
     return Remaining(entry.expiresAt);
 end
 
-M.Fraction = function(entry)
-    local remaining = M.SecondsLeft(entry);
-    if remaining == nil then return 0; end
-
-    local duration = entry.duration;
-    if duration == nil or duration <= 0 then duration = data.BASE_DURATION; end
-
-    return math.min(1, math.max(0, remaining / duration));
-end
-
 M.Slots = function()
-    return slots, MAX_SLOTS;
+    return slots;
 end
 
 M.HasAny = function()
@@ -252,7 +239,7 @@ end
 M.Clear = function()
     slots = {};
     rollSequence = 0;
-    doubleUpExpiresAt = nil;
+    doubleUp = nil;
     lastSyncAt = 0;
 end
 
@@ -269,7 +256,6 @@ M.Demo = function()
             total = total,
             sequence = sequence,
             busted = false,
-            pending = false,
             expiresAt = now + left,
             duration = data.BASE_DURATION,
             context = context,
@@ -281,7 +267,7 @@ M.Demo = function()
         DemoSeat(chaos, chaos.unlucky, 154, 2),
     };
     rollSequence = 2;
-    doubleUpExpiresAt = now + 32;
+    doubleUp = { expiresAt = now + 32, duration = data.DOUBLE_UP_DURATION };
 end
 
 return M;

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -1,0 +1,293 @@
+--[[
+* Tracks the two Phantom Rolls a Corsair can keep. Packets own totals; buff
+* timers own the countdown. Other Corsairs' rolls share status ids — ignore them.
+]]--
+
+local data = require('modules.phantomroll.data');
+local vanatime = require('libs.vanatime');
+
+local M = {};
+
+local MAX_SLOTS = 2;
+-- Bars interpolate from expiresAt; poll buffs a few times a second to refresh/clear.
+local SYNC_INTERVAL = 0.15;
+
+local slots = {};
+local rollSequence = 0;
+local doubleUpExpiresAt = nil;
+local lastSyncAt = 0;
+
+-- Reused across Sync calls so we do not allocate every frame.
+local presentBuf, timersBuf = {}, {};
+
+local function Now()
+    return os.clock();
+end
+
+local function Left(expiresAt)
+    if expiresAt == nil then return 0; end
+    return math.max(0, expiresAt - Now());
+end
+
+local function ClearMap(map)
+    for key in pairs(map) do map[key] = nil; end
+end
+
+local function HorizonMode()
+    local settings = gAdjustedSettings and gAdjustedSettings.phantomRollSettings;
+    return settings ~= nil and settings.horizonMode == true;
+end
+
+-- Seed a packet-time countdown; Sync replaces it once the buff is readable.
+local function ArmCountdown(entry)
+    local now = Now();
+    entry.expiresAt = now + data.BASE_DURATION;
+    entry.duration = data.BASE_DURATION;
+    entry.pending = true;  -- do not clear until the buff has been seen once
+end
+
+-- Split presence from readable timers so an unreadable stamp is not "missing".
+local function ReadRollBuffs()
+    local player = AshitaCore:GetMemoryManager():GetPlayer();
+    if player == nil then return nil, nil; end
+
+    local buffs = player:GetBuffs();
+    if buffs == nil then return nil, nil; end
+    local statusTimers = player:GetStatusTimers();
+    local stamp = vanatime.Utc();
+
+    ClearMap(presentBuf);
+    ClearMap(timersBuf);
+
+    for i = 1, 32 do
+        local statusId = buffs[i];
+        if statusId ~= nil and data.IsTrackedStatus(statusId) then
+            presentBuf[statusId] = true;
+            local seconds = vanatime.StatusSeconds(statusTimers and statusTimers[i] or nil, stamp);
+            if seconds ~= nil then
+                timersBuf[statusId] = seconds;
+            end
+        end
+    end
+    return presentBuf, timersBuf;
+end
+
+local function FindSlot(statusId)
+    for i = 1, MAX_SLOTS do
+        if slots[i] ~= nil and slots[i].status == statusId then return i; end
+    end
+    return nil;
+end
+
+local function NewEntry(def, total)
+    local entry = {
+        ability = def.ability,
+        status = def.status,
+        total = total,
+        sequence = 0,  -- 0: never saw this roll, so it cannot be doubled up
+        busted = false,
+    };
+    ArmCountdown(entry);
+    return entry;
+end
+
+-- Free seat, else soonest-expiring non-bust (what the server drops at two rolls).
+local function ReplacementSlot()
+    for i = 1, MAX_SLOTS do
+        if slots[i] == nil then return i; end
+    end
+
+    local victim, shortest = nil, math.huge;
+    for i = 1, MAX_SLOTS do
+        local remaining = M.SecondsLeft(slots[i]) or 0;
+        if not slots[i].busted and remaining < shortest then
+            victim, shortest = i, remaining;
+        end
+    end
+    return victim or 1;
+end
+
+local function Place(def, total)
+    local index = FindSlot(def.status);
+    if index ~= nil then
+        return index, slots[index];
+    end
+
+    index = ReplacementSlot();
+    local entry = NewEntry(def, total);
+    slots[index] = entry;
+    return index, entry;
+end
+
+-- Keep the same seat/identity; only the countdown switches to the Bust debuff.
+local function MarkBusted(index, entry)
+    for i = 1, MAX_SLOTS do
+        if i ~= index and slots[i] ~= nil and slots[i].busted then slots[i] = nil; end
+    end
+
+    entry.busted = true;
+    ArmCountdown(entry);
+end
+
+local function RollTotal(actionPacket, serverId)
+    if actionPacket.Targets == nil then return nil; end
+
+    local fallback = nil;
+    for _, target in ipairs(actionPacket.Targets) do
+        local action = target.Actions and target.Actions[1];
+        if action ~= nil then
+            if target.Id == serverId then return action.Param; end
+            fallback = fallback or action.Param;
+        end
+    end
+    return fallback;
+end
+
+local function ApplyTimer(entry, seconds, now)
+    if seconds == nil or seconds < 0 then return; end
+    entry.expiresAt = now + seconds;
+    entry.duration = math.max(entry.duration or seconds, seconds);
+end
+
+M.HandleActionPacket = function(actionPacket)
+    if actionPacket == nil or actionPacket.Type ~= data.JOB_ABILITY_CATEGORY then return; end
+
+    local def = data.ByAbility(actionPacket.Param);
+    if def == nil then return; end
+
+    local party = AshitaCore:GetMemoryManager():GetParty();
+    local serverId = party and party:GetMemberServerId(0);
+    if serverId == nil or actionPacket.UserId ~= serverId then return; end
+
+    local total = RollTotal(actionPacket, serverId);
+    if total == nil then return; end
+
+    local index, entry = Place(def, total);
+
+    rollSequence = rollSequence + 1;
+    entry.sequence = rollSequence;
+    entry.total = total;
+
+    if total > data.MAX_TOTAL then
+        MarkBusted(index, entry);
+        doubleUpExpiresAt = nil;
+    else
+        entry.busted = false;
+        ArmCountdown(entry);
+    end
+
+    -- Potency is fixed when the roll lands; snapshot gear/party/level here.
+    entry.context = data.Context(HorizonMode());
+    lastSyncAt = 0;  -- pick the new buff up on the next draw
+end
+
+M.DoubleUpIndex = function()
+    if Left(doubleUpExpiresAt) <= 0 then return nil; end
+
+    local best, bestSequence = nil, 0;
+    for i = 1, MAX_SLOTS do
+        local entry = slots[i];
+        if entry ~= nil and entry.sequence > bestSequence then
+            best, bestSequence = i, entry.sequence;
+        end
+    end
+
+    if best ~= nil and slots[best].busted then return nil; end
+    return best;
+end
+
+M.DoubleUpSeconds = function()
+    return Left(doubleUpExpiresAt);
+end
+
+M.Sync = function()
+    local now = Now();
+    if (now - lastSyncAt) < SYNC_INTERVAL then return; end
+    lastSyncAt = now;
+
+    local present, timers = ReadRollBuffs();
+    if present == nil then return; end
+
+    for i = 1, MAX_SLOTS do
+        local entry = slots[i];
+        if entry ~= nil then
+            local timerId = entry.busted and data.BUST_STATUS or entry.status;
+            if not present[timerId] then
+                -- Bust swap: outgoing roll buff can linger; that is still this seat.
+                local swapping = entry.busted and present[entry.status];
+                if not swapping and not entry.pending then
+                    slots[i] = nil;
+                end
+            else
+                entry.pending = false;
+                ApplyTimer(entry, timers[timerId], now);
+            end
+        end
+    end
+
+    if not present[data.DOUBLE_UP_STATUS] then
+        doubleUpExpiresAt = nil;
+    else
+        local seconds = timers[data.DOUBLE_UP_STATUS];
+        if seconds ~= nil and seconds >= 0 then
+            doubleUpExpiresAt = now + seconds;
+        end
+    end
+end
+
+M.SecondsLeft = function(entry)
+    if entry == nil or entry.expiresAt == nil then return nil; end
+    return Left(entry.expiresAt);
+end
+
+M.Fraction = function(entry)
+    local remaining = M.SecondsLeft(entry);
+    if remaining == nil then return 0; end
+
+    local duration = entry.duration;
+    if duration == nil or duration <= 0 then duration = data.BASE_DURATION; end
+
+    return math.min(1, math.max(0, remaining / duration));
+end
+
+M.Slots = function()
+    return slots, MAX_SLOTS;
+end
+
+M.HasAny = function()
+    for i = 1, MAX_SLOTS do
+        if slots[i] ~= nil then return true; end
+    end
+    return false;
+end
+
+M.Clear = function()
+    slots = {};
+    rollSequence = 0;
+    doubleUpExpiresAt = nil;
+    lastSyncAt = 0;
+end
+
+M.Demo = function()
+    local hunters = data.ByAbility(108);
+    local chaos = data.ByAbility(105);
+    local now = Now();
+    local context = data.Context(false);
+
+    slots = {};
+    slots[1] = NewEntry(hunters, hunters.lucky);
+    slots[1].expiresAt, slots[1].duration, slots[1].sequence = now + 268, 300, 1;
+    slots[1].pending = false;
+    slots[1].context = context;
+
+    -- Lucky + unlucky pair; right die rolled last so it shows bust odds.
+    slots[2] = NewEntry(chaos, chaos.unlucky);
+    slots[2].expiresAt, slots[2].duration, slots[2].sequence = now + 154, 300, 2;
+    slots[2].pending = false;
+    slots[2].context = context;
+
+    rollSequence = 2;
+    doubleUpExpiresAt = now + 32;
+end
+
+return M;

--- a/XIUI/modules/phantomroll/tracker.lua
+++ b/XIUI/modules/phantomroll/tracker.lua
@@ -19,6 +19,8 @@ local lastSyncAt = 0;
 
 -- Reused across Sync calls so we do not allocate every frame.
 local presentBuf, timersBuf = {}, {};
+local bustTimesBuf = {};
+local bustTimesN = 0;
 
 local function Now()
     return os.clock();
@@ -58,23 +60,33 @@ local function ReadRollBuffs()
 
     ClearMap(presentBuf);
     ClearMap(timersBuf);
+    bustTimesN = 0;
 
-    for i = 1, 32 do
+    -- 0..32 covers both 0-based and 1-based Ashita buff arrays.
+    -- Bust can occupy two slots (same status id); collect every copy.
+    for i = 0, 32 do
         local statusId = buffs[i];
         if statusId ~= nil and data.IsTrackedStatus(statusId) then
-            presentBuf[statusId] = true;
             local seconds = vanatime.StatusSeconds(statusTimers and statusTimers[i] or nil, stamp);
-            if seconds ~= nil then
-                timersBuf[statusId] = seconds;
+            if statusId == data.BUST_STATUS then
+                bustTimesN = bustTimesN + 1;
+                bustTimesBuf[bustTimesN] = seconds;
+            else
+                presentBuf[statusId] = true;
+                if seconds ~= nil then timersBuf[statusId] = seconds; end
             end
         end
     end
     return presentBuf, timersBuf;
 end
 
+-- Live rolls only; a busted seat keeps the old status id and must not be reused.
 local function FindSlot(statusId)
     for i = 1, MAX_SLOTS do
-        if slots[i] ~= nil and slots[i].status == statusId then return i; end
+        local entry = slots[i];
+        if entry ~= nil and not entry.busted and entry.status == statusId then
+            return i;
+        end
     end
     return nil;
 end
@@ -91,7 +103,7 @@ local function NewEntry(def, total)
     return entry;
 end
 
--- Free seat, else soonest-expiring non-bust (what the server drops at two rolls).
+-- Free seat, else soonest-expiring live roll. Never evicts a bust.
 local function ReplacementSlot()
     for i = 1, MAX_SLOTS do
         if slots[i] == nil then return i; end
@@ -99,12 +111,15 @@ local function ReplacementSlot()
 
     local victim, shortest = nil, math.huge;
     for i = 1, MAX_SLOTS do
-        local remaining = M.SecondsLeft(slots[i]) or 0;
-        if not slots[i].busted and remaining < shortest then
-            victim, shortest = i, remaining;
+        local entry = slots[i];
+        if entry ~= nil and not entry.busted then
+            local remaining = M.SecondsLeft(entry) or 0;
+            if remaining < shortest then
+                victim, shortest = i, remaining;
+            end
         end
     end
-    return victim or 1;
+    return victim;
 end
 
 local function Place(def, total)
@@ -114,17 +129,15 @@ local function Place(def, total)
     end
 
     index = ReplacementSlot();
+    if index == nil then return nil, nil; end
+
     local entry = NewEntry(def, total);
     slots[index] = entry;
     return index, entry;
 end
 
--- Keep the same seat/identity; only the countdown switches to the Bust debuff.
-local function MarkBusted(index, entry)
-    for i = 1, MAX_SLOTS do
-        if i ~= index and slots[i] ~= nil and slots[i].busted then slots[i] = nil; end
-    end
-
+-- Keep the same seat; a second bust occupies the other die instead of replacing this one.
+local function MarkBusted(entry)
     entry.busted = true;
     ArmCountdown(entry);
 end
@@ -163,13 +176,14 @@ M.HandleActionPacket = function(actionPacket)
     if total == nil then return; end
 
     local index, entry = Place(def, total);
+    if entry == nil then return; end
 
     rollSequence = rollSequence + 1;
     entry.sequence = rollSequence;
     entry.total = total;
 
     if total > data.MAX_TOTAL then
-        MarkBusted(index, entry);
+        MarkBusted(entry);
         doubleUpExpiresAt = nil;
     else
         entry.busted = false;
@@ -200,6 +214,40 @@ M.DoubleUpSeconds = function()
     return Left(doubleUpExpiresAt);
 end
 
+-- Bust dice follow copies of status 309 (you can have two).
+local function SyncBusts(now)
+    local seen = 0;
+    for i = 1, MAX_SLOTS do
+        local entry = slots[i];
+        if entry ~= nil and entry.busted then
+            seen = seen + 1;
+            if seen > bustTimesN and not entry.pending then
+                slots[i] = nil;
+            else
+                if bustTimesN > 0 then entry.pending = false; end
+                ApplyTimer(entry, bustTimesBuf[seen], now);
+            end
+        end
+    end
+
+    for i = seen + 1, bustTimesN do
+        local seat = nil;
+        for s = 1, MAX_SLOTS do
+            if slots[s] == nil then seat = s; break; end
+        end
+        if seat == nil then break; end
+        slots[seat] = {
+            ability = nil,
+            status = data.BUST_STATUS,
+            total = data.BUST_TOTAL,
+            sequence = 0,
+            busted = true,
+            pending = false,
+        };
+        ApplyTimer(slots[seat], bustTimesBuf[i], now);
+    end
+end
+
 M.Sync = function()
     local now = Now();
     if (now - lastSyncAt) < SYNC_INTERVAL then return; end
@@ -210,20 +258,17 @@ M.Sync = function()
 
     for i = 1, MAX_SLOTS do
         local entry = slots[i];
-        if entry ~= nil then
-            local timerId = entry.busted and data.BUST_STATUS or entry.status;
-            if not present[timerId] then
-                -- Bust swap: outgoing roll buff can linger; that is still this seat.
-                local swapping = entry.busted and present[entry.status];
-                if not swapping and not entry.pending then
-                    slots[i] = nil;
-                end
+        if entry ~= nil and not entry.busted then
+            if not present[entry.status] then
+                if not entry.pending then slots[i] = nil; end
             else
                 entry.pending = false;
-                ApplyTimer(entry, timers[timerId], now);
+                ApplyTimer(entry, timers[entry.status], now);
             end
         end
     end
+
+    SyncBusts(now);
 
     if not present[data.DOUBLE_UP_STATUS] then
         doubleUpExpiresAt = nil;


### PR DESCRIPTION
Add Phantom Roll Module!

This module will track your 2 rolls, specifically their:
* roll number
* potency
* bust percentage
* re-roll window 

There is a toggle for horizon mode which will override their changes which are:
* chaos potency per level (also flat dmg instead of %)
* gallant flat def
* healers roll changed to hMP
* extra gear which has +phantom roll

<img width="219" height="181" alt="phantom-roll" src="https://github.com/user-attachments/assets/da03e385-29cb-4ce4-86cc-57709713dcc2" />
