### PR TITLE
Phantom Roll Ashita 4.16 Compatibility Fix Attempt

### DIFF
--- a/XIUI/XIUI.lua
+++ b/XIUI/XIUI.lua
@@ -28,10 +28,8 @@ addon.version   = '1.8.4';
 addon.desc      = 'Multiple UI elements with manager';
 addon.link      = 'https://github.com/tirem/XIUI'
 
--- Ashita version targeting (for ImGui compatibility)
--- Set to nil for auto-detection, true to force 4.3 mode, and false for 4.16 mode
-_G._XIUI_USE_ASHITA_4_3 = nil;
-require('handlers.imgui_compat');
+-- ImGui compatibility (auto-detects current vs legacy Ashita imgui.lua)
+local imguiCompat = require('handlers.imgui_compat');
 
 -- Global switch to hard-disable functionality that is limited on HX servers.
 -- Set before module requires so load-time checks (e.g. petbar data) see the correct value.
@@ -107,9 +105,19 @@ local satchelTooltipFonts = require('modules.satchel.tooltips');
 
 -- Flag to skip settings_update callback during internal saves
 local bInternalSave = false;
--- For Ashita 4.3+, callbacks are async so we need to defer clearing the flag
-local bIsAshita43 = (ImGuiChildFlags_Borders ~= nil);
+local bLegacyImGui = imguiCompat.legacyImGui == true;
 local bPendingInternalSaveClear = false;
+
+-- Call right after settings.save() on an internal (XIUI-initiated) save.
+-- Current Ashita fires settings_update asynchronously, so the flag has to stay
+-- set until that callback runs; legacy Ashita is synchronous and already done.
+local function ClearInternalSaveFlag()
+    if bLegacyImGui then
+        bInternalSave = false;
+    else
+        bPendingInternalSaveClear = true;
+    end
+end
 
 
 
@@ -692,7 +700,7 @@ function ChangeProfile(name)
     config.currentProfile = name;
     bInternalSave = true;
     settings.save(); -- Save character preference
-    if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
+    ClearInternalSaveFlag();
 
     -- Clear textures to prevent ghosting
     TextureManager.clear();
@@ -774,7 +782,7 @@ uiRecovery.Configure({
         profileManager.SaveProfileSettings(config.currentProfile, gConfig);
         bInternalSave = true;
         settings.save();
-        if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
+        ClearInternalSaveFlag();
     end,
 });
 
@@ -841,7 +849,7 @@ function SaveSettingsToDisk()
     profileManager.SaveProfileSettings(config.currentProfile, gConfig);
     bInternalSave = true;
     settings.save();
-    if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
+    ClearInternalSaveFlag();
 end
 
 function SaveSettingsOnly()
@@ -852,7 +860,7 @@ function SaveSettingsOnly()
     profileManager.SaveProfileSettings(config.currentProfile, gConfig);
     bInternalSave = true;
     settings.save();
-    if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
+    ClearInternalSaveFlag();
     UpdateUserSettings();
 end
 
@@ -861,7 +869,7 @@ end
 function SaveCharacterSettingsInternal()
     bInternalSave = true;
     settings.save();
-    if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
+    ClearInternalSaveFlag();
 end
 
 -- New functions for profile management
@@ -899,7 +907,7 @@ function RenameProfile(oldName, newName)
         config.currentProfile = newName;
         bInternalSave = true;
         settings.save();
-        if bIsAshita43 then bPendingInternalSaveClear = true; else bInternalSave = false; end
+        ClearInternalSaveFlag();
     end
 
     return true;

--- a/XIUI/handlers/imgui_compat.lua
+++ b/XIUI/handlers/imgui_compat.lua
@@ -4,7 +4,18 @@
 * This module provides compatibility between the current Ashita v4beta (main)
 * and the upcoming Ashita 4.3 (2025_q3_update branch) which has breaking ImGui changes.
 *
