### PR TITLE
Improved Enemy Debuff Tracking Further

### DIFF
--- a/XIUI/handlers/database/debuff_horizon.lua
+++ b/XIUI/handlers/database/debuff_horizon.lua
@@ -1,5 +1,6 @@
 -- Horizon debuff overlay on handlers/database/debuff_retail.lua.
 -- Only duration fields that differ from retail. Names and kinds stay on the base table.
+-- Field value `false` clears a retail field during merge (e.g. fixed duration -> TP formula).
 
 local overlay = {};
 
@@ -17,6 +18,20 @@ overlay.spells = {
 overlay.jaPhysical = {
     [46] = {duration = 6}, -- Shield Bash
     [77] = {duration = 6}, -- Weapon Bash
+};
+
+overlay.ja = {
+    [45] = {duration = 30, buffId = 448}, -- Mug - Bewildered Daze (crit hit rate bonus)
+};
+
+-- Horizon WS debuffs (see horizonffxi.wiki). Energy Drain Slow durations at 1k/2k/3k TP.
+overlay.weaponSkills = {
+    -- Enemy gets Slow; player Haste is a self-buff (not tracked here).
+    [22] = {buffId = 13, tpTier = {{1000, 90}, {2000, 150}, {3000, 210}}}, -- Energy Drain - Slow
+    [66] = {buffId = 12, duration = false, tpTier = {{1000, 20}, {2000, 40}, {3000, 60}}}, -- Gale Axe - Weight (replaces Choke)
+    [121] = {duration = 30, buffId = 149}, -- Geirskogul - Defense Down (matches Angon)
+    [197] = {duration = 5, buffId = 10}, -- Blast Arrow - Stun (duration unknown; common stun)
+    [213] = {duration = 5, buffId = 10}, -- Blast Shot - Stun (duration unknown; common stun)
 };
 
 return overlay;

--- a/XIUI/handlers/database/debuff_retail.lua
+++ b/XIUI/handlers/database/debuff_retail.lua
@@ -5,26 +5,6 @@
 local durations = {};
 
 durations.spells = {
-    -- Weapon skills with debuffs (do not track Shield Break)
-    [181] = {duration = 180, buffId = 149}, -- Shell Crusher - Defense Down
-    [83] = {duration = 180, buffId = 149},  -- Armor Break - Defense Down
-    [87] = {duration = 180, buffIds = {149, 147}}, -- Full Break - Defense Down & Attack Down
-    [155] = {duration = 180, buffId = 149}, -- Tachi: Ageha - Defense Down
-    [187] = {duration = 180, buffId = 149}, -- Garland of Bliss - Defense Down
-    [89] = {duration = 180, buffId = 149},  -- Metatron Torment - Defense Down
-    [85] = {duration = 180, buffId = 147},  -- Weapon Break - Attack Down
-    [185] = {duration = 180, buffId = 147}, -- Gate of Tartarus - Attack Down
-    [107] = {duration = 180, buffId = 147}, -- Infernal Scythe - Attack Down
-    [16] = {duration = 90, buffId = 3},     -- Wasp Sting - Poison
-    [17] = {duration = 90, buffId = 3},     -- Viper Bite - Poison
-    [18] = {duration = 30, buffId = 11},    -- Shadowstitch - Bind
-    [35] = {duration = 5, buffId = 10},     -- Flat Blade - Stun
-    [115] = {duration = 5, buffId = 10},    -- Leg Sweep - Stun
-    [2] = {duration = 5, buffId = 10},      -- Shoulder Tackle - Stun
-    [65] = {duration = 5, buffId = 10},     -- Smash Axe - Stun
-    [162] = {duration = 5, buffId = 10},    -- Brainshaker - Stun
-    [145] = {duration = 5, buffId = 10},    -- Tachi: Hobaku - Stun
-
     -- Dia/Bio spells
     [23] = {duration = 60, kind = 'enfeeble'},   -- Dia
     [33] = {duration = 60, kind = 'enfeeble'},   -- Diaga
@@ -211,19 +191,75 @@ durations.spells = {
     [707] = {duration = 12, buffId = 156}, -- Retinal Glare - Flash
 };
 
+-- Type 3 weapon skills with debuffs (separate from spells to avoid id collisions).
+durations.weaponSkills = {
+    [2] = {buffId = 10, tpPer500 = 1}, -- Shoulder Tackle - Stun
+    [15] = {buffId = 31, tpDuration = {base = 15, per1000Tp = 3}}, -- Shijin Spiral - Plague
+    [16] = {buffId = 3, tpDuration = {base = 75, per1000Tp = 15}}, -- Wasp Sting - Poison
+    [17] = {buffId = 3, tpDuration = {base = 30, per100Tp = 6}}, -- Viper Bite - Poison
+    [18] = {buffId = 11, tpDuration = {base = 5, per200Tp = 1}}, -- Shadowstitch - Bind
+    [28] = {buffId = 12, duration = 60}, -- Mordant Rime - Weight
+    [29] = {buffId = 148, tpDuration = {per100Tp = 6}}, -- Pyrrhic Kleos - Evasion Down
+    [31] = {buffId = 12, duration = 60}, -- Rudra's Storm - Weight
+    [35] = {buffId = 10, duration = 4}, -- Flat Blade - Stun
+    [44] = {buffId = 404, duration = 60}, -- Death Blossom - Magic Evasion Down
+    [52] = {buffId = 2, tpDuration = {per100Tp = 6}}, -- Shockwave - Sleep
+    [58] = {buffId = 4, tpDuration = {per100Tp = 6}}, -- Herculean Slash - Paralyze
+    [65] = {buffId = 10, tpPer500 = 1}, -- Smash Axe - Stun
+    [66] = {buffId = 130, duration = 60}, -- Gale Axe - Choke
+    [73] = {buffId = 146, duration = 120}, -- Onslaught - Accuracy Down
+    [75] = {buffId = 11, duration = 20}, -- Bora Axe - Bind
+    [80] = {buffId = 148, tpDuration = {base = 120, per100Tp = 6}}, -- Shield Break - Evasion Down
+    [83] = {buffId = 149, tpDuration = {base = 120, per100Tp = 6}}, -- Armor Break - Defense Down
+    [85] = {buffId = 147, tpDuration = {base = 120, per100Tp = 6}}, -- Weapon Break - Attack Down
+    [87] = {buffIds = {147, 149, 146, 148}, tpDuration = {base = 60, per100Tp = 3}}, -- Full Break
+    [89] = {buffId = 149, duration = 120}, -- Metatron Torment - Defense Down
+    [92] = {buffId = 13, duration = 60}, -- Ukko's Fury - Slow
+    [102] = {buffId = 6, tpDuration = {base = 30, per100Tp = 3}}, -- Guillotine - Silence
+    [107] = {buffId = 147, tpDuration = {per100Tp = 6}}, -- Infernal Scythe - Attack Down
+    [115] = {buffId = 10, duration = 4}, -- Leg Sweep - Stun
+    [125] = {buffId = 298, duration = 60}, -- Stardiver - Crit Hit Evasion Down
+    [129] = {buffId = 4, tpFTP = {30, 60, 120}}, -- Blade: Retsu - Paralyze
+    [137] = {buffId = 4, duration = 60}, -- Blade: Metsu - Paralyze
+    [138] = {buffId = 146, tpDuration = {per1000Tp = 6}}, -- Blade: Kamu - Accuracy Down
+    [139] = {buffId = 3, tpDuration = {base = 75, per1000Tp = 15}}, -- Blade: Yu - Poison
+    [145] = {buffId = 10, duration = 3}, -- Tachi: Hobaku - Stun
+    [150] = {buffId = 5, duration = 60}, -- Tachi: Yukikaze - Blind
+    [151] = {buffId = 6, duration = 45}, -- Tachi: Gekko - Silence
+    [152] = {buffId = 4, duration = 60}, -- Tachi: Kasha - Paralyze
+    [155] = {buffId = 149, tpDuration = {per100Tp = 6}}, -- Tachi: Ageha - Defense Down
+    [162] = {buffId = 10, tpPer500 = 1}, -- Brainshaker - Stun
+    [165] = {buffId = 140, duration = 140}, -- Skullbreaker - INT Down
+    [170] = {buffId = 148, duration = 120}, -- Randgrith - Evasion Down
+    [181] = {buffId = 149, tpDuration = {base = 120, per100Tp = 6}}, -- Shell Crusher - Defense Down
+    [185] = {buffId = 147, duration = 120}, -- Gate of Tartarus - Attack Down
+    [186] = {buffId = 167, tpDuration = {per100Tp = 6}}, -- Vidohunir - Magic Def Down
+    [187] = {buffId = 149, tpDuration = {per100Tp = 6}}, -- Garland of Bliss - Defense Down
+    [188] = {buffId = 175, tpDuration = {per100Tp = 6}}, -- Omniscience - Magic Atk Down
+    [191] = {buffId = 167, duration = 120}, -- Shattersoul - Magic Def Down
+    [210] = {buffId = 140, duration = 140}, -- Sniper Shot - INT Down
+    [219] = {buffId = 4, tpDuration = {per100Tp = 6}}, -- Numbing Shot - Paralyze
+    [224] = {buffId = 146, tpDuration = {base = 45, per1000Tp = 45}}, -- Exenterator - Accuracy Down
+    [238] = {buffId = 156, duration = 15}, -- Uriel Blade - Flash
+    [239] = {buffId = 10, tpPer500 = 1}, -- Glory Slash - Stun
+};
+
+-- Job abilities that apply a debuff on the next melee/ranged hit (not on use).
+durations.onHit = {
+    [156] = {buffId = 148, duration = 30, window = 60}, -- Feint -> Evasion Down
+};
+
 -- Type 3 job abilities that land like a weaponskill.
 durations.jaPhysical = {
-    [22] = {duration = 120, buffId = 144}, -- Energy Drain - Max HP Down
-    [45] = {duration = 30, buffId = 448},  -- Mug
     [46] = {duration = 8, buffId = 10},    -- Shield Bash - Stun (LSB 2-8)
     [77] = {duration = 8, buffId = 10},    -- Weapon Bash - Stun
-    [170] = {duration = 30, buffId = 149}, -- Angon - Defense Down
+    [170] = {duration = 30, buffId = 149, certainOnHit = true}, -- Angon - Defense Down (no resist roll)
 };
 
 -- Type 6 / 14 job abilities. 16-23 are packet JA ids; 688-695 are mob-skill ids
 -- (type 11). Keep 688-695 out of spells so they do not collide with BLU.
 durations.ja = {
-    [72] = {duration = 30, buffId = 11}, -- Shadowbind - Bind
+    [57] = {duration = 30, buffId = 11}, -- Shadowbind - Bind
     [139] = {duration = 30, buffId = 149}, -- Tomahawk - Defense Down
     [201] = {duration = 30, buffId = 386}, -- Quickstep - Lethargic Daze
     [202] = {duration = 30, buffId = 396}, -- Stutter Step - Weakened Daze
@@ -254,9 +290,28 @@ durations.pet = {
 
 -- Additional-effect procs keyed by the landed buff id (not spell/WS id).
 durations.additionalEffect = {
-    [2] = {duration = 25},   -- Sleep Bolt
+    [2] = {duration = 25},   -- Sleep
+    [3] = {duration = 90},   -- Poison
+    [4] = {duration = 120},  -- Paralyze
+    [5] = {duration = 180},  -- Blind
+    [6] = {duration = 120},  -- Silence
+    [10] = {duration = 5},   -- Stun
+    [11] = {duration = 30},  -- Bind
+    [12] = {duration = 30},  -- Weight / Gravity
+    [13] = {duration = 180}, -- Slow
+    [31] = {duration = 60},  -- Plague
+    [130] = {duration = 90}, -- Choke
+    [136] = {duration = 60}, -- STR Down
+    [140] = {duration = 120}, -- INT Down
+    [146] = {duration = 120}, -- Accuracy Down
+    [147] = {duration = 120}, -- Attack Down
+    [148] = {duration = 120}, -- Evasion Down
     [149] = {duration = 60}, -- Defense Down / Acid Bolt
-    [12] = {duration = 30},  -- Gravity / Mandau
+    [156] = {duration = 12}, -- Flash
+    [167] = {duration = 120}, -- Magic Def Down
+    [175] = {duration = 120}, -- Magic Atk Down
+    [298] = {duration = 60}, -- Crit Hit Evasion Down
+    [404] = {duration = 60}, -- Magic Evasion Down
 };
 
 return durations;

--- a/XIUI/handlers/debuffhandler.lua
+++ b/XIUI/handlers/debuffhandler.lua
@@ -7,6 +7,8 @@ local debuffHandler =
 T{
     -- All enemies we have seen take a debuff
     enemies = T{};
+    -- Feint and similar: debuff lands on next melee/ranged hit from this actor
+    pendingOnHit = T{};
 };
 
 -- Reusable tables for GetActiveDebuffs to avoid per-frame allocations
@@ -23,8 +25,12 @@ local spellDamageMes = {[2]=true, [252]=true, [264]=true, [265]=true};
 -- Physical/ability hits (110 = bash/jump, 185 = WS). Not a per-ability list.
 local physicalHitMes = {[103]=true, [110]=true, [185]=true, [187]=true, [238]=true, [242]=true, [317]=true, [802]=true};
 local additionalEffectMes = {[160]=true, [164]=true};
--- JA 22 is Energy Drain on type 3 and Invincible on type 6. Drain only on WS-hit 185.
-local ENERGY_DRAIN_JA = 22;
+-- "No effect" confirms a matching uncertain debuff is already present (do not refresh timer).
+-- Distinct from complete resist / immunity (655), which means the effect is not present.
+local noEffectMes = {[75]=true, [189]=true, [283]=true, [323]=true};
+local immuneMes = {[655]=true}; -- MagicCompleteResist — target immune / cannot take the effect
+local MAX_TP = 3000;
+local ALLIANCE_MEMBER_SLOTS = 18;
 
 local BUFF_SABOTEUR = 454;
 local BUFF_STYMIE = 494;
@@ -83,7 +89,12 @@ local function ApplyHorizonOverlay(base, overlay)
                 elseif type(patch) == 'table' and type(base[cat][id]) == 'table' then
                     local merged = CloneDurationEntry(base[cat][id]);
                     for k, v in pairs(patch) do
-                        merged[k] = v;
+                        -- false clears a retail field (e.g. fixed duration -> TP formula).
+                        if v == false then
+                            merged[k] = nil;
+                        else
+                            merged[k] = v;
+                        end
                     end
                     base[cat][id] = merged;
                 else
@@ -101,10 +112,12 @@ if HzLimitedMode then
 end
 
 local SPELL_DURATIONS = durations.spells;
+local WEAPON_SKILL_DURATIONS = durations.weaponSkills or {};
 local JA_PHYSICAL_DURATIONS = durations.jaPhysical;
 local JA_DURATIONS = durations.ja;
 local PET_DURATIONS = durations.pet;
 local ADDITIONAL_EFFECT_DURATIONS = durations.additionalEffect;
+local ON_HIT_DURATIONS = durations.onHit or {};
 
 local function ClampSongPlus(value)
     value = tonumber(value) or 0;
@@ -229,14 +242,154 @@ end
 local function ApplyBuffExpiry(targetDebuffs, buffId, expiry, uncertain)
     if buffId == nil then return; end
     local prev = targetDebuffs[buffId];
+    -- Keep certainty if an active certain timer already exists (do not downgrade).
     if type(prev) == 'table' and prev.expiry and prev.expiry >= os.time() and not prev.uncertain then
         uncertain = false;
     end
     targetDebuffs[buffId] = { expiry = expiry, uncertain = uncertain == true };
 end
 
--- Non-spell Param lookup. Old tracker used one table for every action type.
-local function LookupNonSpell(id)
+-- Status already present ("no effect"): upgrade uncertain -> certain without refreshing timer.
+local function ConfirmUncertainDebuff(targetDebuffs, buffId, now)
+    if buffId == nil or buffId == 0 then return; end
+    local prev = targetDebuffs[buffId];
+    if type(prev) == 'table' and prev.uncertain and prev.expiry and prev.expiry >= now then
+        prev.uncertain = false;
+    end
+end
+
+-- Immunity / complete resist: effect cannot be on the target — clear tracked entry.
+local function ClearTrackedDebuff(targetDebuffs, buffId)
+    if buffId == nil or buffId == 0 then return; end
+    targetDebuffs[buffId] = nil;
+end
+
+local function ResolveActionBuffIds(actionType, spellId, abilityParam)
+    local ids = {};
+    if abilityParam ~= nil and abilityParam ~= 0 then
+        ids[#ids + 1] = abilityParam;
+        return ids;
+    end
+    if actionType == 4 then
+        local buffId = buffTable.GetBuffIdBySpellId(spellId);
+        if buffId ~= nil and buffId ~= 0 then
+            ids[#ids + 1] = buffId;
+        end
+        return ids;
+    end
+    if actionType == 3 then
+        local wsData = WEAPON_SKILL_DURATIONS[spellId];
+        if wsData then
+            if wsData.buffIds then
+                for _, id in ipairs(wsData.buffIds) do
+                    ids[#ids + 1] = id;
+                end
+            elseif wsData.buffId then
+                ids[#ids + 1] = wsData.buffId;
+            end
+        end
+    end
+    return ids;
+end
+
+local function GetActorTp(actorId)
+    if actorId == nil then return nil; end
+    local mem = AshitaCore:GetMemoryManager();
+    if not mem then return nil; end
+    local party = mem:GetParty();
+    if not party then return nil; end
+    for memIdx = 0, ALLIANCE_MEMBER_SLOTS - 1 do
+        if party:GetMemberIsActive(memIdx) ~= 0 then
+            if party:GetMemberServerId(memIdx) == actorId then
+                return party:GetMemberTP(memIdx);
+            end
+        end
+    end
+    return nil;
+end
+
+local function ResolveTpTierDuration(tpTier, tp)
+    for i = #tpTier, 1, -1 do
+        if tp >= tpTier[i][1] then
+            return tpTier[i][2];
+        end
+    end
+    if tpTier[1][1] > 0 then
+        return math.floor(tpTier[1][2] * tp / tpTier[1][1]);
+    end
+    return tpTier[1][2];
+end
+
+local function ResolveTpDuration(wsData, tp)
+    if wsData.duration then
+        return wsData.duration;
+    end
+    if wsData.tpTier then
+        return ResolveTpTierDuration(wsData.tpTier, tp);
+    end
+    if wsData.tpFTP then
+        local anchors = wsData.tpFTP;
+        if tp >= 3000 then
+            return anchors[3];
+        elseif tp >= 2000 then
+            return math.floor(anchors[2] + (anchors[3] - anchors[2]) * (tp - 2000) / 1000);
+        elseif tp >= 1000 then
+            return math.floor(anchors[1] + (anchors[2] - anchors[1]) * (tp - 1000) / 1000);
+        end
+        return math.floor(anchors[1] * tp / 1000);
+    end
+    if wsData.tpPer500 then
+        return math.floor(tp / 500);
+    end
+    local formula = wsData.tpDuration or wsData;
+    local duration = formula.base or 0;
+    if formula.per100Tp then
+        duration = duration + formula.per100Tp * tp / 100;
+    end
+    if formula.per1000Tp then
+        duration = duration + formula.per1000Tp * tp / 1000;
+    end
+    if formula.per200Tp then
+        duration = duration + formula.per200Tp * tp / 200;
+    end
+    return math.floor(duration);
+end
+
+local function ResolveWeaponSkillDuration(wsData, actorId)
+    local tp = GetActorTp(actorId);
+    local tpKnown = tp ~= nil;
+    if not tpKnown then
+        tp = MAX_TP;
+    end
+    return ResolveTpDuration(wsData, tp), tpKnown;
+end
+
+local function UsesTpDuration(data)
+    return data.tpTier ~= nil or data.tpDuration ~= nil or data.tpFTP ~= nil or data.tpPer500 ~= nil;
+end
+
+-- uncertain: true when land is inferred (WS hit) or TP is unknown (non-party actor).
+local function ApplyWeaponSkillData(targetDebuffs, wsData, actorId, now, uncertain)
+    local duration, tpKnown = ResolveWeaponSkillDuration(wsData, actorId);
+    if uncertain == nil then
+        uncertain = true;
+    end
+    if not tpKnown then
+        uncertain = true;
+    end
+    local entry = CloneDurationEntry(wsData);
+    entry.duration = duration;
+    ApplySpellData(targetDebuffs, entry, false, now, nil, uncertain);
+end
+
+-- Non-spell Param lookup. Order matters for id collisions (e.g. Invincible vs Energy Drain).
+local function LookupNonSpell(id, actionType)
+    if actionType == 3 then
+        return WEAPON_SKILL_DURATIONS[id] or JA_PHYSICAL_DURATIONS[id];
+    end
+    if actionType == 6 or actionType == 14 then
+        return JA_DURATIONS[id];
+    end
     return JA_DURATIONS[id] or JA_PHYSICAL_DURATIONS[id] or PET_DURATIONS[id];
 end
 
@@ -254,7 +407,7 @@ local function JobAbilityId(id)
     return id;
 end
 
--- Type 4 is spells-only so BLU ids do not collide with 2-hours.
+-- Type 4 is spells-only so BLU ids do not collide with 2-hours or weapon skills.
 local function GetDurationData(actionType, id)
     id = PacketParamId(id);
     local jaId = JobAbilityId(id);
@@ -262,18 +415,18 @@ local function GetDurationData(actionType, id)
         return SPELL_DURATIONS[id];
     end
     if actionType == 3 then
-        return SPELL_DURATIONS[id] or LookupNonSpell(jaId);
+        return WEAPON_SKILL_DURATIONS[id] or JA_PHYSICAL_DURATIONS[jaId];
     end
     if actionType == 6 or actionType == 14 then
-        return JA_DURATIONS[id] or LookupNonSpell(jaId);
+        return JA_DURATIONS[jaId] or JA_DURATIONS[id];
     end
     if actionType == 13 then
         return PET_DURATIONS[id] or PET_DURATIONS[jaId];
     end
     if actionType == 11 then
-        return LookupNonSpell(id) or SPELL_DURATIONS[id];
+        return LookupNonSpell(id, actionType) or SPELL_DURATIONS[id];
     end
-    return SPELL_DURATIONS[id] or LookupNonSpell(id) or LookupNonSpell(jaId);
+    return SPELL_DURATIONS[id] or LookupNonSpell(id, actionType) or LookupNonSpell(jaId, actionType);
 end
 
 local function ApplySpellData(targetDebuffs, spellData, isOwnActor, now, packetBuffId, uncertain)
@@ -328,10 +481,23 @@ local function ApplyMessage(debuffs, action)
                 if spellData then
                     ApplySpellData(targetDebuffs, spellData, isOwnActor, now, 2, true);
                 end
-            -- Type 3 WS/JA on a physical hit. Energy Drain only on 185 (JA 22 collision).
-            elseif action.Type == 3 and spellData and physicalHitMes[message] then
-                if JobAbilityId(spell) ~= ENERGY_DRAIN_JA or message == 185 then
-                    ApplySpellData(targetDebuffs, spellData, isOwnActor, now, nil, true);
+            -- Type 1 melee only: Feint applies on regular melee hits (not ranged, not WS).
+            elseif action.Type == 1 and physicalHitMes[message] then
+                local pending = debuffHandler.pendingOnHit[actorId];
+                if pending and pending.expires > now then
+                    -- Guaranteed on connecting melee hit (including 0 dmg / countered).
+                    ApplyBuffExpiry(targetDebuffs, pending.buffId, now + pending.duration, false);
+                    debuffHandler.pendingOnHit[actorId] = nil;
+                end
+            -- Type 3 WS or physical JA on a hit
+            elseif action.Type == 3 and physicalHitMes[message] then
+                local wsData = WEAPON_SKILL_DURATIONS[spell];
+                if wsData then
+                    ApplyWeaponSkillData(targetDebuffs, wsData, actorId, now, true);
+                elseif spellData then
+                    -- Angon etc.: certainOnHit when land is guaranteed on connecting hit.
+                    local uncertain = spellData.certainOnHit ~= true;
+                    ApplySpellData(targetDebuffs, spellData, isOwnActor, now, nil, uncertain);
                 end
             -- Handle dia/bio/helix and physical additional-effect spells (Type 4 damage)
             elseif action.Type == 4 and spellDamageMes[message] then
@@ -349,10 +515,13 @@ local function ApplyMessage(debuffs, action)
                         ApplySpellData(targetDebuffs, spellData, isOwnActor, now, buffTable.GetBuffIdBySpellId(spell), true);
                     end
                 end
-            -- Handle regular status effect spells and magical BLU
+            -- Handle regular status effect spells and magical BLU / confirmed WS status
             elseif statusOnMes[message] then
                 local buffId = ability.Param or (action.Type == 4 and buffTable.GetBuffIdBySpellId(spell) or nil);
-                if spellData then
+                local wsData = action.Type == 3 and WEAPON_SKILL_DURATIONS[spell] or nil;
+                if wsData or (spellData and UsesTpDuration(spellData)) then
+                    ApplyWeaponSkillData(targetDebuffs, wsData or spellData, actorId, now, false);
+                elseif spellData then
                     ApplySpellData(targetDebuffs, spellData, isOwnActor, now, buffId, false);
                 elseif buffId ~= nil then
                     ApplyBuffExpiry(targetDebuffs, buffId, now + 300, false);
@@ -362,15 +531,36 @@ local function ApplyMessage(debuffs, action)
                 if ability.Param ~= nil then
                     targetDebuffs[ability.Param] = nil
                 end
+            -- "No effect": debuff already present — confirm uncertain, keep timer.
+            -- Not used for immunity (that is complete resist / immuneMes).
+            elseif noEffectMes[message] then
+                for _, buffId in ipairs(ResolveActionBuffIds(action.Type, spell, ability.Param)) do
+                    ConfirmUncertainDebuff(targetDebuffs, buffId, now);
+                end
+            -- Complete resist / immunity: effect is not on the target — clear tracker.
+            elseif immuneMes[message] then
+                for _, buffId in ipairs(ResolveActionBuffIds(action.Type, spell, ability.Param)) do
+                    ClearTrackedDebuff(targetDebuffs, buffId);
+                end
             -- Type 11: ja/jaPhysical/pet only (spell ids collide with WS/BLU).
             elseif action.Type == 11 then
-                local nonSpell = LookupNonSpell(spell);
+                local nonSpell = LookupNonSpell(spell, action.Type);
                 if nonSpell then
                     ApplySpellData(targetDebuffs, nonSpell, isOwnActor, now, ability.Param, false);
                 end
-            -- Type 6 / 14: any JA in the duration tables (512-normalized in GetDurationData).
-            elseif (action.Type == 6 or action.Type == 14) and spellData then
-                ApplySpellData(targetDebuffs, spellData, isOwnActor, now, ability.Param, false);
+            -- Type 6 / 14: job abilities (512-normalized in GetDurationData).
+            elseif action.Type == 6 or action.Type == 14 then
+                local jaId = JobAbilityId(spell);
+                local onHitData = ON_HIT_DURATIONS[jaId];
+                if onHitData then
+                    debuffHandler.pendingOnHit[actorId] = {
+                        buffId = onHitData.buffId,
+                        duration = onHitData.duration,
+                        expires = now + (onHitData.window or 60),
+                    };
+                elseif spellData then
+                    ApplySpellData(targetDebuffs, spellData, isOwnActor, now, ability.Param, false);
+                end
             end
 
             -- Additional-effect procs. Do not replace a known timer with the 30s guess.
@@ -452,6 +642,7 @@ end
 
 debuffHandler.HandleZonePacket = function(e)
     debuffHandler.enemies = {};
+    debuffHandler.pendingOnHit = T{};
 end
 
 debuffHandler.HandleMessagePacket = function(e)


### PR DESCRIPTION
### Improved Enemy Debuff Tracking Further
- Separated weapon skill debuffs from spell debuffs so they no longer mix up with each other
- Added missing weapon skill debuffs and timed them using party or alliance TP when possible
- Marked weapon skill debuffs as uncertain when we cannot confirm they landed
- Added Feint so evasion down applies on the next melee hit instead of when the ability is used
- Fixed Shadowbind so it tracks under the correct ability
- Expanded extra effect timers for common weapon and ammo procs
- Made Angon show as certain when it hits
- Added Horizon only changes for Mug, Energy Drain, Gale Axe, Geirskogul, Blast Arrow, and Blast Shot
- Confirmed uncertain debuffs when a matching spell has no effect because the enemy already has it
- Cleared tracked debuffs when a spell shows the enemy is immune