-* Set _XIUI_USE_ASHITA_4_3 = true in XIUI.lua to enable 4.3 mode.
+* "Main" here includes Ashita 4.16-final private-server installs that ship the
+* older addons/libs/imgui.lua. Prefer this shim over telling users to replace
+* their shared libs folder (mismatched StyleVar indices break XIUI and other addons).
+*
+* Auto-detect only (no manual override):
+*   - Native ImGuiChildFlags_Borders present  -> current ImGui (Ashita 4.3+)
+*   - Native ImGuiChildFlags_Borders missing  -> legacy ImGui (Ashita 4.16-final libs)
+* Detect runs BEFORE polyfills. Callers that need the answer must read the
+* returned legacyImGui flag:
+*     local legacy = require('handlers.imgui_compat').legacyImGui;
+* Never re-check ImGuiChildFlags_Borders yourself — the legacy path polyfills
+* those constant names for call-site compatibility, so they exist on both.
 *
 * Changes in 4.3:
 *   - BeginChild: cflags default changed, now needs explicit ImGuiChildFlags_Borders
@@ -12,6 +23,11 @@
 *   - ImGuiCol_Tab* constants renamed (TabActive -> TabSelected, etc.)
 *   - ImDrawCornerFlags renamed to ImDrawFlags_RoundCorners*
 *   - BeginDisabled/EndDisabled: exists in 4.3 (ImGui 1.85+), polyfilled for main
+*
+* Additional legacy (4.16) / main notes:
+*   - BeginChild third arg is a boolean border (not ImGuiChildFlags)
+*   - Passing nil child-flag constants into BeginChild breaks config/satchel/etc.
+*   - Use ImDrawCornerFlags_* in draw calls; values differ from RoundCorners* bits
 ]]--
 
 local imgui = require('imgui');
@@ -19,18 +35,15 @@ local imgui = require('imgui');
 -- Store original functions
 local orig_imgui_BeginChild = imgui.BeginChild;
 
--- Auto-detect Ashita 4.3 vs main branch based on ImGui constants
--- 4.3 has ImGuiChildFlags_Borders constant, main branch does not
--- Manual override via _XIUI_USE_ASHITA_4_3 global is still supported
-local use43 = rawget(_G, '_XIUI_USE_ASHITA_4_3');
-if use43 == nil then
-    -- Auto-detect: ImGuiChildFlags_Borders exists only in 4.3
-    use43 = (ImGuiChildFlags_Borders ~= nil);
-end
+-- Auto-detect current vs legacy ImGui based on native constants
+-- Current (4.3+) ships ImGuiChildFlags_Borders; legacy (4.16) stock libs do not
+-- Detect BEFORE polyfills so a missing ImGuiChildFlags_Borders stays meaningful
+local legacyImGui = (ImGuiChildFlags_Borders == nil);
 
 -- ImDrawCornerFlags -> ImDrawFlags_RoundCorners* aliases
 -- 4.3 uses ImDrawFlags_RoundCorners* (new naming), main uses ImDrawCornerFlags_* (old naming)
 -- Create aliases so code can use ImDrawCornerFlags_* consistently on both branches
+-- (Bit layouts differ: do not hardcode 0xF / 15; use ImDrawCornerFlags_All instead)
 if ImDrawFlags_RoundCornersAll ~= nil then
     -- 4.3 branch: new names exist, create old name aliases pointing to new names
     ImDrawCornerFlags_None = ImDrawFlags_RoundCornersNone;
@@ -46,8 +59,34 @@ if ImDrawFlags_RoundCornersAll ~= nil then
 end
 -- On main branch: ImDrawCornerFlags_* already exist natively, no aliases needed
 
-if use43 then
-    -- Running on 4.3 branch - add backwards compatibility aliases for old constant names
+-- Convert current-style child flags / legacy bools into a legacy boolean border arg
+local function toBoolBorder(cflags)
+    if cflags == true then
+        return true;
+    end
+    if cflags == false or cflags == nil then
+        return false;
+    end
+    if type(cflags) == 'number' then
+        -- Current ImGuiChildFlags_Borders is bit 0 (= 1)
+        return bit.band(cflags, 1) ~= 0;
+    end
+    return false;
+end
+
+-- Convert legacy bool border args into current ImGuiChildFlags values
+local function toChildFlags(cflags)
+    if cflags == true then
+        return ImGuiChildFlags_Borders;
+    end
+    if cflags == false or cflags == nil then
+        return ImGuiChildFlags_None;
+    end
+    return cflags;
+end
+
+if not legacyImGui then
+    -- Running on current ImGui (4.3+) - add backwards compatibility aliases for old constant names
     -- These were renamed in ImGui 1.90+
     -- Always set fallbacks first, then override with actual values if they exist
     ImGuiCol_Tab = ImGuiCol_Tab or ImGuiCol_Header or 0;
@@ -64,16 +103,28 @@ if use43 then
 
     -- BeginChild: Handle boolean->flags conversion for backwards compat
     imgui.BeginChild = function(id, size, cflags, wflags)
-        if cflags == true then
-            cflags = ImGuiChildFlags_Borders;
-        elseif cflags == false then
-            cflags = ImGuiChildFlags_None;
-        end
-        return orig_imgui_BeginChild(id, size, cflags, wflags);
+        return orig_imgui_BeginChild(id, size, toChildFlags(cflags), wflags);
     end
 
 else
-    -- Running on MAIN branch - apply compatibility shims for 4.3-style code
+    -- Running on legacy ImGui - apply compatibility shims for current-style code
+    -- (Includes Ashita 4.16-final stock imgui.lua used by many private servers)
+
+    -- Polyfill ImGuiChildFlags_* names so current-style call sites (config, satchel, etc.)
+    -- can pass them. BeginChild below maps these back to a real boolean border.
+    -- Do not treat presence of these names as proof of current ImGui after this block runs.
+    if ImGuiChildFlags_None == nil then
+        ImGuiChildFlags_None = 0;
+        ImGuiChildFlags_Borders = 1;
+        ImGuiChildFlags_AlwaysUseWindowPadding = bit.lshift(1, 1);
+        ImGuiChildFlags_ResizeX = bit.lshift(1, 2);
+        ImGuiChildFlags_ResizeY = bit.lshift(1, 3);
+        ImGuiChildFlags_AutoResizeX = bit.lshift(1, 4);
+        ImGuiChildFlags_AutoResizeY = bit.lshift(1, 5);
+        ImGuiChildFlags_AlwaysAutoResize = bit.lshift(1, 6);
+        ImGuiChildFlags_FrameStyle = bit.lshift(1, 7);
+        ImGuiChildFlags_NavFlattened = bit.lshift(1, 8);
+    end
 
     -- ImGuiWindowFlags_NoDocking doesn't exist on main branch (added in 4.3)
     -- Define as 0 so bit.bor() calls don't fail
@@ -128,9 +179,12 @@ else
     end
 
     -- BeginChild: 4.3 changed default cflags behavior
-    -- On main, true = ImGuiChildFlags_Borders, on 4.3 it's more explicit
+    -- On legacy/4.16 the third arg is a boolean border; on current it is ImGuiChildFlags
+    -- Map bools and polyfilled flag values to a real boolean (never pass nil flags)
+    -- Older shim forwarded ImGuiChildFlags_* which are nil on stock 4.16 libs and
+    -- broke BeginChild for config, satchel, and Phantom Roll preview windows
     imgui.BeginChild = function(id, size, cflags, wflags)
-        return orig_imgui_BeginChild(id, size, cflags == true and ImGuiChildFlags_Borders or ImGuiChildFlags_None, wflags);
+        return orig_imgui_BeginChild(id, size, toBoolBorder(cflags), wflags);
     end
 
     -- PushStyleColor wrapper removed - all constants now guaranteed to exist via fallbacks above
@@ -140,7 +194,8 @@ end
 
 -- Return module info for debugging
 return {
-    version = '1.0.0',
-    mode = use43 and '4.3' or 'main',
-    description = 'ImGui compatibility layer for Ashita v4beta main/4.3'
+    version = '1.1.0',
+    legacyImGui = legacyImGui,
+    mode = legacyImGui and 'legacy' or 'current',
+    description = 'ImGui compatibility layer for Ashita v4beta current/legacy (4.3 / 4.16)',
 };

--- a/XIUI/libs/imtext.lua
+++ b/XIUI/libs/imtext.lua
@@ -192,7 +192,37 @@ function M.Reset()
     colorCache = {};
 end
 
+-- Normalize CalcTextSize / CalcTextSizeA results across Ashita bindings
+-- (number width, ImVec2 userdata/table, or width+height multi-return).
+local function sizeXY(a, b)
+    if type(a) == 'number' then
+        return a, (type(b) == 'number' and b) or nil;
+    end
+    if a ~= nil then
+        local x = a.x or a[1];
+        local y = a.y or a[2];
+        if type(x) == 'number' then
+            return x, (type(y) == 'number' and y) or nil;
+        end
+    end
+    return 0, nil;
+end
+
+-- FLT_MAX: wrap width large enough that text is measured on a single line.
+local NO_WRAP_WIDTH = 3.402823e+38;
+
+-- Width and line height of `text` in whatever font is currently pushed.
+local function measurePushedFont(text)
+    local lineHeight = imgui.GetTextLineHeight();
+    local width = sizeXY(imgui.CalcTextSize(text));
+    return width, lineHeight;
+end
+
 --- Measure text width and height at the given font size.
+--- Prefer ImFont:CalcTextSizeA so we never PushFont during measure. On Ashita
+--- 4.16 (ImGui 1.80), PushFont also PushTextureID on the current window draw
+--- list; unbalanced or high-frequency Push/Pop from hot paths (Phantom Roll
+--- with config open) corrupts global layout and makes windows pulse/vanish.
 --- @param text string
 --- @param fontSize number|nil Pixel size (nil uses ImGui default)
 --- @return number width, number height
@@ -202,24 +232,37 @@ function M.Measure(text, fontSize)
 
     local font = activeFont;
     if font and fontSize then
-        local pushOk = pcall(imgui.PushFont, font);
-        if pushOk then
-            local lineH = imgui.GetTextLineHeight();
-            local w = imgui.CalcTextSize(text);
-            imgui.PopFont();
-            if lineH > 0 then
-                local scale = fontSize / lineH;
-                return w * scale, fontSize;
+        -- Direct glyph metrics at the draw size — no font/texture stack.
+        -- A zero width for non-empty text means the binding returned junk, so
+        -- only trust a positive result.
+        local ok, a, b = pcall(function()
+            return font:CalcTextSizeA(fontSize, NO_WRAP_WIDTH, 0.0, text);
+        end);
+        if ok then
+            local width, height = sizeXY(a, b);
+            if width > 0 then
+                return width, height or fontSize;
+            end
+        end
+
+        -- Binding has no CalcTextSizeA: measure with the font pushed, and
+        -- always PopFont on the same path so the stack stays balanced.
+        if pcall(imgui.PushFont, font) then
+            local measured, width, lineHeight = pcall(measurePushedFont, text);
+            pcall(imgui.PopFont);
+            if measured and lineHeight > 0 then
+                return width * (fontSize / lineHeight), fontSize;
             end
         end
     end
 
+    -- Default font: scale its metrics to the requested size.
     local defaultHeight = getLineHeight();
+    local width, height = sizeXY(imgui.CalcTextSize(text));
     if fontSize and defaultHeight > 0 then
-        local scale = fontSize / defaultHeight;
-        return imgui.CalcTextSize(text) * scale, fontSize;
+        return width * (fontSize / defaultHeight), fontSize;
     end
-    return imgui.CalcTextSize(text), defaultHeight;
+    return width, height or defaultHeight;
 end
 
 --- Draw outlined text on an ImGui draw list.

--- a/XIUI/modules/phantomroll/dice.lua
+++ b/XIUI/modules/phantomroll/dice.lua
@@ -51,6 +51,8 @@ M.CenteredText = function(drawList, text, centerX, centerY, size, argbColor)
 end
 
 -- Face already has contrast; global bold/outline turns the numeral into a blob.
+-- Switch to regular/no-outline only for this draw, then restore. Fonts are
+-- cache lookups (no atlas load); Measure itself must not PushFont (see imtext).
 local function DrawNumeral(drawList, text, boxX, boxY, boxSize, fontSize, argbColor, fontSettings)
     imtext.SetConfig(fontSettings.font_family or 'Tahoma', false, 0);
 

--- a/XIUI/modules/phantomroll/display.lua
+++ b/XIUI/modules/phantomroll/display.lua
@@ -39,6 +39,15 @@ local BAR_FILL = {
 local BAR_BACKDROP = { 0.10, 0.11, 0.13, 0.80 };
 local BAR_BORDER = { 0, 0, 0, 1 };
 
+-- Layout ratios. Everything except ODDS_GAP is a multiple of dieSize so the
+-- whole window scales as one unit when the user changes die size.
+local COLUMN_WIDTH   = 1.35;
+local COLUMN_GAP     = 0.50;
+local ROW_GAP        = 0.09;
+local NAME_GAP       = 0.30;  -- clears the flame tips above a hot die
+local ICE_HEADROOM   = 0.32;  -- room for the icicles below a cold die
+local ODDS_GAP       = 0.45;  -- x oddsSize, between "Bust %" and its timer
+
 local function FormatClock(seconds)
     if seconds == nil then return ''; end
     if seconds < 0 then return '--:--'; end
@@ -118,40 +127,122 @@ local function DrawBar(drawList, x, y, width, height, column)
         dice.Color(BAR_BACKDROP), rounding);
 
     if column.fraction > 0 then
-        -- Inset fill so AA stays in the track (bar 2's left sits in the gap).
+        -- Width-clipped fill (no PushClipRect): on 4.16, clip stacks on the
+        -- shared BackgroundDrawList while config is open interact badly with
+        -- RunWithScreenClip and can leave global ImGui layout unstable.
         local inset = 1;
-        local innerRounding = math.max(0, rounding - inset);
-        local fillRight = x + math.max(inset, width * column.fraction - inset);
-        drawList:PushClipRect({ x + inset, y + inset }, { fillRight, y + height - inset }, true);
-        drawList:AddRectFilled({ x + inset, y + inset }, { x + width - inset, y + height - inset },
-            dice.Color(column.fill), innerRounding);
-        drawList:PopClipRect();
+        local fillWidth = width * column.fraction - inset * 2;
+        if fillWidth > 0 then
+            drawList:AddRectFilled(
+                { x + inset, y + inset },
+                { x + inset + fillWidth, y + height - inset },
+                dice.Color(column.fill), math.max(0, rounding - inset));
+        end
     end
 
     -- Same idea as player/target bars: a thin stroke around the fill.
     drawList:AddRect({ x, y }, { x + width, y + height },
-        dice.Color(BAR_BORDER), rounding, 15, 1.0);
+        dice.Color(BAR_BORDER), rounding, ImDrawCornerFlags_All, 1.0);
 
     dice.CenteredText(drawList, column.clock, x + width / 2, y + height / 2,
         height * 0.86, TEXT.clock);
 end
 
-M.DrawWindow = function(settings)
+-- One roll column, drawn top-down: name, die, potency, duration bar, odds.
+local function DrawColumn(drawList, settings, column, centerX, top, clock)
     local dieSize = settings.dieSize;
-    local gap = dieSize * 0.50;
-    local rowGap = dieSize * 0.09;
-    local nameGap = dieSize * 0.30;      -- clears flame tips above the die
-    local iceHeadroom = dieSize * 0.32;  -- room for icicles below
+    local rowGap = dieSize * ROW_GAP;
+    local y = top;
 
+    dice.CenteredText(drawList, column.name, centerX, y + settings.nameSize / 2,
+        settings.nameSize, column.nameColor);
+    y = y + settings.nameSize + dieSize * NAME_GAP;
+
+    dice.Draw(drawList, centerX - dieSize / 2, y, dieSize, column.state, clock,
+        settings.font_settings);
+    y = y + dieSize + dieSize * ICE_HEADROOM + rowGap;
+
+    dice.CenteredText(drawList, column.potency, centerX, y + settings.potencySize / 2,
+        settings.potencySize, column.potencyColor);
+    y = y + settings.potencySize + rowGap;
+
+    local columnWidth = dieSize * COLUMN_WIDTH;
+    DrawBar(drawList, centerX - columnWidth / 2, y, columnWidth, settings.barHeight, column);
+    y = y + settings.barHeight + rowGap;
+
+    if column.odds == '' then return; end
+
+    local oddsY = y + settings.oddsSize / 2;
+    if column.oddsTimer == '' then
+        dice.CenteredText(drawList, column.odds, centerX, oddsY,
+            settings.oddsSize, column.oddsColor);
+        return;
+    end
+
+    -- Odds and its countdown are centered together as one group.
+    local oddsGap = settings.oddsSize * ODDS_GAP;
+    local oddsW = imtext.Measure(column.odds, settings.oddsSize);
+    local timerW = imtext.Measure(column.oddsTimer, settings.oddsSize);
+    local left = centerX - (oddsW + oddsGap + timerW) / 2;
+    dice.CenteredText(drawList, column.odds, left + oddsW / 2, oddsY,
+        settings.oddsSize, column.oddsColor);
+    dice.CenteredText(drawList, column.oddsTimer, left + oddsW + oddsGap + timerW / 2,
+        oddsY, settings.oddsSize, TEXT.muted);
+end
+
+-- Window body. Kept separate so DrawWindow can pcall it and still guarantee
+-- the matching imgui.End() / PopStyleVar().
+local function DrawColumns(settings, columns, contentWidth, contentHeight)
+    SaveWindowPosition(WINDOW_NAME);
+
+    local originX, originY = imgui.GetCursorScreenPos();
+    imgui.Dummy({ contentWidth, contentHeight });
+
+    -- Window draw list (not GetUIDrawList/Background): keeps text and
+    -- primitives on the same list as this window. Measuring via PushFont
+    -- on 4.16 touches CurrentWindow's texture stack; drawing to the
+    -- background list while config is open was splitting those targets.
+    local drawList = imgui.GetWindowDrawList();
+    local clock = os.clock();
+    local columnWidth = settings.dieSize * COLUMN_WIDTH;
+    local stride = columnWidth + settings.dieSize * COLUMN_GAP;
+
+    for i = 1, #columns do
+        DrawColumn(drawList, settings, columns[i],
+            originX + (i - 1) * stride + columnWidth / 2, originY, clock);
+    end
+end
+
+-- Explicit size, no AlwaysAutoResize: on legacy ImGui an always-applied
+-- auto-resize fights the explicit size every frame and can make other windows
+-- appear to stretch/shrink. That rules out sharing GetBaseWindowFlags().
+local baseWindowFlags = nil;
+local function WindowFlags(lockPositions)
+    if baseWindowFlags == nil then
+        baseWindowFlags = bit.bor(
+            ImGuiWindowFlags_NoDecoration,
+            ImGuiWindowFlags_NoFocusOnAppearing,
+            ImGuiWindowFlags_NoNav,
+            ImGuiWindowFlags_NoBackground,
+            ImGuiWindowFlags_NoBringToFrontOnFocus,
+            ImGuiWindowFlags_NoDocking
+        );
+    end
+
+    if lockPositions then
+        return bit.bor(baseWindowFlags, ImGuiWindowFlags_NoMove);
+    end
+
+    return baseWindowFlags;
+end
+
+M.DrawWindow = function(settings)
     imtext.SetConfigFromSettings(settings.font_settings);
 
     local slots = tracker.Slots();
     local doubleUpIndex, doubleUpSeconds = tracker.DoubleUp();
 
     local columns = {};
-    local columnWidth = dieSize * 1.35;
-    local oddsGap = settings.oddsSize * 0.45;
-
     for i = 1, 2 do
         if slots[i] ~= nil then
             columns[#columns + 1] = BuildColumn(
@@ -162,64 +253,33 @@ M.DrawWindow = function(settings)
     local count = #columns;
     if count == 0 then return; end
 
-    local contentWidth = columnWidth * count + gap * (count - 1);
-    local contentHeight = settings.nameSize + nameGap + dieSize + iceHeadroom
-        + rowGap + settings.potencySize + rowGap + settings.barHeight + rowGap + settings.oddsSize;
+    local dieSize = settings.dieSize;
+    local rowGap = dieSize * ROW_GAP;
+    local columnWidth = dieSize * COLUMN_WIDTH;
+    local contentWidth = columnWidth * count + dieSize * COLUMN_GAP * (count - 1);
+    local contentHeight = settings.nameSize + dieSize * NAME_GAP
+        + dieSize + dieSize * ICE_HEADROOM + rowGap
+        + settings.potencySize + rowGap + settings.barHeight + rowGap + settings.oddsSize;
 
-    imgui.SetNextWindowSize({ -1, -1 }, ImGuiCond_Always);
+    -- Explicit size (not -1,-1) so legacy ImGui isn't re-fitting the window
+    -- every frame; see WindowFlags above.
+    imgui.SetNextWindowSize({ contentWidth, contentHeight }, ImGuiCond_Always);
     imgui.PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
 
     ApplyWindowPosition(WINDOW_NAME);
-    if imgui.Begin(WINDOW_NAME, true, GetBaseWindowFlags(gConfig.lockPositions)) then
-        SaveWindowPosition(WINDOW_NAME);
+    local open = imgui.Begin(WINDOW_NAME, true, WindowFlags(gConfig and gConfig.lockPositions));
 
-        local originX, originY = imgui.GetCursorScreenPos();
-        imgui.Dummy({ contentWidth, contentHeight });
-
-        local drawList = GetUIDrawList();
-        local clock = os.clock();
-
-        for i = 1, count do
-            local column = columns[i];
-            local centerX = originX + (i - 1) * (columnWidth + gap) + columnWidth / 2;
-            local y = originY;
-
-            dice.CenteredText(drawList, column.name, centerX, y + settings.nameSize / 2,
-                settings.nameSize, column.nameColor);
-            y = y + settings.nameSize + nameGap;
-
-            dice.Draw(drawList, centerX - dieSize / 2, y, dieSize, column.state, clock,
-                settings.font_settings);
-            y = y + dieSize + iceHeadroom + rowGap;
-
-            dice.CenteredText(drawList, column.potency, centerX, y + settings.potencySize / 2,
-                settings.potencySize, column.potencyColor);
-            y = y + settings.potencySize + rowGap;
-
-            DrawBar(drawList, centerX - columnWidth / 2, y, columnWidth, settings.barHeight, column);
-            y = y + settings.barHeight + rowGap;
-
-            if column.odds ~= '' then
-                local oddsY = y + settings.oddsSize / 2;
-                if column.oddsTimer ~= '' then
-                    local oddsW = imtext.Measure(column.odds, settings.oddsSize);
-                    local timerW = imtext.Measure(column.oddsTimer, settings.oddsSize);
-                    local totalW = oddsW + oddsGap + timerW;
-                    local left = centerX - totalW / 2;
-                    dice.CenteredText(drawList, column.odds, left + oddsW / 2, oddsY,
-                        settings.oddsSize, column.oddsColor);
-                    dice.CenteredText(drawList, column.oddsTimer, left + oddsW + oddsGap + timerW / 2,
-                        oddsY, settings.oddsSize, TEXT.muted);
-                else
-                    dice.CenteredText(drawList, column.odds, centerX, oddsY,
-                        settings.oddsSize, column.oddsColor);
-                end
-            end
-        end
+    -- Only the body is protected: End/PopStyleVar must run even if a draw call
+    -- errors, or ImGui's window and style stacks stay unbalanced for every
+    -- other addon window this frame. End() is required even when Begin() is false.
+    local ok, err = true, nil;
+    if open then
+        ok, err = pcall(DrawColumns, settings, columns, contentWidth, contentHeight);
     end
-    imgui.End();
 
+    imgui.End();
     imgui.PopStyleVar();
+    if not ok then error(err); end
 end
 
 M.ResetPositions = function()

--- a/XIUI/modules/satchel/itemlogic.lua
+++ b/XIUI/modules/satchel/itemlogic.lua
@@ -1,5 +1,6 @@
 local breader = require('bitreader')
 local imgui = require('imgui')
+local imguiCompat = require('handlers.imgui_compat')
 local TextureManager = require('libs.texturemanager')
 local tooltips = require('modules.satchel.tooltips')
 local satchelfontcore = require('modules.satchel.satchelfontcore')
@@ -1280,7 +1281,7 @@ local function create_item_logic(ctx)
 
     -- Ashita main/4.16 TextColored treats strings as printf formats (% must be doubled).
     -- Ashita 4.3 does not, so escaping would show a literal "%%".
-    local imgui_needs_printf_escape = (ImGuiChildFlags_Borders == nil)
+    local imgui_needs_printf_escape = imguiCompat.legacyImGui == true
 
     local function escape_imgui_format(text)
         if type(text) ~= 'string' or text == '' then

--- a/XIUI/modules/satchel/tooltips.lua
+++ b/XIUI/modules/satchel/tooltips.lua
@@ -6,6 +6,7 @@
 ]]--
 
 local imgui = require('imgui')
+local imguiCompat = require('handlers.imgui_compat')
 local fontcore = require('modules.satchel.satchelfontcore')
 local TextureManager = require('libs.texturemanager')
 
@@ -527,7 +528,7 @@ local SPECIALS = {
 local glyph_cache = {}
 
 -- Ashita main/4.16 TextColored is printf-style; 4.3 is not.
-local imgui_needs_printf_escape = (ImGuiChildFlags_Borders == nil)
+local imgui_needs_printf_escape = imguiCompat.legacyImGui == true
 
 local function escape_imgui_format(text)
     if type(text) ~= 'string' or text == '' then


### PR DESCRIPTION
### Phantom Roll Ashita 4.16 Compatibility Fix Attempt
- Removed the manual _XIUI_USE_ASHITA_4_3 override and auto-detected legacy vs current ImGui from native ImGuiChildFlags_Borders before any polyfills ran
- Exposed legacyImGui from handlers/imgui_compat.lua and replaced ImGuiChildFlags_Borders checks in XIUI.lua, satchel itemlogic, and satchel tooltips with that flag so detection stayed correct after polyfills
- Polyfilled ImGuiChildFlags_* constants on legacy Ashita 4.16 stock imgui.lua and remapped BeginChild child flags through toBoolBorder so config, satchel, and Phantom Roll preview windows no longer passed nil border arguments into the native boolean border API
- Added toChildFlags for current ImGui, tab color fallbacks, BeginDisabled and EndDisabled polyfill on legacy, and ImDrawCornerFlags aliases on current ImGui
- Centralized internal save flag clearing in ClearInternalSaveFlag so legacy Ashita cleared bInternalSave synchronously after settings.save while current Ashita kept the pending clear path for async settings_update callbacks
- Rewrote imtext.Measure to use ImFont CalcTextSizeA instead of PushFont so high frequency text measurement during Phantom Roll config preview no longer leaked font and texture stack state on ImGui 1.80 and stopped config, notification, and Phantom Roll windows from stretching and shrinking in a loop
- Added sizeXY normalization for CalcTextSize and CalcTextSizeA return values across Ashita bindings and kept a PushFont fallback path that always called PopFont
- Stopped Phantom Roll from drawing through GetUIDrawList BackgroundDrawList while the config window was open and routed dice, bars, and labels through imgui.GetWindowDrawList so text measurement and drawing used the same window draw list
- Removed AlwaysAutoResize and SetNextWindowSize -1 -1 from the Phantom Roll window, applied an explicit content size each frame, and split rendering into DrawColumn and DrawColumns wrapped in pcall so imgui.End and PopStyleVar always ran even when a draw call failed
- Replaced duration bar PushClipRect on the shared background draw list with a width clipped AddRectFilled fill to avoid clip stack interaction with RunWithScreenClip on 4.16
- Documented Phantom Roll numeral font switching in dice.lua as cache lookups only and noted that imtext.Measure no longer uses PushFont